### PR TITLE
Remove test scope from log4j as it's needed during runtime too.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,6 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>${log4j.version}</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.scopt</groupId>


### PR DESCRIPTION
For the moment we need to include the library, otherwise you can get the following error:
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/log4j/or/RendererMap
        at org.apache.log4j.Hierarchy.<init>(Hierarchy.java:97)
        at org.apache.log4j.LogManager.<clinit>(LogManager.java:82)
        at org.slf4j.impl.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:66)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:358)
        at io.smartdatalake.util.misc.SmartDataLakeLogger$class.logger(SmartDataLakeLogger.scala:26)
