### PR TITLE
Improve checks for config and feed selection

### DIFF
--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -180,7 +180,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     // parse config objects and search actions to execute by feedSel
     implicit val registry: InstanceRegistry = ConfigParser.parse(config)
     val actions = registry.getActions.filter(_.metadata.flatMap(_.feed).exists( _.matches(appConfig.feedSel)))
-    require(actions.nonEmpty, s"No action was selected with the given criteria (${appConfig.feedSel}). At least one action needs to be selected.")
+    require(actions.nonEmpty, s"No action matched the given feed selector: ${appConfig.feedSel}. At least one action needs to be selected.")
     logger.info(s"selected actions ${actions.map(_.id).mkString(", ")}")
 
     // create Spark Session

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -169,7 +169,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     logger.info(s"Deploy-Mode: ${appConfig.deployMode}")
 
     // load config
-    val config:Config = appConfig.configuration match {
+    val config: Config = appConfig.configuration match {
       case Some(configuration) => ConfigLoader.loadConfigFromFilesystem(configuration)
       case None => ConfigLoader.loadConfigFromClasspath
     }

--- a/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -93,7 +93,7 @@ object ConfigLoader extends SmartDataLakeLogger {
     val jsonFiles = configFileIndex("json")
     val propertyFiles = configFileIndex("properties")
     if (confFiles.isEmpty && jsonFiles.isEmpty && propertyFiles.isEmpty) {
-      logger.warn(s"$hadoopPath does not contain valid configuration files. " +
+      logger.error(s"Path $hadoopPath does not contain valid configuration files. " +
         s"Ensure the configuration files have one of the following extensions: ${configFileExtensions.map(ext => s".$ext").mkString(", ")}")
     }
     //read file extensions in the same order as typesafe config


### PR DESCRIPTION
Abort if config could not be loaded, doesn't contain actions or dataObjects.
Abort if no feeds were selected.

Resolves #11 