### PR TITLE
Implement saveMode overwrite for FileSubFeed's.

### DIFF
--- a/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -84,8 +84,13 @@ object SparkSubFeed {
  * @param fileRefs path to files to be processed
  * @param dataObjectId id of the DataObject this SubFeed corresponds to
  * @param partitionValues Values of Partitions transported by this SubFeed
+ * @param processedInputFileRefs used to remember processed input FileRef's for post processing (e.g. delete after read)
  */
-case class FileSubFeed(fileRefs: Option[Seq[FileRef]], override val dataObjectId: DataObjectId, override val partitionValues: Seq[PartitionValues])
+case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
+                       override val dataObjectId: DataObjectId,
+                       override val partitionValues: Seq[PartitionValues],
+                       processedInputFileRefs: Option[Seq[FileRef]] = None
+                      )
   extends SubFeed {
   override def breakLineage(): FileSubFeed = {
     this.copy(fileRefs = None)

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -44,7 +44,7 @@ case class CustomFileAction(override val id: ActionObjectId,
                             inputId: DataObjectId,
                             outputId: DataObjectId,
                             transformer: CustomFileTransformerConfig,
-                            deleteDataAfterRead: Boolean = false,
+                            override val deleteDataAfterRead: Boolean = false,
                             filesPerPartition: Int = 10,
                             override val breakFileRefLineage: Boolean = false,
                             override val initExecutionMode: Option[ExecutionMode] = None,
@@ -60,7 +60,7 @@ case class CustomFileAction(override val id: ActionObjectId,
   override def initSubFeed(subFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
     val inputFileRefs = subFeed.fileRefs.getOrElse( input.getFileRefs(subFeed.partitionValues))
     val tgtFileRefs = output.translateFileRefs(inputFileRefs)
-    subFeed.copy(fileRefs = Some(tgtFileRefs), dataObjectId = output.id)
+    subFeed.copy(fileRefs = Some(tgtFileRefs), dataObjectId = output.id, processedInputFileRefs = Some(inputFileRefs))
   }
 
   override def execSubFeed(subFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
@@ -97,15 +97,7 @@ case class CustomFileAction(override val id: ActionObjectId,
     }
 
     // return
-    subFeed.copy(fileRefs = Some(tgtFileRefs), dataObjectId = output.id)
-  }
-
-  override def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    // delete Input Files if desired
-    if(deleteDataAfterRead) (input, inputSubFeed) match {
-      case (fileRefInput: FileRefDataObject, fileSubFeed: FileSubFeed) =>
-        fileSubFeed.fileRefs.map( fileRefs => fileRefInput.deleteFileRefs(fileRefs))
-    }
+    subFeed.copy(fileRefs = Some(tgtFileRefs), dataObjectId = output.id, processedInputFileRefs = Some(inputFileRefs))
   }
 
   /**

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -96,9 +96,6 @@ case class CustomFileAction(override val id: ActionObjectId,
       else logger.error(s"transformed $tgt with error $ex")
     }
 
-    // apply ACL's
-    output.applyAcls
-
     // return
     subFeed.copy(fileRefs = Some(tgtFileRefs), dataObjectId = output.id)
   }

--- a/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -106,8 +106,13 @@ abstract class FileSubFeedAction extends Action {
     postExecSubFeed(inputSubFeeds.head, outputSubFeeds.head)
   }
 
-  def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit
-
+  def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    // delete Input Files if desired
+    if (deleteDataAfterRead()) (input, outputSubFeed) match {
+      case (fileRefInput: FileRefDataObject, fileSubFeed: FileSubFeed) =>
+        fileSubFeed.processedInputFileRefs.foreach(fileRefs => fileRefInput.deleteFileRefs(fileRefs))
+    }
+  }
 
   /**
    * Stop propagating input FileRefs through action and instead get new FileRefs from DataObject according to the SubFeed's partitionValue.
@@ -119,5 +124,10 @@ abstract class FileSubFeedAction extends Action {
    * Execution mode if this Action is a start node of a DAG run
    */
   def initExecutionMode: Option[ExecutionMode]
+
+  /**
+   * If true delete files after they are successfully processed.
+   */
+  def deleteDataAfterRead(): Boolean
 
 }

--- a/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -19,9 +19,9 @@
 package io.smartdatalake.workflow.action
 
 import io.smartdatalake.definitions.ExecutionMode
-import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, FileRefDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed, InitSubFeed, SubFeed}
-import org.apache.spark.sql.SparkSession
+import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, CanHandlePartitions, FileRefDataObject}
+import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed, InitSubFeed, SparkSubFeed, SubFeed}
+import org.apache.spark.sql.{SaveMode, SparkSession}
 
 abstract class FileSubFeedAction extends Action {
 
@@ -36,8 +36,8 @@ abstract class FileSubFeedAction extends Action {
   def output:  FileRefDataObject with CanCreateOutputStream
 
   /**
-   * Initialize Action with for a given [[FileSubFeed]]
-   * Note that is only checks the prerequisits to do the processing and simulates the output FileRef's that would be created.
+   * Initialize Action with a given [[FileSubFeed]]
+   * Note that this only checks the prerequisits to do the processing and simulates the output FileRef's that would be created.
    *
    * @param subFeed subFeed to be processed (referencing files to be read)
    * @return processed subFeed (referencing files that would be written by this action)
@@ -86,6 +86,13 @@ abstract class FileSubFeedAction extends Action {
     } else preparedSubFeed
     // break lineage if requested
     preparedSubFeed = if (breakFileRefLineage) preparedSubFeed.breakLineage() else preparedSubFeed
+    // delete existing files on overwrite
+    if (output.saveMode == SaveMode.Overwrite) {
+      if (output.partitions.nonEmpty)
+        if (subFeed.partitionValues.nonEmpty) output.deletePartitions(subFeed.partitionValues)
+        else logger.warn(s"($id) Cannot delete data from partitioned data object ${output.id} as no partition values are given but saveMode=overwrite")
+      else output.deleteAll
+    }
     // transform
     val transformedSubFeed = execSubFeed(preparedSubFeed)
     // update partition values to output's partition columns and update dataObjectId
@@ -93,6 +100,7 @@ abstract class FileSubFeedAction extends Action {
   }
 
   override final def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.postExec(inputSubFeeds,outputSubFeeds)
     assert(inputSubFeeds.size == 1, s"Only one inputSubFeed allowed for FileSubFeedAction (Action $id, inputSubfeed's ${inputSubFeeds.map(_.dataObjectId).mkString(",")})")
     assert(outputSubFeeds.size == 1, s"Only one outputSubFeed allowed for FileSubFeedAction (Action $id, inputSubfeed's ${outputSubFeeds.map(_.dataObjectId).mkString(",")})")
     postExecSubFeed(inputSubFeeds.head, outputSubFeeds.head)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.util.hdfs.{PartitionLayout, PartitionValues}
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SaveMode, SparkSession}
 
 private[smartdatalake] trait FileRefDataObject extends FileDataObject {
 
@@ -101,11 +101,21 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
     PartitionLayout.extractPartitionValues(partitionLayout().get, fileName, filePath.stripPrefix(path + separator))
   }
 
-
   /**
    * Delete given files. This is used to cleanup files after they are processed.
    */
   def deleteFileRefs(fileRefs: Seq[FileRef])(implicit session: SparkSession): Unit = throw new RuntimeException(s"deleteFileRefs not implemented for $id")
+
+  /**
+   * Delete all data. This is used to implement SaveMode.Overwrite.
+   */
+  def deleteAll(implicit session: SparkSession): Unit = throw new RuntimeException(s"deleteAll not implemented for $id")
+
+  /**
+   * Overwrite or Append new data.
+   * When writing partitioned data, this applies only to partitions concerned.
+   */
+  def saveMode: SaveMode
 }
 
 private[smartdatalake] case class FileRef( fullPath:String, fileName: String, partitionValues: PartitionValues) {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -209,6 +209,10 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     }
   }
 
+  override def deleteAll(implicit session: SparkSession): Unit = {
+    filesystem.delete(hadoopPath, true) // recursive=true
+  }
+
   protected[workflow] def applyAcls(implicit session: SparkSession): Unit = {
     val aclToApply = acl().orElse(connection.flatMap(_.acl))
     if (aclToApply.isDefined) AclUtil.addACLs(acl().get, hadoopPath)(filesystem)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -127,8 +127,8 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
 
   override def deleteFileRefs(fileRefs: Seq[FileRef])(implicit session:SparkSession): Unit = {
     // delete given files on hdfs
-    fileRefs.foreach { _ =>
-      filesystem.delete(new Path(path), false) // recursive=false
+    fileRefs.foreach { file =>
+      filesystem.delete(new Path(file.fullPath), false) // recursive=false
     }
   }
 

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
@@ -22,14 +22,17 @@ import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.misc.AclDef
+import org.apache.spark.sql.SaveMode
 
 /**
  * DataObject of type raw for files with unknown content.
  * Provides details to an Action to access raw files.
+ * @param saveMode Overwrite or Append new data.
  */
 case class RawFileDataObject( override val id: DataObjectId,
                               override val path: String,
                               override val partitions: Seq[String] = Seq(),
+                              override val saveMode: SaveMode = SaveMode.Overwrite,
                               override val acl: Option[AclDef] = None,
                               override val connectionId: Option[ConnectionId] = None,
                               override val metadata: Option[DataObjectMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -28,29 +28,31 @@ import io.smartdatalake.util.hdfs.{PartitionLayout, PartitionValues}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.connection.SftpFileRefConnection
 import net.schmizz.sshj.sftp.SFTPClient
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SaveMode, SparkSession}
 
 import scala.util.{Failure, Success, Try}
 
 /**
-  * Connects to SFtp files
-  * Needs java library "com.hieronymus % sshj % 0.21.1"
-  * The following authentication mechanisms are supported
-  * -> public/private-key: private key must be saved in ~/.ssh, public key must be registered on server.
-  * -> user/pwd authentication: user and password is taken from two variables set as parameters.
-  *                             These variables could come from clear text (CLEAR), a file (FILE) or an environment variable (ENV)
-  *
-  *  @param partitionLayout partition layout defines how partition values can be extracted from the path.
-  *                         Use "%<colname>%" as token to extract the value for a partition column.
-  *                         With "%<colname:regex>%" a regex can be given to limit search. This is especially useful
-  *                         if there is no char to delimit the last token from the rest of the path or also between
-  *                         two tokens.
-  */
+ * Connects to SFtp files
+ * Needs java library "com.hieronymus % sshj % 0.21.1"
+ * The following authentication mechanisms are supported
+ * -> public/private-key: private key must be saved in ~/.ssh, public key must be registered on server.
+ * -> user/pwd authentication: user and password is taken from two variables set as parameters.
+ *                             These variables could come from clear text (CLEAR), a file (FILE) or an environment variable (ENV)
+ *
+ * @param partitionLayout partition layout defines how partition values can be extracted from the path.
+ *                        Use "%<colname>%" as token to extract the value for a partition column.
+ *                        With "%<colname:regex>%" a regex can be given to limit search. This is especially useful
+ *                        if there is no char to delimit the last token from the rest of the path or also between
+ *                        two tokens.
+ * @param saveMode Overwrite or Append new data.
+ */
 case class SFtpFileRefDataObject(override val id: DataObjectId,
                                  override val path: String,
                                  connectionId: ConnectionId,
                                  override val partitions: Seq[String] = Seq(),
                                  override val partitionLayout: Option[String] = None,
+                                 override val saveMode: SaveMode = SaveMode.Overwrite,
                                  override val metadata: Option[DataObjectMetadata] = None)
                                 (@transient implicit val instanceRegistry: InstanceRegistry)
   extends FileRefDataObject with CanCreateInputStream with CanCreateOutputStream with SmartDataLakeLogger {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -38,11 +38,6 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
     def format: String
 
     /**
-     * Overwrite or Append new data
-     */
-    def saveMode: SaveMode
-
-    /**
      * Returns the configured options for the Spark [[DataFrameReader]]/[[DataFrameWriter]].
      *
      * @see [[DataFrameReader]]

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -26,7 +26,7 @@ import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, Insta
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{CredentialsUtil, SmartDataLakeLogger}
 import io.smartdatalake.util.webservice._
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.keycloak.admin.client.Keycloak
 import org.keycloak.representations.AccessTokenResponse
 
@@ -56,6 +56,9 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
   private val webServicePassword = webserviceOptions.passwordVariable.map(CredentialsUtil.getCredentials)
 
   val keycloak: Option[Keycloak] = webserviceOptions.keycloakAuth.map(_.prepare(webServiceClientId.get, webServiceClientSecret.get))
+
+  // not used for now as writing data is not yet implemented
+  override val saveMode: SaveMode = SaveMode.Overwrite
 
   override def partitions: Seq[String] = partitionDefs.map(_.name)
 

--- a/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
@@ -28,7 +28,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.connection.SftpFileRefConnection
 import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed}
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.sshd.server.SshServer
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
 
@@ -298,6 +298,87 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     val r1 = tgtDO.getFileRefs(Seq())
     assert(r1.size == 1)
     assert(r1.head.fileName == resourceFile)
+  }
+
+  test("copy file from hadoop to hadoop without partitions and mode overwrite and deleteDataAfterRead") {
+
+    val feed = "filetransfer"
+    val srcDir = "testSrc"
+    val tgtDir = "testTgt"
+    val resourceFile = "AB_NYC_2019.csv"
+    val tempDir = Files.createTempDirectory(feed)
+
+    // copy data 1 file to hadoop
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"1").toFile)
+
+    // setup DataObjects
+    val srcDO = CsvFileDataObject("src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"))
+    val tgtDO = CsvFileDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"), saveMode = SaveMode.Overwrite)
+    instanceRegistry.register(srcDO)
+    instanceRegistry.register(tgtDO)
+
+    // prepare & start load 1
+    implicit val context1 = ActionPipelineContext(feed, "test", instanceRegistry)
+    val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id, deleteDataAfterRead = true)
+    val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq())
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    assert(tgtSubFeed.dataObjectId == tgtDO.id)
+
+    // check 1
+    val r1 = tgtDO.getFileRefs(Seq())
+    assert(r1.size == 1)
+    assert(r1.head.fileName == resourceFile+"1")
+
+    // copy data 2 file to hadoop
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"2").toFile)
+
+    // start load 2
+    action1.exec(Seq(srcSubFeed)).head
+
+    // check 2
+    val r2 = tgtDO.getFileRefs(Seq())
+    assert(r2.size == 1)
+    assert(r2.head.fileName == resourceFile+"2")
+  }
+
+  test("copy file from hadoop to hadoop without partitions and mode append and deleteDataAfterRead") {
+
+    val feed = "filetransfer"
+    val srcDir = "testSrc"
+    val tgtDir = "testTgt"
+    val resourceFile = "AB_NYC_2019.csv"
+    val tempDir = Files.createTempDirectory(feed)
+
+    // copy data 1 file to hadoop
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"1").toFile)
+
+    // setup DataObjects
+    val srcDO = CsvFileDataObject("src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"))
+    val tgtDO = CsvFileDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"), saveMode = SaveMode.Append)
+    instanceRegistry.register(srcDO)
+    instanceRegistry.register(tgtDO)
+
+    // prepare & start load 1
+    implicit val context1 = ActionPipelineContext(feed, "test", instanceRegistry)
+    val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id, deleteDataAfterRead = true)
+    val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq())
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    assert(tgtSubFeed.dataObjectId == tgtDO.id)
+
+    // check 1
+    val r1 = tgtDO.getFileRefs(Seq())
+    assert(r1.size == 1)
+    assert(r1.head.fileName == resourceFile+"1")
+
+    // copy data 2 file to hadoop
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"2").toFile)
+
+    // start load 2
+    action1.exec(Seq(srcSubFeed)).head
+
+    // check 2
+    val r2 = tgtDO.getFileRefs(Seq())
+    assert(r2.size == 2)
   }
 
   test("copy webservice output to hadoop file") {

--- a/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
@@ -321,8 +321,10 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     implicit val context1 = ActionPipelineContext(feed, "test", instanceRegistry)
     val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id, deleteDataAfterRead = true)
     val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
-    assert(tgtSubFeed.dataObjectId == tgtDO.id)
+    action1.preExec
+    val tgtSubFeed1 = action1.exec(Seq(srcSubFeed)).head
+    action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed1))
+    assert(tgtSubFeed1.dataObjectId == tgtDO.id)
 
     // check 1
     val r1 = tgtDO.getFileRefs(Seq())
@@ -333,7 +335,9 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"2").toFile)
 
     // start load 2
-    action1.exec(Seq(srcSubFeed)).head
+    action1.preExec
+    val tgtSubFeed2 = action1.exec(Seq(srcSubFeed)).head
+    action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed2))
 
     // check 2
     val r2 = tgtDO.getFileRefs(Seq())


### PR DESCRIPTION
If saveMode is set to overwrite, FileSubFeedAction will delete concerned partitions data or all data if output data object is not partitioned.

There are other small bugfixes for handling setting acls consistently.