### PR TITLE
allow multiple config files/directories as command line arg

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -80,15 +80,18 @@ We used an open data set for these tests which you can download from [Kaggle](ht
 1. For simplicity, put all files in one working directory: The smartdatalake-jar-with-dependencies, the application.conf and the sample CSV file.
 1. Execute the feed: 
     
-    `java -jar smartdatalake-jar-with-dependencies.jar --feed-sel getting-started --name getting-started`
+    `java -jar smartdatalake-jar-with-dependencies.jar --feed-sel getting-started`
    
 1. Check to see if the target folder was created and contains the Excel file.   
 
 Note, that you need to run the jar file with Java 8 (or higher). 
    
 Use `--help` to see additional command line parameters and options.
-The `-c` option for example can be used to define a location of your application.conf if it's not in the working directory.
-You can also define a path that contains one or multiple configuration files that all get combined.   
+
+The `-c` option for example can be used to define one ore more locations of your configurations files, if SDLB should not look for the application.conf resource in your classpath.
+You can define configuration files directly or directories which contain configuration files.
+If a directory is given, all configuration files found in this directory and it's subdirectories will be merged together.   
+
 If you placed the CSV file in another directory, you need to define it's location in your application.conf instead of just providing the name of the CSV file.
 
 That's it!   

--- a/docs/MicrosoftAzure.md
+++ b/docs/MicrosoftAzure.md
@@ -85,7 +85,7 @@ This can hopefully be simplified in the future.
 1.  Now create a Job with the following details:<br/>
     Task: Upload JAR - Choose the smartdatalake-\<version>-jar-with-dependencies.jar<br/>
     Main Class: io.smartdatalake.app.DatabricksSmartDataLakeBuilder
-    Arguments: -c file:///dbfs/conf/ --feed-sel ab-azure --name azure -m yarn<br/>
+    Arguments: -c file:///dbfs/conf/ --feed-sel ab-azure -m yarn<br/>
     The option *--override-jars* is set automatically to the correct value for DatabricksConfigurableApp. 
     If you want to override any additional libraries, you can provide a list with this option. 
     

--- a/src/main/scala/io/smartdatalake/app/DatabricksSmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/DatabricksSmartDataLakeBuilder.scala
@@ -33,7 +33,7 @@ object DatabricksSmartDataLakeBuilder extends SmartDataLakeBuilder {
    * @param args Command-line arguments.
    */
   def main(args: Array[String]): Unit = {
-    logger.info(s"Start programm ${appName}")
+    logger.info(s"Start programm ${appType}")
 
     val config = initConfigFromEnvironment.copy (
       overrideJars = Some(Seq("config-1.3.4.jar"))

--- a/src/main/scala/io/smartdatalake/app/DefaultSmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/DefaultSmartDataLakeBuilder.scala
@@ -26,15 +26,15 @@ package io.smartdatalake.app
 class DefaultSmartDataLakeBuilder extends SmartDataLakeBuilder {
 
   def parseAndRun(args: Array[String], ignoreOverrideJars: Boolean = false): Unit = {
-    logger.info(s"Starting Program $appName v$appVersion")
+    logger.info(s"Starting Program $appType v$appVersion")
 
     parseCommandLineArguments(args, initConfigFromEnvironment) match {
       case Some(config) =>
         assert(config.overrideJars.isEmpty || ignoreOverrideJars, "Option override-jars is not supported by DefaultSmartDataLakeBuilder. Use DatabricksSmartDataLakeBuilder for this option.")
         run(config)
-        logger.info(s"$appName v$appVersion finished successfully.")
+        logger.info(s"$appType v$appVersion finished successfully.")
       case None =>
-        logger.error(s"$appName v$appVersion terminated due to an error.")
+        logger.error(s"$appType v$appVersion terminated due to an error.")
     }
   }
 }

--- a/src/main/scala/io/smartdatalake/app/LocalSmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/LocalSmartDataLakeBuilder.scala
@@ -33,7 +33,7 @@ object LocalSmartDataLakeBuilder extends SmartDataLakeBuilder {
    * @param args Command-line arguments.
    */
   def main(args: Array[String]): Unit = {
-    logger.info(s"Starting Program $appName v$appVersion")
+    logger.info(s"Starting Program $appType v$appVersion")
 
     // Set local defaults
     val config = initConfigFromEnvironment.copy(
@@ -51,9 +51,9 @@ object LocalSmartDataLakeBuilder extends SmartDataLakeBuilder {
 
         // start
         run(config)
-        logger.info(s"$appName finished successfully.")
+        logger.info(s"$appType finished successfully.")
       case None =>
-        logAndThrowException(s"Aborting ${appName} after error", new ConfigurationException("Couldn't set command line parameters correctly."))
+        logAndThrowException(s"Aborting ${appType} after error", new ConfigurationException("Couldn't set command line parameters correctly."))
     }
   }
 }

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -75,7 +75,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
   // read version from package manifest (not defined if project is executed in IntellJ)
   val appVersion: String = Option(getClass.getPackage.getImplementationVersion).getOrElse("develop")
-  val appType: String = getClass.getSimpleName.replaceAll("\\$$","") // remove $ from object name and use it as appName
+  val appType: String = getClass.getSimpleName.replaceAll("\\$$","") // remove $ from object name and use it as appType
 
   /**
    * Create a new SDL configuration and initialize it with environment variables if they are set.

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -46,7 +46,7 @@ import scopt.OptionParser
  * @param keytabPath      Path to Kerberos keytab file for local mode.
  */
 case class SmartDataLakeBuilderConfig(feedSel: String = null,
-                                      applicationName: String = null,
+                                      applicationName: Option[String] = None,
                                       configuration: Option[String] = None,
                                       master: Option[String] = None,
                                       deployMode: Option[String] = None,
@@ -75,7 +75,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
   // read version from package manifest (not defined if project is executed in IntellJ)
   val appVersion: String = Option(getClass.getPackage.getImplementationVersion).getOrElse("develop")
-  val appName: String = getClass.getSimpleName.replaceAll("\\$$","") // remove $ from object name and use it as appName
+  val appType: String = getClass.getSimpleName.replaceAll("\\$$","") // remove $ from object name and use it as appName
 
   /**
    * Create a new SDL configuration and initialize it with environment variables if they are set.
@@ -98,22 +98,21 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
    * The Parser defines how to extract the options from the command line args.
    * Subclasses SmartDataLakeBuilder can define additional options to be extracted.
    */
-  protected val parser: OptionParser[SmartDataLakeBuilderConfig] = new OptionParser[SmartDataLakeBuilderConfig](appName) {
+  protected val parser: OptionParser[SmartDataLakeBuilderConfig] = new OptionParser[SmartDataLakeBuilderConfig](appType) {
     override def showUsageOnError = true
 
-    head(appName, appVersion)
+    head(appType, appVersion)
 
     opt[String]('f', "feed-sel")
       .required
       .action( (arg, config) => config.copy(feedSel = arg) )
       .text("Regex pattern to select the feed to execute.")
     opt[String]('n', "name")
-      .required
-      .action( (arg, config) => config.copy(applicationName = arg) )
-      .text("The name of the application.")
+      .action( (arg, config) => config.copy(applicationName = Some(arg)) )
+      .text("Optional name of the application. If not specified feed-sel is used.")
     opt[String]('c', "config")
       .action( (arg, config) => config.copy(configuration = Some(arg)) )
-      .text("A configuration file or a directory containing configuration files.")
+      .text("One or multiple configuration files or directories containing configuration files, separated by comma.")
     opt[String]('m', "master")
       .action( (arg, config) => config.copy(master = Some(arg)))
       .text("The Spark master URL passed to SparkContext (default=local[*], yarn, spark://HOST:PORT, mesos://HOST:PORT, k8s://HOST:PORT).")
@@ -167,10 +166,11 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     logger.info(s"Application: ${appConfig.applicationName}")
     logger.info(s"Master: ${appConfig.master}")
     logger.info(s"Deploy-Mode: ${appConfig.deployMode}")
+    val appName = appConfig.applicationName.getOrElse(appConfig.feedSel)
 
     // load config
     val config: Config = appConfig.configuration match {
-      case Some(configuration) => ConfigLoader.loadConfigFromFilesystem(configuration)
+      case Some(configuration) => ConfigLoader.loadConfigFromFilesystem(configuration.split(',').toSeq)
       case None => ConfigLoader.loadConfigFromClasspath
     }
     require(config.hasPath("actions"), s"No configuration parsed or it does not have a section called actions")
@@ -185,7 +185,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
     // create Spark Session
     implicit val session: SparkSession = AppUtil.createSparkSession(
-      name = s"${appConfig.applicationName} ${appConfig.feedSel}",
+      name = appName,
       appConfig.master.get,
       appConfig.deployMode,
       globalConfig.kryoClasses,
@@ -193,7 +193,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     LogUtil.setLogLevel(session.sparkContext)
 
     // create and execute actions
-    implicit val context: ActionPipelineContext = ActionPipelineContext(appConfig.feedSel, appConfig.applicationName, registry, referenceTimestamp = Some(LocalDateTime.now))
+    implicit val context: ActionPipelineContext = ActionPipelineContext(appConfig.feedSel, appName, registry, referenceTimestamp = Some(LocalDateTime.now))
     // TODO: what about runId?
     val actionDAGRun = ActionDAGRun(actions, runId = "test", appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism )
     actionDAGRun.prepare

--- a/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -149,7 +149,7 @@ object ConfigLoader extends SmartDataLakeLogger {
    *
    * This is an internal method to create a utility data structure.
    *
-   * @param rootPaths     root [[Path]]'s pointing to a configuration file or a directory from where the traversal starts.
+   * @param rootPaths     root [[Path]]s pointing to a configuration file or a directory from where the traversal starts.
    * @param fs            a configured HDFS [[FileSystem]] handle.
    * @return              a map with BFS ordered file lists for each file extension in [[ConfigLoader.configFileExtensions]].
    */

--- a/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -80,7 +80,7 @@ object ConfigLoader extends SmartDataLakeLogger {
    * @param configLocations     configuration files or directories containing configuration files.
    * @return                    a resolved [[Config]] merged from all found configuration files.
    */
-  def loadConfigFromFilesystem(configLocations: Seq[String]): Config = try {
+  def loadConfigFromFilesystem(configLocations: Seq[String]): Config = {
     val hadoopPaths = configLocations.map( l => HdfsUtil.addHadoopDefaultSchemaAuthority(new Path(l)))
     logger.info(s"Loading configuration from filesystem location: ${hadoopPaths.map(_.toUri).mkString(", ")}.")
     implicit val fileSystem: FileSystem = HdfsUtil.getHadoopFs(hadoopPaths.head)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
@@ -68,7 +68,7 @@ case class ActionsExporterDataObject(id: DataObjectId,
     // Get all actions from registry
     val actions: Seq[Action with Product] = config match {
       case Some(configLocation) =>
-        val config = ConfigLoader.loadConfigFromFilesystem(configLocation)
+        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq)
         ConfigParser.parse(config).getActions.map(_.asInstanceOf[Action with Product])
       case None => instanceRegistry.getActions.map(_.asInstanceOf[Action with Product])
     }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/DataObjectsExporterDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/DataObjectsExporterDataObject.scala
@@ -67,7 +67,7 @@ case class DataObjectsExporterDataObject(id: DataObjectId,
     // Get all DataObjects from registry
     val dataObjects: Seq[DataObject with Product] = config match {
       case Some(configLocation) =>
-        val config = ConfigLoader.loadConfigFromFilesystem(configLocation)
+        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq)
         ConfigParser.parse(config).getDataObjects.map(_.asInstanceOf[DataObject with Product])
       case None => instanceRegistry.getDataObjects.map(_.asInstanceOf[DataObject with Product])
     }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
@@ -62,7 +62,7 @@ case class PKViolatorsDataObject(id: DataObjectId,
     // Get all DataObjects from registry
     val dataObjects: Seq[DataObject with Product] = config match {
       case Some(configLocation) =>
-        val config = ConfigLoader.loadConfigFromFilesystem(configLocation)
+        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq)
         ConfigParser.parse(config).getDataObjects.map(_.asInstanceOf[DataObject with Product])
       case None => instanceRegistry.getDataObjects.map(_.asInstanceOf[DataObject with Product])
     }

--- a/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -25,35 +25,35 @@ import org.scalatest.{FlatSpec, Matchers}
 class ConfigLoaderTest extends FlatSpec with Matchers {
 
   "ConfigLoader" must "parse a single configuration file" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(getClass.getResource("/config/config.conf").toString)
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString))
     config.getString("config") shouldBe "config"
   }
 
   it must "parse all configuration files in a directory and its sub-directories" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(getClass.getResource("/config").toString)
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString))
     config.getString("config") shouldBe "config"
     config.getString("config2") shouldBe "config2"
     config.getString("foo") shouldBe "foo"
   }
 
   it must "overwrite values in configurations in BFS order and by extension precedence" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(getClass.getResource("/config").toString)
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString))
     config.getString("overwrite") shouldBe "overwritten by config2"
     config.getString("donotoverwrite") shouldBe "original"
     config.getString("overwrite2") shouldBe "overwritten by bar"
   }
 
   it must "fail parsing a non-existing location" in {
-    an [IllegalArgumentException] should be thrownBy ConfigLoader.loadConfigFromFilesystem("foo/bar")
+    an [IllegalArgumentException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("foo/bar"))
   }
 
   it must "not parse a file that is not a config file" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(getClass.getResource("/config/subdirectory/file.txt").toString)
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory/file.txt").toString))
     an [ConfigException] should be thrownBy config.getString("noconfig")
   }
 
   it must "only parse config files in directories" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(getClass.getResource("/config/subdirectory").toString)
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString))
     config.getString("foo") shouldBe "foo"
     config.getString("config2") shouldBe "config2"
     an [ConfigException] should be thrownBy config.getString("noconfig")


### PR DESCRIPTION
small non-breaking changes to command line:
- allow multiple config files/directories, separated by comma
- make name optional and use feed-sel as name if not given