### PR TITLE
skip pk violators report if no tables to report on

### DIFF
--- a/src/main/scala/io/smartdatalake/workflow/ActionDAG.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAG.scala
@@ -78,18 +78,19 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: String, 
         case ex: DAGException => ex.getDAGRootExceptions
         case ex => throw ex // this should not happen
       }
+      val dagExceptionsToStop = dagExceptions.filter(_.severity <= ExceptionSeverity.SKIPPED)
       // log all exceptions
       dagExceptions.foreach {
         case ex if (ex.severity <= ExceptionSeverity.CANCELLED) => logger.error(s"${ex.getClass.getSimpleName}: ${ex.getMessage}")
         case ex => logger.warn(s"${ex.getClass.getSimpleName}: ${ex.getMessage}")
       }
       // log dag on error
-      if (dagExceptions.nonEmpty) ActionDAGRun.logDag(s"$op failed for dag $runId", dag)
+      if (dagExceptionsToStop.nonEmpty) ActionDAGRun.logDag(s"$op failed for dag $runId", dag)
       // throw most severe exception
-      dagExceptions.sortBy(_.severity).foreach{ throw _ }
+      dagExceptionsToStop.sortBy(_.severity).foreach{ throw _ }
 
       // extract & return subfeeds
-      result.map(_.get)
+      result.filter(_.isSuccess).map(_.get)
     } finally {
       session.sparkContext.removeSparkListener(stageMetricsListener)
       if (stageMetricsListener.stageMetricsCollection.nonEmpty) {

--- a/src/main/scala/io/smartdatalake/workflow/DAGException.scala
+++ b/src/main/scala/io/smartdatalake/workflow/DAGException.scala
@@ -42,6 +42,10 @@ private[smartdatalake] class TaskSkippedWarning(id: NodeId, msg: String) extends
   override def getDAGRootExceptions: Seq[DAGException] = Seq(this)
 }
 
+private[smartdatalake] class TaskSkippedDontStopWarning(id: NodeId, msg: String) extends TaskSkippedWarning(id, msg) {
+  override val severity: ExceptionSeverity.ExceptionSeverity = ExceptionSeverity.SKIPPED_DONT_STOP
+}
+
 private[smartdatalake] case class TaskPredecessorFailureWarning(id: NodeId, cause: DAGException, allCauses: Seq[DAGException]) extends DAGException(id, cause) {
   override val severity: ExceptionSeverity.ExceptionSeverity = cause.severity
   override def getDAGRootExceptions: Seq[DAGException] = allCauses.flatMap(_.getDAGRootExceptions)
@@ -49,5 +53,5 @@ private[smartdatalake] case class TaskPredecessorFailureWarning(id: NodeId, caus
 
 private[smartdatalake] object ExceptionSeverity extends Enumeration {
   type ExceptionSeverity = Value
-  val FAILED, CANCELLED, SKIPPED = Value
+  val FAILED, CANCELLED, SKIPPED, SKIPPED_DONT_STOP = Value
 }

--- a/src/test/scala/io/smartdatalake/workflow/dataobject/PKviolatorDOtest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/dataobject/PKviolatorDOtest.scala
@@ -128,8 +128,6 @@ class PKviolatorDOtest extends FunSuite with BeforeAndAfter with SmartDataLakeLo
 
     // actual: reading the table containing the PK violators
     val actual = PKViolatorsDataObject("pkViol").getDataFrame()
-    println("actual:")
-    actual.printSchema()
 
     // creating expected
     val rows_expectedWithData: java.util.List[Row] = ArrayBuffer(
@@ -161,9 +159,6 @@ class PKviolatorDOtest extends FunSuite with BeforeAndAfter with SmartDataLakeLo
 
     val expected = session.createDataFrame(rows_expectedWithData,PKviolatorSchema)
       .union(session.createDataFrame(rows_expectedWithOutData,PKviolatorSchemaWithOutDataCol).withColumn("data",nullDataCol))
-
-    println("expected:")
-    expected.printSchema()
 
     val resultat: Boolean = expected.isEqual(actual)
     if (!resultat) printFailedTestResult("PKviolators_multipleDOs",


### PR DESCRIPTION
Implements two improvements:
- ignore missing table in PKViolatorsCheck 
- skip PKViolatorsCheck action without stopping the rest of the DAG if no table was found to check for pk violations