### PR TITLE
Initiale DataStreamWriter Support für Parquet/Hive/JDBC + KafkaTopicD…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-sql-kafka-0-10_${scala.minor.version}</artifactId>
+			<version>${spark.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.databricks</groupId>
 			<artifactId>spark-xml_${scala.minor.version}</artifactId>
 			<version>${databricks.spark-xml.version}</version>

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataStream.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataStream.scala
@@ -1,0 +1,57 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject
+
+import io.smartdatalake.util.hdfs.PartitionValues
+import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+private[smartdatalake] trait CanWriteDataStream extends CanWriteDataFrame {
+
+  // At minimum a checkpointLocation must be defined and passed to DataStreamWriter
+  def streamingOptions: Map[String, String]
+
+  //Trigger frequency for stream must be set as parameter
+  def trigger: Trigger
+
+  /**
+    * Write input from a DataStreamReader (streaming DataFrame)
+    *
+    * @param df The Streaming DataFrame to write
+    * @param partitionValues See DataFrameWriter
+    */
+  def writeDataStream(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+
+    require(streamingOptions.contains("checkpointLocation"), s"Checkpoint location must be specified for streaming sources.")
+
+    df
+      .writeStream
+      .trigger(trigger)
+      .options(streamingOptions)
+      .foreachBatch((df_microbatch, batchid) =>
+        writeDataFrame(df_microbatch, partitionValues)
+      )
+      .start()
+      .awaitTermination()
+
+  }
+
+
+
+}

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -28,6 +28,7 @@ import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.util.misc.{AclDef, AclUtil, SmartDataLakeLogger}
 import io.smartdatalake.workflow.connection.HiveTableConnection
 import org.apache.hadoop.fs.FileSystem
+import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 
@@ -62,9 +63,11 @@ case class HiveTableDataObject(override val id: DataObjectId,
                                saveMode: SaveMode = SaveMode.Overwrite,
                                acl: Option[AclDef] = None,
                                connectionId: Option[ConnectionId] = None,
+                               override val streamingOptions: Map[String, String] = Map(),
+                               override val trigger: Trigger = Trigger.Once,
                                override val metadata: Option[DataObjectMetadata] = None)
                               (@transient implicit val instanceRegistry: InstanceRegistry)
-  extends TableDataObject with CanWriteDataFrame with CanHandlePartitions with SmartDataLakeLogger {
+  extends TableDataObject with CanWriteDataFrame with CanWriteDataStream with CanHandlePartitions with SmartDataLakeLogger {
 
   /**
    * Connection defines db, path prefix (scheme, authority, base path) and acl's in central location
@@ -99,7 +102,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
     writeDataFrame(df, createTableOnly = false, partitionValues)
   }
 
-  /**
+   /**
    * Writes DataFrame to HDFS/Parquet and creates Hive table.
    * DataFrames are repartitioned in order not to write too many small files
    * or only a few HDFS files that are too large.
@@ -118,6 +121,8 @@ case class HiveTableDataObject(override val id: DataObjectId,
     // make sure empty partitions are created as well
     createMissingPartitions(partitionValues)
   }
+
+
 
   override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
     // on write: create tables if possible

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
@@ -1,0 +1,107 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject
+
+import java.time.Duration.ofMinutes
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter.ofPattern
+import java.time.{Duration, LocalDateTime}
+
+import com.splunk._
+import com.typesafe.config.Config
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.util.hdfs.PartitionValues
+import org.apache.spark.sql._
+
+
+/**
+ * [[DataObject]] of type KafkaTopic.
+ * Provides details to an action to read from Kafka Topics using either
+  * [[org.apache.spark.sql.DataFrameReader]] or [[org.apache.spark.sql.streaming.DataStreamReader]]
+  *
+  * @param stream Use checkpointing to manage own state and read only new records from topic (default = true)
+  * @param topicName The name of the topic to read
+  * @param kafkaOptions Options for the Kafka stream reader (see https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html)
+  */
+case class KafkaTopicDataObject(override val id: DataObjectId,
+                                stream: String = "true",
+                                topicName: String,
+                                kafkaOptions: Map[String, String] = Map(),
+                                override val metadata: Option[DataObjectMetadata] = None
+                           )(implicit instanceRegistry: InstanceRegistry)
+  extends DataObject with CanCreateDataFrame {
+
+
+  val options: Map[String, String] = kafkaOptions
+
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit spark: SparkSession): DataFrame = {
+
+    import spark.implicits._
+
+    //Default behaviour is to stream with checkpointing
+    //as this mirrors default behaviour in non-Spark Kafka applications
+    //with auto-commit = true
+    val dfs = if(stream.toBoolean) {
+      // Initialise a DataStream based on a topic to write using
+      // DataObject with CanWriteDataStream
+      spark
+        .readStream
+        .format("kafka")
+        .options(options)
+        .option("subscribe", topicName)
+        .load()
+    } else {
+      // Initialise a DataFrame to read an entire topic to write using
+      // DataObject with CanWriteDataFrame
+      spark
+        .read
+        .format("kafka")
+        .options(options)
+        .option("subscribe", topicName)
+        .load()
+    }
+
+    // Deserialize key/value to make human readable
+    //TODO: Deal with other payload types
+    dfs
+      .withColumn("key", $"key" cast "string")
+      .withColumn("value", $"value" cast "string")
+
+  }
+
+  /**
+   * @inheritdoc
+   */
+  override def factory: FromConfigFactory[DataObject] = KafkaTopicDataObject
+}
+
+object KafkaTopicDataObject extends FromConfigFactory[DataObject] {
+
+  /**
+    * @inheritdoc
+    */
+  override def fromConfig(config: Config, instanceRegistry: InstanceRegistry): KafkaTopicDataObject = {
+    import configs.syntax.ConfigOps
+    import io.smartdatalake.config._
+
+    implicit val instanceRegistryImpl: InstanceRegistry = instanceRegistry
+    config.extract[KafkaTopicDataObject].value
+  }
+}

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
@@ -23,6 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SaveMode}
 
@@ -59,9 +60,11 @@ case class ParquetFileDataObject( override val id: DataObjectId,
                                   override val saveMode: SaveMode = SaveMode.Overwrite,
                                   override val acl: Option[AclDef] = None,
                                   override val connectionId: Option[ConnectionId] = None,
-                                  override val metadata: Option[DataObjectMetadata] = None
+                                  override val metadata: Option[DataObjectMetadata] = None,
+                                  override val streamingOptions : Map[String, String] = Map(),
+                                  override val trigger : Trigger = Trigger.Once
                                 )(@transient implicit override val instanceRegistry: InstanceRegistry)
-  extends SparkFileDataObjectWithEmbeddedSchema with CanCreateDataFrame with CanWriteDataFrame {
+  extends SparkFileDataObjectWithEmbeddedSchema with CanCreateDataFrame with CanWriteDataFrame with CanWriteDataStream{
 
   override val format = "parquet"
 


### PR DESCRIPTION
Als Diskussionsgrundlage! Nur einfache Funktionstests durchgeführt von Kafka nach Parquet/Hive/JDBC. Risiko aber gering durch Verwendung von foreachbatch. Trigger nur mit Default Wert getestet. Checkpointing geht auch in client mode.