### PR TITLE
Enable authentication and switch toobjec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         current-version: ${{ env.MVN_RELEASE_VERSION }}
         version-fragment: bug
     - name: Develop Set Next Snapshot version
-      run: mvn versions:set -DnewVersion=${{ steps.bump_version.outputs.next-version }}-SNAPSHOT
+      run: sed -i "/${MVN_RELEASE_VERSION}/{s//${{ steps.bump_version.outputs.next-version }}-SNAPSHOT/;:p;n;bp}" pom.xml
     - name: Develop Git Commit Snapshot
       run: |
         git config --local user.email "action@github.com"

--- a/src/main/scala/io/smartdatalake/app/KerberosSmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/KerberosSmartDataLakeBuilder.scala
@@ -20,25 +20,55 @@ package io.smartdatalake.app
 
 import java.io.File
 
+import io.smartdatalake.app.DatabricksSmartDataLakeBuilder.{appType, logger, parseCommandLineArguments}
+import io.smartdatalake.config.ConfigurationException
+
 /**
  * Command Line Application to check for Kerberos specific parameters
  * Extend this class and call parseKerberosSpecificParameters
  * if you want to force Kerberos specific parameters to be enforced.
  */
-private[smartdatalake] abstract class KerberosSmartDataLakeBuilder extends SmartDataLakeBuilder {
+object KerberosSmartDataLakeBuilder extends SmartDataLakeBuilder {
 
-  // define additional options for kerberos to parse from command line arguments
-  parser.opt[String]('d', "kerberos-domain")
-    .required()
-    .action( (arg, config) => config.copy(kerberosDomain = Some(arg)))
-    .text("Kerberos-Domain for authentication (USERNAME@KERBEROS-DOMAIN).")
-  parser.opt[String]('u', "username")
-    .required()
-    .action( (arg, config) => config.copy(username = Some(arg)))
-    .text("Kerberos username for authentication (USERNAME@KERBEROS-DOMAIN).")
-  parser.opt[File]('k', "keytab-path")
-    .required()
-    .action((arg, config) => config.copy(keytabPath = Some(arg)))
-    .text("Path to the Kerberos keytab file for authentication.")
+  def main(args: Array[String]): Unit = {
+    logger.info(s"Start programm $appType")
 
+    // define additional options for kerberos to parse from command line arguments
+    parser.opt[String]('d', "kerberos-domain")
+      .required()
+      .action((arg, config) => config.copy(kerberosDomain = Some(arg)))
+      .text("Kerberos-Domain for authentication (USERNAME@KERBEROS-DOMAIN).")
+    parser.opt[String]('u', "username")
+      .required()
+      .action((arg, config) => config.copy(username = Some(arg)))
+      .text("Kerberos username for authentication (USERNAME@KERBEROS-DOMAIN).")
+    parser.opt[File]('k', "keytab-path")
+      .required()
+      .action((arg, config) => config.copy(keytabPath = Some(arg)))
+      .text("Path to the Kerberos keytab file for authentication.")
+
+    val config = parseCommandLineArguments(args, initConfigFromEnvironment)
+
+    config match {
+      case Some(c) =>
+        //If local authenticate the application - unnecessary on cluster
+        if (c.master.contains("local[*]")) {
+
+          val username = c.username.getOrElse(throw new IllegalArgumentException( "Username needs to be set in local mode!" ))
+          val kerberosDomain = c.kerberosDomain.getOrElse(throw new IllegalArgumentException( "Kerberos domain needs to be set in local mode!" ))
+
+          val kp = c.keytabPath.map(_.getPath).orElse(Some(ClassLoader.getSystemClassLoader.getResource(s"$username.keytab")).map(_.getPath))
+            .getOrElse(throw new IllegalArgumentException("Couldn't find keytab file for authentication."))
+          val principal = s"$username@$kerberosDomain"
+          logger.info(s"Starting kerberos authentication as $principal")
+          AppUtil.authenticate(kp, principal)
+        }
+        run(c)
+        logger.info(s"$appType v$appVersion finished successfully.")
+
+      case None =>
+        logger.error(s"$appType v$appVersion terminated due to an error.")
+    }
+  }
+  
 }


### PR DESCRIPTION
Enable authentication in KerberosSmartDataLake builder and switch to object for direct CLI use.
Question: do we need this in a non-local context? Or put otherwise, could we combine Kerberos and Local in one object? At present I have retained the logic of the original code, which requested the kerberos parameters but did nothing with them, and added authentication only for when running on local master.