### PR TITLE
Prepare for maven central and fix actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: master
+        persist-credentials: false
     - name: JDK 8 Set
       uses: actions/setup-java@v1.3.0
       with: 
@@ -49,14 +50,14 @@ jobs:
       run: |
         mkdir -p ~/.m2
         echo "<settings><servers><server><id>bintray-smart-data-lake-smart-data-lake</id><username>smartdatalake</username><password>${BINTRAY_API_KEY}</password></server></servers></settings>" > ~/.m2/settings.xml
-        mvn clean deploy -f pom.xml
+        mvn -P scala-doc-nolinkwarnings clean scala:doc-jar deploy -f pom.xml
     - name: Maven Deploy to Bintray for Scala 2.12
       env:
         BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
       run: |
         mkdir -p ~/.m2
         echo "<settings><servers><server><id>bintray-smart-data-lake-smart-data-lake</id><username>smartdatalake</username><password>${BINTRAY_API_KEY}</password></server></servers></settings>" > ~/.m2/settings.xml
-        mvn -P scala-2.12 clean deploy -f pom.xml
+        mvn -P scala-2.12,scala-doc-nolinkwarnings clean scala:doc-jar deploy -f pom.xml
         
     - name: Git Commit and Tag Release
       run: |
@@ -73,7 +74,7 @@ jobs:
     - name: Git Push Master
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PAT_ACTIONS }}
         
                   
     # DEVELOP BRANCH
@@ -82,6 +83,7 @@ jobs:
       with:
         ref: develop
         fetch-depth: 0
+        persist-credentials: false
     - name: Git Merge to develop
       run: |
         git config --local user.email "action@github.com"
@@ -97,7 +99,7 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         branch: develop
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PAT_ACTIONS }}
     
     - name: Develop Get Next Version
       id: bump_version
@@ -116,4 +118,4 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         branch: develop
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PAT_ACTIONS }}

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,21 @@
 	<!-- Used for license header by maven-license-plugin -->
 	<name>Smart Data Lake</name>
 	<description>Build your data lake the smart way.</description>
+	<url>http://www.smartdatalake.io</url>
 	<inceptionYear>2019</inceptionYear>
 	<organization>
 		<name>ELCA Informatique SA</name>
 		<url>https://www.elca.ch</url>
 	</organization>
+
+	<developers>
+		<developer>
+			<name>Smart Data Lake</name>
+			<email>smartdatalake@elca.ch</email>
+			<organization>ELCA Informatik AG</organization>
+			<organizationUrl>http://www.elca.ch</organizationUrl>
+		</developer>
+	</developers>
 
 	<profiles>
 		<profile>


### PR DESCRIPTION
- Generate javadoc jar when deploying
- Use personal access token (PAT) in order to activate branch restrictions again
- Add url and developer information in pom.xml