### PR TITLE
implement using jdbc query parameter

### DIFF
--- a/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
@@ -62,7 +62,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
                 existingOnly: Boolean = true): Unit = {
     val existsClause = if (existingOnly) "if exists " else ""
     val purgeClause = if (doPurge) " purge" else ""
-    val stmt = s"drop table $existsClause $hiveDb.$tableName$purgeClause"
+    val stmt = s"drop table $existsClause$hiveDb.$tableName$purgeClause"
     execSqlStmt(session, stmt)
   }
 

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObject.scala
@@ -117,6 +117,8 @@ case class AccessTableDataObject(override val id: DataObjectId,
     tableExisting
   }
 
+  override def dropTable(implicit session: SparkSession): Unit = throw new NotImplementedError
+
   /**
    * @inheritdoc
    */

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -161,11 +161,6 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     files.nonEmpty
   }
 
-  /**
-   * @inheritdoc
-   */
-  override def factory: FromConfigFactory[DataObject] = TickTockHiveTableDataObject
-
   protected val separator: Char = Environment.defaultPathSeparator
 
   /**
@@ -197,6 +192,13 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
           .toSeq
     }.getOrElse(Seq())
   }
+
+  override def dropTable(implicit session: SparkSession): Unit = throw new NotImplementedError()
+
+  /**
+   * @inheritdoc
+   */
+  override def factory: FromConfigFactory[DataObject] = TickTockHiveTableDataObject
 
 }
 

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -149,6 +149,10 @@ case class HiveTableDataObject(override val id: DataObjectId,
     else logger.warn(s"($id) No empty partition was created for $partitionValues because there are not all partition columns defined")
   }
 
+  override def dropTable(implicit session: SparkSession): Unit = {
+    HiveUtil.dropTable(session, table.db.get, table.name)
+  }
+
   /**
    * @inheritdoc
    */

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
@@ -33,6 +33,8 @@ private[smartdatalake] trait TableDataObject extends DataObject with CanCreateDa
 
   def isTableExisting(implicit session: SparkSession): Boolean
 
+  def dropTable(implicit session: SparkSession): Unit
+
   def getPKduplicates(implicit session: SparkSession): DataFrame = if (table.primaryKey.isEmpty) {
     getDataFrame().where(lit(false))
   } else {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -148,6 +148,10 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     else logger.warn(s"($id) No empty partition was created for $partitionValues because there are not all partition columns defined")
   }
 
+  override def dropTable(implicit session: SparkSession): Unit = {
+    HiveUtil.dropTable(session, table.db.get, table.name)
+  }
+
   /**
    * @inheritdoc
    */

--- a/src/test/scala/io/smartdatalake/config/TestDataObject.scala
+++ b/src/test/scala/io/smartdatalake/config/TestDataObject.scala
@@ -52,6 +52,8 @@ case class TestDataObject( id: DataObjectId,
 
   override def isTableExisting(implicit session: SparkSession): Boolean = true
 
+  override def dropTable(implicit session: SparkSession): Unit = throw new NotImplementedError()
+
   override def factory: FromConfigFactory[DataObject] = TestDataObject
 }
 

--- a/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject
+
+import io.smartdatalake.workflow.connection.JdbcTableConnection
+
+class JdbcTableDataObjectTest extends DataObjectTestSuite {
+
+  import testSession.implicits._
+
+  private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:JdbcTableDataObjectTest/hsqldb", "org.hsqldb.jdbcDriver")
+
+  test("write and read jdbc table") {
+    import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+    instanceRegistry.register(jdbcConnection)
+    val table = Table(Some("public"), "table1")
+    val dataObject = JdbcTableDataObject( "jdbcDO1", table = table, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
+    dataObject.dropTable
+    val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
+    dataObject.writeDataFrame(df, Seq())
+    val dfRead = dataObject.getDataFrame(Seq())
+    assert(dfRead.symmetricDifference(df).isEmpty)
+  }
+
+  // query parameter doesn't work with hsqldb
+  ignore("read jdbc table with query") {
+    import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+    instanceRegistry.register(jdbcConnection)
+
+    // prepare data
+    val table1 = Table(Some("public"), "table1")
+    val dataObject1 = JdbcTableDataObject( "jdbcDO1", table = table1, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
+    dataObject1.dropTable
+    val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
+    dataObject1.writeDataFrame(df, Seq())
+
+    // read prepared data
+    val table2 = Table(Some("public"), "table1", query = Some("select lastname, firstname from public.table1"))
+    val dataObject2 = JdbcTableDataObject( "jdbcDO2", table = table2, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
+    val dfRead = dataObject2.getDataFrame(Seq())
+    assert(dfRead.symmetricDifference(df.select($"lastname", $"firstname")).isEmpty)
+
+    // assert cannot write to DataObject with query defined
+    intercept[IllegalArgumentException](dataObject2.writeDataFrame(df, Seq()))
+  }
+}


### PR DESCRIPTION
closes #92 

additionally implements:
- possibility to configure arbitrary jdbc Spark options
- TableDataObject.dropTable.