### PR TITLE
fix limitations on applying acls when scheme/authority is given in path

### DIFF
--- a/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -45,20 +45,45 @@ object Environment {
    * Modifying ACL's is only allowed below and including the following level (default=2)
    * See also [[io.smartdatalake.util.misc.AclUtil]]
    */
-  var hdfsAclsMinLevelPermissionModify = 2 // up to user home
+  var hdfsAclsMinLevelPermissionModify: Int = {
+    EnvironmentUtil.getSdlParameter("hdfsAclsMinLevelPermissionModify")
+      .map(_.toInt).getOrElse(2)
+  }
 
   /**
    * Overwriting ACL's is only allowed below and including the following level (default=5)
    * See also [[io.smartdatalake.util.misc.AclUtil]]
    */
-  var hdfsAclsMinLevelPermissionOverwrite = 5 // incl. and underneath feed
+  var hdfsAclsMinLevelPermissionOverwrite: Int = {
+    EnvironmentUtil.getSdlParameter("hdfsAclsMinLevelPermissionOverwrite")
+      .map(_.toInt).getOrElse(5)
+  }
 
   /**
-   * Limit setting ACL's to user home (default=true)
-   Declare on which level in the directory hierarchy your user homes are (usually on level 2)
+   * Limit setting ACL's to Basedir (default=true)
+   * See hdfsAclsUserHomeLevel or hdfsBasedir on how the basedir is determined
    */
-  var hdfsAclsLimitToUserHome = true
-  var hdfsAclsUserHomeLevel = 2
+  var hdfsAclsLimitToBasedir: Boolean = {
+    EnvironmentUtil.getSdlParameter("hdfsAclsLimitToBasedir")
+      .map(_.toBoolean).getOrElse(true)
+  }
+
+  /**
+   * Set path level of user home to determine basedir automatically (Default=2 -> /user/myUserHome)
+   */
+  var hdfsAclsUserHomeLevel: Int = {
+    EnvironmentUtil.getSdlParameter("hdfsAclsUserHomeLevel")
+      .map(_.toInt).getOrElse(2)
+  }
+
+  /**
+   * Set basedir explicitly.
+   * This overrides automatically detected user home for acl constraints by hdfsAclsUserHomeLevel.
+   */
+  var hdfsBasedir: Option[URI] = {
+    EnvironmentUtil.getSdlParameter("hdfsBasedir")
+      .map(new URI(_))
+  }
 
   /**
    * Set default hadoop schema and authority for path

--- a/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -20,15 +20,26 @@ package io.smartdatalake.definitions
 
 import java.net.URI
 
+import io.smartdatalake.util.misc.EnvironmentUtil
+
 /**
- * Set this environment dependent configurations at the beginning of the [[io.smartdatalake.app.SmartDataLakeBuilder]] implementation for your environment.
+ * Environment dependent configurations.
+ * They can be set
+ * - by Java system properties (prefixed with "sdl.", e.g. "sdl.hadoopAuthoritiesWithAclsRequired")
+ * - by Environment variables (prefixed with "SDL_" and camelCase converted to uppercase, e.g. "SDL_HADOOP_AUTHORITIES_WITH_ACLS_REQUIRED")
+ * - by a custom [[io.smartdatalake.app.SmartDataLakeBuilder]] implementation for your environment, which sets these variables directly.
  */
 object Environment {
 
   /**
-   * Set to true if configuration of acls for HadoopDataObjects is mandatory
+   * List of hadoop authorities for which acls must be configured
+   * The environment parameter can contain multiple authorities separated by comma.
+   * An authority is compared against the filesystem URI with contains(...)
    */
-  var hdfsAclsRequired: Boolean = false
+  var hadoopAuthoritiesWithAclsRequired: Seq[String] = {
+    EnvironmentUtil.getSdlParameter("hadoopAuthoritiesWithAclsRequired")
+      .toSeq.flatMap(_.split(','))
+  }
 
   /**
    * Modifying ACL's is only allowed below and including the following level (default=2)
@@ -52,20 +63,29 @@ object Environment {
   /**
    * Set default hadoop schema and authority for path
    */
-  var hadoopDefaultSchemeAuthority: Option[URI] = None
+  var hadoopDefaultSchemeAuthority: Option[URI] = {
+    EnvironmentUtil.getSdlParameter("hadoopDefaultSchemeAuthority")
+      .map(new URI(_))
+  }
 
   /**
    * ordering of columns in SchemaEvolution result
    * - true: result schema is ordered according to existing schema, new columns are appended
    * - false: result schema is ordered according to new schema, deleted columns are appended
    */
-  var schemaEvolutionNewColumnsLast: Boolean = true
+  var schemaEvolutionNewColumnsLast: Boolean = {
+    EnvironmentUtil.getSdlParameter("schemaEvolutionNewColumnsLast")
+      .map(_.toBoolean).getOrElse(true)
+  }
 
   /**
    * If `true`, schema validation does not consider nullability of columns/fields when checking for equality.
    * If `false`, schema validation considers two columns/fields different when their nullability property is not equal.
    */
-  var schemaValidationIgnoresNullability: Boolean = true
+  var schemaValidationIgnoresNullability: Boolean = {
+    EnvironmentUtil.getSdlParameter("schemaValidationIgnoresNullability")
+      .map(_.toBoolean).getOrElse(true)
+  }
 
   /**
    * If `true`, schema validation inspects the whole hierarchy of structured data types. This allows partial matches
@@ -76,13 +96,19 @@ object Environment {
    *          val schema = StructType.fromDDL("c1 STRING, c2 STRUCT(c2_1 INT, c2_2 STRING)") validates
    *          against StructType.fromDDL("c1 STRING, c2 STRUCT(c2_1 INT)") only if `schemaValidationDeepComarison == true`.
    */
-  var schemaValidationDeepComarison: Boolean = true
+  var schemaValidationDeepComarison: Boolean = {
+    EnvironmentUtil.getSdlParameter("schemaValidationDeepComarison")
+      .map(_.toBoolean).getOrElse(true)
+  }
 
   /**
    * Set to true if you want table and database names to be case sensitive when loading over JDBC.
    * If your database supports case sensitive table names and you want to use that feature, set this to true.
    */
-  var enableJdbcCaseSensitivity: Boolean = false
+  var enableJdbcCaseSensitivity: Boolean = {
+    EnvironmentUtil.getSdlParameter("enableJdbcCaseSensitivity")
+      .map(_.toBoolean).getOrElse(false)
+  }
 
   // static configurations
   val configPathsForLocalSubstitution: Seq[String] = Seq("path", "table.name", "create-sql", "createSql", "pre-sql", "preSql", "post-sql", "postSql")

--- a/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -31,6 +31,24 @@ object Environment {
   var hdfsAclsRequired: Boolean = false
 
   /**
+   * Modifying ACL's is only allowed up to the following level (default=2)
+   * See also [[io.smartdatalake.util.misc.AclUtil]]
+   */
+  var hdfsAclsMinLevelPermissionModify = 2 // up to user home
+
+  /**
+   * Overwriting ACL's is only allowed up to the following level (default=2)
+   * See also [[io.smartdatalake.util.misc.AclUtil]]
+   */
+  var hdfsAclsMinLevelPermissionOverwrite = 5 // incl. and underneath feed
+
+  /**
+   * Limit setting ACL's to user home (default=true)
+   */
+  var hdfsAclsLimitToUserHome = true
+  var hdfsAclsUserHomeLevel = 2
+
+  /**
    * Set default hadoop schema and authority for path
    */
   var hadoopDefaultSchemeAuthority: Option[URI] = None

--- a/src/main/scala/io/smartdatalake/util/misc/AclUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/misc/AclUtil.scala
@@ -129,7 +129,8 @@ private[smartdatalake] object AclUtil extends SmartDataLakeLogger {
     */
   def checkBasedirPath(currentUser: String, path: Path): Unit = {
     if (Environment.hdfsBasedir.isDefined) {
-      require(path.toUri.getPath.startsWith(Environment.hdfsBasedir.get.getPath), s"Permissions can only be set under hadoop basedir if hdfsAclsLimitToBasedir is enabled, path=$path")
+      val baseDirName = Environment.hdfsBasedir.get
+      require(path.toUri.getPath.startsWith(baseDirName.getPath), s"Permissions can only be set under hadoop basedir if hdfsAclsLimitToBasedir is enabled, path=$path, basedir=${baseDirName}")
     } else {
       val userHome = extractPathLevel(path, Environment.hdfsAclsUserHomeLevel)
       // userHome or username might be pre/postfixed. Check is therefore if one contains the other and vice versa.

--- a/src/main/scala/io/smartdatalake/util/misc/AclUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/misc/AclUtil.scala
@@ -125,13 +125,12 @@ private[smartdatalake] object AclUtil extends SmartDataLakeLogger {
   }
 
   /**
-    *
-    * @param path
+    * Make sure that path is under user home.
     */
   def checkUserPath(currentUser: String, path: Path): Unit = {
     val userHome = extractPathLevel(path, Environment.hdfsAclsUserHomeLevel)
-    // user home might be prefixed. Check is therefore only if it ends with currentUser.
-    require( userHome.endsWith(currentUser), s"Permissions can only be set under hadoop Homedir if hdfsAclsLimitToUserHome is enabled, path=$path")
+    // userHome or username might be pre/postfixed. Check is therefore if one contains the other and vice versa.
+    require( userHome.contains(currentUser) || currentUser.contains(userHome), s"Permissions can only be set under hadoop Homedir if hdfsAclsLimitToUserHome is enabled, path=$path")
   }
 
   def extractPathLevel(path: Path, level: Int): String = {

--- a/src/main/scala/io/smartdatalake/util/misc/AclUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/misc/AclUtil.scala
@@ -63,15 +63,15 @@ private[smartdatalake] case class AclElement (aclType:String, name:String, permi
  * It checks if path at hdfsAclsUserHomeLevel ends with username.
  *
  * A common structure for directories on HDFS is as follows:
- * hdfs://nameservice1/user/app_dir/<layer>/<source_name>/<feed_name>
+ * hdfs://dfs.nameservices/user/app_dir/<layer>/<source_name>/<feed_name>
  *
  * Levels are counted as follows
- * Root hdfs://nameservice1/ or also "/" -> 0
- * User Dir on Hadoop hdfs://nameservice1/user -> 1
- * User Home hdfs://nameservice1/user/app_dir -> 2
- * Layer hdfs://nameservice1/user/app_dir/<layer> -> 3
- * Source hdfs://nameservice1/user/app_dir/<layer>/<source_name> -> 4
- * Feed hdfs://nameservice1/user/app_dir/<layer>/<source_name>/<feed_name> -> 5
+ * Root hdfs://dfs.nameservices/ or also "/" -> 0
+ * User Dir on Hadoop hdfs://dfs.nameservices/user -> 1
+ * User Home hdfs://dfs.nameservices/user/app_dir -> 2
+ * Layer hdfs://dfs.nameservices/user/app_dir/<layer> -> 3
+ * Source hdfs://dfs.nameservices/user/app_dir/<layer>/<source_name> -> 4
+ * Feed hdfs://dfs.nameservices/user/app_dir/<layer>/<source_name>/<feed_name> -> 5
  * ...
  *
  * In this structure good limitations are: MinLevelPermissionModify=2, MinLevelPermissionOverwrite=5

--- a/src/main/scala/io/smartdatalake/util/misc/EnvironmentUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/misc/EnvironmentUtil.scala
@@ -20,7 +20,28 @@
 package io.smartdatalake.util.misc
 
 object EnvironmentUtil {
+
+  /**
+   * check if running on windows os
+   */
   def isWindowsOS = {
     sys.env.get("OS").exists(_.toLowerCase.startsWith("windows"))
   }
+
+  /**
+   * get environment parameter value from Java system properties or environment variables.
+   * To lookup java system properties the key is prefixed with "sdl.".
+   * To lookup environment variables the key is prefixed with "SDL_" and camelcase notation is converted to uppercase notation separated by "_".
+   * Java system properties have precedence over environment variables.
+   *
+   * @param key the name of the parameter in camelCase notation, starting with a lowercase letter.
+   */
+  def getSdlParameter(key: String): Option[String] = {
+
+    sys.props.get("sdl."+key)
+      .orElse(sys.env.get("SDL_"+camelCaseToUpper(key)))
+  }
+
+  private[smartdatalake] def camelCaseToUpper(key: String): String = key.replaceAll("([A-Z])", "_$1").toUpperCase
+
 }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.DateColumnType
+import io.smartdatalake.definitions.{DateColumnType, Environment}
 import io.smartdatalake.definitions.DateColumnType.DateColumnType
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.hive.HiveUtil
@@ -91,6 +91,14 @@ case class HiveTableDataObject(override val id: DataObjectId,
     val df = session.table(s"${table.fullName}")
     validateSchemaMin(df)
     df
+  }
+
+  override def preWrite(implicit session: SparkSession): Unit = {
+    super.preWrite
+    // validate if acl's must be / are configured before writing
+    if (Environment.hadoopAuthoritiesWithAclsRequired.exists( a => filesystem.getUri.toString.contains(a))) {
+      require(acl.isDefined, s"($id) ACL definitions are required for writing DataObjects on hadoop authority ${filesystem.getUri} by environment setting hadoopAuthoritiesWithAclsRequired")
+    }
   }
 
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.DateColumnType
+import io.smartdatalake.definitions.{DateColumnType, Environment}
 import io.smartdatalake.definitions.DateColumnType.DateColumnType
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.hive.HiveUtil
@@ -84,6 +84,14 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     if (!isTableExisting) {
       logger.info(s"($id) Creating table ${table.fullName}.")
       writeDataFrame(df, createTableOnly = true, partitionValues)
+    }
+  }
+
+  override def preWrite(implicit session: SparkSession): Unit = {
+    super.preWrite
+    // validate if acl's must be / are configured before writing
+    if (Environment.hadoopAuthoritiesWithAclsRequired.exists( a => filesystem.getUri.toString.contains(a))) {
+      require(acl.isDefined, s"($id) ACL definitions are required for writing DataObjects on hadoop authority ${filesystem.getUri} by environment setting hadoopAuthoritiesWithAclsRequired")
     }
   }
 

--- a/src/test/scala/io/smartdatalake/util/misc/EnvironmentUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/misc/EnvironmentUtilTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.misc
+
+import org.scalatest.FunSuite
+
+class EnvironmentUtilTest extends FunSuite {
+
+  test("camelCaseToUpper") {
+    assert(EnvironmentUtil.camelCaseToUpper("camelCaseToUpper") == "CAMEL_CASE_TO_UPPER")
+  }
+
+}

--- a/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.util.util
 
+import java.net.URI
 import java.nio.file.{Files, Paths}
 
 import io.smartdatalake.definitions.Environment

--- a/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
@@ -253,4 +253,18 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
     assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir/test/abc"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
     intercept[IllegalArgumentException](AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
   }
+
+  test("check hdfsAclsLimitToBasedir") {
+
+    // check user home validation
+    AclUtil.checkBasedirPath("app_dir", new Path("hdfs://dfs.nameservices/user/app_dir"))
+    intercept[IllegalArgumentException](AclUtil.checkBasedirPath("app_other_dir", new Path("hdfs://dfs.nameservices/user/app_dir")))
+    val hdfsBaseDirOrg = Environment.hdfsBasedir
+
+    // check basedir valdiation
+    Environment.hdfsBasedir = Some(new Path("hdfs://dfs.nameservices/user/app_other_dir").toUri)
+    AclUtil.checkBasedirPath("app_dir", new Path("hdfs://dfs.nameservices/user/app_other_dir"))
+    intercept[IllegalArgumentException](AclUtil.checkBasedirPath("app_dir", new Path("hdfs://dfs.nameservices/user/app_dir")))
+    Environment.hdfsBasedir = hdfsBaseDirOrg // revert environment config
+  }
 }

--- a/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
@@ -20,6 +20,7 @@ package io.smartdatalake.util.util
 
 import java.nio.file.{Files, Paths}
 
+import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.misc.AclUtil
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
@@ -42,31 +43,31 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Parent method returns None when there is no parent.") {
-    assert(AclUtil.parent(Some(new Path("/"))) === None)
+    assert(AclUtil.parent(new Path("/")) === None)
   }
 
-  test("Parent method returns the root directory of a root subsirectory.") {
-    val parentPath = AclUtil.parent(Some(new Path("/child")))
+  test("Parent method returns the root directory of a root subdirectory.") {
+    val parentPath = AclUtil.parent(new Path("/child"))
     assert(parentPath.value === new Path("/"))
   }
 
   test("Parent method returns the parent directory of the supplied path.") {
-    val parentPath = AclUtil.parent(Some(new Path("/path/to/parent/child")))
+    val parentPath = AclUtil.parent(new Path("/path/to/parent/child"))
     assert(parentPath.value === new Path("/path/to/parent/"))
   }
 
   test("Parent method works when child path contains a wildcard inside the last path element.") {
-    val parentPath = AclUtil.parent(Some(new Path("/path/to/parent/child_*_suffix")))
+    val parentPath = AclUtil.parent(new Path("/path/to/parent/child_*_suffix"))
     assert(parentPath.value === new Path("/path/to/parent"))
   }
 
   test("Parent method works when child path contains a wildcard at the beginning of the last path element.") {
-    val parentPath = AclUtil.parent(Some(new Path("/path/to/parent/*_middle_suffix")))
+    val parentPath = AclUtil.parent(new Path("/path/to/parent/*_middle_suffix"))
     assert(parentPath.value === new Path("/path/to/parent"))
   }
 
   test("Parent method works when child path contains a wildcard at the end of the last path element.") {
-    val parentPath = AclUtil.parent(Some(new Path("/path/to/parent/child_middle_*")))
+    val parentPath = AclUtil.parent(new Path("/path/to/parent/child_middle_*"))
     assert(parentPath.value === new Path("/path/to/parent"))
   }
 
@@ -82,38 +83,41 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
     assert(exists === true)
   }
 
-  test("Parent of root direcory") {
-    val rootPath = Some(new Path("/"))
+  test("Parent method returns the parent directory of the supplied path with scheme/authority.") {
+    val parentPath = AclUtil.parent(new Path("hdfs://nameservice1/path/to/parent/child"))
+    assert(parentPath.value === new Path("hdfs://nameservice1/path/to/parent/"))
+  }
+
+  test("Parent of root directory with schema/authority") {
+    val rootPath = new Path("hdfs://nameservice1/")
     val rootParentPath = AclUtil.parent(rootPath)
     assert(rootParentPath.isEmpty)
   }
 
-  test("Traverse directoryUpTo some existing directory (user home)") {
-    val path = Some(new Path("/user/app_datalake/integration/someapp"))
-    val upperPath = AclUtil.traverseDirectoryUpTo("app_datalake", path)
-    assert(upperPath.get == new Path("/user/app_datalake"))
+  test("Parent of root directory") {
+    val rootPath = new Path("/")
+    val rootParentPath = AclUtil.parent(rootPath)
+    assert(rootParentPath.isEmpty)
   }
 
-  test("Traverse directoryUpTo some existing directory (feed)") {
-    val path = Some(new Path("/user/app_datalake/integration/someapp/somefeed/data"))
-    val upperPath = AclUtil.traverseDirectoryUpTo("somefeed", path)
-    assert(upperPath.get == new Path("/user/app_datalake/integration/someapp/somefeed"))
+  def noOpAclSetter(p:Path): Unit = Unit
+
+  test("Traverse directoryUp some existing directory (user home)") {
+    val path = new Path("/user/app_dir/integration/someapp")
+    val upperPath = AclUtil.traverseDirectoryUp(path, Environment.hdfsAclsUserHomeLevel, noOpAclSetter)
+    assert(upperPath == new Path("/user/app_dir"))
   }
 
-  test("Traverse directoryUpTo some non existent directory") {
-    val path = Some(new Path("/user/app_datalake/integration/someapp"))
-    val upperPath = AclUtil.traverseDirectoryUpTo("non_existing", path)
-    assert(upperPath.isEmpty)
+  test("Traverse directoryUp some existing directory (user home) with scheme/authority") {
+    val path = new Path("hdfs://nameservice1/user/app_dir/integration/someapp")
+    val upperPath = AclUtil.traverseDirectoryUp(path, Environment.hdfsAclsUserHomeLevel, noOpAclSetter)
+    assert(upperPath == new Path("hdfs://nameservice1/user/app_dir"))
   }
 
-  test("Path contains Feed") {
-    val path = Some(new Path("/user/app_datalake/integration/someapp/somefeed/data"))
-    assert(AclUtil.pathContainsFeed(path, "somefeed"))
-  }
-
-  test("Path does not contain Feed") {
-    val path = Some(new Path("/tmp/u123456/someapp"))
-    assert(!AclUtil.pathContainsFeed(path, "randomfeed"))
+  test("Traverse directoryUp some existing directory (feed)") {
+    val path = new Path("/user/app_dir/integration/someapp/somefeed/data")
+    val upperPath = AclUtil.traverseDirectoryUp(path, Environment.hdfsAclsUserHomeLevel, noOpAclSetter)
+    assert(upperPath == new Path("/user/app_dir"))
   }
 
   test("Path to file exists") {
@@ -139,73 +143,113 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Root dir has level 0") {
-    val rootPath = "/"
+    val rootPath = new Path("/")
+    assert(AclUtil.getPathLevel(rootPath) == 0)
+  }
+
+  test("Root dir with scheme/authority has level 0") {
+    val rootPath = new Path("hdfs://nameservice1/")
     assert(AclUtil.getPathLevel(rootPath) == 0)
   }
 
   test("User dir has level 1") {
-    val path1 = "/user"
+    val path1 = new Path("/user")
     assert(AclUtil.getPathLevel(path1) == 1)
 
-    val path2 = "/user/"
+    val path2 = new Path("/user/")
     assert(AclUtil.getPathLevel(path2) == 1)
   }
 
   test("User home dir has level 2") {
-    val path1 = "/user/app_dir"
+    val path1 = new Path("/user/app_dir")
     assert(AclUtil.getPathLevel(path1) == 2)
 
-    val path2 = "/user/app_dir/"
+    val path2 = new Path("/user/app_dir/")
     assert(AclUtil.getPathLevel(path2) == 2)
   }
 
-  test("ACL modify on  root dir is NOT allowed") {
-    val path = "/user"
+  test("User home dir with scheme/authority has level 2") {
+    val path1 = new Path("hdfs://nameservice1/user/app_dir")
+    assert(AclUtil.getPathLevel(path1) == 2)
+
+    val path2 = new Path("hdfs://nameservice1/user/app_dir/")
+    assert(AclUtil.getPathLevel(path2) == 2)
+  }
+
+  test("ACL modify on root dir is NOT allowed") {
+    val path = new Path("/")
+    assert(!AclUtil.isAclModifyAllowed(path))
+  }
+
+  test("ACL modify on root dir with scheme/authority is NOT allowed") {
+    val path = new Path("hdfs://nameservice1/")
     assert(!AclUtil.isAclModifyAllowed(path))
   }
 
   test("ACL modify on /user dir is NOT allowed") {
-    val path = "/user"
+    val path = new Path("/user")
+    assert(!AclUtil.isAclModifyAllowed(path))
+  }
+
+  test("ACL modify on /user with scheme/authority dir is NOT allowed") {
+    val path = new Path("hdfs://nameservice1/user")
     assert(!AclUtil.isAclModifyAllowed(path))
   }
 
   test("ACL modify on user home dir is allowed") {
-    val path = "/user/app_dir"
+    val path = new Path("/user/app_dir")
+    assert(AclUtil.isAclModifyAllowed(path))
+  }
+
+  test("ACL modify on user home dir with scheme/authority is allowed") {
+    val path = new Path("hdfs://nameservice1/user/app_dir")
     assert(AclUtil.isAclModifyAllowed(path))
   }
 
   test("ACL overwrite on user home dir is NOT allowed") {
-    val path = "/user/app_dir"
+    val path = new Path("/user/app_dir")
+    assert(!AclUtil.isAclOverwriteAllowed(path))
+  }
+
+  test("ACL overwrite on user home dir with scheme/authority is NOT allowed") {
+    val path = new Path("hdfs://nameservice1/user/app_dir")
     assert(!AclUtil.isAclOverwriteAllowed(path))
   }
 
   test("ACL modify on stage dir is allowed") {
-    val path = "/user/app_dir/stage"
+    val path = new Path("/user/app_dir/stage")
     assert(AclUtil.isAclModifyAllowed(path))
   }
 
   test("ACL overwrite on stage dir is NOT allowed") {
-    val path = "/user/app_dir/stage"
+    val path = new Path("/user/app_dir/stage")
     assert(!AclUtil.isAclOverwriteAllowed(path))
   }
 
   test("ACL modify on source dir is allowed") {
-    val path = "/user/app_dir/stage/somesource"
+    val path = new Path("/user/app_dir/stage/somesource")
     assert(AclUtil.isAclModifyAllowed(path))
   }
 
   test("ACL overwrite on source dir is NOT allowed") {
-    val path = "/user/app_dir/stage/somesource"
+    val path = new Path("/user/app_dir/stage/somesource")
     assert(!AclUtil.isAclOverwriteAllowed(path))
   }
 
-  test("ACL modify on feed dir is NOT allowed") {
-    val path = "/user/app_dir/stage/somesource/somefeed"
-    assert(!AclUtil.isAclModifyAllowed(path))
+  test("ACL overwrite on feed dir is allowed") {
+    val path = new Path("/user/app_dir/stage/somesource/somefeed")
+    assert(AclUtil.isAclOverwriteAllowed(path))
   }
 
-  test("ACL overwrite on feed dir is allowed") {
-    val path = "/user/app_dir/stage/somesource/somefeed"
+  test("ACL overwrite on feed dir with scheme/authority is allowed") {
+    val path = new Path("hdfs://nameservice1/user/app_dir/stage/somesource/somefeed")
     assert(AclUtil.isAclOverwriteAllowed(path))
+  }
+
+  test("extract user home") {
+    assert(AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/app_dir"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/app_dir/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/app_dir/test/abc"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    intercept[IllegalArgumentException](AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
   }
 }

--- a/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/util/AclUtilTest.scala
@@ -84,12 +84,12 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Parent method returns the parent directory of the supplied path with scheme/authority.") {
-    val parentPath = AclUtil.parent(new Path("hdfs://nameservice1/path/to/parent/child"))
-    assert(parentPath.value === new Path("hdfs://nameservice1/path/to/parent/"))
+    val parentPath = AclUtil.parent(new Path("hdfs://dfs.nameservices/path/to/parent/child"))
+    assert(parentPath.value === new Path("hdfs://dfs.nameservices/path/to/parent/"))
   }
 
   test("Parent of root directory with schema/authority") {
-    val rootPath = new Path("hdfs://nameservice1/")
+    val rootPath = new Path("hdfs://dfs.nameservices/")
     val rootParentPath = AclUtil.parent(rootPath)
     assert(rootParentPath.isEmpty)
   }
@@ -109,9 +109,9 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Traverse directoryUp some existing directory (user home) with scheme/authority") {
-    val path = new Path("hdfs://nameservice1/user/app_dir/integration/someapp")
+    val path = new Path("hdfs://dfs.nameservices/user/app_dir/integration/someapp")
     val upperPath = AclUtil.traverseDirectoryUp(path, Environment.hdfsAclsUserHomeLevel, noOpAclSetter)
-    assert(upperPath == new Path("hdfs://nameservice1/user/app_dir"))
+    assert(upperPath == new Path("hdfs://dfs.nameservices/user/app_dir"))
   }
 
   test("Traverse directoryUp some existing directory (feed)") {
@@ -148,7 +148,7 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("Root dir with scheme/authority has level 0") {
-    val rootPath = new Path("hdfs://nameservice1/")
+    val rootPath = new Path("hdfs://dfs.nameservices/")
     assert(AclUtil.getPathLevel(rootPath) == 0)
   }
 
@@ -169,10 +169,10 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("User home dir with scheme/authority has level 2") {
-    val path1 = new Path("hdfs://nameservice1/user/app_dir")
+    val path1 = new Path("hdfs://dfs.nameservices/user/app_dir")
     assert(AclUtil.getPathLevel(path1) == 2)
 
-    val path2 = new Path("hdfs://nameservice1/user/app_dir/")
+    val path2 = new Path("hdfs://dfs.nameservices/user/app_dir/")
     assert(AclUtil.getPathLevel(path2) == 2)
   }
 
@@ -182,7 +182,7 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("ACL modify on root dir with scheme/authority is NOT allowed") {
-    val path = new Path("hdfs://nameservice1/")
+    val path = new Path("hdfs://dfs.nameservices/")
     assert(!AclUtil.isAclModifyAllowed(path))
   }
 
@@ -192,7 +192,7 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("ACL modify on /user with scheme/authority dir is NOT allowed") {
-    val path = new Path("hdfs://nameservice1/user")
+    val path = new Path("hdfs://dfs.nameservices/user")
     assert(!AclUtil.isAclModifyAllowed(path))
   }
 
@@ -202,7 +202,7 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("ACL modify on user home dir with scheme/authority is allowed") {
-    val path = new Path("hdfs://nameservice1/user/app_dir")
+    val path = new Path("hdfs://dfs.nameservices/user/app_dir")
     assert(AclUtil.isAclModifyAllowed(path))
   }
 
@@ -212,7 +212,7 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("ACL overwrite on user home dir with scheme/authority is NOT allowed") {
-    val path = new Path("hdfs://nameservice1/user/app_dir")
+    val path = new Path("hdfs://dfs.nameservices/user/app_dir")
     assert(!AclUtil.isAclOverwriteAllowed(path))
   }
 
@@ -242,14 +242,14 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("ACL overwrite on feed dir with scheme/authority is allowed") {
-    val path = new Path("hdfs://nameservice1/user/app_dir/stage/somesource/somefeed")
+    val path = new Path("hdfs://dfs.nameservices/user/app_dir/stage/somesource/somefeed")
     assert(AclUtil.isAclOverwriteAllowed(path))
   }
 
   test("extract user home") {
-    assert(AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/app_dir"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
-    assert(AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/app_dir/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
-    assert(AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/app_dir/test/abc"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
-    intercept[IllegalArgumentException](AclUtil.extractPathLevel(new Path("hdfs://nameservice1/user/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir/test/abc"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    intercept[IllegalArgumentException](AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
   }
 }


### PR DESCRIPTION
Bug was in getPathLevel. Custom implementation is now replaced with hadoop default implementation which should be robust.

Additional changes:
Custom Implementation of parent replaced with hadoop default implementation.
Added additional test cases for paths with schema/authority.
Converted path:String parameters to path:Path to have a better definition.
Remove unneeded Options in method declarations.
Implemented user home check more generic.
Extracted configuration parameters to Environment object.
Forced validation of hdfsAclsMinLevelPermissionOverwrite on start of addACLs.
Removed unused methods.
Changed test cases to methods which are actually in use (traverseDirectoryUp).
Improved documentation.