### PR TITLE
implement support for different jdbc catalogs (#91)

### DIFF
--- a/src/main/scala/io/smartdatalake/workflow/connection/JdbcTableConnection.scala
+++ b/src/main/scala/io/smartdatalake/workflow/connection/JdbcTableConnection.scala
@@ -23,8 +23,9 @@ import java.sql.{DriverManager, ResultSet, Statement, Connection => SqlConnectio
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.{AuthMode, BasicAuthMode}
+import io.smartdatalake.definitions.{AuthMode, BasicAuthMode, Environment}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import org.apache.spark.sql.SparkSession
 
 /**
  * Connection information for jdbc tables.
@@ -48,6 +49,9 @@ case class JdbcTableConnection( override val id: ConnectionId,
   // Allow only supported authentication modes
   private val supportedAuths = Seq(classOf[BasicAuthMode])
   require(authMode.isEmpty || supportedAuths.contains(authMode.get.getClass), s"${authMode.getClass.getSimpleName} not supported by ${this.getClass.getSimpleName}. Supported auth modes are ${supportedAuths.map(_.getSimpleName).mkString(", ")}.")
+
+  // prepare catalog implementation
+  val catalog: SQLCatalog = SQLCatalog.fromJdbcDriver(driver, this)
 
   def execJdbcStatement(sql:String ) : Boolean = {
     var conn: SqlConnection = null
@@ -98,17 +102,10 @@ case class JdbcTableConnection( override val id: ConnectionId,
     } else Map()
   }
 
-  /**
-   * @inheritdoc
-   */
   override def factory: FromConfigFactory[Connection] = JdbcTableConnection
 }
 
 object JdbcTableConnection extends FromConfigFactory[Connection] {
-
-  /**
-   * @inheritdoc
-   */
   override def fromConfig(config: Config, instanceRegistry: InstanceRegistry): JdbcTableConnection = {
     import configs.syntax.ConfigOps
     import io.smartdatalake.config._
@@ -119,3 +116,67 @@ object JdbcTableConnection extends FromConfigFactory[Connection] {
 }
 
 
+/**
+ * SQL JDBC Catalog query method definition.
+ * Implementations may vary depending on the concrete DB system.
+ */
+private[smartdatalake] abstract class SQLCatalog(connection: JdbcTableConnection) {
+  def isDbExisting(db: String)(implicit session: SparkSession): Boolean
+  def isTableExisting(db: String, table: String)(implicit session: SparkSession): Boolean
+  protected def evalRecordExists( rs:ResultSet ) : Boolean = {
+    rs.next
+    rs.getInt(1) == 1
+  }
+}
+private[smartdatalake] object SQLCatalog {
+  def fromJdbcDriver(driver: String, connection: JdbcTableConnection): SQLCatalog = {
+    driver match {
+      case d if d.toLowerCase.contains("oracle") => new OracleSQLCatalog(connection)
+      case _ => new DefaultSQLCatalog(connection)
+    }
+  }
+}
+
+/**
+ * Default SQL JDBC Catalog query implementation using INFORMATION_SCHEMA
+ */
+private[smartdatalake] class DefaultSQLCatalog(connection: JdbcTableConnection) extends SQLCatalog(connection) {
+  override def isDbExisting(db: String)(implicit session: SparkSession): Boolean = {
+    val cntTableInCatalog =
+      if (Environment.enableJdbcCaseSensitivity)
+        s"select count(*) from INFORMATION_SCHEMA.SCHEMATA where TABLE_SCHEMA='$db'"
+      else
+        s"select count(*) from INFORMATION_SCHEMA.SCHEMATA where upper(TABLE_SCHEMA)=upper('$db')"
+    connection.execJdbcQuery(cntTableInCatalog, evalRecordExists )
+  }
+  override def isTableExisting(db: String, table: String)(implicit session: SparkSession): Boolean = {
+    val cntTableInCatalog =
+      if (Environment.enableJdbcCaseSensitivity)
+        s"select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME='$table' and TABLE_SCHEMA='$db'"
+      else
+        s"select count(*) from INFORMATION_SCHEMA.TABLES where upper(TABLE_NAME)=upper('$table') and upper(TABLE_SCHEMA)=upper('$db')"
+    connection.execJdbcQuery( cntTableInCatalog, evalRecordExists )
+  }
+}
+
+/**
+ * Oracle SQL JDBC Catalog query implementation
+ */
+private[smartdatalake] class OracleSQLCatalog(connection: JdbcTableConnection) extends SQLCatalog(connection) {
+  override def isDbExisting(db: String)(implicit session: SparkSession): Boolean = {
+    val cntTableInCatalog =
+      if (Environment.enableJdbcCaseSensitivity)
+        s"select count(*) from ALL_USERS where USERNAME='$db'"
+      else
+        s"select count(*) from ALL_USERS where upper(USERNAME)=upper('$db')"
+    connection.execJdbcQuery(cntTableInCatalog, evalRecordExists)
+  }
+  override def isTableExisting(db: String, table: String)(implicit session: SparkSession): Boolean = {
+    val cntTableInCatalog =
+      if (Environment.enableJdbcCaseSensitivity)
+        s"select count(*) from ALL_TABLES where TABLE_NAME='$table' and OWNER='$db'"
+      else
+        s"select count(*) from ALL_TABLES where upper(TABLE_NAME)=upper('$table') and upper(OWNER)=upper('$db')"
+    connection.execJdbcQuery( cntTableInCatalog, evalRecordExists )
+  }
+}

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -18,12 +18,9 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import java.sql.ResultSet
-
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import io.smartdatalake.workflow.connection.JdbcTableConnection
@@ -123,48 +120,17 @@ case class JdbcTableDataObject(override val id: DataObjectId,
     }
   }
 
-  override def isDbExisting(implicit session: SparkSession): Boolean = {
-    val cntTableInCatalog =
-      if (Environment.enableJdbcCaseSensitivity)
-        s"select count(*) from INFORMATION_SCHEMA.SCHEMATA where TABLE_SCHEMA='${table.db.get}'"
-      else
-        s"select count(*) from INFORMATION_SCHEMA.SCHEMATA where upper(TABLE_SCHEMA)=upper('${table.db.get}')"
-    def evalTableExistsInCatalog( rs:ResultSet ) : Boolean = {
-      rs.next
-      rs.getInt(1) == 1
-    }
-    connection.execJdbcQuery(cntTableInCatalog, evalTableExistsInCatalog)
-  }
-
-  override def isTableExisting(implicit session: SparkSession): Boolean = {
-    val cntTableInCatalog =
-      if (Environment.enableJdbcCaseSensitivity)
-        s"select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME='${table.name}' and TABLE_SCHEMA='${table.db.get}'"
-      else
-        s"select count(*) from INFORMATION_SCHEMA.TABLES where upper(TABLE_NAME)=upper('${table.name}') and upper(TABLE_SCHEMA)=upper('${table.db.get}')"
-    def evalTableExistsInCatalog( rs:ResultSet ) : Boolean = {
-      rs.next
-      rs.getInt(1)==1
-    }
-    connection.execJdbcQuery( cntTableInCatalog, evalTableExistsInCatalog )
-  }
+  override def isDbExisting(implicit session: SparkSession): Boolean = connection.catalog.isDbExisting(table.db.get)
+  override def isTableExisting(implicit session: SparkSession): Boolean = connection.catalog.isTableExisting(table.db.get, table.name)
 
   override def dropTable(implicit session: SparkSession): Unit = {
     connection.execJdbcStatement(s"drop table if exists ${table.fullName}")
   }
 
-  /**
-   * @inheritdoc
-   */
   override def factory: FromConfigFactory[DataObject] = JdbcTableDataObject
-
 }
 
 object JdbcTableDataObject extends FromConfigFactory[DataObject] {
-
-  /**
-   * @inheritdoc
-   */
   override def fromConfig(config: Config, instanceRegistry: InstanceRegistry): JdbcTableDataObject = {
     import configs.syntax.ConfigOps
     import io.smartdatalake.config._


### PR DESCRIPTION
### What changes are included in the pull request?
Bugfix querying Oracle catalog (isDbExisting, isTableExisting) in JdbcTableDataObject (#91).
The corresponding Methods have been extract in a Trait SQLCatalog and a DefaultSQLCatalog and OracleSQLCatalog have been implemented. Detection of Oracle catalog is done by searching for oracle in the JDBC driver class name.

### Why are the changes needed?
Oracle uses not the standard SQL information catalog to query metadata over SQL.