### PR TITLE
Correct historisation when null values swapped

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/src/main/scala/io/smartdatalake/util/historization/Historization.scala
+++ b/src/main/scala/io/smartdatalake/util/historization/Historization.scala
@@ -139,7 +139,7 @@ private[smartdatalake] object Historization extends SmartDataLakeLogger {
     }
 
     // Generic column expression to generate a JSON string of the hash fields
-    def colHashExpr(cols: Seq[String]): Column = hash(to_json(struct(cols.map(col): _*)))
+    def colHashExpr(cols: Seq[String]): Column = to_json(struct(cols.map(col): _*))
 
     val newFeedHashed = newFeedDf.withColumn("hash", colHashExpr(historizeHashCols))
 

--- a/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -105,9 +105,7 @@ object TestUtil extends SmartDataLakeLogger {
 
   // compare column name and type of two dataframes
   def isDataFrameDataEqual( df1:DataFrame, df2:DataFrame ) : Boolean = {
-    df1.withColumn("col1", lit(true))
-      .join(df2.withColumn("col2", lit(true)), df1.columns, "full")
-      .where(col("col1").isNull or col("col2").isNull)
+    df1.union(df2).except(df1.intersect(df2))
       .count == 0
   }
 


### PR DESCRIPTION
* Historization mechanism based on JSON string
* Generalized function to hash a list of columns
* Additional Test for Null-Swaps
* Correction to isDataFrameData equal which was incorrectly failing identical dataframes

### What changes are included in the pull request?

Link to Issue: #110 

### Why are the changes needed?
See issue.