### PR TITLE
Allow SparkSession to exist already

### DIFF
--- a/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -35,7 +35,8 @@ import org.apache.spark.{ExecutorPlugin, SparkConf, SparkEnv}
  * @param memoryLogTimer enable periodic memory usage logging, see detailled configuration [[MemoryLogTimerConfig]]
  * @param shutdownHookLogger enable shutdown hook logger to trace shutdown cause
  */
-case class GlobalConfig( kryoClasses: Option[Seq[String]] = None, sparkOptions: Option[Map[String,String]] = None, enableHive: Boolean = true, memoryLogTimer: Option[MemoryLogTimerConfig] = None, shutdownHookLogger: Boolean = false ) {
+case class GlobalConfig( kryoClasses: Option[Seq[String]] = None, sparkOptions: Option[Map[String,String]] = None, enableHive: Boolean = true, memoryLogTimer: Option[MemoryLogTimerConfig] = None, shutdownHookLogger: Boolean = false )
+extends SmartDataLakeLogger {
 
   // start memory logger, else log memory once
   if (memoryLogTimer.isDefined) {
@@ -50,7 +51,7 @@ case class GlobalConfig( kryoClasses: Option[Seq[String]] = None, sparkOptions: 
    * Create a spark session using settings from this global config
    */
   def createSparkSession(appName: String, master: Option[String], deployMode: Option[String] = None): SparkSession = {
-    if (Environment._sparkSession != null) throw new IllegalStateException("SparkSession already initialized. Something is wrong.")
+    if (Environment._sparkSession != null) logger.warn("Your SparkSession was already set, that should not happen. We will re-initialize it anyway now.")
     // prepare additional spark options
     // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
     val executorPlugins = (sparkOptions.flatMap(_.get("spark.executor.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq())).mkString(",")


### PR DESCRIPTION
### What changes are included in the pull request?
Only log a warning when the SparkSession is already initialized in Environment.

### Why are the changes needed?
When running jobs on a Databricks cluster, only the first execution will succeed if we throw an exception, which is why it should be changed to a warning only.