### PR TITLE
#100 Follow redirects when calling Http

### DIFF
--- a/src/main/scala/io/smartdatalake/util/webservice/DefaultWebserviceClient.scala
+++ b/src/main/scala/io/smartdatalake/util/webservice/DefaultWebserviceClient.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.util.webservice
 
 import io.smartdatalake.config.ConfigurationException
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import scalaj.http.{Http, HttpRequest, HttpResponse}
+import scalaj.http.{Http, HttpOptions, HttpRequest, HttpResponse}
 
 import scala.util.{Failure, Success, Try}
 
@@ -145,6 +145,7 @@ private[smartdatalake] object DefaultWebserviceClient extends SmartDataLakeLogge
   def buildRequest(url: String): HttpRequest = {
     logger.debug(s"Building HttpRequest with url: <$url>")
     Http(url)
+      .option(HttpOptions.followRedirects(true))
   }
 
   /**


### PR DESCRIPTION
### What changes are included in the pull request?
Http calls via DefaultWebserviceClient will now follow redirects.

Note that the proposed fix doesn't allow the user to change the behavior. I hard coded the redirect option because I think we shouldn't overwhelm the user with options or we then would need to think about giving the possibility to change ANY Http options.

### Why are the changes needed?
Closes #100 
