### PR TITLE
Bugfix/125 init methods not called

### DIFF
--- a/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -23,9 +23,9 @@ import java.time.{Duration, LocalDateTime}
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, InstanceRegistry, ParsableFromConfig, SdlConfigObject}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow._
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.dataobject.DataObject
-import io.smartdatalake.workflow._
 import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -67,6 +67,7 @@ abstract class SparkSubFeedAction extends Action {
    */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for SparkSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
+    outputs.collect{ case x: CanWriteDataFrame => x }.foreach(_.init())
     Seq(doTransform(subFeeds.head))
   }
 

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
@@ -91,6 +91,7 @@ abstract class SparkSubFeedsAction extends Action {
    * */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == inputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
+    outputs.collect{ case x: CanWriteDataFrame => x }.foreach(_.init())
     doTransform(subFeeds)
   }
 

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
@@ -26,7 +26,7 @@ private[smartdatalake] trait CanWriteDataFrame {
   /**
    * Initialize callback before writing data out to disk/sinks.
    */
-  def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = Unit
+  def init(partitionValues: Seq[PartitionValues]=Seq())(implicit session: SparkSession): Unit = Unit
 
   def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit
 

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -91,8 +91,6 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     df
   }
 
-  override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = prepare(session)
-
   override def preWrite(implicit session: SparkSession): Unit = {
     super.preWrite
     // validate if acl's must be / are configured before writing

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -137,15 +137,6 @@ case class HiveTableDataObject(override val id: DataObjectId,
     createMissingPartitions(partitionValues)
   }
 
-  override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
-    // on write: create tables if possible
-    require(isDbExisting, s"Hive DB ${table.db.get} doesn't exist (needs to be created manually).")
-    if (!isTableExisting) {
-      logger.info(s"Creating table ${table.fullName}.")
-      writeDataFrame(df, createTableOnly = true, partitionValues)
-    }
-  }
-
   override def isDbExisting(implicit session: SparkSession): Boolean = {
     session.catalog.databaseExists(table.db.get)
   }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -80,16 +80,6 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     df
   }
 
-  override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
-    // create tables if possible
-    require(isDbExisting, s"Hive DB ${table.db.get} doesn't exist (needs to be created manually).")
-    if (!isTableExisting) {
-      logger.info(s"($id) Creating table ${table.fullName}.")
-      require(path.isDefined, "If Hive table does not exist yet, the path must be set.")
-      writeDataFrame(df, createTableOnly = true, partitionValues)
-    }
-  }
-
   override def preWrite(implicit session: SparkSession): Unit = {
     super.preWrite
     // validate if acl's must be / are configured before writing


### PR DESCRIPTION
### What changes are included in the pull request?
Cleanup existing init methods on Hive- and DeltaTable Data Objects as it turns out, they are not needed. 
Make sure that future implementations of the init methods are called correctly.

### Why are the changes needed?
Fixes  #125 