### PR TITLE
Feature/refactor executionmode needing main

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -56,11 +56,11 @@ Data objects are structured in a hierarchy as many attributes are shared between
 Here is an overview of all data objects:
 ![data object hierarchy](images/dataobject_hierarchy.png)
 
-
 ## Actions
 For a list of all available actions, please consult the [API docs](site/scaladocs/io/smartdatalake/workflow/action/package.html) directly.
 
 In the package overview, you can also see the parameters available to each type of action and which parameters are optional.
+
 
 # Command Line
 SmartDataLakeBuilder is a java application. To run on a cluster with spark-submit use **DefaultSmartDataLakeBuilder** application.
@@ -89,6 +89,7 @@ There exists the following adapted applications versions:
 - **LocalSmartDataLakeBuilder**:<br>default for Spark master is `local[*]` and it has additional properties to configure Kerberos authentication. Use this application to run in a local environment (e.g. IntelliJ) without cluster deployment.  
 - **DatabricksSmartDataLakeBuilder**:<br>see [MicrosoftAzure](MicrosoftAzure.md)
 
+
 # Concepts
 
 ## DAG
@@ -102,44 +103,59 @@ Execution therefore involves the following phases.
 4. DAG exec: Execution of Actions, data is effectively (and only) transferred during this phase.
 
 ## Execution modes
-Execution modes select the data to be processed. By default, if you start SmartDataLakeBuilder, there is no filter applied. This means every Action reads all data from its input DataObjects. 
+Execution modes select the data to be processed. By default, if you start SmartDataLakeBuilder, there is no filter applied. This means every Action reads all data from its input DataObjects.
+
+You can set an execution mode by defining attribute "executionMode" of an Action. Define the chosen ExecutionMode by setting type as follows:
+```
+executionMode {
+  type = PartitionDiffMode
+  attribute1 = ...
+}
+```
 
 ### Fixed partition values filter
 You can apply a filter manually by specifying parameter --partition-values or --multi-partition-values on the command line. The partition values specified are passed to all start-Actions of a DAG and filtered for every input DataObject by its defined partition columns.
 On execution every Action takes the partition values of the input and filters them again for every output DataObject by its defined partition columns, which serve again as partition values for the input of the next Action. 
-Note that during execution of the dag, no new partition values are added, they are only filtered.
+Note that during execution of the dag, no new partition values are added, they are only filtered. An exception is if you place a PartitionDiffMode in the middle of your pipeline, see next section.
 
-### Dynamic partition values filter - PartitionDiffMode
+### PartitionDiffMode: Dynamic partition values filter 
 Alternatively you can let SmartDataLakeBuilder find missing partitions and set partition values automatically by specifying execution mode PartitionDiffMode.
 
-Often this should only happen on the start-Actions of a DAG, so it's clear what partitions are processed through a specific DAG run.
-But its also possible to let every Action in the DAG decide again dynamically, what partitions are missing and should be processed.
-You can configure this by the following attributes of an Action:
-- initExecutionMode: define the execution mode if this Action is a start-Actions of the DAG
-- executionMode: define the execution mode independently of its position is the DAG.
-If both attributes are set, initExecutionMode overrides executionMode if the Action is a a start-Action of the DAG.
+By defining the applyCondition attribute you can give a condition to decide at runtime if the PartitionDiffMode should be applied or not.
+Default is to apply the PartitionDiffMode if the given partition values are empty (partition values from command line or passed from previous action). 
+Define an applyCondition by a spark sql expression working with attributes of DefaultExecutionModeExpressionData returning a boolean.
 
-### Dynamic partition values filter - PartitionDiffMode
-Alternatively you can let SmartDataLakeBuilder find missing partitions and set partition values automatically by specifying execution mode PartitionDiffMode.
+By defining the failCondition attribute you can give a condition to fail application of execution mode if true.
+It can be used fail a run based on expected partitions, time and so on.
+Default is that the application of the PartitionDiffMode does not fail the action. If there is no data to process, the following actions are skipped.
+Define a failCondition by a spark sql expression working with attributes of PartitionDiffModeExpressionData returning a boolean.
+Example - fail if partitions are not processed in strictly increasing order of partition column "dt":
+```
+  failCondition = "(size(selectedPartitionValues) > 0 and array_min(transform(selectedPartitionValues, x -> x.dt)) < array_max(transform(outputPartitionValues, x -> x.dt)))"
+```
 
-Often this should only happen on the start-Actions of a DAG, so it's clear what partitions are processed through a specific DAG run.
-But its also possible to let every Action in the DAG decide again dynamically, what partitions are missing and should be processed.
-You can configure this by the following attributes of an Action:
-- initExecutionMode: define the execution mode if this Action is a start-Actions of the DAG
-- executionMode: define the execution mode independently of its position in the DAG.
-If both attributes are set, initExecutionMode overrides executionMode if the Action is a a start-Action of the DAG.
-
-### Incremental load - SparkStreamingOnceMode
+### SparkStreamingOnceMode: Incremental load 
 Some DataObjects are not partitioned, but nevertheless you dont want to read all data from the input on every run. You want to load it incrementally.
 This can be accomplished by specifying execution mode SparkStreamingOnceMode. Under the hood it uses "Spark Structured Streaming" and triggers a single microbatch (Trigger.Once).
 "Spark Structured Streaming" helps keeping state information about processed data. It needs a checkpointLocation configured which can be given as parameter to SparkStreamingOnceMode.
 
 Note that "Spark Structured Streaming" needs an input DataObject supporting the creation of streaming DataFrames. 
 For the time being, only the input sources delivered with Spark Streaming are supported. 
-This is KafkaTopicDataObject and all SparkFileDataObjects, see also [Spark StructuredStreaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#creating-streaming-dataframes-and-streaming-datasets).
+This are KafkaTopicDataObject and all SparkFileDataObjects, see also [Spark StructuredStreaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#creating-streaming-dataframes-and-streaming-datasets).
 
-### Incremental Load - DeltaMode
-to be implemented 
+### SparkIncrementalMode: Incremental Load
+As not every input DataObject supports the creation of streaming DataFrames, there is an other execution mode called SparkIncrementalMode.
+You configure it by defining the attribute "compareCol" with a column name present in input and output DataObject. 
+SparkIncrementalMode then compares the maximum values between input and output and creates a filter condition.
+On execution the filter condition is applied to the input DataObject to load the missing increment.
+Note that compareCol needs to have a sortable datatype.
+
+By defining the applyCondition attribute you can give a condition to decide at runtime if the SparkIncrementalMode should be applied or not.
+Default is to apply the SparkIncrementalMode. Define an applyCondition by a spark sql expression working with attributes of DefaultExecutionModeExpressionData returning a boolean.
+
+### FailIfNoPartitionValuesMode
+To simply check if partition values are present and fail otherwise, configure execution mode FailIfNoPartitionValuesMode.
+This is useful to prevent potential reprocessing of whole table through wrong usage.
 
 ## Metrics
 Metrics are gathered per Action and output-DataObject when running a DAG. They can be found in log statements and are written to the state file.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>smartdatalake_${scala.minor.version}</artifactId>
-	<version>1.0.8-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<licenses>

--- a/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -134,8 +134,10 @@ case class SparkIncrementalMode(compareCol: String, override val alternativeOutp
     // check alternativeOutput exists
     alternativeOutput
   }
-  override def apply(actionId: ActionObjectId, input: DataObject, output: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
     import session.implicits._
+    val input = mainInput
+    val output = alternativeOutput.getOrElse(mainOutput)
     (input,output) match {
       case (sparkInput: CanCreateDataFrame, sparkOutput: CanCreateDataFrame) =>
         // if data object is new, it might not be able to create a DataFrame

--- a/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -49,7 +49,7 @@ sealed trait ExecutionMode extends SmartDataLakeLogger {
   def mainInputOutputNeeded: Boolean = false
 }
 
-trait ExecutionModeWithMainInputOutput {
+private[smartdatalake] trait ExecutionModeWithMainInputOutput {
   def alternativeOutputId: Option[String] = None
   def alternativeOutput(implicit context: ActionPipelineContext): Option[DataObject] = {
     import io.smartdatalake.config.SdlConfigObject.stringToDataObjectId

--- a/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.definitions
 
 import io.smartdatalake.config.ConfigurationException
-import io.smartdatalake.config.SdlConfigObject.ActionObjectId
+import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -50,9 +50,8 @@ sealed trait ExecutionMode extends SmartDataLakeLogger {
 }
 
 private[smartdatalake] trait ExecutionModeWithMainInputOutput {
-  def alternativeOutputId: Option[String] = None
+  def alternativeOutputId: Option[DataObjectId] = None
   def alternativeOutput(implicit context: ActionPipelineContext): Option[DataObject] = {
-    import io.smartdatalake.config.SdlConfigObject.stringToDataObjectId
     alternativeOutputId.map(context.instanceRegistry.get[DataObject](_))
   }
 }
@@ -67,7 +66,7 @@ private[smartdatalake] trait ExecutionModeWithMainInputOutput {
  *                            It can be used to ensure processing all partitions over multiple actions in case of errors.
  * @param nbOfPartitionValuesPerRun optional restriction of the number of partition values per run.
  */
-case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val alternativeOutputId: Option[String] = None, nbOfPartitionValuesPerRun: Option[Int] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
+case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val alternativeOutputId: Option[DataObjectId] = None, nbOfPartitionValuesPerRun: Option[Int] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
   override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
   override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     // check alternativeOutput exists
@@ -128,7 +127,7 @@ case class SparkStreamingOnceMode(checkpointLocation: String, inputOptions: Map[
  * @param alternativeOutputId optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
  *                            It can be used to ensure processing all partitions over multiple actions in case of errors.
  */
-case class SparkIncrementalMode(compareCol: String, override val alternativeOutputId: Option[String] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
+case class SparkIncrementalMode(compareCol: String, override val alternativeOutputId: Option[DataObjectId] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
   override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
   override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     // check alternativeOutput exists

--- a/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -18,11 +18,13 @@
  */
 package io.smartdatalake.definitions
 
+import java.sql.Timestamp
+
 import io.smartdatalake.config.ConfigurationException
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.util.misc.{SmartDataLakeLogger, SparkExpressionUtil}
+import io.smartdatalake.workflow.{ActionPipelineContext, SubFeed}
 import io.smartdatalake.workflow.action.ActionHelper.{getOptionalDataFrame, searchCommonInits}
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, DataObject}
@@ -43,10 +45,17 @@ import org.apache.spark.sql.types._
  * }}}
  */
 sealed trait ExecutionMode extends SmartDataLakeLogger {
-  def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
-  def init(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
-  def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = None
+  def prepare(actionId: ActionObjectId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    // validate condition
+    applyCondition.foreach( c => SparkExpressionUtil.evaluateBoolean(actionId, Some("applyCondition"), c, DefaultExecutionModeExpressionData.from(context), onlySyntaxCheck = true))
+  }
+  def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = None
   def mainInputOutputNeeded: Boolean = false
+  def applyCondition: Option[String] = None
+  final def evaluateApplyCondition(actionId: ActionObjectId, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[Boolean] = {
+    val data = DefaultExecutionModeExpressionData.from(context).copy(givenPartitionValues = subFeed.partitionValues.map(_.getMapString), isStartNode = subFeed.isDAGStart)
+    applyCondition.map( c => SparkExpressionUtil.evaluateBoolean(actionId, Some("applyCondition"), c, data))
+  }
 }
 
 private[smartdatalake] trait ExecutionModeWithMainInputOutput {
@@ -61,51 +70,77 @@ private[smartdatalake] trait ExecutionModeWithMainInputOutput {
  * Partition columns to be used for comparision need to be a common 'init' of input and output partition columns.
  * This mode needs mainInput/Output DataObjects which CanHandlePartitions to list partitions.
  * Partition values are passed to following actions, if for partition columns which they have in common.
- * @param partitionColNb optional number of partition columns to use as a common 'init'.
- * @param alternativeOutputId optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
- *                            It can be used to ensure processing all partitions over multiple actions in case of errors.
+ *
+ * @param partitionColNb            optional number of partition columns to use as a common 'init'.
+ * @param alternativeOutputId       optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
+ *                                  It can be used to ensure processing all partitions over multiple actions in case of errors.
  * @param nbOfPartitionValuesPerRun optional restriction of the number of partition values per run.
+ * @param applyCondition            Condition to decide if execution mode should be applied or not. Define a spark sql expression working with attributes of [[DefaultExecutionModeExpressionData]] returning a boolean.
+ *                                  Default is to apply the execution mode if given partition values (partition values from command line or passed from previous action) are not empty.
+ * @param failCondition             Condition to fail application of execution mode if true. Define a spark sql expression working with attributes of [[PartitionDiffModeExpressionData]] returning a boolean.
+ *                                  Default is that the application of the PartitionDiffMode does not fail the action. If there is no data to process, the following actions are skipped.
  */
-case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val alternativeOutputId: Option[DataObjectId] = None, nbOfPartitionValuesPerRun: Option[Int] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
+case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val alternativeOutputId: Option[DataObjectId] = None, nbOfPartitionValuesPerRun: Option[Int] = None, override val applyCondition: Option[String] = None, failCondition: Option[String] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
   override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def prepare(actionId: ActionObjectId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.prepare(actionId)
+    // validate condition
+    failCondition.foreach( c => SparkExpressionUtil.evaluateBoolean(actionId, Some("failCondition"), c, PartitionDiffModeExpressionData.from(context), onlySyntaxCheck = true))
     // check alternativeOutput exists
     alternativeOutput
   }
-  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
-    val input = mainInput
-    val output = alternativeOutput.getOrElse(mainOutput)
-    (input, output) match {
-      case (partitionInput: CanHandlePartitions, partitionOutput: CanHandlePartitions)  =>
-        if (partitionInput.partitions.nonEmpty) {
-          if (partitionOutput.partitions.nonEmpty) {
-            // prepare common partition columns
-            val commonInits = searchCommonInits(partitionInput.partitions, partitionOutput.partitions)
-            require(commonInits.nonEmpty, s"$actionId has set initExecutionMode = 'PartitionDiffMode' but no common init was found in partition columns for $input and $output")
-            val commonPartitions = if (partitionColNb.isDefined) {
-              commonInits.find(_.size==partitionColNb.get).getOrElse(throw ConfigurationException(s"$actionId has set initExecutionMode = 'PartitionDiffMode' but no common init with ${partitionColNb.get} was found in partition columns of $input and $output from $commonInits!"))
-            } else {
-              commonInits.maxBy(_.size)
-            }
-            // calculate missing partition values
-            val partitionValuesToBeProcessed = partitionInput.listPartitions.map(_.filterKeys(commonPartitions)).toSet
-              .diff(partitionOutput.listPartitions.map(_.filterKeys(commonPartitions)).toSet).toSeq
-            // stop processing if no new data
-            if (partitionValuesToBeProcessed.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No partitions to process found for ${input.id}")
-            // sort and limit number of partitions processed
-            val ordering = PartitionValues.getOrdering(commonPartitions)
-            val selectedPartitionValues = nbOfPartitionValuesPerRun match {
-              case Some(n) => partitionValuesToBeProcessed.sorted(ordering).take(n)
-              case None => partitionValuesToBeProcessed.sorted(ordering)
-            }
-            logger.info(s"($actionId) PartitionDiffMode selected partition values ${selectedPartitionValues.mkString(", ")} to process")
-            //return
-            Some((selectedPartitionValues, None))
-          } else throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $output has no partition columns defined!")
-        } else throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $input has no partition columns defined!")
-      case (_: CanHandlePartitions, _) => throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $output does not support partitions!")
-      case (_, _) => throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $input does not support partitions!")
-    }
+  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+    val doApply = evaluateApplyCondition(actionId, subFeed)
+      .getOrElse(subFeed.partitionValues.isEmpty) // default is to apply PartitionDiffMode if no partition values are given
+    if (doApply) {
+      val input = mainInput
+      val output = alternativeOutput.getOrElse(mainOutput)
+      (input, output) match {
+        case (partitionInput: CanHandlePartitions, partitionOutput: CanHandlePartitions) =>
+          if (partitionInput.partitions.nonEmpty) {
+            if (partitionOutput.partitions.nonEmpty) {
+              // prepare common partition columns
+              val commonInits = searchCommonInits(partitionInput.partitions, partitionOutput.partitions)
+              require(commonInits.nonEmpty, s"$actionId has set executionMode = 'PartitionDiffMode' but no common init was found in partition columns for $input and $output")
+              val commonPartitions = if (partitionColNb.isDefined) {
+                commonInits.find(_.size == partitionColNb.get).getOrElse(throw ConfigurationException(s"$actionId has set executionMode = 'PartitionDiffMode' but no common init with ${partitionColNb.get} was found in partition columns of $input and $output from $commonInits!"))
+              } else {
+                commonInits.maxBy(_.size)
+              }
+              // calculate missing partition values
+              val inputPartitionValues = partitionInput.listPartitions.map(_.filterKeys(commonPartitions))
+              val outputPartitionValues = partitionOutput.listPartitions.map(_.filterKeys(commonPartitions))
+              val partitionValuesToBeProcessed = inputPartitionValues.toSet.diff(outputPartitionValues.toSet).toSeq
+              // sort and limit number of partitions processed
+              val ordering = PartitionValues.getOrdering(commonPartitions)
+              val selectedPartitionValues = nbOfPartitionValuesPerRun match {
+                case Some(n) => partitionValuesToBeProcessed.sorted(ordering).take(n)
+                case None => partitionValuesToBeProcessed.sorted(ordering)
+              }
+              // evaluate fail condition
+              val data = PartitionDiffModeExpressionData.from(context).copy(inputPartitionValues = inputPartitionValues.map(_.getMapString), outputPartitionValues = outputPartitionValues.map(_.getMapString), selectedPartitionValues = selectedPartitionValues.map(_.getMapString))
+              val doFail = failCondition.exists(c => SparkExpressionUtil.evaluateBoolean(actionId, Some("failCondition"), c, data)) // default is to not fail
+              if (doFail) throw ExecutionModeFailedException(s"($actionId) Execution mode failed because of failCondition '${failCondition.get}' for $data")
+              // stop processing if no new data
+              if (partitionValuesToBeProcessed.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No partitions to process found for ${input.id}")
+              //return
+              logger.info(s"($actionId) PartitionDiffMode selected partition values ${selectedPartitionValues.mkString(", ")} to process")
+              Some((selectedPartitionValues, None))
+            } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $output has no partition columns defined!")
+          } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $input has no partition columns defined!")
+        case (_: CanHandlePartitions, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $output does not support partitions!")
+        case (_, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $input does not support partitions!")
+      }
+    } else None
+  }
+}
+case class PartitionDiffModeExpressionData(feed: String, application: String, runId: Int, attemptId: Int, referenceTimestamp: Option[Timestamp]
+                                           , runStartTime: Timestamp, attemptStartTime: Timestamp
+                                           , inputPartitionValues: Seq[Map[String,String]], outputPartitionValues: Seq[Map[String,String]], selectedPartitionValues: Seq[Map[String,String]])
+private[smartdatalake] object PartitionDiffModeExpressionData {
+  def from(context: ActionPipelineContext): PartitionDiffModeExpressionData = {
+    PartitionDiffModeExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
+      , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), Seq(), Seq(), Seq())
   }
 }
 
@@ -127,45 +162,82 @@ case class SparkStreamingOnceMode(checkpointLocation: String, inputOptions: Map[
  */
 case class SparkIncrementalMode(compareCol: String, override val alternativeOutputId: Option[DataObjectId] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
   override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def prepare(actionId: ActionObjectId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.prepare(actionId)
     // check alternativeOutput exists
     alternativeOutput
   }
-  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
-    import session.implicits._
-    val input = mainInput
-    val output = alternativeOutput.getOrElse(mainOutput)
-    (input,output) match {
-      case (sparkInput: CanCreateDataFrame, sparkOutput: CanCreateDataFrame) =>
-        // if data object is new, it might not be able to create a DataFrame
-        val dfInputOpt = getOptionalDataFrame(sparkInput)
-        val dfOutputOpt = getOptionalDataFrame(sparkOutput)
-        (dfInputOpt, dfOutputOpt) match {
-          // if both DataFrames exist, compare and create filter
-          case (Some(dfInput), Some(dfOutput)) =>
-            val inputColType = dfInput.schema(compareCol).dataType
-            require(SparkIncrementalMode.allowedDataTypes.contains(inputColType), s"($actionId) Type of compare column ${compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkInput.id}")
-            val outputColType = dfOutput.schema(compareCol).dataType
-            require(SparkIncrementalMode.allowedDataTypes.contains(outputColType), s"($actionId) Type of compare column ${compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkOutput.id}")
-            require(inputColType == outputColType, s"($actionId) Type of compare column ${compareCol} is different between ${sparkInput.id} ($inputColType) and ${sparkOutput.id} ($outputColType)")
-            // get latest values
-            val inputLatestValue = dfInput.agg(max(col(compareCol)).cast(StringType)).as[String].head
-            val outputLatestValue = dfOutput.agg(max(col(compareCol)).cast(StringType)).as[String].head
-            // stop processing if no new data
-            if (outputLatestValue == inputLatestValue) throw NoDataToProcessWarning(actionId.id, s"($actionId) No increment to process found for ${output.id} column ${compareCol} (lastestValue=$outputLatestValue)")
-            logger.info(s"($actionId) SparkIncrementalMode selected increment for writing to ${output.id}: column ${compareCol} from $outputLatestValue to $inputLatestValue to process")
-            // prepare filter
-            val selectedData = s"${compareCol} > cast('$outputLatestValue' as ${inputColType.sql})"
-            Some((Seq(), Some(selectedData)))
-          // otherwise don't filter
-          case _ =>
-            logger.info(s"($actionId) SparkIncrementalMode selected all records for writing to ${output.id}, because input or output DataObject is still empty.")
-            Some((Seq(), None))
-        }
-      case _ => throw ConfigurationException(s"$actionId has set executionMode = $SparkIncrementalMode but $input or $output does not support creating Spark DataFrames!")
-    }
+  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+    val doApply = evaluateApplyCondition(actionId, subFeed)
+      .getOrElse(true) // default is to apply SparkIncrementalMode
+    if (doApply) {
+      import session.implicits._
+      val input = mainInput
+      val output = alternativeOutput.getOrElse(mainOutput)
+      (input, output) match {
+        case (sparkInput: CanCreateDataFrame, sparkOutput: CanCreateDataFrame) =>
+          // if data object is new, it might not be able to create a DataFrame
+          val dfInputOpt = getOptionalDataFrame(sparkInput)
+          val dfOutputOpt = getOptionalDataFrame(sparkOutput)
+          (dfInputOpt, dfOutputOpt) match {
+            // if both DataFrames exist, compare and create filter
+            case (Some(dfInput), Some(dfOutput)) =>
+              val inputColType = dfInput.schema(compareCol).dataType
+              require(SparkIncrementalMode.allowedDataTypes.contains(inputColType), s"($actionId) Type of compare column ${compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkInput.id}")
+              val outputColType = dfOutput.schema(compareCol).dataType
+              require(SparkIncrementalMode.allowedDataTypes.contains(outputColType), s"($actionId) Type of compare column ${compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkOutput.id}")
+              require(inputColType == outputColType, s"($actionId) Type of compare column ${compareCol} is different between ${sparkInput.id} ($inputColType) and ${sparkOutput.id} ($outputColType)")
+              // get latest values
+              val inputLatestValue = dfInput.agg(max(col(compareCol)).cast(StringType)).as[String].head
+              val outputLatestValue = dfOutput.agg(max(col(compareCol)).cast(StringType)).as[String].head
+              // stop processing if no new data
+              if (outputLatestValue == inputLatestValue) throw NoDataToProcessWarning(actionId.id, s"($actionId) No increment to process found for ${output.id} column ${compareCol} (lastestValue=$outputLatestValue)")
+              logger.info(s"($actionId) SparkIncrementalMode selected increment for writing to ${output.id}: column ${compareCol} from $outputLatestValue to $inputLatestValue to process")
+              // prepare filter
+              val selectedData = s"${compareCol} > cast('$outputLatestValue' as ${inputColType.sql})"
+              Some((Seq(), Some(selectedData)))
+            // otherwise don't filter
+            case _ =>
+              logger.info(s"($actionId) SparkIncrementalMode selected all records for writing to ${output.id}, because input or output DataObject is still empty.")
+              Some((Seq(), None))
+          }
+        case _ => throw ConfigurationException(s"$actionId has set executionMode = $SparkIncrementalMode but $input or $output does not support creating Spark DataFrames!")
+      }
+    } else None
   }
 }
 object SparkIncrementalMode {
   private[smartdatalake] val allowedDataTypes = Seq(StringType, LongType, IntegerType, ShortType, FloatType, DoubleType, TimestampType)
 }
+
+/**
+ * An execution mode which just validates that partition values are given.
+ * Note: For start nodes of the DAG partition values can be defined by command line, for subsequent nodes partition values are passed on from previous nodes.
+ */
+case class FailIfNoPartitionValuesMode() extends ExecutionMode {
+  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+    // check if partition values present
+    if (subFeed.partitionValues.isEmpty) throw ExecutionModeFailedException(s"($actionId) Partition values are empty")
+    // return
+    None
+  }
+}
+
+
+/**
+ * Attributes definition for spark expressions used as ExecutionMode conditions.
+ * @param givenPartitionValues Partition values specified with command line (start action) or passed from previous action
+ * @param isStartNode True if the current action is a start node of the DAG.
+ */
+case class DefaultExecutionModeExpressionData( feed: String, application: String, runId: Int, attemptId: Int, referenceTimestamp: Option[Timestamp]
+                                             , runStartTime: Timestamp, attemptStartTime: Timestamp
+                                             , givenPartitionValues: Seq[Map[String,String]], isStartNode: Boolean)
+private[smartdatalake] object DefaultExecutionModeExpressionData {
+  def from(context: ActionPipelineContext): DefaultExecutionModeExpressionData = {
+    DefaultExecutionModeExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
+      , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), Seq(), false)
+  }
+}
+
+private[smartdatalake] case class ExecutionModeFailedException(msg: String) extends Exception(msg)
+

--- a/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.types._
 sealed trait ExecutionMode extends SmartDataLakeLogger {
   def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
   def init(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
-  def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])]
+  def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = None
   def mainInputOutputNeeded: Boolean = false
 }
 
@@ -116,9 +116,7 @@ case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val al
  * @param inputOptions additional option to apply when reading streaming source. This overwrites options set by the DataObjects.
  * @param outputOptions additional option to apply when writing to streaming sink. This overwrites options set by the DataObjects.
  */
-case class SparkStreamingOnceMode(checkpointLocation: String, inputOptions: Map[String,String] = Map(), outputOptions: Map[String,String] = Map(), outputMode: OutputMode = OutputMode.Append) extends ExecutionMode {
-  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = throw new NotImplementedError
-}
+case class SparkStreamingOnceMode(checkpointLocation: String, inputOptions: Map[String,String] = Map(), outputOptions: Map[String,String] = Map(), outputMode: OutputMode = OutputMode.Append) extends ExecutionMode
 
 /**
  * Compares max entry in "compare column" between mainOutput and mainInput and incrementally loads the delta.

--- a/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -52,6 +52,7 @@ private[smartdatalake] case class PartitionValues(elements: Map[String, Any]) {
   def keys: Set[String] = elements.keySet
   def isDefinedAt(colName: String): Boolean = elements.isDefinedAt(colName)
   def filterKeys(colNames: Seq[String]): PartitionValues = this.copy(elements = elements.filterKeys(colNames.contains))
+  def getMapString: Map[String,String] = elements.mapValues(_.toString)
 }
 
 private[smartdatalake] object PartitionValues {

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -172,7 +172,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
    * Save state of dag to file
    */
   def saveState(isFinal: Boolean = false)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    stateStore.foreach(_.saveState(ActionDAGRunState(context.appConfig, runId, attemptId, getRuntimeInfos, isFinal)))
+    stateStore.foreach(_.saveState(ActionDAGRunState(context.appConfig, runId, attemptId, context.runStartTime, context.attemptStartTime, getRuntimeInfos, isFinal)))
   }
 
   private class ActionEventListener(phase: ExecutionPhase)(implicit session: SparkSession, context: ActionPipelineContext) extends DAGEventListener[Action] with SmartDataLakeLogger {

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -30,7 +30,8 @@ import io.smartdatalake.workflow.action.{RuntimeEventState, RuntimeInfo}
 /**
  * ActionDAGRunState contains all configuration and state of an ActionDAGRun needed to start a recovery run in case of failure.
  */
-private[smartdatalake] case class ActionDAGRunState(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, actionsState: Map[ActionObjectId, RuntimeInfo], isFinal: Boolean) {
+private[smartdatalake] case class ActionDAGRunState( appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int,runStartTime: LocalDateTime, attemptStartTime: LocalDateTime
+                                                   , actionsState: Map[ActionObjectId, RuntimeInfo], isFinal: Boolean) {
   def toJson: String = ActionDAGRunState.toJson(this)
   def isFailed: Boolean = actionsState.exists(_._2.state==RuntimeEventState.FAILED)
   def isSucceeded: Boolean = isFinal && !isFailed

--- a/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -32,6 +32,8 @@ private[smartdatalake] case class ActionPipelineContext(
                                                          instanceRegistry: InstanceRegistry,
                                                          referenceTimestamp: Option[LocalDateTime] = None,
                                                          appConfig: SmartDataLakeBuilderConfig, // application config is needed to persist action dag state for recovery
+                                                         runStartTime: LocalDateTime = LocalDateTime.now(),
+                                                         attemptStartTime: LocalDateTime = LocalDateTime.now(),
                                                          simulation: Boolean = false,
                                                          var phase: ExecutionPhase = ExecutionPhase.Prepare
 ) {

--- a/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -22,17 +22,15 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 
 import io.smartdatalake.config.ConfigurationException
-import io.smartdatalake.config.SdlConfigObject.ActionObjectId
-import io.smartdatalake.definitions.{ExecutionMode, PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
+import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, DataObject}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{StringType, TimestampType}
+import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, SparkSession}
 
-object ActionHelper extends SmartDataLakeLogger {
+private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
 
   /**
    * Removes all columns from a [[DataFrame]] except those specified in whitelist.
@@ -111,82 +109,7 @@ object ActionHelper extends SmartDataLakeLogger {
     else None
   }
 
-  /**
-   * Apply execution mode to partition values
-   */
-  def applyExecutionMode(executionMode: ExecutionMode, actionId: ActionObjectId, input: DataObject, output: DataObject, phase: ExecutionPhase)(implicit session: SparkSession): Option[(Seq[PartitionValues], Option[String])] = {
-    import session.implicits._
-
-    executionMode match {
-      case mode:PartitionDiffMode =>
-        (input,output) match {
-          case (partitionInput: CanHandlePartitions, partitionOutput: CanHandlePartitions)  =>
-            if (partitionInput.partitions.nonEmpty) {
-              if (partitionOutput.partitions.nonEmpty) {
-                // prepare common partition columns
-                val commonInits = searchCommonInits(partitionInput.partitions, partitionOutput.partitions)
-                require(commonInits.nonEmpty, s"$actionId has set initExecutionMode = 'PartitionDiffMode' but no common init was found in partition columns for $input and $output")
-                val commonPartitions = if (mode.partitionColNb.isDefined) {
-                  commonInits.find(_.size==mode.partitionColNb.get).getOrElse(throw ConfigurationException(s"$actionId has set initExecutionMode = 'PartitionDiffMode' but no common init with ${mode.partitionColNb.get} was found in partition columns of $input and $output from $commonInits!"))
-                } else {
-                  commonInits.maxBy(_.size)
-                }
-                // calculate missing partition values
-                val partitionValuesToBeProcessed = partitionInput.listPartitions.map(_.filterKeys(commonPartitions)).toSet
-                  .diff(partitionOutput.listPartitions.map(_.filterKeys(commonPartitions)).toSet).toSeq
-                // stop processing if no new data
-                if (partitionValuesToBeProcessed.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No partitions to process found for ${input.id}")
-                // sort and limit number of partitions processed
-                val ordering = PartitionValues.getOrdering(commonPartitions)
-                val selectedPartitionValues = mode.nbOfPartitionValuesPerRun match {
-                  case Some(n) => partitionValuesToBeProcessed.sorted(ordering).take(n)
-                  case None => partitionValuesToBeProcessed.sorted(ordering)
-                }
-                logger.info(s"($actionId) PartitionDiffMode selected partition values ${selectedPartitionValues.mkString(", ")} to process")
-                //return
-                Some((selectedPartitionValues, None))
-              } else throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $output has no partition columns defined!")
-            } else throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $input has no partition columns defined!")
-          case (_: CanHandlePartitions, _) => throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $output does not support partitions!")
-          case (_, _) => throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $input does not support partitions!")
-        }
-
-      case mode:SparkIncrementalMode =>
-        (input,output) match {
-          case (sparkInput: CanCreateDataFrame, sparkOutput: CanCreateDataFrame) =>
-            // if data object is new, it might not be able to create a DataFrame
-            val dfInputOpt = getOptionalDataFrame(sparkInput)
-            val dfOutputOpt = getOptionalDataFrame(sparkOutput)
-            (dfInputOpt, dfOutputOpt) match {
-              // if both DataFrames exist, compare and create filter
-              case (Some(dfInput), Some(dfOutput)) =>
-                val inputColType = dfInput.schema(mode.compareCol).dataType
-                require(SparkIncrementalMode.allowedDataTypes.contains(inputColType), s"($actionId) Type of compare column ${mode.compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkInput.id}")
-                val outputColType = dfOutput.schema(mode.compareCol).dataType
-                require(SparkIncrementalMode.allowedDataTypes.contains(outputColType), s"($actionId) Type of compare column ${mode.compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkOutput.id}")
-                require(inputColType == outputColType, s"($actionId) Type of compare column ${mode.compareCol} is different between ${sparkInput.id} ($inputColType) and ${sparkOutput.id} ($outputColType)")
-                // get latest values
-                val inputLatestValue = dfInput.agg(max(col(mode.compareCol)).cast(StringType)).as[String].head
-                val outputLatestValue = dfOutput.agg(max(col(mode.compareCol)).cast(StringType)).as[String].head
-                // stop processing if no new data
-                if (outputLatestValue == inputLatestValue) throw NoDataToProcessWarning(actionId.id, s"($actionId) No increment to process found for ${output.id} column ${mode.compareCol} (lastestValue=$outputLatestValue)")
-                logger.info(s"($actionId) SparkIncrementalMode selected increment for writing to ${output.id}: column ${mode.compareCol} from $outputLatestValue to $inputLatestValue to process")
-                // prepare filter
-                val selectedData = s"${mode.compareCol} > cast('$outputLatestValue' as ${inputColType.sql})"
-                Some((Seq(), Some(selectedData)))
-              // otherwise don't filter
-              case _ =>
-                logger.info(s"($actionId) SparkIncrementalMode selected all records for writing to ${output.id}, because input or output DataObject is still empty.")
-                Some((Seq(), None))
-            }
-          case _ => throw ConfigurationException(s"$actionId has set executionMode = $SparkIncrementalMode but $input or $output does not support creating Spark DataFrames!")
-        }
-
-      case _ => None
-    }
-  }
-
-  private def getOptionalDataFrame(sparkInput: CanCreateDataFrame, partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession) : Option[DataFrame] = try {
+  def getOptionalDataFrame(sparkInput: CanCreateDataFrame, partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession) : Option[DataFrame] = try {
     Some(sparkInput.getDataFrame(partitionValues))
   } catch {
     case e: IllegalArgumentException if e.getMessage.contains("DataObject schema is undefined") => None
@@ -204,5 +127,19 @@ object ActionHelper extends SmartDataLakeLogger {
     invalidCharacters.replaceAllIn(str, "_")
   }
 
+  def getMainDataObject[T <: DataObject](mainId: Option[DataObjectId], dataObjects: Seq[T], inputOutput: String, mainNeeded: Boolean, actionId: ActionObjectId): T = {
+    mainId.map {
+      id => dataObjects.find(_.id == id).getOrElse(throw ConfigurationException(s"($actionId) main${inputOutput}Id $id not found in ${inputOutput}s"))
+    }.orElse {
+      val paritionedDataObjects = dataObjects.collect{ case x: T with CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
+      if (paritionedDataObjects.size==1) paritionedDataObjects.headOption
+      else None
+    }.orElse {
+      if (dataObjects.size==1) dataObjects.headOption else None
+    }.getOrElse {
+      if (mainNeeded) logger.warn(s"($actionId) Could not determine unique main $inputOutput but execution mode might need it. Decided for ${dataObjects.head.id}.")
+      dataObjects.head
+    }
+  }
 }
 

--- a/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -131,8 +131,8 @@ private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
     mainId.map {
       id => dataObjects.find(_.id == id).getOrElse(throw ConfigurationException(s"($actionId) main${inputOutput}Id $id not found in ${inputOutput}s"))
     }.orElse {
-      val paritionedDataObjects = dataObjects.collect{ case x: T with CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
-      if (paritionedDataObjects.size==1) paritionedDataObjects.headOption
+      val partitionedDataObjects = dataObjects.collect{ case x: T @unchecked with CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
+      if (partitionedDataObjects.size==1) partitionedDataObjects.headOption
       else None
     }.orElse {
       if (dataObjects.size==1) dataObjects.headOption else None

--- a/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -37,7 +37,6 @@ import scala.util.{Failure, Success, Try}
  * @param outputId output DataObject
  * @param deleteDataAfterRead a flag to enable deletion of input partitions after copying.
  * @param transformer a custom transformation that is applied to each SubFeed separately
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -53,7 +52,6 @@ case class CopyAction(override val id: ActionObjectId,
                       standardizeDatatypes: Boolean = false,
                       override val breakDataFrameLineage: Boolean = false,
                       override val persist: Boolean = false,
-                      override val initExecutionMode: Option[ExecutionMode] = None,
                       override val executionMode: Option[ExecutionMode] = None,
                       override val metricsFailCondition: Option[String] = None,
                       override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -49,7 +49,7 @@ case class CustomFileAction(override val id: ActionObjectId,
                             override val deleteDataAfterRead: Boolean = false,
                             filesPerPartition: Int = 10,
                             override val breakFileRefLineage: Boolean = false,
-                            override val initExecutionMode: Option[ExecutionMode] = None,
+                            override val executionMode: Option[ExecutionMode] = None,
                             override val metricsFailCondition: Option[String] = None,
                             override val metadata: Option[ActionMetadata] = None
                            )(implicit instanceRegistry: InstanceRegistry)

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -44,6 +44,8 @@ case class CustomSparkAction ( override val id: ActionObjectId,
                                transformer: CustomDfsTransformerConfig,
                                override val breakDataFrameLineage: Boolean = false,
                                override val persist: Boolean = false,
+                               override val mainInputId: Option[DataObjectId] = None,
+                               override val mainOutputId: Option[DataObjectId] = None,
                                override val initExecutionMode: Option[ExecutionMode] = None,
                                override val executionMode: Option[ExecutionMode] = None,
                                override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -35,6 +35,8 @@ import org.apache.spark.sql.SparkSession
  * @param inputIds input DataObject's
  * @param outputIds output DataObject's
  * @param transformer Custom Transformer to transform Seq[DataFrames]
+ * @param mainInputId optional selection of main inputId used for execution mode and partition values propagation. Only needed if there are multiple input DataObject's.
+ * @param mainOutputId optional selection of main outputId used for execution mode and partition values propagation. Only needed if there are multiple output DataObject's.
  * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -37,7 +37,6 @@ import org.apache.spark.sql.SparkSession
  * @param transformer Custom Transformer to transform Seq[DataFrames]
  * @param mainInputId optional selection of main inputId used for execution mode and partition values propagation. Only needed if there are multiple input DataObject's.
  * @param mainOutputId optional selection of main outputId used for execution mode and partition values propagation. Only needed if there are multiple output DataObject's.
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -50,7 +49,6 @@ case class CustomSparkAction ( override val id: ActionObjectId,
                                override val persist: Boolean = false,
                                override val mainInputId: Option[DataObjectId] = None,
                                override val mainOutputId: Option[DataObjectId] = None,
-                               override val initExecutionMode: Option[ExecutionMode] = None,
                                override val executionMode: Option[ExecutionMode] = None,
                                override val metricsFailCondition: Option[String] = None,
                                override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
@@ -46,7 +46,6 @@ import scala.util.{Failure, Success, Try}
  * @param ignoreOldDeletedNestedColumns if true, remove no longer existing columns from nested data types in Schema Evolution.
  *                                      Keeping deleted columns in complex data types has performance impact as all new data
  *                                      in the future has to be converted by a complex function.
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -63,7 +62,6 @@ case class DeduplicateAction(override val id: ActionObjectId,
                              ignoreOldDeletedNestedColumns: Boolean = true,
                              override val breakDataFrameLineage: Boolean = false,
                              override val persist: Boolean = false,
-                             override val initExecutionMode: Option[ExecutionMode] = None,
                              override val executionMode: Option[ExecutionMode] = None,
                              override val metricsFailCondition: Option[String] = None,
                              override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -42,7 +42,7 @@ case class FileTransferAction(override val id: ActionObjectId,
                               override val deleteDataAfterRead: Boolean = false,
                               overwrite: Boolean = true,
                               override val breakFileRefLineage: Boolean = false,
-                              override val initExecutionMode: Option[ExecutionMode] = None,
+                              override val executionMode: Option[ExecutionMode] = None,
                               override val metricsFailCondition: Option[String] = None,
                               override val metadata: Option[ActionMetadata] = None)
                              ( implicit instanceRegistry: InstanceRegistry)

--- a/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
@@ -48,7 +48,6 @@ import scala.util.{Failure, Success, Try}
  * @param ignoreOldDeletedNestedColumns if true, remove no longer existing columns from nested data types in Schema Evolution.
  *                                      Keeping deleted columns in complex data types has performance impact as all new data
  *                                      in the future has to be converted by a complex function.
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -68,7 +67,6 @@ case class HistorizeAction(
                             ignoreOldDeletedNestedColumns: Boolean = true,
                             override val breakDataFrameLineage: Boolean = false,
                             override val persist: Boolean = false,
-                            override val initExecutionMode: Option[ExecutionMode] = None,
                             override val executionMode: Option[ExecutionMode] = None,
                             override val metricsFailCondition: Option[String] = None,
                             override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -30,12 +30,11 @@ import io.smartdatalake.util.streaming.DummyStreamProvider
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.action.ActionHelper.{filterBlacklist, filterWhitelist}
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
-import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanCreateStreamingDataFrame, CanHandlePartitions, CanWriteDataFrame, DataObject, SparkFileDataObject, TableDataObject, UserDefinedSchema}
+import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.apache.spark.sql.streaming.Trigger
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
 private[smartdatalake] abstract class SparkAction extends Action {
 
@@ -70,6 +69,12 @@ private[smartdatalake] abstract class SparkAction extends Action {
   def runtimeExecutionMode(subFeed: SubFeed): Option[ExecutionMode] = {
     // override executionMode with initExecutionMode if is start node of a DAG run
     if (subFeed.isDAGStart) initExecutionMode.orElse(executionMode) else executionMode
+  }
+
+  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.prepare
+    initExecutionMode.foreach(_.prepare)
+    executionMode.foreach(_.prepare)
   }
 
   /**

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -82,7 +82,7 @@ abstract class SparkSubFeedAction extends SparkAction {
     // transform
     val transformedSubFeed = doTransform(subFeed)
     // check output
-    output.init(transformedSubFeed.partitionValues)
+    output.init(transformedSubFeed.dataFrame.get, transformedSubFeed.partitionValues)
     // return
     Seq(updateSubFeedAfterWrite(transformedSubFeed))
   }

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -45,13 +45,13 @@ abstract class SparkSubFeedAction extends SparkAction {
    */
   def transform(subFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed
 
-  private def doTransform(subFeed: SubFeed, thisExecutionMode: Option[ExecutionMode])(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  private def doTransform(subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     // convert subfeed to SparkSubFeed type or initialize if not yet existing
     var preparedSubFeed = SparkSubFeed.fromSubFeed(subFeed)
     // apply execution mode
-    preparedSubFeed = thisExecutionMode match {
+    preparedSubFeed = executionMode match {
       case Some(mode) =>
-        mode.apply(id, input, output) match {
+        mode.apply(id, input, output, preparedSubFeed) match {
           case Some((newPartitionValues, newFilter)) => preparedSubFeed.copy(partitionValues = newPartitionValues, filter = newFilter)
           case None => preparedSubFeed
         }
@@ -60,7 +60,7 @@ abstract class SparkSubFeedAction extends SparkAction {
     // prepare as input SubFeed
     preparedSubFeed = prepareInputSubFeed(preparedSubFeed, input)
     // enrich with fresh DataFrame if needed
-    preparedSubFeed = enrichSubFeedDataFrame(input, preparedSubFeed, thisExecutionMode, context.phase)
+    preparedSubFeed = enrichSubFeedDataFrame(input, preparedSubFeed, context.phase)
     // transform
     val transformedSubFeed = transform(preparedSubFeed)
     // update partition values to output's partition columns and update dataObjectId
@@ -72,10 +72,13 @@ abstract class SparkSubFeedAction extends SparkAction {
    */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for SparkSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
-    outputs.collect{ case x: CanWriteDataFrame => x }.foreach(_.init())
     val subFeed = subFeeds.head
-    val thisExecutionMode = runtimeExecutionMode(subFeed)
-    Seq(doTransform(subFeed, thisExecutionMode))
+    // transform
+    val transformedSubFeed = doTransform(subFeed)
+    // check output
+    output.init(transformedSubFeed.partitionValues)
+    // return
+    Seq(updateSubFeedAfterWrite(transformedSubFeed))
   }
 
   /**
@@ -84,22 +87,21 @@ abstract class SparkSubFeedAction extends SparkAction {
   override final def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for SparkSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
     val subFeed = subFeeds.head
-    val thisExecutionMode = runtimeExecutionMode(subFeed)
     // transform
-    val transformedSubFeed = doTransform(subFeed, thisExecutionMode)
+    val transformedSubFeed = doTransform(subFeed)
     // write output
     val msg = s"writing to ${output.id}" + (if (transformedSubFeed.partitionValues.nonEmpty) s", partitionValues ${transformedSubFeed.partitionValues.mkString(" ")}" else "")
     logger.info(s"($id) start " + msg)
     setSparkJobMetadata(Some(msg))
     val (noData,d) = PerformanceUtils.measureDuration {
-      writeSubFeed(thisExecutionMode, transformedSubFeed, output)
+      writeSubFeed(transformedSubFeed, output)
     }
     setSparkJobMetadata()
     val metricsLog = if (noData) ", no data found"
     else getFinalMetrics(output.id).map(_.getMainInfos).map(" "+_.map( x => x._1+"="+x._2).mkString(" ")).getOrElse("")
     logger.info(s"($id) finished writing DataFrame to ${output.id}: duration=$d" + metricsLog)
     // return
-    Seq(updateSubFeedAfterWrite(transformedSubFeed, thisExecutionMode))
+    Seq(updateSubFeedAfterWrite(transformedSubFeed))
   }
 
   override final def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -18,12 +18,11 @@
  */
 package io.smartdatalake.workflow.action
 
-import io.smartdatalake.definitions.{ExecutionMode, PartitionDiffMode}
+import io.smartdatalake.definitions.ExecutionMode
 import io.smartdatalake.util.misc.PerformanceUtils
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed, SubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.col
 
 abstract class SparkSubFeedAction extends SparkAction {
 
@@ -52,7 +51,7 @@ abstract class SparkSubFeedAction extends SparkAction {
     // apply execution mode
     preparedSubFeed = thisExecutionMode match {
       case Some(mode) =>
-        ActionHelper.applyExecutionMode(mode, id, input, output, context.phase) match {
+        mode.apply(id, input, output) match {
           case Some((newPartitionValues, newFilter)) => preparedSubFeed.copy(partitionValues = newPartitionValues, filter = newFilter)
           case None => preparedSubFeed
         }
@@ -66,10 +65,6 @@ abstract class SparkSubFeedAction extends SparkAction {
     val transformedSubFeed = transform(preparedSubFeed)
     // update partition values to output's partition columns and update dataObjectId
     validateAndUpdateSubFeedPartitionValues(output, transformedSubFeed).copy(dataObjectId = output.id)
-  }
-
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    super.prepare
   }
 
   /**

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
@@ -92,7 +92,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
     outputs.foreach{
       output =>
         val subFeed = transformedSubFeeds.find(_.dataObjectId == output.id).getOrElse(throw new IllegalStateException(s"subFeed for output ${output.id} not found"))
-        output.init(subFeed.partitionValues)
+        output.init(subFeed.dataFrame.get, subFeed.partitionValues)
     }
     // return
     transformedSubFeeds.map( transformedSubFeed => updateSubFeedAfterWrite(transformedSubFeed))

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -143,7 +143,8 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   }
   private def preparedAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext) = {
     sqlOpt.foreach { sql =>
-      val params = DefaultExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf), partitionValues.map(_.elements.mapValues(_.toString)) )
+      val params = DefaultExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
+        , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), partitionValues.map(_.elements.mapValues(_.toString)))
       val preparedSql = SparkExpressionUtil.substitute(id, configName, sql, params)
       logger.info(s"($id) ${configName.getOrElse("SQL")} is being executed: $preparedSql")
       connection.execJdbcStatement(preparedSql, logging = false)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
@@ -27,10 +27,13 @@ import org.apache.spark.sql.SaveMode
 /**
  * DataObject of type raw for files with unknown content.
  * Provides details to an Action to access raw files.
+ * @param fileName Definition of fileName. This is concatenated with path and partition layout to search for files. Default is an asterix to match everything.
  * @param saveMode Overwrite or Append new data.
+ *
  */
 case class RawFileDataObject( override val id: DataObjectId,
                               override val path: String,
+                              override val fileName: String = "*",
                               override val partitions: Seq[String] = Seq(),
                               override val saveMode: SaveMode = SaveMode.Overwrite,
                               override val acl: Option[AclDef] = None,

--- a/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -176,7 +176,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // start first dag run
     // use only first partition col (dt) for partition diff mode
-    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, initExecutionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName))))
+    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action1.copy())
     val configStart = SmartDataLakeBuilderConfig(feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
     sdlb.run(configStart)

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
@@ -37,7 +37,7 @@ class ActionDAGRunTest extends FunSuite {
   test("convert ActionDAGRunState to json and back") {
     val df = Seq(("a",1)).toDF("txt", "value")
     val infoA = RuntimeInfo(RuntimeEventState.SUCCEEDED, startTstmp = Some(LocalDateTime.now()), duration = Some(Duration.ofMinutes(5)), msg = Some("test"), results = Seq(ResultRuntimeInfo(SparkSubFeed(Some(df), "do1", partitionValues = Seq(PartitionValues(Map("test"->1)))),Map("test"->1, "test2"->"abc"))))
-    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, LocalDateTime.now, LocalDateTime.now, Map("a" -> infoA), isFinal = false)
+    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, LocalDateTime.now, LocalDateTime.now, Map(ActionObjectId("a") -> infoA), isFinal = false)
     val json = state.toJson
     // remove DataFrame from SparkSubFeed, it should not be serialized
     val expectedState = state.copy(actionsState = state.actionsState

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
@@ -37,7 +37,7 @@ class ActionDAGRunTest extends FunSuite {
   test("convert ActionDAGRunState to json and back") {
     val df = Seq(("a",1)).toDF("txt", "value")
     val infoA = RuntimeInfo(RuntimeEventState.SUCCEEDED, startTstmp = Some(LocalDateTime.now()), duration = Some(Duration.ofMinutes(5)), msg = Some("test"), results = Seq(ResultRuntimeInfo(SparkSubFeed(Some(df), "do1", partitionValues = Seq(PartitionValues(Map("test"->1)))),Map("test"->1, "test2"->"abc"))))
-    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, Map(ActionObjectId("a") -> infoA), isFinal = false)
+    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, LocalDateTime.now, LocalDateTime.now, Map(ActionObjectId("a") -> infoA), isFinal = false)
     val json = state.toJson
     //println(json)
     // remove DataFrame from SparkSubFeed, it should not be serialized

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -417,7 +417,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     val dfSrc = Seq(("20180101", "person", "doe","john",5) // partition 20180101 is included in partition values filter
       ,("20190101", "company", "olmo","-",10)) // partition 20190101 is not included
       .toDF("dt", "type", "lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, dfSrc, Seq("dt","type"))
+    srcDO.writeDataFrame(dfSrc, Seq())
 
     // prepare DAG
     val refTimestamp1 = LocalDateTime.now()

--- a/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -210,8 +210,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // prepare action
     val refTimestamp = LocalDateTime.now()
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
-    val action = CopyAction("a1", srcDO.id, tgtDO.id, initExecutionMode = Some(PartitionDiffMode()))
-    val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
+    val action = CopyAction("a1", srcDO.id, tgtDO.id, executionMode = Some(PartitionDiffMode()))
+    val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test executionMode!
 
     // prepare & start first load
     val l1 = Seq(("A","doe","john",5)).toDF("type", "lastname", "firstname", "rating")

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
@@ -111,7 +111,7 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
     // prepare & start load
     implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
     val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Map("test"->"true"))
-    val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, false, 1, initExecutionMode = Some(PartitionDiffMode()))
+    val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, false, 1, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", srcPartitionValues) // InitSubFeed needed to test initExecutionMode!
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -124,7 +124,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     val refTimestamp = LocalDateTime.now()
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
-    val action = CustomSparkAction("a1", Seq(srcDO.id), Seq(tgtDO.id), transformer = customTransformerConfig, initExecutionMode = Some(PartitionDiffMode()))
+    val action = CustomSparkAction("a1", Seq(srcDO.id), Seq(tgtDO.id), transformer = customTransformerConfig, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
 
     // prepare & start first load
@@ -183,7 +183,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
     val action = CustomSparkAction("a1", Seq(srcDO.id, srcDO2.id), Seq(tgtDO.id, tgtDO2.id), transformer = customTransformerConfig
-      , mainInputId = Some("src1"), mainOutputId = Some("tgt1"), initExecutionMode = Some(PartitionDiffMode()))
+      , mainInputId = Some("src1"), mainOutputId = Some("tgt1"), executionMode = Some(PartitionDiffMode()))
     val srcSubFeed1 = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
     val srcSubFeed2 = InitSubFeed("src2", Seq())
 

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -183,7 +183,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
     val action = CustomSparkAction("a1", Seq(srcDO.id, srcDO2.id), Seq(tgtDO.id, tgtDO2.id), transformer = customTransformerConfig
-      , initExecutionMode = Some(PartitionDiffMode(mainInputId = Some("src1"), mainOutputId = Some("tgt1"))))
+      , mainInputId = Some("src1"), mainOutputId = Some("tgt1"), initExecutionMode = Some(PartitionDiffMode()))
     val srcSubFeed1 = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
     val srcSubFeed2 = InitSubFeed("src2", Seq())
 

--- a/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
@@ -22,15 +22,11 @@ import java.time.LocalDateTime
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.config.SdlConfigObject.DataObjectId
-import io.smartdatalake.definitions.PartitionDiffMode
 import io.smartdatalake.testutils.TestUtil
-import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.action.CustomSparkAction
 import io.smartdatalake.workflow.action.customlogic.{CustomDfsTransformer, CustomDfsTransformerConfig}
-import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}


### PR DESCRIPTION
### What changes are included in the pull request?
- configuration of mainInput/Output of CustomSparkAction is moved from execution modes to CustomSparkAction/SparkSubFeedsAction.
- refactoring of ExecutionMode code - it get's much simpler if it's implemented in methods of the corresponding ExecutionMode instead of method in ActionHelper.
- extension of PartitionDiffMode with an alternativeOutputId. It allows to build a partition diff with an arbitrary DataObject later in the DAG.

### Why are the changes needed?
- Simpler, cleaner implementation.
- Selection of mainInput/Output is only needed in CustomSparkAction/SparkSubFeedsAction.
- alternativeOutputId can be used to ensure processing all partitions over multiple actions in case of errors.