### PR TITLE
Feature/150 recursive inputs

### DIFF
--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.workflow.DAGHelper._
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.action.{Action, RuntimeEventState, RuntimeInfo}
+import io.smartdatalake.workflow.dataobject.TransactionalSparkTableDataObject
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 import org.apache.spark.sql.SparkSession
@@ -120,6 +121,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
       case (node: Action, subFeeds) =>
+        assert(node.recursiveInputs.map(_.isInstanceOf[TransactionalSparkTableDataObject]).forall(_==true),"Recursive inputs only work for TransactionalSparkTableDataObjects.")
         val recursiveSubFeeds = node.recursiveInputs.map(dataObject => getInitialSubFeed(dataObject.id))
         node.init(subFeeds ++ recursiveSubFeeds)
       case x => throw new IllegalStateException(s"Unmatched case $x")

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -120,7 +120,8 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
       case (node: Action, subFeeds) =>
-        node.init(subFeeds)
+        val recursiveSubFeeds = node.recursiveInputs.map(dataObject => getInitialSubFeed(dataObject.id))
+        node.init(subFeeds ++ recursiveSubFeeds)
       case x => throw new IllegalStateException(s"Unmatched case $x")
     }
   }
@@ -136,7 +137,8 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
           node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
         case (node: Action, subFeeds) =>
           node.preExec(subFeeds)
-          val resultSubFeeds = node.exec(subFeeds)
+          val recursiveSubFeeds = node.recursiveInputs.map(dataObject => getInitialSubFeed(dataObject.id))
+          val resultSubFeeds = node.exec(subFeeds ++ recursiveSubFeeds)
           node.postExec(subFeeds, resultSubFeeds)
           //return
           resultSubFeeds

--- a/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -28,7 +28,6 @@ import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow._
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.dataobject.DataObject
-import io.smartdatalake.workflow._
 import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable
@@ -57,6 +56,15 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * To be implemented by subclasses
    */
   def inputs: Seq[DataObject]
+
+  /**
+   * Recursive Inputs are DataObjects that are used as Output and Input in the same action
+   * This is usually prohibited as it creates loops in the DAG.
+   * In special cases this makes sense, i.e. when building a complex delta logic
+   *
+   * @return
+   */
+  def recursiveInputs: Seq[DataObject]
 
   /**
    * Output [[DataObject]]s

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -39,6 +39,8 @@ import org.apache.spark.sql.SparkSession
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
+ * @param metadata
+ * @param recursiveInputIds output of action that are used as input in the same action
  */
 case class CustomSparkAction ( override val id: ActionObjectId,
                                inputIds: Seq[DataObjectId],
@@ -49,9 +51,12 @@ case class CustomSparkAction ( override val id: ActionObjectId,
                                override val initExecutionMode: Option[ExecutionMode] = None,
                                override val executionMode: Option[ExecutionMode] = None,
                                override val metricsFailCondition: Option[String] = None,
-                               override val metadata: Option[ActionMetadata] = None
+                               override val metadata: Option[ActionMetadata] = None,
+                               recursiveInputIds: Seq[DataObjectId] = Seq()
 )(implicit instanceRegistry: InstanceRegistry) extends SparkSubFeedsAction {
 
+  assert(recursiveInputIds.forall(outputIds.contains(_)), "All recursive inputs must be in output of the same action.")
+  override val recursiveInputs: Seq[DataObject with CanCreateDataFrame] = recursiveInputIds.map(getInputDataObject[DataObject with CanCreateDataFrame])
   override val inputs: Seq[DataObject with CanCreateDataFrame] = inputIds.map(getInputDataObject[DataObject with CanCreateDataFrame])
   override val outputs: Seq[DataObject with CanWriteDataFrame] = outputIds.map(getOutputDataObject[DataObject with CanWriteDataFrame])
 

--- a/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.definitions.ExecutionMode
 import io.smartdatalake.util.misc.PerformanceUtils
-import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, CanHandlePartitions, FileRefDataObject}
+import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, CanHandlePartitions, DataObject, FileRefDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed, InitSubFeed, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
@@ -35,6 +35,12 @@ abstract class FileSubFeedAction extends Action {
    * Output [[FileRefDataObject]] which can CanCreateOutputStream
    */
   def output:  FileRefDataObject with CanCreateOutputStream
+
+  /**
+   * Recursive Inputs on FileSubFeeds are not supported so empty Seq is set.
+   *  @return
+   */
+  override def recursiveInputs: Seq[FileRefDataObject with CanCreateInputStream] = Seq()
 
   /**
    * Initialize Action with a given [[FileSubFeed]]

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -38,6 +38,12 @@ abstract class SparkSubFeedAction extends SparkAction {
   def output:  DataObject with CanWriteDataFrame
 
   /**
+   * Recursive Inputs are not supported on SparkSubFeedAction (only on SparkSubFeedsAction) so set to empty Seq
+   *  @return
+   */
+  override def recursiveInputs: Seq[DataObject with CanCreateDataFrame] = Seq()
+
+  /**
    * Transform a [[SparkSubFeed]].
    * To be implemented by subclasses.
    *

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
@@ -29,6 +29,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
 
   override def inputs: Seq[DataObject with CanCreateDataFrame]
   override def outputs: Seq[DataObject with CanWriteDataFrame]
+  override def recursiveInputs: Seq[DataObject with CanCreateDataFrame] = Seq()
 
   // prepare main input / output
   // this must be lazy because inputs / outputs is evaluated later in subclasses
@@ -96,7 +97,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
       case _ => preparedSubFeeds
     }
     preparedSubFeeds = preparedSubFeeds.map{ subFeed =>
-      val input = inputs.find(_.id == subFeed.dataObjectId).get
+      val input = (inputs ++ recursiveInputs).find(_.id == subFeed.dataObjectId).get
       // prepare as input SubFeed
       val preparedSubFeed = prepareInputSubFeed(subFeed, input)
       // enrich with fresh DataFrame if needed
@@ -117,7 +118,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
    * Generic init implementation for Action.init
    * */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
-    assert(subFeeds.size == inputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
+    assert(subFeeds.size == inputs.size + recursiveInputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
     outputs.collect{ case x: CanWriteDataFrame => x }.foreach(_.init())
     val mainInputSubFeed = subFeeds.find(_.dataObjectId == mainInput.id).getOrElse(throw new IllegalStateException(s"subFeed for main input ${mainInput.id} not found"))
     val thisExecutionMode = runtimeExecutionMode(mainInputSubFeed)
@@ -128,7 +129,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
    * Action.exec implementation
    */
   override final def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
-    assert(subFeeds.size == inputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
+    assert(subFeeds.size == inputs.size + recursiveInputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
     val mainInputSubFeed = subFeeds.find(_.dataObjectId == mainInput.id).getOrElse(throw new IllegalStateException(s"subFeed for main input ${mainInput.id} not found"))
     val thisExecutionMode = runtimeExecutionMode(mainInputSubFeed)
     //transform
@@ -158,8 +159,8 @@ abstract class SparkSubFeedsAction extends SparkAction {
    * @param subFeeds input SubFeeds.
    */
   protected def enrichSubFeedsDataFrame(inputs: Seq[DataObject with CanCreateDataFrame], subFeeds: Seq[SparkSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
-    assert(inputs.size==subFeeds.size, s"Number of inputs must match number of subFeeds given for $id")
-    inputs.map { input =>
+    assert(inputs.size+recursiveInputs.size == subFeeds.size, s"Number of inputs must match number of subFeeds given for $id")
+    (inputs ++ recursiveInputs).map { input =>
       val subFeed = subFeeds.find(_.dataObjectId == input.id).getOrElse(throw new IllegalStateException(s"subFeed for input ${input.id} not found"))
       enrichSubFeedDataFrame(input, subFeed, runtimeExecutionMode(subFeed), context.phase)
     }

--- a/src/test/scala/io/smartdatalake/config/TestAction.scala
+++ b/src/test/scala/io/smartdatalake/config/TestAction.scala
@@ -51,6 +51,7 @@ case class TestAction(override val id: ActionObjectId,
   private[config] val output = instanceRegistry.get[TransactionalSparkTableDataObject](outputId)
   override val inputs: Seq[DataObject with CanCreateDataFrame] = Seq(input)
   override val outputs: Seq[TransactionalSparkTableDataObject] = Seq(output)
+  override val recursiveInputs:Seq[DataObject with CanCreateDataFrame] = Seq()
 
   /**
    * @inheritdoc

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -29,7 +29,7 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.action.customlogic.{CustomDfsTransformer, CustomDfsTransformerConfig}
-import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
+import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
@@ -103,6 +103,57 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
       .as[Int].collect().toSeq
     assert(r2.size == 1)
     assert(r2.head == 6)
+  }
+
+  test("spark action with recursive input") {
+    // setup DataObjects
+    val feed = "recursive_inputs"
+
+    val srcTable1 = Table(Some("default"), "copy_input1")
+    HiveUtil.dropTable(session, srcTable1.db.get, srcTable1.name)
+    val srcPath1 = tempPath + s"/${srcTable1.fullName}"
+    val srcDO1 = TickTockHiveTableDataObject("src1", Some(srcPath1), table = srcTable1, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO1)
+
+    val tgtTable1 = Table(Some("default"), "copy_output1", None, Some(Seq("lastname", "firstname")))
+    HiveUtil.dropTable(session, tgtTable1.db.get, tgtTable1.name)
+    val tgtPath1 = tempPath + s"/${tgtTable1.fullName}"
+    val tgtDO1 = TickTockHiveTableDataObject("tgt1", Some(tgtPath1), table = tgtTable1, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(tgtDO1)
+
+    // prepare & start load
+    val refTimestamp1 = LocalDateTime.now()
+    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerRecursive"))
+
+    // first action to create output table as it does not exist yet
+    val action1 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig)(context1.instanceRegistry)
+
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    TestUtil.prepareHiveTable(srcTable1, srcPath1, l1)
+
+    val tgtSubFeedsNonRecursive = action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))
+    assert(tgtSubFeedsNonRecursive.size == 1)
+    assert(tgtSubFeedsNonRecursive.map(_.dataObjectId) == Seq(tgtDO1.id))
+
+    val r1 = session.table(s"${tgtTable1.fullName}")
+      .select($"rating")
+      .as[Int].collect().toSeq
+    assert(r1.size == 1)
+    assert(r1.head == 6) // should be increased by 1 through TestDfTransformer
+
+    // second action to test recursive inputs
+    val action2 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig, recursiveInputIds = List(tgtDO1.id))(context1.instanceRegistry)
+
+    val tgtSubFeedsRecursive = action2.exec(Seq(SparkSubFeed(None, "src1", Seq()), SparkSubFeed(None, "tgt1", Seq())))
+    assert(tgtSubFeedsRecursive.size == 1) // still 1 as recursive inputs are handled separately
+
+    val r2 = session.table(s"${tgtTable1.fullName}")
+      .select($"rating")
+      .as[Int].collect().toSeq
+    assert(r2.size == 1)
+    assert(r2.head == 11) // Record should be updated a second time with data from tgt1
+
   }
 
   test("copy with partition diff execution mode 2 iterations") {
@@ -259,6 +310,25 @@ class TestDfsTransformerIncrement extends CustomDfsTransformer {
       "tgt1" -> dfs("src1").withColumn("rating", $"rating"+1)
     , "tgt2" -> dfs("src2").withColumn("rating", $"rating"+1)
     )
+  }
+}
+
+class TestDfsTransformerRecursive extends CustomDfsTransformer {
+  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String,DataFrame]): Map[String,DataFrame] = {
+    import session.implicits._
+    if(!dfs.contains("tgt1")) {
+      // first run without recursive inputs
+      Map(
+        "tgt1" -> dfs("src1").withColumn("rating", $"rating"+1)
+      )
+    }
+    else {
+      // second run with recursive inputs
+      Map(
+        "tgt1" -> dfs("tgt1").withColumn("rating", $"rating"+5)
+      )
+    }
+
   }
 }
 


### PR DESCRIPTION
### What changes are included in the pull request?
Implements #150 

### Why are the changes needed?
See #150 
For transactional tables, it should be possible to read the action output as recursive input in the same action. This allows to implement custom delta logic where the output is dependent on the existing data in the output dataObject.