### PR TITLE
Version 1.1.0

### DIFF
--- a/.idea/scala_settings.xml
+++ b/.idea/scala_settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ScalaProjectSettings">
+    <option name="ignorePerformance" value="true" />
     <option name="intInjectionMapping">
       <map>
         <entry key="xml" value="XML" />

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To see how all this works in action, head over to the [Getting Started](docs/Get
 [Getting Started](docs/GettingStarted.md)  
 [Reference](docs/Reference.md)  
 [Architecture](docs/Architecture.md)  
+[Testing](docs/Testing.md)  
 [Glossary](docs/Glossary.md)  
 [Troubleshooting](docs/Troubleshooting.md)    
 [FAQ](docs/FAQ.md)  

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -81,6 +81,7 @@ Usage: DefaultSmartDataLakeBuilder [options]
   --parallelism <value>    Parallelism for DAG run.
   --state-path <value>     Path to save run state files. Must be set to enable recovery in case of failures.
   --override-jars <value>  Comma separated list of jars for child-first class loader. The jars must be present in classpath.
+  --test <value>           Run in test mode: config -> validate configuration, dry-run -> execute prepare- and init-phase only to check environment and spark lineage
   --help                   Display the help text.
   --version                Display version information.
 ```

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -56,11 +56,11 @@ Data objects are structured in a hierarchy as many attributes are shared between
 Here is an overview of all data objects:
 ![data object hierarchy](images/dataobject_hierarchy.png)
 
-
 ## Actions
 For a list of all available actions, please consult the [API docs](site/scaladocs/io/smartdatalake/workflow/action/package.html) directly.
 
 In the package overview, you can also see the parameters available to each type of action and which parameters are optional.
+
 
 # Command Line
 SmartDataLakeBuilder is a java application. To run on a cluster with spark-submit use **DefaultSmartDataLakeBuilder** application.
@@ -89,6 +89,7 @@ There exists the following adapted applications versions:
 - **LocalSmartDataLakeBuilder**:<br>default for Spark master is `local[*]` and it has additional properties to configure Kerberos authentication. Use this application to run in a local environment (e.g. IntelliJ) without cluster deployment.  
 - **DatabricksSmartDataLakeBuilder**:<br>see [MicrosoftAzure](MicrosoftAzure.md)
 
+
 # Concepts
 
 ## DAG
@@ -102,44 +103,59 @@ Execution therefore involves the following phases.
 4. DAG exec: Execution of Actions, data is effectively (and only) transferred during this phase.
 
 ## Execution modes
-Execution modes select the data to be processed. By default, if you start SmartDataLakeBuilder, there is no filter applied. This means every Action reads all data from its input DataObjects. 
+Execution modes select the data to be processed. By default, if you start SmartDataLakeBuilder, there is no filter applied. This means every Action reads all data from its input DataObjects.
+
+You can set an execution mode by defining attribute "executionMode" of an Action. Define the chosen ExecutionMode by setting type as follows:
+```
+executionMode {
+  type = PartitionDiffMode
+  attribute1 = ...
+}
+```
 
 ### Fixed partition values filter
 You can apply a filter manually by specifying parameter --partition-values or --multi-partition-values on the command line. The partition values specified are passed to all start-Actions of a DAG and filtered for every input DataObject by its defined partition columns.
 On execution every Action takes the partition values of the input and filters them again for every output DataObject by its defined partition columns, which serve again as partition values for the input of the next Action. 
-Note that during execution of the dag, no new partition values are added, they are only filtered.
+Note that during execution of the dag, no new partition values are added, they are only filtered. An exception is if you place a PartitionDiffMode in the middle of your pipeline, see next section.
 
-### Dynamic partition values filter - PartitionDiffMode
+### PartitionDiffMode: Dynamic partition values filter 
 Alternatively you can let SmartDataLakeBuilder find missing partitions and set partition values automatically by specifying execution mode PartitionDiffMode.
 
-Often this should only happen on the start-Actions of a DAG, so it's clear what partitions are processed through a specific DAG run.
-But its also possible to let every Action in the DAG decide again dynamically, what partitions are missing and should be processed.
-You can configure this by the following attributes of an Action:
-- initExecutionMode: define the execution mode if this Action is a start-Actions of the DAG
-- executionMode: define the execution mode independently of its position is the DAG.
-If both attributes are set, initExecutionMode overrides executionMode if the Action is a a start-Action of the DAG.
+By defining the applyCondition attribute you can give a condition to decide at runtime if the PartitionDiffMode should be applied or not.
+Default is to apply the PartitionDiffMode if the given partition values are empty (partition values from command line or passed from previous action). 
+Define an applyCondition by a spark sql expression working with attributes of DefaultExecutionModeExpressionData returning a boolean.
 
-### Dynamic partition values filter - PartitionDiffMode
-Alternatively you can let SmartDataLakeBuilder find missing partitions and set partition values automatically by specifying execution mode PartitionDiffMode.
+By defining the failCondition attribute you can give a condition to fail application of execution mode if true.
+It can be used fail a run based on expected partitions, time and so on.
+Default is that the application of the PartitionDiffMode does not fail the action. If there is no data to process, the following actions are skipped.
+Define a failCondition by a spark sql expression working with attributes of PartitionDiffModeExpressionData returning a boolean.
+Example - fail if partitions are not processed in strictly increasing order of partition column "dt":
+```
+  failCondition = "(size(selectedPartitionValues) > 0 and array_min(transform(selectedPartitionValues, x -> x.dt)) < array_max(transform(outputPartitionValues, x -> x.dt)))"
+```
 
-Often this should only happen on the start-Actions of a DAG, so it's clear what partitions are processed through a specific DAG run.
-But its also possible to let every Action in the DAG decide again dynamically, what partitions are missing and should be processed.
-You can configure this by the following attributes of an Action:
-- initExecutionMode: define the execution mode if this Action is a start-Actions of the DAG
-- executionMode: define the execution mode independently of its position in the DAG.
-If both attributes are set, initExecutionMode overrides executionMode if the Action is a a start-Action of the DAG.
-
-### Incremental load - SparkStreamingOnceMode
+### SparkStreamingOnceMode: Incremental load 
 Some DataObjects are not partitioned, but nevertheless you dont want to read all data from the input on every run. You want to load it incrementally.
 This can be accomplished by specifying execution mode SparkStreamingOnceMode. Under the hood it uses "Spark Structured Streaming" and triggers a single microbatch (Trigger.Once).
 "Spark Structured Streaming" helps keeping state information about processed data. It needs a checkpointLocation configured which can be given as parameter to SparkStreamingOnceMode.
 
 Note that "Spark Structured Streaming" needs an input DataObject supporting the creation of streaming DataFrames. 
 For the time being, only the input sources delivered with Spark Streaming are supported. 
-This is KafkaTopicDataObject and all SparkFileDataObjects, see also [Spark StructuredStreaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#creating-streaming-dataframes-and-streaming-datasets).
+This are KafkaTopicDataObject and all SparkFileDataObjects, see also [Spark StructuredStreaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#creating-streaming-dataframes-and-streaming-datasets).
 
-### Incremental Load - DeltaMode
-to be implemented 
+### SparkIncrementalMode: Incremental Load
+As not every input DataObject supports the creation of streaming DataFrames, there is an other execution mode called SparkIncrementalMode.
+You configure it by defining the attribute "compareCol" with a column name present in input and output DataObject. 
+SparkIncrementalMode then compares the maximum values between input and output and creates a filter condition.
+On execution the filter condition is applied to the input DataObject to load the missing increment.
+Note that compareCol needs to have a sortable datatype.
+
+By defining the applyCondition attribute you can give a condition to decide at runtime if the SparkIncrementalMode should be applied or not.
+Default is to apply the SparkIncrementalMode. Define an applyCondition by a spark sql expression working with attributes of DefaultExecutionModeExpressionData returning a boolean.
+
+### FailIfNoPartitionValuesMode
+To simply check if partition values are present and fail otherwise, configure execution mode FailIfNoPartitionValuesMode.
+This is useful to prevent potential reprocessing of whole table through wrong usage.
 
 ## Metrics
 Metrics are gathered per Action and output-DataObject when running a DAG. They can be found in log statements and are written to the state file.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,101 @@
+# Testing
+
+Testing is crucial for software quality and maintenance. This is also true for data pipelines.
+
+SDL provides the following possibilities for Testing:
+
+## Config validation
+
+Parsing of configuration can be validated by specifying command line parameter `--test config` or programmatically:
+```scala
+class ConfigTest extends FunSuite with TestUtil {
+  test("validate configuration") {
+    val (registry, globalConfig) = ConfigToolbox.loadAndParseConfig(Seq("src/main/resources"))
+    assert(registry.getActions.nonEmpty)
+  }
+}
+```
+
+This should be done in continuous integration. 
+
+## Dry run
+
+A dry-run can be started by specifying command line parameter `--test dry-run`.
+The dry-run executes only prepare and init phase. It validates configuration, checks connections and validates Spark lineage.
+It doesn't change anything in the environment.
+
+This is suitable for smoke testing after deployment.
+
+## Custom transformation logic unit tests
+
+Logic of custom transformation can easily be unit tested. Example:
+```scala
+class MyCustomTransformerTest extends FunSuite {
+
+  // init spark session
+  val sparkSession = Map("spark.default.parallelism" -> "1", "spark.sql.shuffle.partitions" -> "1", "spark.task.maxFailures" -> "1")
+  lazy val session: SparkSession = GlobalConfig(enableHive = false, sparkOptions = Some(sparkSession))
+    .createSparkSession("test", Some("local[*]"))
+  import session.implicits._
+
+  test("test my custom transformer") {
+
+    // define input
+    val dfInput = Seq(("joe",1)).toDF("name", "cnt")
+
+    // transform
+    val transformer = new MyCustomTransformer
+    val dfsInput = Map("input" -> dfInput)
+    val dfsTransformed = transformer.transform(session, Map(), dfsInput)
+    val dfOutput = dfsTransformed("output")
+
+    // check
+    assert(dfOutput.count == 1)
+  }
+}
+```
+
+## Simulation of spark data pipeline
+
+Instead of testing single transformation logic, it would be interesting to test whole pipelines of spark actions.
+For this you can start a simulation run programmatically. You have to provide all input data frames and get the output data frames of the end nodes of the DAG.
+The simulation mode only executes the init phase with special modification, so it runs without any environment. Of course there are some exceptions like kafka/confluent schema registry.
+Note that simulation mode only supports spark actions for now, you might need to choose "feedSel" accordingly.
+```scala
+class MyDataPipelineTest extends FunSuite with TestUtil {
+
+  // load config
+  val (registry, globalConfig) = ConfigToolbox.loadAndParseConfig(Seq("src/main/resources"))
+
+  // init spark session
+  val sparkSession = Map("spark.default.parallelism" -> "1", "spark.sql.shuffle.partitions" -> "1", "spark.task.maxFailures" -> "1")
+  lazy val session: SparkSession = GlobalConfig(enableHive = false, sparkOptions = Some(sparkSession))
+    .createSparkSession("test", Some("local[*]"))
+  import session.implicits._
+
+  test("enrich and process: create alarm") {
+  
+    // get input1 from modified data object
+    val input1DO = registry.get[CsvFileDataObject]("input1")
+      .copy(connectionId = None, path = "src/test/resources/sample_input1.csv")
+    val dfInput1 = input1DO.getDataFrame()
+
+    // define input2 manually
+    val dfInput2 = Seq(("joe",1)).toDF("name", "cnt")
+
+    // transform
+    val inputSubFeeds = Seq(
+      SparkSubFeed(Some(dfInput1), DataObjectId("input1"), Seq()),
+      SparkSubFeed(Some(dfInput2), DataObjectId("ipnut2"), Seq())
+    )
+    val config = SmartDataLakeBuilderConfig(feedSel = s"my-feed", applicationName = Some("test"), configuration = Some("test"))
+    val sdlb = new DefaultSmartDataLakeBuilder()
+    val (finalSubFeeds, stats) = sdlb.startSimulation(config, inputSubFeeds)
+    val dfOutput = finalSubFeeds.find(_.dataObjectId.id == s"output").get.dataFrame.get.cache
+
+    // check
+    val output = dfOutput.select($"name", $"test").as[(String,Boolean)].collect.toSeq
+    assert(output == Seq(("joe", true)))
+  }
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>smartdatalake_${scala.minor.version}</artifactId>
-	<version>1.0.8-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>smartdatalake_${scala.minor.version}</artifactId>
-	<version>1.0.7</version>
+	<version>1.0.8-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.smartdatalake</groupId>
+			<artifactId>spark-extensions_${scala.minor.version}</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-sql-kafka-0-10_${scala.minor.version}</artifactId>
 			<version>${spark.version}</version>
@@ -510,7 +516,7 @@
 		<!-- this is for reading from kafka using confluent schema registry with Spark -->
 		<dependency>
 			<groupId>io.confluent</groupId>
-			<artifactId>kafka-avro-serializer</artifactId>
+			<artifactId>kafka-schema-registry-client</artifactId>
 			<version>5.4.1</version>
 			<exclusions>
 				<exclusion>
@@ -531,22 +537,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<!-- this is for converting confluent avro message to spark structtype -->
-		<dependency>
-			<groupId>za.co.absa</groupId>
-			<artifactId>abris_${scala.minor.version}</artifactId>
-			<version>3.1.1</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.spark</groupId>
-					<artifactId>spark-streaming</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.spark</groupId>
-					<artifactId>spark-streaming-kafka-0-10_${scala.compat.version}</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 
 		<dependency>
 			<groupId>com.databricks</groupId>
@@ -559,7 +549,6 @@
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-avro_${scala.minor.version}</artifactId>
 			<version>${spark.version}</version>
-			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/scala/io/smartdatalake/app/AppUtil.scala
+++ b/src/main/scala/io/smartdatalake/app/AppUtil.scala
@@ -48,6 +48,7 @@ private[smartdatalake] object AppUtil extends SmartDataLakeLogger {
                          sparkOptionsOpt: Map[String,String] = Map(),
                          enableHive: Boolean = true
                         ): SparkSession = {
+    logger.info(s"Creating spark session: name=$name master=$masterOpt deployMode=$deployModeOpt enableHive=$enableHive")
 
     // create configObject
     val sessionBuilder = SparkSession.builder()

--- a/src/main/scala/io/smartdatalake/app/AppUtil.scala
+++ b/src/main/scala/io/smartdatalake/app/AppUtil.scala
@@ -45,7 +45,7 @@ private[smartdatalake] object AppUtil extends SmartDataLakeLogger {
   def createSparkSession(name:String, masterOpt: Option[String] = None,
                          deployModeOpt: Option[String] = None,
                          kryoClassNamesOpt: Option[Seq[String]] = None,
-                         sparkOptionsOpt: Option[Map[String,String]] = None,
+                         sparkOptionsOpt: Map[String,String] = Map(),
                          enableHive: Boolean = true
                         ): SparkSession = {
 
@@ -124,10 +124,10 @@ private[smartdatalake] object AppUtil extends SmartDataLakeLogger {
         builder.config(key, value.get)
       } else builder
     }
-    def optionalConfigs( options: Option[Map[String,String]] ): SparkSession.Builder = {
-      if (options.isDefined) {
-        logger.info("Additional sparkOptions: " + options.get.map{ case (k,v) => createMaskedSecretsKVLog(k,v) }.mkString(", "))
-        options.get.foldLeft( builder ){
+    def optionalConfigs( options: Map[String,String] ): SparkSession.Builder = {
+      if (options.nonEmpty) {
+        logger.info("Additional sparkOptions: " + options.map{ case (k,v) => createMaskedSecretsKVLog(k,v) }.mkString(", "))
+        options.foldLeft( builder ){
           case (sb,(key,value)) => sb.config(key,value)
         }
       } else builder

--- a/src/main/scala/io/smartdatalake/app/DefaultSmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/DefaultSmartDataLakeBuilder.scala
@@ -34,6 +34,7 @@ class DefaultSmartDataLakeBuilder extends SmartDataLakeBuilder {
       case Some(config) =>
         assert(config.overrideJars.isEmpty || ignoreOverrideJars, "Option override-jars is not supported by DefaultSmartDataLakeBuilder. Use DatabricksSmartDataLakeBuilder for this option.")
         val stats = run(config)
+          .toSeq.sortBy(_._1).map(x => x._1 + "=" + x._2).mkString(" ") // convert stats to string
         logger.info(s"$appType v$appVersion finished successfully: $stats")
       case None =>
         logAndThrowException(s"Aborting ${appType} after error", new ConfigurationException("Couldn't set command line parameters correctly."))

--- a/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -20,11 +20,11 @@
 package io.smartdatalake.app
 
 import com.typesafe.config.Config
-import io.smartdatalake.util.misc.{MemoryUtils, SmartDataLakeLogger}
-import org.apache.spark.sql.SparkSession
+import configs.Configs
 import configs.syntax._
 import io.smartdatalake.definitions.Environment
-import org.apache.spark.{ExecutorPlugin, SparkConf, SparkEnv}
+import io.smartdatalake.util.misc.{MemoryUtils, SmartDataLakeLogger}
+import org.apache.spark.sql.SparkSession
 
 /**
  * Global configuration options
@@ -35,7 +35,9 @@ import org.apache.spark.{ExecutorPlugin, SparkConf, SparkEnv}
  * @param memoryLogTimer enable periodic memory usage logging, see detailled configuration [[MemoryLogTimerConfig]]
  * @param shutdownHookLogger enable shutdown hook logger to trace shutdown cause
  */
-case class GlobalConfig( kryoClasses: Option[Seq[String]] = None, sparkOptions: Option[Map[String,String]] = None, enableHive: Boolean = true, memoryLogTimer: Option[MemoryLogTimerConfig] = None, shutdownHookLogger: Boolean = false )
+case class GlobalConfig( kryoClasses: Option[Seq[String]] = None, sparkOptions: Option[Map[String,String]] = None, enableHive: Boolean = true
+                       , memoryLogTimer: Option[MemoryLogTimerConfig] = None, shutdownHookLogger: Boolean = false
+                       , stateListeners: Seq[StateListenerConfig] = Seq())
 extends SmartDataLakeLogger {
 
   // start memory logger, else log memory once
@@ -65,52 +67,10 @@ extends SmartDataLakeLogger {
 }
 object GlobalConfig {
   private[smartdatalake] def from(config: Config): GlobalConfig = {
+    implicit val customStateListenerConfig: Configs[StateListenerConfig] = Configs.derive[StateListenerConfig]
     globalConfig = Some(config.get[Option[GlobalConfig]]("global").value.getOrElse(GlobalConfig()))
     globalConfig.get
   }
   // store global config to be used in MemoryLoggerExecutorPlugin
   var globalConfig: Option[GlobalConfig] = None
-}
-
-
-/**
- * Configuration for periodic memory usage logging
- *
- * @param intervalSec interval in seconds between memory usage logs
- * @param logLinuxMem enable logging linux memory
- * @param logLinuxCGroupMem enable logging details about linux cgroup memory
- * @param logBuffers enable logging details about different jvm buffers
- */
-case class MemoryLogTimerConfig(intervalSec: Int, logLinuxMem: Boolean = true, logLinuxCGroupMem: Boolean = false, logBuffers: Boolean = false ) {
-  import MemoryLogTimerConfig._
-  private[smartdatalake] def startTimer(): Unit = MemoryUtils.startMemoryLogger(intervalSec, logLinuxMem, logLinuxCGroupMem, logBuffers)
-  private[smartdatalake] def getAsMap: Map[String, String] = Map(INTERVAL_SEC_OPTION -> intervalSec.toString, LOG_LINUX_MEM_OPTION -> logLinuxMem.toString, LOG_LINUX_CGROUP_MEM_OPTION -> logLinuxCGroupMem.toString, LOG_BUFFERS_OPTION -> logBuffers.toString)
-}
-private[smartdatalake] object MemoryLogTimerConfig{
-  def from(conf: SparkConf): MemoryLogTimerConfig = MemoryLogTimerConfig(conf.get(INTERVAL_SEC_OPTION).toInt, conf.get(LOG_LINUX_MEM_OPTION).toBoolean, conf.get(LOG_LINUX_CGROUP_MEM_OPTION).toBoolean, conf.get(LOG_BUFFERS_OPTION).toBoolean)
-  private val INTERVAL_SEC_OPTION = "spark.smartdatalake.memoryLog.intervalSec"
-  private val LOG_LINUX_MEM_OPTION = "spark.smartdatalake.memoryLog.logLinuxMem"
-  private val LOG_LINUX_CGROUP_MEM_OPTION = "spark.smartdatalake.memoryLog.logLinuxCGroupMem"
-  private val LOG_BUFFERS_OPTION = "spark.smartdatalake.memoryLog.logBuffers"
-}
-
-/**
- * Executor plugin to start memory usage logging on executors
- */
-private[smartdatalake] class MemoryLoggerExecutorPlugin extends ExecutorPlugin with SmartDataLakeLogger {
-  override def init(): Unit = {
-    // config can only be transferred to ExecutorPlugin by spark-options
-    val sparkConf = SparkEnv.get.conf
-    logger.debug("sparkConf: " + sparkConf.getAll.map{ case (k,v) => s"$k=$v"}.mkString(" "))
-    try {
-      val memoryLogConfig = MemoryLogTimerConfig.from(sparkConf)
-      memoryLogConfig.startTimer()
-      logger.info("MemoryLoggerExecutorPlugin successfully initialized")
-    } catch {
-      case e: Exception => logger.error(s"cannot initialize MemoryLoggerExecutorPlugin: ${e.getClass.getSimpleName} - ${e.getMessage}")
-    }
-  }
-  override def shutdown(): Unit = {
-    MemoryUtils.stopMemoryLogger()
-  }
 }

--- a/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -54,11 +54,11 @@ extends SmartDataLakeLogger {
     if (Environment._sparkSession != null) logger.warn("Your SparkSession was already set, that should not happen. We will re-initialize it anyway now.")
     // prepare additional spark options
     // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
-    val executorPlugins = (sparkOptions.flatMap(_.get("spark.executor.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq())).mkString(",")
+    val executorPlugins = (sparkOptions.flatMap(_.get("spark.executor.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq()))
     // config for MemoryLoggerExecutorPlugin can only be transfered to Executor by spark-options
     val memoryLogOptions = memoryLogTimer.map(_.getAsMap).getOrElse(Map())
-    val sparkOptionsExtended = sparkOptions.getOrElse(Map()) ++ memoryLogOptions + ("spark.executor.plugins" -> executorPlugins)
-    Environment._sparkSession = AppUtil.createSparkSession(appName, master, deployMode, kryoClasses, Some(sparkOptionsExtended), enableHive)
+    val sparkOptionsExtended = sparkOptions.getOrElse(Map()) ++ memoryLogOptions ++ (if (executorPlugins.nonEmpty) Map("spark.executor.plugins" -> executorPlugins.mkString(",")) else Map())
+    Environment._sparkSession = AppUtil.createSparkSession(appName, master, deployMode, kryoClasses, sparkOptionsExtended, enableHive)
     // return
     Environment._sparkSession
   }

--- a/src/main/scala/io/smartdatalake/app/LocalSmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/LocalSmartDataLakeBuilder.scala
@@ -88,6 +88,7 @@ object LocalSmartDataLakeBuilder extends SmartDataLakeBuilder {
 
         // start
         val stats = run(config)
+          .toSeq.sortBy(_._1).map(x => x._1 + "=" + x._2).mkString(" ") // convert stats to string
         logger.info(s"$appType finished successfully: $stats")
       case None =>
         logAndThrowException(s"Aborting ${appType} after error", new ConfigurationException("Couldn't set command line parameters correctly."))

--- a/src/main/scala/io/smartdatalake/app/MemoryLogger.scala
+++ b/src/main/scala/io/smartdatalake/app/MemoryLogger.scala
@@ -1,0 +1,65 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.app
+
+import io.smartdatalake.util.misc.{MemoryUtils, SmartDataLakeLogger}
+import org.apache.spark.{ExecutorPlugin, SparkConf, SparkEnv}
+
+/**
+ * Configuration for periodic memory usage logging
+ *
+ * @param intervalSec interval in seconds between memory usage logs
+ * @param logLinuxMem enable logging linux memory
+ * @param logLinuxCGroupMem enable logging details about linux cgroup memory
+ * @param logBuffers enable logging details about different jvm buffers
+ */
+case class MemoryLogTimerConfig(intervalSec: Int, logLinuxMem: Boolean = true, logLinuxCGroupMem: Boolean = false, logBuffers: Boolean = false ) {
+  import MemoryLogTimerConfig._
+  private[smartdatalake] def startTimer(): Unit = MemoryUtils.startMemoryLogger(intervalSec, logLinuxMem, logLinuxCGroupMem, logBuffers)
+  private[smartdatalake] def getAsMap: Map[String, String] = Map(INTERVAL_SEC_OPTION -> intervalSec.toString, LOG_LINUX_MEM_OPTION -> logLinuxMem.toString, LOG_LINUX_CGROUP_MEM_OPTION -> logLinuxCGroupMem.toString, LOG_BUFFERS_OPTION -> logBuffers.toString)
+}
+private[smartdatalake] object MemoryLogTimerConfig{
+  def from(conf: SparkConf): MemoryLogTimerConfig = MemoryLogTimerConfig(conf.get(INTERVAL_SEC_OPTION).toInt, conf.get(LOG_LINUX_MEM_OPTION).toBoolean, conf.get(LOG_LINUX_CGROUP_MEM_OPTION).toBoolean, conf.get(LOG_BUFFERS_OPTION).toBoolean)
+  private val INTERVAL_SEC_OPTION = "spark.smartdatalake.memoryLog.intervalSec"
+  private val LOG_LINUX_MEM_OPTION = "spark.smartdatalake.memoryLog.logLinuxMem"
+  private val LOG_LINUX_CGROUP_MEM_OPTION = "spark.smartdatalake.memoryLog.logLinuxCGroupMem"
+  private val LOG_BUFFERS_OPTION = "spark.smartdatalake.memoryLog.logBuffers"
+}
+
+/**
+ * Executor plugin to start memory usage logging on executors
+ */
+private[smartdatalake] class MemoryLoggerExecutorPlugin extends ExecutorPlugin with SmartDataLakeLogger {
+  override def init(): Unit = {
+    // config can only be transferred to ExecutorPlugin by spark-options
+    val sparkConf = SparkEnv.get.conf
+    logger.debug("sparkConf: " + sparkConf.getAll.map{ case (k,v) => s"$k=$v"}.mkString(" "))
+    try {
+      val memoryLogConfig = MemoryLogTimerConfig.from(sparkConf)
+      memoryLogConfig.startTimer()
+      logger.info("MemoryLoggerExecutorPlugin successfully initialized")
+    } catch {
+      case e: Exception => logger.error(s"cannot initialize MemoryLoggerExecutorPlugin: ${e.getClass.getSimpleName} - ${e.getMessage}")
+    }
+  }
+  override def shutdown(): Unit = {
+    MemoryUtils.stopMemoryLogger()
+  }
+}

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -27,7 +27,8 @@ import io.smartdatalake.config.{ConfigLoader, ConfigParser, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{LogUtil, MemoryUtils, SmartDataLakeLogger}
 import io.smartdatalake.workflow._
-import io.smartdatalake.workflow.action.RuntimeEventState
+import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
+import io.smartdatalake.workflow.action.{ResultRuntimeInfo, RuntimeEventState, SparkAction}
 import org.apache.spark.sql.SparkSession
 import scopt.OptionParser
 
@@ -44,6 +45,9 @@ import scopt.OptionParser
  * @param username        Kerberos user name (`username`@`kerberosDomain`) for local mode.
  * @param kerberosDomain  Kerberos domain (`username`@`kerberosDomain`) for local mode.
  * @param keytabPath      Path to Kerberos keytab file for local mode.
+ * @param test            Run in test mode:
+ *                        - "config": validate configuration
+ *                        - "dry-run": execute "prepare" and "init" phase to check environment
  */
 case class SmartDataLakeBuilderConfig(feedSel: String = null,
                                       applicationName: Option[String] = None,
@@ -57,15 +61,33 @@ case class SmartDataLakeBuilderConfig(feedSel: String = null,
                                       multiPartitionValues: Option[Seq[PartitionValues]] = None,
                                       parallelism: Int = 1,
                                       statePath: Option[String] = None,
-                                      overrideJars: Option[Seq[String]] = None
+                                      overrideJars: Option[Seq[String]] = None,
+                                      test: Option[TestMode.Value] = None
                                 ) {
   def validate(): Unit = {
-    assert(!applicationName.exists(_.contains({ActionDAGRunStateStore.fileNamePartSeparator})), s"Application name must not contain character '${ActionDAGRunStateStore.fileNamePartSeparator}' ($applicationName)")
+    assert(!applicationName.exists(_.contains({HadoopFileActionDAGRunStateStore.fileNamePartSeparator})), s"Application name must not contain character '${HadoopFileActionDAGRunStateStore.fileNamePartSeparator}' ($applicationName)")
     assert(!master.contains("yarn") || deployMode.nonEmpty, "spark deploy-mode must be set if spark master=yarn")
     assert(partitionValues.isEmpty || multiPartitionValues.isEmpty, "partitionValues and multiPartitionValues cannot be defined at the same time")
     assert(statePath.isEmpty || applicationName.isDefined, "application name must be defined if state path is set")
   }
   def getPartitionValues: Option[Seq[PartitionValues]] = partitionValues.orElse(multiPartitionValues)
+  val appName: String = applicationName.getOrElse(feedSel)
+}
+object TestMode extends Enumeration {
+  type TestMode = Value
+
+  /**
+   * Test if config is valid.
+   * Note that this only parses and validates the configuration. No attempts are made to check the environment (e.g. connection informations...).
+   */
+  val Config = Value("config")
+
+  /**
+   * Test the environment if connections can be initalized and spark lineage can be created.
+   * Note that no changes are made to the environment if possible.
+   * The test executes "prepare" and "init" phase, but not the "exec" phase of an SDLB run.
+   */
+  val DryRun = Value("dry-run")
 }
 
 /**
@@ -89,7 +111,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
   /**
    * InstanceRegistry instance
    */
-  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry()
+  val instanceRegistry: InstanceRegistry = new InstanceRegistry()
 
   /**
    * The Parser defines how to extract the options from the command line args.
@@ -124,6 +146,9 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     opt[String]("override-jars")
       .action((arg, config) => config.copy(overrideJars = Some(arg.split(','))))
       .text("Comma separated list of jars for child-first class loader. The jars must be present in classpath.")
+    opt[String]("test")
+      .action((arg, config) => config.copy(test = Some(TestMode.withName(arg))))
+      .text("Run in test mode: config -> validate configuration, dry-run -> execute prepare- and init-phase only to check environment and spark lineage")
     help("help").text("Display the help text.")
     version("version").text("Display version information.")
   }
@@ -147,26 +172,26 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
    *
    * @param appConfig Application configuration (parsed from command line).
    */
-  def run(appConfig: SmartDataLakeBuilderConfig): String = try {
+  def run(appConfig: SmartDataLakeBuilderConfig): Map[RuntimeEventState,Int] = try {
     if (appConfig.statePath.isDefined) {
       assert(appConfig.applicationName.nonEmpty, "Application name must be defined if statePath is set")
       // check if latest run succeeded
       val appName = appConfig.applicationName.get
-      val stateStore = ActionDAGRunStateStore(appConfig.statePath.get, appName)
+      val stateStore = HadoopFileActionDAGRunStateStore(appConfig.statePath.get, appName)
       val latestRunId = stateStore.getLatestRunId
       if (latestRunId.isDefined) {
         val latestStateFile = stateStore.getLatestState(latestRunId)
-        val latestRunState = stateStore.recoverRunState(latestStateFile.path)
+        val latestRunState = stateStore.recoverRunState(latestStateFile)
         if (latestRunState.isFailed) {
           // start recovery
-          recoverRun(appConfig, stateStore, latestRunState)
+          recoverRun(appConfig, stateStore, latestRunState)._2
         } else {
-          startRun(appConfig, runId = latestRunState.runId+1, stateStore = Some(stateStore))
+          startRun(appConfig, runId = latestRunState.runId+1, stateStore = Some(stateStore))._2
         }
       } else {
-        startRun(appConfig, stateStore = Some(stateStore))
+        startRun(appConfig, stateStore = Some(stateStore))._2
       }
-    } else startRun(appConfig)
+    } else startRun(appConfig)._2
   } finally {
     // make sure memory logger timer task is stopped
     MemoryUtils.stopMemoryLogger()
@@ -175,34 +200,51 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
   /**
    * Recover previous failed run.
    */
-  private def recoverRun(appConfig: SmartDataLakeBuilderConfig, stateStore: ActionDAGRunStateStore, runState: ActionDAGRunState): String = {
+  private def recoverRun(appConfig: SmartDataLakeBuilderConfig, stateStore: ActionDAGRunStateStore[_ <: StateId], runState: ActionDAGRunState): (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
     logger.info(s"recovering application ${appConfig.applicationName.get} runId=${runState.runId} lastAttemptId=${runState.attemptId}")
     // skip all succeeded actions
     val actionsToSkip = runState.actionsState
       .filter { case (id,info) => info.state==RuntimeEventState.SUCCEEDED }
     val actionIdsToSkip = actionsToSkip
-      .map { case (id,info) => ActionObjectId(id) }.toSeq
+      .map { case (id,info) => id }.toSeq
     val initialSubFeeds = actionsToSkip.flatMap(_._2.results.map(_.subFeed)).toSeq
     // start run, increase attempt counter
     startRun(runState.appConfig, runState.runId, runState.attemptId+1, actionIdsToSkip, initialSubFeeds, Some(stateStore))
   }
 
   /**
-   * Start run.
+   * Start a simulation run.
+   * This executes the DAG and returns all subfeeds including the transformed DataFrames.
+   * Only prepare and init are executed.
+   * All initial subfeeds must be provided as input.
+   *
+   * Note: this only works with SparkActions for now
+   * @param appConfig application configuration
+   * @param initialSubFeeds initial subfeeds for DataObjects at the beginning of the DAG
+   * @return tuple of list of final subfeeds and statistics (action count per RuntimeEventState)
    */
-  private def startRun(appConfig: SmartDataLakeBuilderConfig, runId: Int = 1, attemptId: Int = 1, actionIdsToSkip: Seq[ActionObjectId] = Seq(), initialSubFeeds: Seq[SubFeed] = Seq(), stateStore: Option[ActionDAGRunStateStore] = None): String = {
+  def startSimulation(appConfig: SmartDataLakeBuilderConfig, initialSubFeeds: Seq[SparkSubFeed])(implicit instanceRegistry: InstanceRegistry, session: SparkSession): (Seq[SparkSubFeed], Map[RuntimeEventState,Int]) = {
+    val (subFeeds, stats) = exec(appConfig, runId = 1, attemptId = 1, actionIdsToSkip = Seq(), initialSubFeeds = initialSubFeeds, stateStore = None, simulation = true)
+    (subFeeds.map(_.asInstanceOf[SparkSubFeed]), stats)
+  }
+
+  /**
+   * Start run.
+   * @return tuple of list of final subfeeds and statistics (action count per RuntimeEventState)
+   */
+  private def startRun(appConfig: SmartDataLakeBuilderConfig, runId: Int = 1, attemptId: Int = 1, actionIdsToSkip: Seq[ActionObjectId] = Seq(), initialSubFeeds: Seq[SubFeed] = Seq(), stateStore: Option[ActionDAGRunStateStore[_]] = None, simulation: Boolean = false) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
 
     // validate application config
     appConfig.validate()
 
-    // init config
+    // log start parameters
     logger.info(s"Feed selector: ${appConfig.feedSel}")
-    logger.info(s"Application: ${appConfig.applicationName}")
+    logger.info(s"Application: ${appConfig.appName}")
     logger.info(s"Master: ${appConfig.master.getOrElse(sys.props.get("spark.master"))}")
     logger.info(s"Deploy-Mode: ${appConfig.deployMode.getOrElse(sys.props.get("spark.submit.deployMode"))}")
+    logger.info(s"Test-Mode: ${appConfig.test}")
     logger.debug(s"Environment: " + sys.env.map(x => x._1 + "=" + x._2).mkString(" "))
     logger.debug(s"System properties: " + sys.props.toMap.map(x => x._1 + "=" + x._2).mkString(" "))
-    val appName = appConfig.applicationName.getOrElse(appConfig.feedSel)
 
     // load config
     val config: Config = appConfig.configuration match {
@@ -213,11 +255,26 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     require(config.hasPath("dataObjects"), s"No configuration parsed or it does not have a section called dataObjects")
     val globalConfig = GlobalConfig.from(config)
 
-    // parse config objects and select actions by feedSel
+    // parse config objects
     ConfigParser.parse(config, instanceRegistry)
+
+    // create Spark Session
+    val session: SparkSession = globalConfig.createSparkSession(appConfig.appName, appConfig.master, appConfig.deployMode)
+    LogUtil.setLogLevel(session.sparkContext)
+
+    exec(appConfig, runId, attemptId, actionIdsToSkip, initialSubFeeds, stateStore, simulation)(instanceRegistry, session)
+  }
+
+  private def exec(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, actionIdsToSkip: Seq[ActionObjectId], initialSubFeeds: Seq[SubFeed], stateStore: Option[ActionDAGRunStateStore[_]], simulation: Boolean)(implicit instanceRegistry: InstanceRegistry, session: SparkSession) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
+
+    // select actions by feedSel
     val actionsSelected = instanceRegistry.getActions.filter(_.metadata.flatMap(_.feed).exists(_.matches(appConfig.feedSel)))
     require(actionsSelected.nonEmpty, s"No action matched the given feed selector: ${appConfig.feedSel}. At least one action needs to be selected.")
     logger.info(s"selected actions ${actionsSelected.map(_.id).mkString(", ")}")
+    if (appConfig.test.contains(TestMode.Config)) { // stop here if only config check
+      logger.info(s"${appConfig.test.get}-Test successfull")
+      return (Seq(), Map())
+    }
 
     // filter actions to skip
     val actionIdsSelected = actionsSelected.map(_.id)
@@ -226,27 +283,35 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     val actionIdsSkipped = actionIdsSelected.filter( id => actionIdsToSkip.contains(id))
     val actionsToExec = actionsSelected.filterNot( action => actionIdsToSkip.contains(action.id))
     require(actionsToExec.nonEmpty, s"No actions to execute. All selected actions are skipped (${actionIdsSkipped.mkString(", ")})")
-    logger.info(s"actions to execute ${actionsToExec.map(_.id).mkString(", ")}" + (if (actionIdsSkipped.nonEmpty) s", actions skipped ${actionIdsSkipped.mkString(", ")}"))
-
-    // create Spark Session
-    implicit val session: SparkSession = globalConfig.createSparkSession(appName, appConfig.master, appConfig.deployMode)
-    LogUtil.setLogLevel(session.sparkContext)
+    logger.info(s"actions to execute ${actionsToExec.map(_.id).mkString(", ")}" + (if (actionIdsSkipped.nonEmpty) s", actions skipped ${actionIdsSkipped.mkString(", ")}" else ""))
 
     // create and execute actions
-    logger.info(s"starting application ${appName} runId=$runId attemptId=$attemptId")
-    implicit val context: ActionPipelineContext = ActionPipelineContext(appConfig.feedSel, appName, runId, attemptId, instanceRegistry, referenceTimestamp = Some(LocalDateTime.now), appConfig)
+    logger.info(s"starting application ${appConfig.appName} runId=$runId attemptId=$attemptId")
+    implicit val context: ActionPipelineContext = ActionPipelineContext(appConfig.feedSel, appConfig.appName, runId, attemptId, instanceRegistry, referenceTimestamp = Some(LocalDateTime.now), appConfig, simulation)
     val actionDAGRun = ActionDAGRun(actionsToExec, runId, attemptId, appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism, initialSubFeeds, stateStore)
-    try {
-      actionDAGRun.prepare
-      actionDAGRun.init
-      actionDAGRun.exec
-      actionDAGRun.saveState(true)
+    val finalSubFeeds = try {
+      if (simulation) {
+        require(actionsToExec.forall(_.isInstanceOf[SparkAction]), s"Simulation needs all selected actions to be instances of SparkAction. This is not the case for ${actionsToExec.filterNot(_.isInstanceOf[SparkAction]).map(_.id).mkString(", ")}")
+        actionDAGRun.init
+      } else {
+        actionDAGRun.prepare
+        actionDAGRun.init
+        if (appConfig.test.contains(TestMode.DryRun)) { // stop here if only dry-run
+          logger.info(s"${appConfig.test.get}-Test successfull")
+          return (Seq(), Map())
+        }
+        val subFeeds = actionDAGRun.exec
+        actionDAGRun.saveState(true)
+        subFeeds
+      }
     } catch {
       // don't fail an not severe exceptions like having no data to process
-      case ex: DAGException if (ex.severity == ExceptionSeverity.SKIPPED) => logger.warn(s"dag run is skipped because of ${ex.getClass.getSimpleName}: ${ex.getMessage}")
+      case ex: DAGException if (ex.severity == ExceptionSeverity.SKIPPED) =>
+        logger.warn(s"dag run is skipped because of ${ex.getClass.getSimpleName}: ${ex.getMessage}")
+        Seq()
     }
 
     // return result statistics as string
-    actionDAGRun.getStatistics.map(x => x._1 + "=" + x._2).mkString(" ")
+    (finalSubFeeds, actionDAGRun.getStatistics)
   }
 }

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -24,6 +24,7 @@ import java.time.LocalDateTime
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.ActionObjectId
 import io.smartdatalake.config.{ConfigLoader, ConfigParser, InstanceRegistry}
+import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{LogUtil, MemoryUtils, SmartDataLakeLogger}
 import io.smartdatalake.workflow._
@@ -224,7 +225,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
    * @return tuple of list of final subfeeds and statistics (action count per RuntimeEventState)
    */
   def startSimulation(appConfig: SmartDataLakeBuilderConfig, initialSubFeeds: Seq[SparkSubFeed])(implicit instanceRegistry: InstanceRegistry, session: SparkSession): (Seq[SparkSubFeed], Map[RuntimeEventState,Int]) = {
-    val (subFeeds, stats) = exec(appConfig, runId = 1, attemptId = 1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionIdsToSkip = Seq(), initialSubFeeds = initialSubFeeds, stateStore = None, simulation = true)
+    val (subFeeds, stats) = exec(appConfig, runId = 1, attemptId = 1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionIdsToSkip = Seq(), initialSubFeeds = initialSubFeeds, stateStore = None, stateListeners = Seq(), simulation = true)
     (subFeeds.map(_.asInstanceOf[SparkSubFeed]), stats)
   }
 
@@ -238,11 +239,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     appConfig.validate()
 
     // log start parameters
-    logger.info(s"Feed selector: ${appConfig.feedSel}")
-    logger.info(s"Application: ${appConfig.appName}")
-    logger.info(s"Master: ${appConfig.master.getOrElse(sys.props.get("spark.master"))}")
-    logger.info(s"Deploy-Mode: ${appConfig.deployMode.getOrElse(sys.props.get("spark.submit.deployMode"))}")
-    logger.info(s"Test-Mode: ${appConfig.test}")
+    logger.info(s"Starting run: runId=$runId attemptId=$attemptId feedSel=${appConfig.feedSel} appName=${appConfig.appName} test=${appConfig.test}")
     logger.debug(s"Environment: " + sys.env.map(x => x._1 + "=" + x._2).mkString(" "))
     logger.debug(s"System properties: " + sys.props.toMap.map(x => x._1 + "=" + x._2).mkString(" "))
 
@@ -253,19 +250,20 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     }
     require(config.hasPath("actions"), s"No configuration parsed or it does not have a section called actions")
     require(config.hasPath("dataObjects"), s"No configuration parsed or it does not have a section called dataObjects")
-    val globalConfig = GlobalConfig.from(config)
 
     // parse config objects
-    ConfigParser.parse(config, instanceRegistry)
+    Environment._instanceRegistry = ConfigParser.parse(config, instanceRegistry) // share instance registry for custom code
+    Environment._globalConfig = GlobalConfig.from(config)
+    val stateListeners = Environment._globalConfig.stateListeners.map(_.listener)
 
     // create Spark Session
-    val session: SparkSession = globalConfig.createSparkSession(appConfig.appName, appConfig.master, appConfig.deployMode)
+    val session: SparkSession = Environment._globalConfig.createSparkSession(appConfig.appName, appConfig.master, appConfig.deployMode)
     LogUtil.setLogLevel(session.sparkContext)
 
-    exec(appConfig, runId, attemptId, runStartTime, attemptStartTime, actionIdsToSkip, initialSubFeeds, stateStore, simulation)(instanceRegistry, session)
+    exec(appConfig, runId, attemptId, runStartTime, attemptStartTime, actionIdsToSkip, initialSubFeeds, stateStore, stateListeners, simulation)(Environment._instanceRegistry, session)
   }
 
-  private def exec(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, runStartTime: LocalDateTime, attemptStartTime: LocalDateTime, actionIdsToSkip: Seq[ActionObjectId], initialSubFeeds: Seq[SubFeed], stateStore: Option[ActionDAGRunStateStore[_]], simulation: Boolean)(implicit instanceRegistry: InstanceRegistry, session: SparkSession) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
+  private def exec(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, runStartTime: LocalDateTime, attemptStartTime: LocalDateTime, actionIdsToSkip: Seq[ActionObjectId], initialSubFeeds: Seq[SubFeed], stateStore: Option[ActionDAGRunStateStore[_]], stateListeners: Seq[StateListener], simulation: Boolean)(implicit instanceRegistry: InstanceRegistry, session: SparkSession) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
 
     // select actions by feedSel
     val actionsSelected = instanceRegistry.getActions.filter(_.metadata.flatMap(_.feed).exists(_.matches(appConfig.feedSel)))
@@ -285,10 +283,10 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     require(actionsToExec.nonEmpty, s"No actions to execute. All selected actions are skipped (${actionIdsSkipped.mkString(", ")})")
     logger.info(s"actions to execute ${actionsToExec.map(_.id).mkString(", ")}" + (if (actionIdsSkipped.nonEmpty) s", actions skipped ${actionIdsSkipped.mkString(", ")}" else ""))
 
-    // create and execute actions
+    // create and execute DAG
     logger.info(s"starting application ${appConfig.appName} runId=$runId attemptId=$attemptId")
     implicit val context: ActionPipelineContext = ActionPipelineContext(appConfig.feedSel, appConfig.appName, runId, attemptId, instanceRegistry, referenceTimestamp = Some(LocalDateTime.now), appConfig, runStartTime, attemptStartTime, simulation)
-    val actionDAGRun = ActionDAGRun(actionsToExec, runId, attemptId, appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism, initialSubFeeds, stateStore)
+    val actionDAGRun = ActionDAGRun(actionsToExec, runId, attemptId, appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism, initialSubFeeds, stateStore, stateListeners)
     val finalSubFeeds = try {
       if (simulation) {
         require(actionsToExec.forall(_.isInstanceOf[SparkAction]), s"Simulation needs all selected actions to be instances of SparkAction. This is not the case for ${actionsToExec.filterNot(_.isInstanceOf[SparkAction]).map(_.id).mkString(", ")}")

--- a/src/main/scala/io/smartdatalake/app/StateListener.scala
+++ b/src/main/scala/io/smartdatalake/app/StateListener.scala
@@ -1,0 +1,44 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.app
+
+import io.smartdatalake.config.ConfigurationException
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.{ActionDAGRunState, ActionPipelineContext}
+
+case class StateListenerConfig(className: String, options: Option[Map[String,String]] = None) {
+  // instantiate listener
+  private[smartdatalake] val listener: StateListener = try {
+    val clazz = Class.forName(className)
+    val constructor = clazz.getConstructor(classOf[Map[String,String]])
+    constructor.newInstance(options.getOrElse(Map())).asInstanceOf[StateListener]
+  } catch {
+    case e: NoSuchMethodException => throw ConfigurationException(s"State listener class $className needs constructor with parameter Map[String,String]: ${e.getMessage}", Some("globalConfig.stateListeners"), e)
+    case e: Exception => throw ConfigurationException(s"Cannot instantiate state listener class $className: ${e.getMessage}", Some("globalConfig.stateListeners"), e)
+  }
+}
+
+trait StateListener {
+
+  /**
+   * Notify State
+   */
+  def notifyState(state: ActionDAGRunState, context: ActionPipelineContext): Unit
+}

--- a/src/main/scala/io/smartdatalake/config/SdlConfigObject.scala
+++ b/src/main/scala/io/smartdatalake/config/SdlConfigObject.scala
@@ -47,21 +47,21 @@ object SdlConfigObject {
   /**
    * Value class for connection identifiers.
    */
-  case class ConnectionId(id: String) extends AnyVal with ConfigObjectId {
+  case class ConnectionId(override val id: String) extends AnyVal with ConfigObjectId {
     override def toString: String = "Connection~"+id
   }
 
   /**
    * Value class for data object identifiers.
    */
-  case class DataObjectId(id: String) extends AnyVal with ConfigObjectId {
+  case class DataObjectId(override val id: String) extends AnyVal with ConfigObjectId {
     override def toString: String = "DataObject~"+id
   }
 
   /**
    * Value class for action object identifiers.
    */
-  case class ActionObjectId(id: String) extends AnyVal with ConfigObjectId {
+  case class ActionObjectId(override val id: String) extends AnyVal with ConfigObjectId {
     override def toString: String = "Action~"+id
   }
 

--- a/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -20,6 +20,8 @@ package io.smartdatalake.definitions
 
 import java.net.URI
 
+import io.smartdatalake.app.GlobalConfig
+import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.util.misc.EnvironmentUtil
 import org.apache.spark.sql.SparkSession
 
@@ -146,5 +148,9 @@ object Environment {
   // dynamically shared environment for custom code (see also #106)
   def sparkSession: SparkSession = _sparkSession
   private [smartdatalake] var _sparkSession: SparkSession = _
+  def instanceRegistry: InstanceRegistry = _instanceRegistry
+  private [smartdatalake] var _instanceRegistry: InstanceRegistry = _
+  def globalConfig: GlobalConfig = _globalConfig
+  private [smartdatalake] var _globalConfig: GlobalConfig = _
 
 }

--- a/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -18,6 +18,18 @@
  */
 package io.smartdatalake.definitions
 
+import java.sql.Timestamp
+
+import io.smartdatalake.config.ConfigurationException
+import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.misc.{SmartDataLakeLogger, SparkExpressionUtil}
+import io.smartdatalake.workflow.{ActionPipelineContext, SubFeed}
+import io.smartdatalake.workflow.action.ActionHelper.{getOptionalDataFrame, searchCommonInits}
+import io.smartdatalake.workflow.action.NoDataToProcessWarning
+import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, DataObject}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.{col, max}
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types._
 
@@ -32,11 +44,25 @@ import org.apache.spark.sql.types._
  * }
  * }}}
  */
-sealed trait ExecutionMode
+sealed trait ExecutionMode extends SmartDataLakeLogger {
+  def prepare(actionId: ActionObjectId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    // validate condition
+    applyCondition.foreach( c => SparkExpressionUtil.evaluateBoolean(actionId, Some("applyCondition"), c, DefaultExecutionModeExpressionData.from(context), onlySyntaxCheck = true))
+  }
+  def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = None
+  def mainInputOutputNeeded: Boolean = false
+  def applyCondition: Option[String] = None
+  final def evaluateApplyCondition(actionId: ActionObjectId, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[Boolean] = {
+    val data = DefaultExecutionModeExpressionData.from(context).copy(givenPartitionValues = subFeed.partitionValues.map(_.getMapString), isStartNode = subFeed.isDAGStart)
+    applyCondition.map( c => SparkExpressionUtil.evaluateBoolean(actionId, Some("applyCondition"), c, data))
+  }
+}
 
-trait ExecutionModeWithMainInputOutput {
-  def mainInputId: Option[String]
-  def mainOutputId: Option[String]
+private[smartdatalake] trait ExecutionModeWithMainInputOutput {
+  def alternativeOutputId: Option[DataObjectId] = None
+  def alternativeOutput(implicit context: ActionPipelineContext): Option[DataObject] = {
+    alternativeOutputId.map(context.instanceRegistry.get[DataObject](_))
+  }
 }
 
 /**
@@ -44,12 +70,79 @@ trait ExecutionModeWithMainInputOutput {
  * Partition columns to be used for comparision need to be a common 'init' of input and output partition columns.
  * This mode needs mainInput/Output DataObjects which CanHandlePartitions to list partitions.
  * Partition values are passed to following actions, if for partition columns which they have in common.
- * @param partitionColNb optional number of partition columns to use as a common 'init'.
- * @param mainInputId optional selection of inputId to be used for partition comparision. Only needed if there are multiple input DataObject's.
- * @param mainOutputId optional selection of outputId to be used for partition comparision. Only needed if there are multiple output DataObject's.
+ *
+ * @param partitionColNb            optional number of partition columns to use as a common 'init'.
+ * @param alternativeOutputId       optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
+ *                                  It can be used to ensure processing all partitions over multiple actions in case of errors.
  * @param nbOfPartitionValuesPerRun optional restriction of the number of partition values per run.
+ * @param applyCondition            Condition to decide if execution mode should be applied or not. Define a spark sql expression working with attributes of [[DefaultExecutionModeExpressionData]] returning a boolean.
+ *                                  Default is to apply the execution mode if given partition values (partition values from command line or passed from previous action) are not empty.
+ * @param failCondition             Condition to fail application of execution mode if true. Define a spark sql expression working with attributes of [[PartitionDiffModeExpressionData]] returning a boolean.
+ *                                  Default is that the application of the PartitionDiffMode does not fail the action. If there is no data to process, the following actions are skipped.
  */
-case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val mainInputId: Option[String] = None, override val mainOutputId: Option[String] = None, nbOfPartitionValuesPerRun: Option[Int] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput
+case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val alternativeOutputId: Option[DataObjectId] = None, nbOfPartitionValuesPerRun: Option[Int] = None, override val applyCondition: Option[String] = None, failCondition: Option[String] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
+  override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
+  override def prepare(actionId: ActionObjectId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.prepare(actionId)
+    // validate condition
+    failCondition.foreach( c => SparkExpressionUtil.evaluateBoolean(actionId, Some("failCondition"), c, PartitionDiffModeExpressionData.from(context), onlySyntaxCheck = true))
+    // check alternativeOutput exists
+    alternativeOutput
+  }
+  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+    val doApply = evaluateApplyCondition(actionId, subFeed)
+      .getOrElse(subFeed.partitionValues.isEmpty) // default is to apply PartitionDiffMode if no partition values are given
+    if (doApply) {
+      val input = mainInput
+      val output = alternativeOutput.getOrElse(mainOutput)
+      (input, output) match {
+        case (partitionInput: CanHandlePartitions, partitionOutput: CanHandlePartitions) =>
+          if (partitionInput.partitions.nonEmpty) {
+            if (partitionOutput.partitions.nonEmpty) {
+              // prepare common partition columns
+              val commonInits = searchCommonInits(partitionInput.partitions, partitionOutput.partitions)
+              require(commonInits.nonEmpty, s"$actionId has set executionMode = 'PartitionDiffMode' but no common init was found in partition columns for $input and $output")
+              val commonPartitions = if (partitionColNb.isDefined) {
+                commonInits.find(_.size == partitionColNb.get).getOrElse(throw ConfigurationException(s"$actionId has set executionMode = 'PartitionDiffMode' but no common init with ${partitionColNb.get} was found in partition columns of $input and $output from $commonInits!"))
+              } else {
+                commonInits.maxBy(_.size)
+              }
+              // calculate missing partition values
+              val inputPartitionValues = partitionInput.listPartitions.map(_.filterKeys(commonPartitions))
+              val outputPartitionValues = partitionOutput.listPartitions.map(_.filterKeys(commonPartitions))
+              val partitionValuesToBeProcessed = inputPartitionValues.toSet.diff(outputPartitionValues.toSet).toSeq
+              // sort and limit number of partitions processed
+              val ordering = PartitionValues.getOrdering(commonPartitions)
+              val selectedPartitionValues = nbOfPartitionValuesPerRun match {
+                case Some(n) => partitionValuesToBeProcessed.sorted(ordering).take(n)
+                case None => partitionValuesToBeProcessed.sorted(ordering)
+              }
+              // evaluate fail condition
+              val data = PartitionDiffModeExpressionData.from(context).copy(inputPartitionValues = inputPartitionValues.map(_.getMapString), outputPartitionValues = outputPartitionValues.map(_.getMapString), selectedPartitionValues = selectedPartitionValues.map(_.getMapString))
+              val doFail = failCondition.exists(c => SparkExpressionUtil.evaluateBoolean(actionId, Some("failCondition"), c, data)) // default is to not fail
+              if (doFail) throw ExecutionModeFailedException(s"($actionId) Execution mode failed because of failCondition '${failCondition.get}' for $data")
+              // stop processing if no new data
+              if (partitionValuesToBeProcessed.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No partitions to process found for ${input.id}")
+              //return
+              logger.info(s"($actionId) PartitionDiffMode selected partition values ${selectedPartitionValues.mkString(", ")} to process")
+              Some((selectedPartitionValues, None))
+            } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $output has no partition columns defined!")
+          } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $input has no partition columns defined!")
+        case (_: CanHandlePartitions, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $output does not support partitions!")
+        case (_, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $input does not support partitions!")
+      }
+    } else None
+  }
+}
+case class PartitionDiffModeExpressionData(feed: String, application: String, runId: Int, attemptId: Int, referenceTimestamp: Option[Timestamp]
+                                           , runStartTime: Timestamp, attemptStartTime: Timestamp
+                                           , inputPartitionValues: Seq[Map[String,String]], outputPartitionValues: Seq[Map[String,String]], selectedPartitionValues: Seq[Map[String,String]])
+private[smartdatalake] object PartitionDiffModeExpressionData {
+  def from(context: ActionPipelineContext): PartitionDiffModeExpressionData = {
+    PartitionDiffModeExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
+      , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), Seq(), Seq(), Seq())
+  }
+}
 
 /**
  * Spark streaming execution mode uses Spark Structured Streaming to incrementally execute data loads (trigger=Trigger.Once) and keep track of processed data.
@@ -64,10 +157,87 @@ case class SparkStreamingOnceMode(checkpointLocation: String, inputOptions: Map[
  * Compares max entry in "compare column" between mainOutput and mainInput and incrementally loads the delta.
  * This mode works only with SparkSubFeeds. The filter is not propagated to following actions.
  * @param compareCol a comparable column name existing in mainInput and mainOutput used to identify the delta. Column content should be bigger for newer records.
- * @param mainInputId optional selection of inputId to be used for comparision. Only needed if there are multiple input DataObject's.
- * @param mainOutputId optional selection of outputId to be used for comparision. Only needed if there are multiple output DataObject's.
+ * @param alternativeOutputId optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
+ *                            It can be used to ensure processing all partitions over multiple actions in case of errors.
  */
-case class SparkIncrementalMode(compareCol: String, override val mainInputId: Option[String] = None, override val mainOutputId: Option[String] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput
+case class SparkIncrementalMode(compareCol: String, override val alternativeOutputId: Option[DataObjectId] = None) extends ExecutionMode with ExecutionModeWithMainInputOutput {
+  override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
+  override def prepare(actionId: ActionObjectId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.prepare(actionId)
+    // check alternativeOutput exists
+    alternativeOutput
+  }
+  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+    val doApply = evaluateApplyCondition(actionId, subFeed)
+      .getOrElse(true) // default is to apply SparkIncrementalMode
+    if (doApply) {
+      import session.implicits._
+      val input = mainInput
+      val output = alternativeOutput.getOrElse(mainOutput)
+      (input, output) match {
+        case (sparkInput: CanCreateDataFrame, sparkOutput: CanCreateDataFrame) =>
+          // if data object is new, it might not be able to create a DataFrame
+          val dfInputOpt = getOptionalDataFrame(sparkInput)
+          val dfOutputOpt = getOptionalDataFrame(sparkOutput)
+          (dfInputOpt, dfOutputOpt) match {
+            // if both DataFrames exist, compare and create filter
+            case (Some(dfInput), Some(dfOutput)) =>
+              val inputColType = dfInput.schema(compareCol).dataType
+              require(SparkIncrementalMode.allowedDataTypes.contains(inputColType), s"($actionId) Type of compare column ${compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkInput.id}")
+              val outputColType = dfOutput.schema(compareCol).dataType
+              require(SparkIncrementalMode.allowedDataTypes.contains(outputColType), s"($actionId) Type of compare column ${compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkOutput.id}")
+              require(inputColType == outputColType, s"($actionId) Type of compare column ${compareCol} is different between ${sparkInput.id} ($inputColType) and ${sparkOutput.id} ($outputColType)")
+              // get latest values
+              val inputLatestValue = dfInput.agg(max(col(compareCol)).cast(StringType)).as[String].head
+              val outputLatestValue = dfOutput.agg(max(col(compareCol)).cast(StringType)).as[String].head
+              // stop processing if no new data
+              if (outputLatestValue == inputLatestValue) throw NoDataToProcessWarning(actionId.id, s"($actionId) No increment to process found for ${output.id} column ${compareCol} (lastestValue=$outputLatestValue)")
+              logger.info(s"($actionId) SparkIncrementalMode selected increment for writing to ${output.id}: column ${compareCol} from $outputLatestValue to $inputLatestValue to process")
+              // prepare filter
+              val selectedData = s"${compareCol} > cast('$outputLatestValue' as ${inputColType.sql})"
+              Some((Seq(), Some(selectedData)))
+            // otherwise don't filter
+            case _ =>
+              logger.info(s"($actionId) SparkIncrementalMode selected all records for writing to ${output.id}, because input or output DataObject is still empty.")
+              Some((Seq(), None))
+          }
+        case _ => throw ConfigurationException(s"$actionId has set executionMode = $SparkIncrementalMode but $input or $output does not support creating Spark DataFrames!")
+      }
+    } else None
+  }
+}
 object SparkIncrementalMode {
   private[smartdatalake] val allowedDataTypes = Seq(StringType, LongType, IntegerType, ShortType, FloatType, DoubleType, TimestampType)
 }
+
+/**
+ * An execution mode which just validates that partition values are given.
+ * Note: For start nodes of the DAG partition values can be defined by command line, for subsequent nodes partition values are passed on from previous nodes.
+ */
+case class FailIfNoPartitionValuesMode() extends ExecutionMode {
+  override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+    // check if partition values present
+    if (subFeed.partitionValues.isEmpty) throw ExecutionModeFailedException(s"($actionId) Partition values are empty")
+    // return
+    None
+  }
+}
+
+
+/**
+ * Attributes definition for spark expressions used as ExecutionMode conditions.
+ * @param givenPartitionValues Partition values specified with command line (start action) or passed from previous action
+ * @param isStartNode True if the current action is a start node of the DAG.
+ */
+case class DefaultExecutionModeExpressionData( feed: String, application: String, runId: Int, attemptId: Int, referenceTimestamp: Option[Timestamp]
+                                             , runStartTime: Timestamp, attemptStartTime: Timestamp
+                                             , givenPartitionValues: Seq[Map[String,String]], isStartNode: Boolean)
+private[smartdatalake] object DefaultExecutionModeExpressionData {
+  def from(context: ActionPipelineContext): DefaultExecutionModeExpressionData = {
+    DefaultExecutionModeExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
+      , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), Seq(), false)
+  }
+}
+
+private[smartdatalake] case class ExecutionModeFailedException(msg: String) extends Exception(msg)
+

--- a/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
+++ b/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
@@ -135,7 +135,7 @@ private[smartdatalake] case class SparkStageMetrics(jobInfo: JobInfo, stageId: I
   def getId: String = jobInfo.toString
   def getOrder: Long = stageId
   def getMainInfos: Map[String, Any] = {
-    Map("records_written" -> recordsWrittenCons, "bytes_written" -> bytesWritten, "num_tasks" -> numTasks, "stage" -> stageName.split(' ').head )
+    Map("duration" -> stageRuntime, "records_written" -> recordsWrittenCons, "bytes_written" -> bytesWritten, "num_tasks" -> numTasks.toLong, "stage" -> stageName.split(' ').head )
   }
 }
 private[smartdatalake] case class JobInfo(id: Int, group: String, description: String)

--- a/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -52,6 +52,7 @@ private[smartdatalake] case class PartitionValues(elements: Map[String, Any]) {
   def keys: Set[String] = elements.keySet
   def isDefinedAt(colName: String): Boolean = elements.isDefinedAt(colName)
   def filterKeys(colNames: Seq[String]): PartitionValues = this.copy(elements = elements.filterKeys(colNames.contains))
+  def getMapString: Map[String,String] = elements.mapValues(_.toString)
 }
 
 private[smartdatalake] object PartitionValues {
@@ -107,6 +108,23 @@ private[smartdatalake] object PartitionValues {
   def checkWrongPartitionValues(partitionValues: Seq[PartitionValues], partitions: Seq[String]): Seq[String] = {
     if (partitionValues.nonEmpty) partitionValues.map(_.keys).reduce(_ ++ _).diff(partitions.toSet).toSeq
     else Seq()
+  }
+
+  /**
+   * Checks if expected partition values are covered by existing partition values
+   * challenge: handle multiple partition columns correctly and performant
+   * @return list of missing partition values
+   */
+  def checkExpectedPartitionValues(existingPartitionValues: Seq[PartitionValues], expectedPartitionValues: Seq[PartitionValues]): Seq[PartitionValues] = {
+    val partitionColCombinations = expectedPartitionValues.map(_.keys).distinct
+    def diffPartitionValues(inputPartitions: Seq[PartitionValues], expectedPartitionValues: Seq[PartitionValues], partitionColCombinations: Seq[Set[String]]): Seq[PartitionValues] = {
+      if (partitionColCombinations.isEmpty) return Seq()
+      val partitionColCombination = partitionColCombinations.head
+      val (partitionValuesCurrentCombination, partitionValuesOtherCombination) = expectedPartitionValues.partition(_.keys==partitionColCombination)
+      val missingPartitionValuesCurrentCombination = partitionValuesCurrentCombination.diff(inputPartitions.map(_.filterKeys(partitionColCombination.toSeq)))
+      missingPartitionValuesCurrentCombination ++ diffPartitionValues(inputPartitions, partitionValuesOtherCombination, partitionColCombinations.tail)
+    }
+    diffPartitionValues(existingPartitionValues, expectedPartitionValues, partitionColCombinations)
   }
 }
 

--- a/src/main/scala/io/smartdatalake/util/misc/CredentialsUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/misc/CredentialsUtil.scala
@@ -54,7 +54,7 @@ private[smartdatalake] object CredentialsUtil extends SmartDataLakeLogger {
   }
 
   def getCredentialsInfo(credentialsConfig: String): (String, String) = {
-    logger.info(s"Parsing variable ${credentialsConfig}")
+    logger.debug(s"Parsing variable ${credentialsConfig}")
     credentialsConfig.split("#") match {
       case Array(x, y) => (x, y)
       case _ => throw new ConfigurationException(s"Credentials config variable $credentialsConfig is invalid, make sure it's of the form CREDENTIALSTYPE#VARIABLENAME")
@@ -62,7 +62,7 @@ private[smartdatalake] object CredentialsUtil extends SmartDataLakeLogger {
   }
 
   def getCredentialsFromEnv(variableName: String): String = {
-    logger.info(s"Trying to get credentials from environment variable $variableName")
+    logger.debug(s"Trying to get credentials from environment variable $variableName")
     sys.env.get(variableName) match {
       case Some(key) => key
       case _ => throw new ConfigurationException(s"Environment variable $variableName not found")
@@ -70,7 +70,7 @@ private[smartdatalake] object CredentialsUtil extends SmartDataLakeLogger {
   }
 
   def getCredentialsFromSecret(variableString: String): String = {
-    logger.info(s"Trying to split variable string $variableString")
+    logger.debug(s"Trying to split variable string $variableString")
     variableString.split("\\.") match {
       case Array(x, y) =>
           try {

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -176,7 +176,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
    * Save state of dag to file
    */
   def saveState(isFinal: Boolean = false)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    stateStore.foreach(_.saveState(ActionDAGRunState(context.appConfig, runId, attemptId, getRuntimeInfos, isFinal)))
+    stateStore.foreach(_.saveState(ActionDAGRunState(context.appConfig, runId, attemptId, context.runStartTime, context.attemptStartTime, getRuntimeInfos, isFinal)))
   }
 
   private class ActionEventListener(phase: ExecutionPhase)(implicit session: SparkSession, context: ActionPipelineContext) extends DAGEventListener[Action] with SmartDataLakeLogger {

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -68,7 +68,7 @@ private[smartdatalake] trait ActionMetrics {
   def getAsText: String
 }
 
-private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, attemptId: Int, partitionValues: Seq[PartitionValues], parallelism: Int, initialSubFeeds: Seq[SubFeed], stateStore: Option[ActionDAGRunStateStore]) extends SmartDataLakeLogger {
+private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, attemptId: Int, partitionValues: Seq[PartitionValues], parallelism: Int, initialSubFeeds: Seq[SubFeed], stateStore: Option[ActionDAGRunStateStore[_]]) extends SmartDataLakeLogger {
 
   private def createScheduler(parallelism: Int = 1) = Scheduler.fixedPool(s"dag-$runId", parallelism)
 
@@ -117,7 +117,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
   def init(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     // run init for every node
     context.phase = ExecutionPhase.Init
-    run[SubFeed](context.phase) {
+    val t = run[SubFeed](context.phase) {
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
       case (node: Action, subFeeds) =>
@@ -126,6 +126,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
         node.init(subFeeds ++ recursiveSubFeeds)
       case x => throw new IllegalStateException(s"Unmatched case $x")
     }
+    t
   }
 
   def exec(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
@@ -156,15 +157,19 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
     result
   }
 
-  private def getInitialSubFeed(dataObjectId: DataObjectId) = {
-    initialSubFeeds.find(_.dataObjectId==dataObjectId).getOrElse(InitSubFeed(dataObjectId, partitionValues))
+  private def getInitialSubFeed(dataObjectId: DataObjectId)(implicit context: ActionPipelineContext) = {
+    initialSubFeeds.find(_.dataObjectId==dataObjectId)
+      .getOrElse(
+        if (context.simulation) throw new IllegalStateException(s"Initial subfeed for $dataObjectId missing for dry run.")
+        else InitSubFeed(dataObjectId, partitionValues)
+      )
   }
 
   /**
    * Collect runtime information for every action of the dag
    */
-  def getRuntimeInfos: Map[String, RuntimeInfo] = {
-    dag.getNodes.map( a => (a.id.id, a.getRuntimeInfo.getOrElse(RuntimeInfo(RuntimeEventState.PENDING)))).toMap
+  def getRuntimeInfos: Map[ActionObjectId, RuntimeInfo] = {
+    dag.getNodes.map( a => (a.id, a.getRuntimeInfo.getOrElse(RuntimeInfo(RuntimeEventState.PENDING)))).toMap
   }
 
   /**
@@ -200,8 +205,8 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
   /**
    * Get Action count per RuntimeEventState
    */
-  def getStatistics: Seq[(RuntimeEventState,Int)] = {
-    getRuntimeInfos.map(_._2.state).groupBy(identity).mapValues(_.size).toSeq.sortBy(_._1)
+  def getStatistics: Map[RuntimeEventState,Int] = {
+    getRuntimeInfos.map(_._2.state).groupBy(identity).mapValues(_.size)
   }
 
   /**
@@ -229,7 +234,7 @@ private[smartdatalake] object ActionDAGRun extends SmartDataLakeLogger {
   /**
    * create ActionDAGRun
    */
-  def apply(actions: Seq[Action], runId: Int, attemptId: Int, partitionValues: Seq[PartitionValues] = Seq(), parallelism: Int = 1, initialSubFeeds: Seq[SubFeed] = Seq(), stateStore: Option[ActionDAGRunStateStore] = None)(implicit session: SparkSession, context: ActionPipelineContext): ActionDAGRun = {
+  def apply(actions: Seq[Action], runId: Int, attemptId: Int, partitionValues: Seq[PartitionValues] = Seq(), parallelism: Int = 1, initialSubFeeds: Seq[SubFeed] = Seq(), stateStore: Option[ActionDAGRunStateStore[_]] = None)(implicit session: SparkSession, context: ActionPipelineContext): ActionDAGRun = {
 
     // prepare edges: list of actions dependencies
     // this can be created by combining input and output ids between actions

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.workflow.DAGHelper._
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.action.{Action, RuntimeEventState, RuntimeInfo}
+import io.smartdatalake.workflow.dataobject.TransactionalSparkTableDataObject
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 import org.apache.spark.sql.SparkSession
@@ -120,7 +121,9 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
       case (node: Action, subFeeds) =>
-        node.init(subFeeds)
+        assert(node.recursiveInputs.map(_.isInstanceOf[TransactionalSparkTableDataObject]).forall(_==true),"Recursive inputs only work for TransactionalSparkTableDataObjects.")
+        val recursiveSubFeeds = node.recursiveInputs.map(dataObject => getInitialSubFeed(dataObject.id))
+        node.init(subFeeds ++ recursiveSubFeeds)
       case x => throw new IllegalStateException(s"Unmatched case $x")
     }
   }
@@ -136,7 +139,8 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
           node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
         case (node: Action, subFeeds) =>
           node.preExec(subFeeds)
-          val resultSubFeeds = node.exec(subFeeds)
+          val recursiveSubFeeds = node.recursiveInputs.map(dataObject => getInitialSubFeed(dataObject.id))
+          val resultSubFeeds = node.exec(subFeeds ++ recursiveSubFeeds)
           node.postExec(subFeeds, resultSubFeeds)
           //return
           resultSubFeeds

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -30,7 +30,8 @@ import io.smartdatalake.workflow.action.{RuntimeEventState, RuntimeInfo}
 /**
  * ActionDAGRunState contains all configuration and state of an ActionDAGRun needed to start a recovery run in case of failure.
  */
-private[smartdatalake] case class ActionDAGRunState(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, actionsState: Map[ActionObjectId, RuntimeInfo], isFinal: Boolean) {
+private[smartdatalake] case class ActionDAGRunState( appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int,runStartTime: LocalDateTime, attemptStartTime: LocalDateTime
+                                                   , actionsState: Map[ActionObjectId, RuntimeInfo], isFinal: Boolean) {
   def toJson: String = ActionDAGRunState.toJson(this)
   def isFailed: Boolean = actionsState.exists(_._2.state==RuntimeEventState.FAILED)
   def isSucceeded: Boolean = isFinal && !isFailed

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -19,39 +19,39 @@
 
 package io.smartdatalake.workflow
 
-import java.time.LocalDateTime
-import java.time.{Duration => JavaDuration}
+import java.time.{LocalDateTime, Duration => JavaDuration}
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
-import io.smartdatalake.util.hdfs.HdfsUtil
+import io.smartdatalake.config.SdlConfigObject.ActionObjectId
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.action.{RuntimeEventState, RuntimeInfo}
-import org.apache.hadoop.fs.{FileSystem, FileUtil, Path, PathFilter}
-
-import scala.io.Codec
 
 /**
  * ActionDAGRunState contains all configuration and state of an ActionDAGRun needed to start a recovery run in case of failure.
  */
-private[smartdatalake] case class ActionDAGRunState(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, actionsState: Map[String, RuntimeInfo], isFinal: Boolean) {
+private[smartdatalake] case class ActionDAGRunState(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, actionsState: Map[ActionObjectId, RuntimeInfo], isFinal: Boolean) {
   def toJson: String = ActionDAGRunState.toJson(this)
   def isFailed: Boolean = actionsState.exists(_._2.state==RuntimeEventState.FAILED)
   def isSucceeded: Boolean = isFinal && !isFailed
 }
-private[smartdatalake]object ActionDAGRunState {
-  // json4s is used because kxbmap configs supports converting case classes to config only from verion 5.0 which isn't yet stable
+private[smartdatalake] object ActionDAGRunState {
+  // json4s is used because kxbmap configs supports converting case classes to config only from version 5.0 which isn't yet stable
   // json4s is included with spark-core
   // Note that key-type of Maps must be String in json4s (e.g. actionsState...)
   import org.json4s._
   import org.json4s.jackson.JsonMethods._
   import org.json4s.jackson.Serialization
   implicit val formats =  DefaultFormats.withHints(ShortTypeHints(List(classOf[SparkSubFeed],classOf[FileSubFeed]))).withTypeHintFieldName("type") +
-    RuntimeEventStateSerializer + DurationSerializer + LocalDateTimeSerializer
+    RuntimeEventStateSerializer + DurationSerializer + LocalDateTimeSerializer + ActionObjectIdKeySerializer
 
   def toJson(actionDAGRunState: ActionDAGRunState): String = pretty(parse(Serialization.write(actionDAGRunState)))
 
-  def fromJson(stateJson: String): ActionDAGRunState = parse(stateJson).extract[ActionDAGRunState]
+  def fromJson(stateJson: String): ActionDAGRunState = {
+    val rawState = parse(stateJson).extract[ActionDAGRunState]
+    // fix key class type of "value class ActionObjectId" for scala 2.11 (ActionDAGRunTest fails for scala 2.11 otherwise)
+    rawState.copy(actionsState = rawState.actionsState.map( e => (if (e._1.getClass==classOf[String]) ActionObjectId(e._1.asInstanceOf[String]) else e._1, e._2)))
+  }
 
   // custom serialization for RuntimeEventState which is shorter than the default
   case object RuntimeEventStateSerializer extends CustomSerializer[RuntimeEventState](format => (
@@ -68,99 +68,38 @@ private[smartdatalake]object ActionDAGRunState {
     { case JString(tstmp) => LocalDateTime.parse(tstmp) },
     { case tstmp: LocalDateTime => JString(tstmp.toString) }
   ))
+  // custom serialization for ActionObjectId as key of Maps
+  case object ActionObjectIdKeySerializer extends CustomKeySerializer[ActionObjectId](format => (
+    { case id => ActionObjectId(id) },
+    { case id: ActionObjectId => id.id }
+  ))
 }
 
-private[smartdatalake] case class ActionDAGRunStateStore(statePath: String, appName: String) extends SmartDataLakeLogger {
-
-  private val hadoopStatePath = HdfsUtil.addHadoopDefaultSchemaAuthority(new Path(statePath))
-  private val currentStatePath = new Path(hadoopStatePath, "current")
-  private val succeededStatePath = new Path(hadoopStatePath, "succeeded")
-  implicit private val filesystem: FileSystem = HdfsUtil.getHadoopFs(hadoopStatePath)
-  if (!filesystem.exists(hadoopStatePath)) filesystem.mkdirs(hadoopStatePath)
-  filesystem.setWriteChecksum(false) // disable writing CRC files
+private[smartdatalake] trait ActionDAGRunStateStore[A <: StateId] extends SmartDataLakeLogger {
 
   /**
-   * Save state to file
+   * Save State
    */
-  def saveState(state: ActionDAGRunState): Unit = synchronized {
-    val path = if (state.isSucceeded) succeededStatePath else currentStatePath
-    // write state file
-    val json = state.toJson
-    val fileName = s"$appName${ActionDAGRunStateStore.fileNamePartSeparator}${state.runId}${ActionDAGRunStateStore.fileNamePartSeparator}${state.attemptId}.json"
-    val file = new Path(path, fileName)
-    val os = filesystem.create(file, true) // overwrite if exists
-    os.write(json.getBytes("UTF-8"))
-    os.close()
-    logger.info(s"updated state into ${file.toUri}")
-    // if succeeded:
-    // - delete temporary state file from current directory
-    // - move previous failed attempt files from current to succeeded directory
-    if (state.isSucceeded) {
-      filesystem.delete(new Path(currentStatePath, fileName), /*recursive*/ false)
-      getFiles(Some(currentStatePath))
-        .filter( stateFile => stateFile.runId==state.runId && stateFile.attemptId<state.attemptId)
-        .foreach { stateFile =>
-          logger.info(s"renamed ${stateFile.path}")
-          FileUtil.copy(filesystem, stateFile.path, filesystem, succeededStatePath, /*deleteSource*/ true, filesystem.getConf)
-        }
-    }
-  }
+  def saveState(state: ActionDAGRunState): Unit
 
   /**
    * Get latest state
    * @param runId optional runId to search for latest state
    */
-  def getLatestState(runId: Option[Int] = None): StateFile = {
-    val latestStateFile = getFiles()
-      .filter(x => runId.isEmpty || runId.contains(x.runId))
-      .sortBy(_.getSortAttrs).lastOption
-    require(latestStateFile.nonEmpty, s"No state file for application $appName and runId ${runId.getOrElse("latest")} found.")
-    latestStateFile.get
-  }
+  def getLatestState(runId: Option[Int] = None): A
 
   /**
    * Get latest runId
    */
-  def getLatestRunId: Option[Int] = {
-    val latestStateFile = getFiles()
-      .sortBy(_.getSortAttrs).lastOption
-    latestStateFile.map(_.runId)
-  }
-
-  /**
-   * Search state directory for state files of this app
-   */
-  private def getFiles(path: Option[Path] = None): Seq[StateFile] = {
-    val filenameMatcher = s"([^_]+)\\${ActionDAGRunStateStore.fileNamePartSeparator}([0-9]+)\\${ActionDAGRunStateStore.fileNamePartSeparator}([0-9]+)\\.json".r
-    val pathFilter = new PathFilter {
-      override def accept(path: Path): Boolean = path.getName.startsWith(appName + ActionDAGRunStateStore.fileNamePartSeparator)
-    }
-    val searchPath = path.getOrElse( new Path(hadoopStatePath, "*"))
-    filesystem.globStatus(new Path(searchPath, "*.json"), pathFilter )
-      .filter( x => x.isFile)
-      .flatMap( x => x.getPath.getName match {
-        case filenameMatcher(appName, runId, attemptId) =>
-          Some(StateFile(x.getPath, appName, runId.toInt, attemptId.toInt))
-        case _ => None
-      })
-      .filter(_.appName == this.appName)
-  }
+  def getLatestRunId: Option[Int]
 
   /**
    * recover previous run state
    */
-  def recoverRunState(stateFile: Path): ActionDAGRunState = {
-    require(filesystem.isFile(stateFile), s"Cannot recover previous run state. ${stateFile.toUri} doesn't exists or is not a file.")
-    val is = filesystem.open(stateFile)
-    val json = scala.io.Source.fromInputStream(is)(Codec.UTF8).mkString
-    ActionDAGRunState.fromJson(json)
-  }
-
-  case class StateFile(path: Path, appName: String, runId: Int, attemptId: Int) {
-    def getSortAttrs: (Int, Int) = (runId, attemptId)
-  }
+  def recoverRunState(stateId: A): ActionDAGRunState
 }
 
-private[smartdatalake] object ActionDAGRunStateStore {
-  val fileNamePartSeparator = "."
+private[smartdatalake] trait StateId {
+  def runId: Int
+  def attemptId: Int
 }

--- a/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -32,6 +32,8 @@ private[smartdatalake] case class ActionPipelineContext(
                                                          instanceRegistry: InstanceRegistry,
                                                          referenceTimestamp: Option[LocalDateTime] = None,
                                                          appConfig: SmartDataLakeBuilderConfig, // application config is needed to persist action dag state for recovery
+                                                         runStartTime: LocalDateTime = LocalDateTime.now(),
+                                                         attemptStartTime: LocalDateTime = LocalDateTime.now(),
                                                          simulation: Boolean = false,
                                                          var phase: ExecutionPhase = ExecutionPhase.Prepare
 ) {

--- a/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -25,14 +25,15 @@ import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 
 private[smartdatalake] case class ActionPipelineContext(
-  feed: String,
-  application: String,
-  runId: Int,
-  attemptId: Int,
-  instanceRegistry: InstanceRegistry,
-  referenceTimestamp: Option[LocalDateTime] = None,
-  appConfig: SmartDataLakeBuilderConfig, // application config is needed to persist action dag state for recovery
-  var phase: ExecutionPhase = ExecutionPhase.Prepare
+                                                         feed: String,
+                                                         application: String,
+                                                         runId: Int,
+                                                         attemptId: Int,
+                                                         instanceRegistry: InstanceRegistry,
+                                                         referenceTimestamp: Option[LocalDateTime] = None,
+                                                         appConfig: SmartDataLakeBuilderConfig, // application config is needed to persist action dag state for recovery
+                                                         simulation: Boolean = false,
+                                                         var phase: ExecutionPhase = ExecutionPhase.Prepare
 ) {
   def getReferenceTimestampOrNow: LocalDateTime = referenceTimestamp.getOrElse(LocalDateTime.now)
 }

--- a/src/main/scala/io/smartdatalake/workflow/HadoopFileActionDAGRunStateStore.scala
+++ b/src/main/scala/io/smartdatalake/workflow/HadoopFileActionDAGRunStateStore.scala
@@ -1,0 +1,123 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow
+
+import io.smartdatalake.util.hdfs.HdfsUtil
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import org.apache.hadoop.fs.{FileSystem, FileUtil, Path, PathFilter}
+
+import scala.io.Codec
+
+private[smartdatalake] case class HadoopFileActionDAGRunStateStore(statePath: String, appName: String) extends ActionDAGRunStateStore[HadoopFileStateId] with SmartDataLakeLogger {
+
+  private val hadoopStatePath = HdfsUtil.addHadoopDefaultSchemaAuthority(new Path(statePath))
+  private val currentStatePath = new Path(hadoopStatePath, "current")
+  private val succeededStatePath = new Path(hadoopStatePath, "succeeded")
+  implicit private val filesystem: FileSystem = HdfsUtil.getHadoopFs(hadoopStatePath)
+  if (!filesystem.exists(hadoopStatePath)) filesystem.mkdirs(hadoopStatePath)
+  filesystem.setWriteChecksum(false) // disable writing CRC files
+
+  /**
+   * Save state to file
+   */
+  override def saveState(state: ActionDAGRunState): Unit = synchronized {
+    val path = if (state.isSucceeded) succeededStatePath else currentStatePath
+    // write state file
+    val json = state.toJson
+    val fileName = s"$appName${HadoopFileActionDAGRunStateStore.fileNamePartSeparator}${state.runId}${HadoopFileActionDAGRunStateStore.fileNamePartSeparator}${state.attemptId}.json"
+    val file = new Path(path, fileName)
+    val os = filesystem.create(file, true) // overwrite if exists
+    os.write(json.getBytes("UTF-8"))
+    os.close()
+    logger.info(s"updated state into ${file.toUri}")
+    // if succeeded:
+    // - delete temporary state file from current directory
+    // - move previous failed attempt files from current to succeeded directory
+    if (state.isSucceeded) {
+      filesystem.delete(new Path(currentStatePath, fileName), /*recursive*/ false)
+      getFiles(Some(currentStatePath))
+        .filter( stateFile => stateFile.runId==state.runId && stateFile.attemptId<state.attemptId)
+        .foreach { stateFile =>
+          logger.info(s"renamed ${stateFile.path}")
+          FileUtil.copy(filesystem, stateFile.path, filesystem, succeededStatePath, /*deleteSource*/ true, filesystem.getConf)
+        }
+    }
+  }
+
+  /**
+   * Get latest state
+   * @param runId optional runId to search for latest state
+   */
+  override def getLatestState(runId: Option[Int] = None): HadoopFileStateId = {
+    val latestStateFile = getFiles()
+      .filter(x => runId.isEmpty || runId.contains(x.runId))
+      .sortBy(_.getSortAttrs).lastOption
+    require(latestStateFile.nonEmpty, s"No state file for application $appName and runId ${runId.getOrElse("latest")} found.")
+    latestStateFile.get
+  }
+
+  /**
+   * Get latest runId
+   */
+  override def getLatestRunId: Option[Int] = {
+    val latestStateFile = getFiles()
+      .sortBy(_.getSortAttrs).lastOption
+    latestStateFile.map(_.runId)
+  }
+
+  /**
+   * Search state directory for state files of this app
+   */
+  private def getFiles(path: Option[Path] = None): Seq[HadoopFileStateId] = {
+    val filenameMatcher = s"([^_]+)\\${HadoopFileActionDAGRunStateStore.fileNamePartSeparator}([0-9]+)\\${HadoopFileActionDAGRunStateStore.fileNamePartSeparator}([0-9]+)\\.json".r
+    val pathFilter = new PathFilter {
+      override def accept(path: Path): Boolean = path.getName.startsWith(appName + HadoopFileActionDAGRunStateStore.fileNamePartSeparator)
+    }
+    val searchPath = path.getOrElse( new Path(hadoopStatePath, "*"))
+    filesystem.globStatus(new Path(searchPath, "*.json"), pathFilter )
+      .filter( x => x.isFile)
+      .flatMap( x => x.getPath.getName match {
+        case filenameMatcher(appName, runId, attemptId) =>
+          Some(HadoopFileStateId(x.getPath, appName, runId.toInt, attemptId.toInt))
+        case _ => None
+      })
+      .filter(_.appName == this.appName)
+  }
+
+  /**
+   * recover previous run state
+   */
+  override def recoverRunState(stateId: HadoopFileStateId): ActionDAGRunState = {
+    val stateFile = stateId.path
+    require(filesystem.isFile(stateFile), s"Cannot recover previous run state. ${stateFile.toUri} doesn't exists or is not a file.")
+    val is = filesystem.open(stateFile)
+    val json = scala.io.Source.fromInputStream(is)(Codec.UTF8).mkString
+    ActionDAGRunState.fromJson(json)
+  }
+
+}
+
+case class HadoopFileStateId(path: Path, appName: String, runId: Int, attemptId: Int) extends StateId {
+  def getSortAttrs: (Int, Int) = (runId, attemptId)
+}
+
+private[smartdatalake] object HadoopFileActionDAGRunStateStore {
+  val fileNamePartSeparator = "."
+}

--- a/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -42,7 +42,7 @@ trait SubFeed extends DAGResult {
    * This is usable to break long DataFrame Lineages over multiple Actions and instead reread the data from an intermediate table
    * @return
    */
-  def breakLineage(implicit session: SparkSession): SubFeed
+  def breakLineage(implicit session: SparkSession, context: ActionPipelineContext): SubFeed
 
   def clearPartitionValues(): SubFeed
 
@@ -71,10 +71,10 @@ case class SparkSubFeed(@transient dataFrame: Option[DataFrame],
                         filter: Option[String] = None
                        )
   extends SubFeed {
-  override def breakLineage(implicit session: SparkSession): SparkSubFeed = {
+  override def breakLineage(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     // in order to keep the schema but truncate spark logical plan, a dummy DataFrame is created.
     // dummy DataFrames must be exchanged to real DataFrames before reading in exec-phase.
-    if(dataFrame.isDefined) convertToDummy(dataFrame.get.schema) else this
+    if(dataFrame.isDefined && !context.simulation) convertToDummy(dataFrame.get.schema) else this
   }
   override def clearPartitionValues(): SparkSubFeed = {
     this.copy(partitionValues = Seq())
@@ -86,7 +86,7 @@ case class SparkSubFeed(@transient dataFrame: Option[DataFrame],
   override def clearDAGStart(): SparkSubFeed = {
     this.copy(isDAGStart = false)
   }
-  def clearFilter(implicit session: SparkSession): SparkSubFeed = {
+  def clearFilter(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     // if filter is removed, also the DataFrame must be removed so that the next action get's an unfiltered DataFrame
     if (filter.isDefined) this.copy(filter = None).breakLineage else this
   }
@@ -130,7 +130,7 @@ case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
                        processedInputFileRefs: Option[Seq[FileRef]] = None
                       )
   extends SubFeed {
-  override def breakLineage(implicit session: SparkSession): FileSubFeed = {
+  override def breakLineage(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
     this.copy(fileRefs = None)
   }
   override def clearPartitionValues(): FileSubFeed = {
@@ -162,7 +162,7 @@ object FileSubFeed {
 case class InitSubFeed(override val dataObjectId: DataObjectId, override val partitionValues: Seq[PartitionValues])
   extends SubFeed {
   override def isDAGStart: Boolean = true
-  override def breakLineage(implicit session: SparkSession): InitSubFeed = this
+  override def breakLineage(implicit session: SparkSession, context: ActionPipelineContext): InitSubFeed = this
   override def clearPartitionValues(): InitSubFeed = {
     this.copy(partitionValues = Seq())
   }

--- a/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -28,7 +28,6 @@ import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow._
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.dataobject.DataObject
-import io.smartdatalake.workflow._
 import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable
@@ -57,6 +56,15 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * To be implemented by subclasses
    */
   def inputs: Seq[DataObject]
+
+  /**
+   * Recursive Inputs are DataObjects that are used as Output and Input in the same action
+   * This is usually prohibited as it creates loops in the DAG.
+   * In special cases this makes sense, i.e. when building a complex delta logic
+   *
+   * @return
+   */
+  def recursiveInputs: Seq[DataObject]
 
   /**
    * Output [[DataObject]]s

--- a/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -22,17 +22,15 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 
 import io.smartdatalake.config.ConfigurationException
-import io.smartdatalake.config.SdlConfigObject.ActionObjectId
-import io.smartdatalake.definitions.{ExecutionMode, PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
+import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, DataObject}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{StringType, TimestampType}
+import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, SparkSession}
 
-object ActionHelper extends SmartDataLakeLogger {
+private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
 
   /**
    * Removes all columns from a [[DataFrame]] except those specified in whitelist.
@@ -111,82 +109,7 @@ object ActionHelper extends SmartDataLakeLogger {
     else None
   }
 
-  /**
-   * Apply execution mode to partition values
-   */
-  def applyExecutionMode(executionMode: ExecutionMode, actionId: ActionObjectId, input: DataObject, output: DataObject, phase: ExecutionPhase)(implicit session: SparkSession): Option[(Seq[PartitionValues], Option[String])] = {
-    import session.implicits._
-
-    executionMode match {
-      case mode:PartitionDiffMode =>
-        (input,output) match {
-          case (partitionInput: CanHandlePartitions, partitionOutput: CanHandlePartitions)  =>
-            if (partitionInput.partitions.nonEmpty) {
-              if (partitionOutput.partitions.nonEmpty) {
-                // prepare common partition columns
-                val commonInits = searchCommonInits(partitionInput.partitions, partitionOutput.partitions)
-                require(commonInits.nonEmpty, s"$actionId has set initExecutionMode = 'PartitionDiffMode' but no common init was found in partition columns for $input and $output")
-                val commonPartitions = if (mode.partitionColNb.isDefined) {
-                  commonInits.find(_.size==mode.partitionColNb.get).getOrElse(throw ConfigurationException(s"$actionId has set initExecutionMode = 'PartitionDiffMode' but no common init with ${mode.partitionColNb.get} was found in partition columns of $input and $output from $commonInits!"))
-                } else {
-                  commonInits.maxBy(_.size)
-                }
-                // calculate missing partition values
-                val partitionValuesToBeProcessed = partitionInput.listPartitions.map(_.filterKeys(commonPartitions)).toSet
-                  .diff(partitionOutput.listPartitions.map(_.filterKeys(commonPartitions)).toSet).toSeq
-                // stop processing if no new data
-                if (partitionValuesToBeProcessed.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No partitions to process found for ${input.id}")
-                // sort and limit number of partitions processed
-                val ordering = PartitionValues.getOrdering(commonPartitions)
-                val selectedPartitionValues = mode.nbOfPartitionValuesPerRun match {
-                  case Some(n) => partitionValuesToBeProcessed.sorted(ordering).take(n)
-                  case None => partitionValuesToBeProcessed.sorted(ordering)
-                }
-                logger.info(s"($actionId) PartitionDiffMode selected partition values ${selectedPartitionValues.mkString(", ")} to process")
-                //return
-                Some((selectedPartitionValues, None))
-              } else throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $output has no partition columns defined!")
-            } else throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $input has no partition columns defined!")
-          case (_: CanHandlePartitions, _) => throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $output does not support partitions!")
-          case (_, _) => throw ConfigurationException(s"$actionId has set initExecutionMode = PartitionDiffMode but $input does not support partitions!")
-        }
-
-      case mode:SparkIncrementalMode =>
-        (input,output) match {
-          case (sparkInput: CanCreateDataFrame, sparkOutput: CanCreateDataFrame) =>
-            // if data object is new, it might not be able to create a DataFrame
-            val dfInputOpt = getOptionalDataFrame(sparkInput)
-            val dfOutputOpt = getOptionalDataFrame(sparkOutput)
-            (dfInputOpt, dfOutputOpt) match {
-              // if both DataFrames exist, compare and create filter
-              case (Some(dfInput), Some(dfOutput)) =>
-                val inputColType = dfInput.schema(mode.compareCol).dataType
-                require(SparkIncrementalMode.allowedDataTypes.contains(inputColType), s"($actionId) Type of compare column ${mode.compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkInput.id}")
-                val outputColType = dfOutput.schema(mode.compareCol).dataType
-                require(SparkIncrementalMode.allowedDataTypes.contains(outputColType), s"($actionId) Type of compare column ${mode.compareCol} must be one of ${SparkIncrementalMode.allowedDataTypes.mkString(", ")} in ${sparkOutput.id}")
-                require(inputColType == outputColType, s"($actionId) Type of compare column ${mode.compareCol} is different between ${sparkInput.id} ($inputColType) and ${sparkOutput.id} ($outputColType)")
-                // get latest values
-                val inputLatestValue = dfInput.agg(max(col(mode.compareCol)).cast(StringType)).as[String].head
-                val outputLatestValue = dfOutput.agg(max(col(mode.compareCol)).cast(StringType)).as[String].head
-                // stop processing if no new data
-                if (outputLatestValue == inputLatestValue) throw NoDataToProcessWarning(actionId.id, s"($actionId) No increment to process found for ${output.id} column ${mode.compareCol} (lastestValue=$outputLatestValue)")
-                logger.info(s"($actionId) SparkIncrementalMode selected increment for writing to ${output.id}: column ${mode.compareCol} from $outputLatestValue to $inputLatestValue to process")
-                // prepare filter
-                val selectedData = s"${mode.compareCol} > cast('$outputLatestValue' as ${inputColType.sql})"
-                Some((Seq(), Some(selectedData)))
-              // otherwise don't filter
-              case _ =>
-                logger.info(s"($actionId) SparkIncrementalMode selected all records for writing to ${output.id}, because input or output DataObject is still empty.")
-                Some((Seq(), None))
-            }
-          case _ => throw ConfigurationException(s"$actionId has set executionMode = $SparkIncrementalMode but $input or $output does not support creating Spark DataFrames!")
-        }
-
-      case _ => None
-    }
-  }
-
-  private def getOptionalDataFrame(sparkInput: CanCreateDataFrame, partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession) : Option[DataFrame] = try {
+  def getOptionalDataFrame(sparkInput: CanCreateDataFrame, partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession) : Option[DataFrame] = try {
     Some(sparkInput.getDataFrame(partitionValues))
   } catch {
     case e: IllegalArgumentException if e.getMessage.contains("DataObject schema is undefined") => None
@@ -204,5 +127,19 @@ object ActionHelper extends SmartDataLakeLogger {
     invalidCharacters.replaceAllIn(str, "_")
   }
 
+  def getMainDataObject[T <: DataObject](mainId: Option[DataObjectId], dataObjects: Seq[T], inputOutput: String, mainNeeded: Boolean, actionId: ActionObjectId): T = {
+    mainId.map {
+      id => dataObjects.find(_.id == id).getOrElse(throw ConfigurationException(s"($actionId) main${inputOutput}Id $id not found in ${inputOutput}s"))
+    }.orElse {
+      val partitionedDataObjects = dataObjects.collect{ case x: T @unchecked with CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
+      if (partitionedDataObjects.size==1) partitionedDataObjects.headOption
+      else None
+    }.orElse {
+      if (dataObjects.size==1) dataObjects.headOption else None
+    }.getOrElse {
+      if (mainNeeded) logger.warn(s"($actionId) Could not determine unique main $inputOutput but execution mode might need it. Decided for ${dataObjects.head.id}.")
+      dataObjects.head
+    }
+  }
 }
 

--- a/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -37,7 +37,6 @@ import scala.util.{Failure, Success, Try}
  * @param outputId output DataObject
  * @param deleteDataAfterRead a flag to enable deletion of input partitions after copying.
  * @param transformer a custom transformation that is applied to each SubFeed separately
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -53,7 +52,6 @@ case class CopyAction(override val id: ActionObjectId,
                       standardizeDatatypes: Boolean = false,
                       override val breakDataFrameLineage: Boolean = false,
                       override val persist: Boolean = false,
-                      override val initExecutionMode: Option[ExecutionMode] = None,
                       override val executionMode: Option[ExecutionMode] = None,
                       override val metricsFailCondition: Option[String] = None,
                       override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -49,7 +49,7 @@ case class CustomFileAction(override val id: ActionObjectId,
                             override val deleteDataAfterRead: Boolean = false,
                             filesPerPartition: Int = 10,
                             override val breakFileRefLineage: Boolean = false,
-                            override val initExecutionMode: Option[ExecutionMode] = None,
+                            override val executionMode: Option[ExecutionMode] = None,
                             override val metricsFailCondition: Option[String] = None,
                             override val metadata: Option[ActionMetadata] = None
                            )(implicit instanceRegistry: InstanceRegistry)

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -78,10 +78,8 @@ case class CustomSparkAction ( override val id: ActionObjectId,
         case (dataObjectId, dataFrame) =>
           val output = outputs.find(_.id.id == dataObjectId)
             .getOrElse(throw ConfigurationException(s"No output found for result ${dataObjectId} in $id. Configured outputs are ${outputs.map(_.id.id).mkString(", ")}."))
-          // if main output, get partition values from main input
-          val partitionValues = if (mainOutput.id.id == dataObjectId) {
-            mainInputSubFeed.map(_.partitionValues).getOrElse(Seq())
-          } else Seq()
+          // get partition values from main input
+          val partitionValues = mainInputSubFeed.map(_.partitionValues).getOrElse(Seq())
           SparkSubFeed(Some(dataFrame),dataObjectId, partitionValues)
       }.toSeq
   }

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -35,7 +35,8 @@ import org.apache.spark.sql.SparkSession
  * @param inputIds input DataObject's
  * @param outputIds output DataObject's
  * @param transformer Custom Transformer to transform Seq[DataFrames]
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
+ * @param mainInputId optional selection of main inputId used for execution mode and partition values propagation. Only needed if there are multiple input DataObject's.
+ * @param mainOutputId optional selection of main outputId used for execution mode and partition values propagation. Only needed if there are multiple output DataObject's.
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -48,7 +49,8 @@ case class CustomSparkAction ( override val id: ActionObjectId,
                                transformer: CustomDfsTransformerConfig,
                                override val breakDataFrameLineage: Boolean = false,
                                override val persist: Boolean = false,
-                               override val initExecutionMode: Option[ExecutionMode] = None,
+                               override val mainInputId: Option[DataObjectId] = None,
+                               override val mainOutputId: Option[DataObjectId] = None,
                                override val executionMode: Option[ExecutionMode] = None,
                                override val metricsFailCondition: Option[String] = None,
                                override val metadata: Option[ActionMetadata] = None,

--- a/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -39,6 +39,8 @@ import org.apache.spark.sql.SparkSession
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
+ * @param metadata
+ * @param recursiveInputIds output of action that are used as input in the same action
  */
 case class CustomSparkAction ( override val id: ActionObjectId,
                                inputIds: Seq[DataObjectId],
@@ -49,9 +51,12 @@ case class CustomSparkAction ( override val id: ActionObjectId,
                                override val initExecutionMode: Option[ExecutionMode] = None,
                                override val executionMode: Option[ExecutionMode] = None,
                                override val metricsFailCondition: Option[String] = None,
-                               override val metadata: Option[ActionMetadata] = None
+                               override val metadata: Option[ActionMetadata] = None,
+                               recursiveInputIds: Seq[DataObjectId] = Seq()
 )(implicit instanceRegistry: InstanceRegistry) extends SparkSubFeedsAction {
 
+  assert(recursiveInputIds.forall(outputIds.contains(_)), "All recursive inputs must be in output of the same action.")
+  override val recursiveInputs: Seq[DataObject with CanCreateDataFrame] = recursiveInputIds.map(getInputDataObject[DataObject with CanCreateDataFrame])
   override val inputs: Seq[DataObject with CanCreateDataFrame] = inputIds.map(getInputDataObject[DataObject with CanCreateDataFrame])
   override val outputs: Seq[DataObject with CanWriteDataFrame] = outputIds.map(getOutputDataObject[DataObject with CanWriteDataFrame])
 

--- a/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
@@ -46,7 +46,6 @@ import scala.util.{Failure, Success, Try}
  * @param ignoreOldDeletedNestedColumns if true, remove no longer existing columns from nested data types in Schema Evolution.
  *                                      Keeping deleted columns in complex data types has performance impact as all new data
  *                                      in the future has to be converted by a complex function.
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -63,7 +62,6 @@ case class DeduplicateAction(override val id: ActionObjectId,
                              ignoreOldDeletedNestedColumns: Boolean = true,
                              override val breakDataFrameLineage: Boolean = false,
                              override val persist: Boolean = false,
-                             override val initExecutionMode: Option[ExecutionMode] = None,
                              override val executionMode: Option[ExecutionMode] = None,
                              override val metricsFailCondition: Option[String] = None,
                              override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.definitions.ExecutionMode
 import io.smartdatalake.util.misc.PerformanceUtils
-import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, CanHandlePartitions, FileRefDataObject}
+import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, CanHandlePartitions, DataObject, FileRefDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed, InitSubFeed, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
@@ -35,6 +35,12 @@ abstract class FileSubFeedAction extends Action {
    * Output [[FileRefDataObject]] which can CanCreateOutputStream
    */
   def output:  FileRefDataObject with CanCreateOutputStream
+
+  /**
+   * Recursive Inputs on FileSubFeeds are not supported so empty Seq is set.
+   *  @return
+   */
+  override def recursiveInputs: Seq[FileRefDataObject with CanCreateInputStream] = Seq()
 
   /**
    * Initialize Action with a given [[FileSubFeed]]

--- a/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -42,7 +42,7 @@ case class FileTransferAction(override val id: ActionObjectId,
                               override val deleteDataAfterRead: Boolean = false,
                               overwrite: Boolean = true,
                               override val breakFileRefLineage: Boolean = false,
-                              override val initExecutionMode: Option[ExecutionMode] = None,
+                              override val executionMode: Option[ExecutionMode] = None,
                               override val metricsFailCondition: Option[String] = None,
                               override val metadata: Option[ActionMetadata] = None)
                              ( implicit instanceRegistry: InstanceRegistry)

--- a/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
@@ -48,7 +48,6 @@ import scala.util.{Failure, Success, Try}
  * @param ignoreOldDeletedNestedColumns if true, remove no longer existing columns from nested data types in Schema Evolution.
  *                                      Keeping deleted columns in complex data types has performance impact as all new data
  *                                      in the future has to be converted by a complex function.
- * @param initExecutionMode optional execution mode if this Action is a start node of a DAG run
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -68,7 +67,6 @@ case class HistorizeAction(
                             ignoreOldDeletedNestedColumns: Boolean = true,
                             override val breakDataFrameLineage: Boolean = false,
                             override val persist: Boolean = false,
-                            override val initExecutionMode: Option[ExecutionMode] = None,
                             override val executionMode: Option[ExecutionMode] = None,
                             override val metricsFailCondition: Option[String] = None,
                             override val metadata: Option[ActionMetadata] = None

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -78,10 +78,10 @@ private[smartdatalake] abstract class SparkAction extends Action {
    * @param input input data object.
    * @param subFeed input SubFeed.
    */
-  def enrichSubFeedDataFrame(input: DataObject with CanCreateDataFrame, subFeed: SparkSubFeed, executionMode: Option[ExecutionMode], phase: ExecutionPhase)(implicit session: SparkSession): SparkSubFeed = {
+  def enrichSubFeedDataFrame(input: DataObject with CanCreateDataFrame, subFeed: SparkSubFeed, executionMode: Option[ExecutionMode], phase: ExecutionPhase)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     assert(input.id == subFeed.dataObjectId, s"($id) DataObject.Id ${input.id} doesnt match SubFeed.DataObjectId ${subFeed.dataObjectId} ")
     executionMode match {
-      case Some(m: SparkStreamingOnceMode) =>
+      case Some(m: SparkStreamingOnceMode) if !context.simulation =>
         if (subFeed.dataFrame.isEmpty || phase==ExecutionPhase.Exec) { // in exec phase we always needs a fresh streaming DataFrame
           // recreate DataFrame from DataObject
           assert(input.isInstanceOf[CanCreateStreamingDataFrame], s"($id) DataObject ${input.id} doesn't implement CanCreateStreamingDataFrame. Can not create StreamingDataFrame for executionMode=SparkStreamingOnceMode")
@@ -271,7 +271,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
     updatedSubFeed.clearDAGStart()
   }
 
-  def updateSubFeedAfterWrite(subFeed: SparkSubFeed, executionMode: Option[ExecutionMode])(implicit session: SparkSession): SparkSubFeed = {
+  def updateSubFeedAfterWrite(subFeed: SparkSubFeed, executionMode: Option[ExecutionMode])(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     subFeed.clearFilter // clear filter must be applied after write, because it includes removing the DataFrame
   }
 
@@ -316,7 +316,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
   /**
    * Applies changes to a SubFeed from a previous action in order to be used as input for this actions transformation.
    */
-  def prepareInputSubFeed(subFeed: SparkSubFeed, input: DataObject with CanCreateDataFrame)(implicit session: SparkSession): SparkSubFeed = {
+  def prepareInputSubFeed(subFeed: SparkSubFeed, input: DataObject with CanCreateDataFrame)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     // persist if requested
     var preparedSubFeed = if (persist) subFeed.persist else subFeed
     // create dummy DataFrame if read schema is different from write schema on this DataObject

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -30,12 +30,11 @@ import io.smartdatalake.util.streaming.DummyStreamProvider
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.action.ActionHelper.{filterBlacklist, filterWhitelist}
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
-import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanCreateStreamingDataFrame, CanHandlePartitions, CanWriteDataFrame, DataObject, SparkFileDataObject, TableDataObject, UserDefinedSchema}
+import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.apache.spark.sql.streaming.Trigger
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
 private[smartdatalake] abstract class SparkAction extends Action {
 
@@ -53,23 +52,13 @@ private[smartdatalake] abstract class SparkAction extends Action {
   def persist: Boolean
 
   /**
-   * Execution mode if this Action is a start node of a DAG run
-   */
-  def initExecutionMode: Option[ExecutionMode]
-  require(initExecutionMode.isEmpty || initExecutionMode.exists(_.isInstanceOf[PartitionDiffMode]), s"($id) $initExecutionMode not supported as initExecutionMode")
-
-  /**
-   * General execution mode for this action.
-   * Note that this is overridden by initExecutionMode if it is defined and this Action is a start node of a DAG run.
+   * execution mode for this action.
    */
   def executionMode: Option[ExecutionMode]
 
-  /**
-   * Returns the execution mode used on runtime of the action, depending if this Action is a start node of a DAG run
-   */
-  def runtimeExecutionMode(subFeed: SubFeed): Option[ExecutionMode] = {
-    // override executionMode with initExecutionMode if is start node of a DAG run
-    if (subFeed.isDAGStart) initExecutionMode.orElse(executionMode) else executionMode
+  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.prepare
+    executionMode.foreach(_.prepare(id))
   }
 
   /**
@@ -78,7 +67,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
    * @param input input data object.
    * @param subFeed input SubFeed.
    */
-  def enrichSubFeedDataFrame(input: DataObject with CanCreateDataFrame, subFeed: SparkSubFeed, executionMode: Option[ExecutionMode], phase: ExecutionPhase)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  def enrichSubFeedDataFrame(input: DataObject with CanCreateDataFrame, subFeed: SparkSubFeed, phase: ExecutionPhase)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     assert(input.id == subFeed.dataObjectId, s"($id) DataObject.Id ${input.id} doesnt match SubFeed.DataObjectId ${subFeed.dataObjectId} ")
     executionMode match {
       case Some(m: SparkStreamingOnceMode) if !context.simulation =>
@@ -96,6 +85,14 @@ private[smartdatalake] abstract class SparkAction extends Action {
         } else subFeed
       case _ =>
         if (phase==ExecutionPhase.Exec && (subFeed.dataFrame.isEmpty || subFeed.isDummy || subFeed.isStreaming.contains(true))) {
+          // validate partition values existing for input
+          input match {
+            case partitionedInput: DataObject with CanHandlePartitions if subFeed.partitionValues.nonEmpty =>
+              val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(partitionedInput.listPartitions, subFeed.partitionValues)
+              assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
+            case _ => Unit
+          }
+          if (subFeed.partitionValues.nonEmpty)
           // recreate DataFrame from DataObject
           logger.info(s"($id) getting DataFrame for ${input.id}" + (if (subFeed.partitionValues.nonEmpty) s" filtered by partition values ${subFeed.partitionValues.mkString(" ")}" else ""))
           val df = input.getDataFrame(subFeed.partitionValues)
@@ -126,7 +123,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
    * writes subfeed to output respecting given execution mode
    * @return true if no data was transfered, otherwise false
    */
-  def writeSubFeed(executionMode: Option[ExecutionMode], subFeed: SparkSubFeed, output: DataObject with CanWriteDataFrame)(implicit session: SparkSession): Boolean = {
+  def writeSubFeed(subFeed: SparkSubFeed, output: DataObject with CanWriteDataFrame)(implicit session: SparkSession): Boolean = {
     executionMode match {
       case Some(m: SparkStreamingOnceMode) =>
         // Write in streaming mode - use spark streaming with Trigger.Once and awaitTermination
@@ -271,7 +268,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
     updatedSubFeed.clearDAGStart()
   }
 
-  def updateSubFeedAfterWrite(subFeed: SparkSubFeed, executionMode: Option[ExecutionMode])(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  def updateSubFeedAfterWrite(subFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     subFeed.clearFilter // clear filter must be applied after write, because it includes removing the DataFrame
   }
 

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -22,7 +22,7 @@ package io.smartdatalake.workflow.action
 import java.time.LocalDateTime
 
 import io.smartdatalake.config.ConfigurationException
-import io.smartdatalake.definitions.{ExecutionMode, PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
+import io.smartdatalake.definitions.{ExecutionMode, FailIfNoPartitionValuesMode, PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.DataFrameUtil
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
@@ -134,7 +134,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
         if (noData) logger.info(s"($id) no data to process for ${output.id} in streaming mode")
         // return
         noData
-      case None | Some(_: PartitionDiffMode) | Some(_: SparkIncrementalMode) =>
+      case None | Some(_: PartitionDiffMode) | Some(_: SparkIncrementalMode) | Some(_: FailIfNoPartitionValuesMode) =>
         // Write in batch mode
         assert(!subFeed.dataFrame.get.isStreaming, s"($id) Input from ${subFeed.dataObjectId} is a streaming DataFrame, but executionMode!=${SparkStreamingOnceMode.getClass.getSimpleName}")
         output.writeDataFrame(subFeed.dataFrame.get, subFeed.partitionValues)

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -83,10 +83,14 @@ abstract class SparkSubFeedAction extends SparkAction {
    */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for SparkSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
-    outputs.collect{ case x: CanWriteDataFrame => x }.foreach(_.init())
     val subFeed = subFeeds.head
     val thisExecutionMode = runtimeExecutionMode(subFeed)
-    Seq(doTransform(subFeed, thisExecutionMode))
+    // transform
+    val transformedSubFeed = doTransform(subFeed, thisExecutionMode)
+    // check output
+    output.init(transformedSubFeed.dataFrame.get, transformedSubFeed.partitionValues)
+    // return
+    Seq(updateSubFeedAfterWrite(transformedSubFeed, thisExecutionMode))
   }
 
   /**

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -38,6 +38,12 @@ abstract class SparkSubFeedAction extends SparkAction {
   def output:  DataObject with CanWriteDataFrame
 
   /**
+   * Recursive Inputs are not supported on SparkSubFeedAction (only on SparkSubFeedsAction) so set to empty Seq
+   *  @return
+   */
+  override def recursiveInputs: Seq[DataObject with CanCreateDataFrame] = Seq()
+
+  /**
    * Transform a [[SparkSubFeed]].
    * To be implemented by subclasses.
    *

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -18,12 +18,11 @@
  */
 package io.smartdatalake.workflow.action
 
-import io.smartdatalake.definitions.{ExecutionMode, PartitionDiffMode}
+import io.smartdatalake.definitions.ExecutionMode
 import io.smartdatalake.util.misc.PerformanceUtils
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed, SubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.col
 
 abstract class SparkSubFeedAction extends SparkAction {
 
@@ -52,13 +51,13 @@ abstract class SparkSubFeedAction extends SparkAction {
    */
   def transform(subFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed
 
-  private def doTransform(subFeed: SubFeed, thisExecutionMode: Option[ExecutionMode])(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  private def doTransform(subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     // convert subfeed to SparkSubFeed type or initialize if not yet existing
     var preparedSubFeed = SparkSubFeed.fromSubFeed(subFeed)
     // apply execution mode
-    preparedSubFeed = thisExecutionMode match {
+    preparedSubFeed = executionMode match {
       case Some(mode) =>
-        ActionHelper.applyExecutionMode(mode, id, input, output, context.phase) match {
+        mode.apply(id, input, output, preparedSubFeed) match {
           case Some((newPartitionValues, newFilter)) => preparedSubFeed.copy(partitionValues = newPartitionValues, filter = newFilter)
           case None => preparedSubFeed
         }
@@ -67,15 +66,11 @@ abstract class SparkSubFeedAction extends SparkAction {
     // prepare as input SubFeed
     preparedSubFeed = prepareInputSubFeed(preparedSubFeed, input)
     // enrich with fresh DataFrame if needed
-    preparedSubFeed = enrichSubFeedDataFrame(input, preparedSubFeed, thisExecutionMode, context.phase)
+    preparedSubFeed = enrichSubFeedDataFrame(input, preparedSubFeed, context.phase)
     // transform
     val transformedSubFeed = transform(preparedSubFeed)
     // update partition values to output's partition columns and update dataObjectId
     validateAndUpdateSubFeedPartitionValues(output, transformedSubFeed).copy(dataObjectId = output.id)
-  }
-
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    super.prepare
   }
 
   /**
@@ -84,13 +79,12 @@ abstract class SparkSubFeedAction extends SparkAction {
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for SparkSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
     val subFeed = subFeeds.head
-    val thisExecutionMode = runtimeExecutionMode(subFeed)
     // transform
-    val transformedSubFeed = doTransform(subFeed, thisExecutionMode)
+    val transformedSubFeed = doTransform(subFeed)
     // check output
     output.init(transformedSubFeed.dataFrame.get, transformedSubFeed.partitionValues)
     // return
-    Seq(updateSubFeedAfterWrite(transformedSubFeed, thisExecutionMode))
+    Seq(updateSubFeedAfterWrite(transformedSubFeed))
   }
 
   /**
@@ -99,22 +93,21 @@ abstract class SparkSubFeedAction extends SparkAction {
   override final def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for SparkSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
     val subFeed = subFeeds.head
-    val thisExecutionMode = runtimeExecutionMode(subFeed)
     // transform
-    val transformedSubFeed = doTransform(subFeed, thisExecutionMode)
+    val transformedSubFeed = doTransform(subFeed)
     // write output
     val msg = s"writing to ${output.id}" + (if (transformedSubFeed.partitionValues.nonEmpty) s", partitionValues ${transformedSubFeed.partitionValues.mkString(" ")}" else "")
     logger.info(s"($id) start " + msg)
     setSparkJobMetadata(Some(msg))
     val (noData,d) = PerformanceUtils.measureDuration {
-      writeSubFeed(thisExecutionMode, transformedSubFeed, output)
+      writeSubFeed(transformedSubFeed, output)
     }
     setSparkJobMetadata()
     val metricsLog = if (noData) ", no data found"
     else getFinalMetrics(output.id).map(_.getMainInfos).map(" "+_.map( x => x._1+"="+x._2).mkString(" ")).getOrElse("")
     logger.info(s"($id) finished writing DataFrame to ${output.id}: duration=$d" + metricsLog)
     // return
-    Seq(updateSubFeedAfterWrite(transformedSubFeed, thisExecutionMode))
+    Seq(updateSubFeedAfterWrite(transformedSubFeed))
   }
 
   override final def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
@@ -19,9 +19,10 @@
 package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.ConfigurationException
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.definitions.{ExecutionMode, ExecutionModeWithMainInputOutput}
 import io.smartdatalake.util.misc.PerformanceUtils
-import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, CanWriteDataFrame, DataObject}
+import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.SparkSession
 
@@ -31,45 +32,13 @@ abstract class SparkSubFeedsAction extends SparkAction {
   override def outputs: Seq[DataObject with CanWriteDataFrame]
   override def recursiveInputs: Seq[DataObject with CanCreateDataFrame] = Seq()
 
+  def mainInputId: Option[DataObjectId]
+  def mainOutputId: Option[DataObjectId]
+
   // prepare main input / output
   // this must be lazy because inputs / outputs is evaluated later in subclasses
-  val initExecutionModeMainInputOutput: Option[ExecutionModeWithMainInputOutput] = initExecutionMode.collect{ case mode: ExecutionModeWithMainInputOutput => mode }
-  lazy val initMainInput: Option[DataObject with CanCreateDataFrame] = initExecutionModeMainInputOutput.flatMap {
-    _.mainInputId.map( inputId => inputs.find(_.id.id == inputId).getOrElse(throw ConfigurationException(s"$id has set an initExecutionMode with inputId $inputId, which was not found in inputs")))
-  }
-  val normalExecutionModeMainInputOutput: Option[ExecutionModeWithMainInputOutput] = executionMode.collect{ case mode: ExecutionModeWithMainInputOutput => mode }
-  lazy val normalMainInput: Option[DataObject with CanCreateDataFrame] = normalExecutionModeMainInputOutput.flatMap {
-    _.mainInputId.map( inputId => inputs.find(_.id.id == inputId).getOrElse(throw ConfigurationException(s"$id has set an initExecutionMode with inputId $inputId, which was not found in inputs")))
-  }
-  lazy protected val mainInput: DataObject with CanCreateDataFrame = initMainInput
-  .orElse(normalMainInput)
-  .orElse {
-    val paritionedInputs = inputs.collect{ case x: CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
-    if (paritionedInputs.size==1) paritionedInputs.headOption
-    else None
-  }.orElse {
-    if (inputs.size==1) inputs.headOption else None
-  }.getOrElse {
-    if (executionModeNeedsMainInputOutput) logger.warn(s"($id) Could not determine unique main input but execution mode might need it. Decided for ${inputs.head.id}.")
-    inputs.head
-  }
-  lazy protected val initMainOutput: Option[DataObject with CanWriteDataFrame] = initExecutionModeMainInputOutput.flatMap {
-    _.mainOutputId.map( outputId => outputs.find(_.id.id == outputId).getOrElse(throw ConfigurationException(s"$id has set an initExecutionMode with outputId $outputId, which was not found in outputs")))
-  }
-  lazy protected val normalMainOutput: Option[DataObject with CanWriteDataFrame] = normalExecutionModeMainInputOutput.flatMap {
-    _.mainOutputId.map( outputId => outputs.find(_.id.id == outputId).getOrElse(throw ConfigurationException(s"$id has set an initExecutionMode with outputId $outputId, which was not found in outputs")))
-  }
-  lazy protected val mainOutput: DataObject with CanWriteDataFrame = initMainOutput
-  .orElse(normalMainOutput)
-  .orElse{
-    val paritionedOutputs = outputs.collect{ case x: CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
-    if (paritionedOutputs.size==1) paritionedOutputs.headOption else None
-  }.orElse{
-    if (outputs.size==1) outputs.headOption else None
-  }.getOrElse {
-    if (executionModeNeedsMainInputOutput) logger.warn(s"($id) Could not determine unique main output but execution mode might need it. Decided for ${outputs.head.id}.")
-    outputs.head
-  }
+  lazy val mainInput: DataObject with CanCreateDataFrame = ActionHelper.getMainDataObject[DataObject with CanCreateDataFrame](mainInputId, inputs, "input", executionModeNeedsMainInputOutput, id)
+  lazy val mainOutput: DataObject with CanWriteDataFrame = ActionHelper.getMainDataObject[DataObject with CanWriteDataFrame](mainOutputId, outputs, "output", executionModeNeedsMainInputOutput, id)
 
   /**
    * Transform [[SparkSubFeed]]'s.
@@ -80,19 +49,17 @@ abstract class SparkSubFeedsAction extends SparkAction {
    */
   def transform(subFeeds: Seq[SparkSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed]
 
-  private def doTransform(subFeeds: Seq[SubFeed], thisExecutionMode: Option[ExecutionMode])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
+  private def doTransform(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
     // convert subfeeds to SparkSubFeed type or initialize if not yet existing
     var preparedSubFeeds = subFeeds.map( SparkSubFeed.fromSubFeed )
     // apply execution mode
-    preparedSubFeeds = thisExecutionMode match {
+    preparedSubFeeds = executionMode match {
       case Some(mode) =>
-        val executionModeParameters = ActionHelper.applyExecutionMode(mode, id, mainInput, mainOutput, context.phase)
-        preparedSubFeeds.map {
-          subFeed =>
-            executionModeParameters match {
-              case Some((newPartitionValues, newFilter)) => subFeed.copy(partitionValues = newPartitionValues, filter = newFilter)
-              case None => subFeed
-            }
+        val mainSubFeed = preparedSubFeeds.find(_.dataObjectId == mainInput.id).get
+        mode.apply(id, mainInput, mainOutput, mainSubFeed) match {
+          case Some((newPartitionValues, newFilter)) =>
+            preparedSubFeeds.map( subFeed => subFeed.copy(partitionValues = newPartitionValues, filter = newFilter))
+          case None => preparedSubFeeds
         }
       case _ => preparedSubFeeds
     }
@@ -101,7 +68,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
       // prepare as input SubFeed
       val preparedSubFeed = prepareInputSubFeed(subFeed, input)
       // enrich with fresh DataFrame if needed
-      enrichSubFeedDataFrame(input, preparedSubFeed, thisExecutionMode, context.phase)
+      enrichSubFeedDataFrame(input, preparedSubFeed, context.phase)
     }
     // transform
     val transformedSubFeeds = transform(preparedSubFeeds)
@@ -119,10 +86,8 @@ abstract class SparkSubFeedsAction extends SparkAction {
    * */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == inputs.size + recursiveInputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
-    val mainInputSubFeed = subFeeds.find(_.dataObjectId == mainInput.id).getOrElse(throw new IllegalStateException(s"subFeed for main input ${mainInput.id} not found"))
-    val thisExecutionMode = runtimeExecutionMode(mainInputSubFeed)
     // transform
-    val transformedSubFeeds = doTransform(subFeeds, thisExecutionMode)
+    val transformedSubFeeds = doTransform(subFeeds)
     // check output
     outputs.foreach{
       output =>
@@ -130,7 +95,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
         output.init(subFeed.dataFrame.get, subFeed.partitionValues)
     }
     // return
-    transformedSubFeeds.map( transformedSubFeed => updateSubFeedAfterWrite(transformedSubFeed, thisExecutionMode))
+    transformedSubFeeds.map( transformedSubFeed => updateSubFeedAfterWrite(transformedSubFeed))
   }
 
   /**
@@ -139,9 +104,8 @@ abstract class SparkSubFeedsAction extends SparkAction {
   override final def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == inputs.size + recursiveInputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
     val mainInputSubFeed = subFeeds.find(_.dataObjectId == mainInput.id).getOrElse(throw new IllegalStateException(s"subFeed for main input ${mainInput.id} not found"))
-    val thisExecutionMode = runtimeExecutionMode(mainInputSubFeed)
     // transform
-    val transformedSubFeeds = doTransform(subFeeds, thisExecutionMode)
+    val transformedSubFeeds = doTransform(subFeeds)
     // write output
     outputs.foreach { output =>
       val subFeed = transformedSubFeeds.find(_.dataObjectId == output.id).getOrElse(throw new IllegalStateException(s"subFeed for output ${output.id} not found"))
@@ -149,7 +113,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
       logger.info(s"($id) start " + msg)
       setSparkJobMetadata(Some(msg))
       val (noData,d) = PerformanceUtils.measureDuration {
-        writeSubFeed(thisExecutionMode, subFeed, output)
+        writeSubFeed(subFeed, output)
       }
       setSparkJobMetadata()
       val metricsLog = if (noData) ", no data found"
@@ -157,7 +121,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
       logger.info(s"($id) finished writing DataFrame to ${output.id}: duration=$d" + metricsLog)
     }
     // return
-    transformedSubFeeds.map( transformedSubFeed => updateSubFeedAfterWrite(transformedSubFeed, thisExecutionMode))
+    transformedSubFeeds.map( transformedSubFeed => updateSubFeedAfterWrite(transformedSubFeed))
   }
 
   /**
@@ -170,11 +134,11 @@ abstract class SparkSubFeedsAction extends SparkAction {
     assert(inputs.size+recursiveInputs.size == subFeeds.size, s"Number of inputs must match number of subFeeds given for $id")
     (inputs ++ recursiveInputs).map { input =>
       val subFeed = subFeeds.find(_.dataObjectId == input.id).getOrElse(throw new IllegalStateException(s"subFeed for input ${input.id} not found"))
-      enrichSubFeedDataFrame(input, subFeed, runtimeExecutionMode(subFeed), context.phase)
+      enrichSubFeedDataFrame(input, subFeed, context.phase)
     }
   }
 
   private def executionModeNeedsMainInputOutput: Boolean = {
-    initExecutionMode.exists{_.isInstanceOf[ExecutionModeWithMainInputOutput]} || executionMode.exists{_.isInstanceOf[ExecutionModeWithMainInputOutput]}
+    executionMode.exists{_.isInstanceOf[ExecutionModeWithMainInputOutput]}
   }
 }

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
@@ -29,6 +29,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
 
   override def inputs: Seq[DataObject with CanCreateDataFrame]
   override def outputs: Seq[DataObject with CanWriteDataFrame]
+  override def recursiveInputs: Seq[DataObject with CanCreateDataFrame] = Seq()
 
   // prepare main input / output
   // this must be lazy because inputs / outputs is evaluated later in subclasses
@@ -96,7 +97,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
       case _ => preparedSubFeeds
     }
     preparedSubFeeds = preparedSubFeeds.map{ subFeed =>
-      val input = inputs.find(_.id == subFeed.dataObjectId).get
+      val input = (inputs ++ recursiveInputs).find(_.id == subFeed.dataObjectId).get
       // prepare as input SubFeed
       val preparedSubFeed = prepareInputSubFeed(subFeed, input)
       // enrich with fresh DataFrame if needed
@@ -117,7 +118,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
    * Generic init implementation for Action.init
    * */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
-    assert(subFeeds.size == inputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
+    assert(subFeeds.size == inputs.size + recursiveInputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
     outputs.collect{ case x: CanWriteDataFrame => x }.foreach(_.init())
     val mainInputSubFeed = subFeeds.find(_.dataObjectId == mainInput.id).getOrElse(throw new IllegalStateException(s"subFeed for main input ${mainInput.id} not found"))
     val thisExecutionMode = runtimeExecutionMode(mainInputSubFeed)
@@ -128,7 +129,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
    * Action.exec implementation
    */
   override final def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
-    assert(subFeeds.size == inputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
+    assert(subFeeds.size == inputs.size + recursiveInputs.size, s"Number of subFeed's must match number of inputs for SparkSubFeedActions (Action $id, subfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}, inputs ${inputs.map(_.id).mkString(",")})")
     val mainInputSubFeed = subFeeds.find(_.dataObjectId == mainInput.id).getOrElse(throw new IllegalStateException(s"subFeed for main input ${mainInput.id} not found"))
     val thisExecutionMode = runtimeExecutionMode(mainInputSubFeed)
     //transform
@@ -158,8 +159,8 @@ abstract class SparkSubFeedsAction extends SparkAction {
    * @param subFeeds input SubFeeds.
    */
   protected def enrichSubFeedsDataFrame(inputs: Seq[DataObject with CanCreateDataFrame], subFeeds: Seq[SparkSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
-    assert(inputs.size==subFeeds.size, s"Number of inputs must match number of subFeeds given for $id")
-    inputs.map { input =>
+    assert(inputs.size+recursiveInputs.size == subFeeds.size, s"Number of inputs must match number of subFeeds given for $id")
+    (inputs ++ recursiveInputs).map { input =>
       val subFeed = subFeeds.find(_.dataObjectId == input.id).getOrElse(throw new IllegalStateException(s"subFeed for input ${input.id} not found"))
       enrichSubFeedDataFrame(input, subFeed, runtimeExecutionMode(subFeed), context.phase)
     }

--- a/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
+++ b/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
@@ -22,13 +22,13 @@ package io.smartdatalake.workflow.connection
 import java.util.Properties
 
 import com.typesafe.config.Config
-import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.config.SdlConfigObject.ConnectionId
+import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.{AuthMode, SSLCertsAuthMode}
-import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig}
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.common.config.SslConfigs
+import org.apache.spark.sql.avro.confluent.ConfluentClient
 
 import scala.collection.JavaConverters._
 
@@ -55,6 +55,8 @@ case class KafkaConnection(override val id: ConnectionId,
     props.putAll(authProps)
     AdminClient.create(props)
   }
+
+  @transient lazy val confluentHelper: Option[ConfluentClient] = schemaRegistry.map(new ConfluentClient(_))
 
   private val KafkaConfigOptionPrefix = "kafka."
   private val KafkaSSLSecurityProtocol = "SSL"
@@ -85,6 +87,14 @@ case class KafkaConnection(override val id: ConnectionId,
 
   def topicExists(topic: String): Boolean = {
     adminClient.listTopics.names.get.asScala.contains(topic)
+  }
+
+  def testSchemaRegistry(): Unit = {
+    try {
+      confluentHelper.foreach(_.test())
+    } catch {
+      case e:Exception => throw ConfigurationException(s"($id) Can not connect to schema registry (${schemaRegistry.get})")
+    }
   }
 
   override def factory: FromConfigFactory[Connection] = KafkaConnection

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
@@ -28,9 +28,10 @@ private[smartdatalake] trait CanWriteDataFrame {
   def streamingOptions: Map[String, String] = Map()
 
   /**
-   * Initialize callback before writing data out to disk/sinks.
+   * Called during init phase for checks and initialization.
+   * If possible dont change the system until execution phase.
    */
-  def init(partitionValues: Seq[PartitionValues]=Seq())(implicit session: SparkSession): Unit = Unit
+  def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = Unit
 
   def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit
 

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -143,7 +143,8 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   }
   private def preparedAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext) = {
     sqlOpt.foreach { sql =>
-      val params = DefaultExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf), partitionValues.map(_.elements.mapValues(_.toString)) )
+      val params = DefaultExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
+        , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), partitionValues.map(_.elements.mapValues(_.toString)))
       val preparedSql = SparkExpressionUtil.substitute(id, configName, sql, params)
       logger.info(s"($id) ${configName.getOrElse("SQL")} is being executed: $preparedSql")
       connection.execJdbcStatement(preparedSql, logging = false)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
@@ -27,10 +27,13 @@ import org.apache.spark.sql.SaveMode
 /**
  * DataObject of type raw for files with unknown content.
  * Provides details to an Action to access raw files.
+ * @param fileName Definition of fileName. This is concatenated with path and partition layout to search for files. Default is an asterix to match everything.
  * @param saveMode Overwrite or Append new data.
+ *
  */
 case class RawFileDataObject( override val id: DataObjectId,
                               override val path: String,
+                              override val fileName: String = "*",
                               override val partitions: Seq[String] = Seq(),
                               override val saveMode: SaveMode = SaveMode.Overwrite,
                               override val acl: Option[AclDef] = None,

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -19,3 +19,6 @@
 
 actions {}
 dataObjects {}
+global = {
+  stateListeners = [{ className = io.smartdatalake.app.TestStateListener }]
+}

--- a/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -180,7 +180,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // start first dag run
     // use only first partition col (dt) for partition diff mode
-    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, initExecutionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName))))
+    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action1.copy())
     val configStart = SmartDataLakeBuilderConfig(feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
     sdlb.run(configStart)

--- a/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -27,15 +27,16 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.util.misc.EnvironmentUtil
-import io.smartdatalake.workflow.{ActionDAGRunStateStore, TaskFailedException}
 import io.smartdatalake.workflow.action.customlogic.{CustomDfTransformer, CustomDfTransformerConfig}
 import io.smartdatalake.workflow.action.{ActionMetadata, CopyAction, DeduplicateAction, RuntimeEventState}
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
+import io.smartdatalake.workflow.{HadoopFileActionDAGRunStateStore, SparkSubFeed, TaskFailedException}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
+import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 
 class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
@@ -103,19 +104,21 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check latest state
     {
-      val stateStore = ActionDAGRunStateStore(statePath, appName)
+      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName)
       val stateFile = stateStore.getLatestState()
-      val runState = stateStore.recoverRunState(stateFile.path)
+      val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 1)
-      assert(runState.actionsState.mapValues(_.state) == Map(action1.id.id -> RuntimeEventState.SUCCEEDED, action2fail.id.id -> RuntimeEventState.FAILED))
+      val resultActionsState = runState.actionsState.mapValues(_.state)
+      val expectedActionsState = Map((action1.id, RuntimeEventState.SUCCEEDED), (action2fail.id, RuntimeEventState.FAILED))
+      assert(resultActionsState == expectedActionsState)
     }
 
     // now fill tgt1 with both partitions
     tgt1DO.writeDataFrame(dfSrc, Seq())
 
     // reset DataObjects
-    instanceRegistry.clear
+    instanceRegistry.clear()
     instanceRegistry.register(srcDO)
     instanceRegistry.register(tgt1DO)
     instanceRegistry.register(tgt2DO)
@@ -133,12 +136,14 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check latest state
     {
-      val stateStore = ActionDAGRunStateStore(statePath, appName)
+      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName)
       val stateFile = stateStore.getLatestState()
-      val runState = stateStore.recoverRunState(stateFile.path)
+      val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 2)
-      assert(runState.actionsState.mapValues(_.state) == Map(action2success.id.id -> RuntimeEventState.SUCCEEDED))
+      val resultActionsState = runState.actionsState.mapValues(_.state)
+      val expectedActionsState = Map((action2success.id, RuntimeEventState.SUCCEEDED))
+      assert(resultActionsState == expectedActionsState)
       assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == selectedPartitions)
       if (!EnvironmentUtil.isWindowsOS) assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty)
     }
@@ -185,12 +190,14 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check latest state
     {
-      val stateStore = ActionDAGRunStateStore(statePath, appName)
+      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName)
       val stateFile = stateStore.getLatestState()
-      val runState = stateStore.recoverRunState(stateFile.path)
+      val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 1)
-      assert(runState.actionsState.mapValues(_.state) == Map(action1.id.id -> RuntimeEventState.SUCCEEDED))
+      val resultActionsState = runState.actionsState.mapValues(_.state)
+      val expectedActionsState = Map((action1.id , RuntimeEventState.SUCCEEDED))
+      assert(resultActionsState == expectedActionsState)
       assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt"->"20180101"))))
     }
 
@@ -213,17 +220,61 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check latest state
     {
-      val stateStore = ActionDAGRunStateStore(statePath, appName)
+      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName)
       val stateFile = stateStore.getLatestState()
-      val runState = stateStore.recoverRunState(stateFile.path)
+      val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 2)
       assert(runState.attemptId == 1)
-      assert(runState.actionsState.mapValues(_.state) == Map(action1.id.id -> RuntimeEventState.SUCCEEDED))
+      val resultActionsState = runState.actionsState.mapValues(_.state)
+      val expectedActionsState = Map((action1.id , RuntimeEventState.SUCCEEDED))
+      assert(resultActionsState == expectedActionsState)
       assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt"->"20190101"))))
       if (!EnvironmentUtil.isWindowsOS) assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty) // doesnt work on windows
     }
   }
 
+  test("sdlb simulation run") {
+
+    // init sdlb
+    val appName = "sdlb-simulation"
+    val feedName = "test"
+
+    HdfsUtil.deleteFiles(s"$statePath", filesystem, false)
+    val sdlb = new DefaultSmartDataLakeBuilder()
+    implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
+
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "ap_input")
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    // source table has partitions columns dt and type
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname", "firstname")))
+    val tgt1Path = tempPath + s"/${tgt1Table.fullName}"
+    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(tgt1DO)
+    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname", "firstname")))
+    val tgt2Path = tempPath + s"/${tgt1Table.fullName}"
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tgt2Path), table = tgt2Table, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(tgt2DO)
+
+    // prepare input DataFrame
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5))
+      .toDF("dt", "type", "lastname", "firstname", "rating")
+
+    // start first dag run
+    val action1 = DeduplicateAction("a", srcDO.id, tgt1DO.id, metadata = Some(ActionMetadata(feed = Some(feedName))))
+    instanceRegistry.register(action1)
+    val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id, metadata = Some(ActionMetadata(feed = Some(feedName))))
+    instanceRegistry.register(action2)
+    val configStart = SmartDataLakeBuilderConfig(feedSel = feedName, applicationName = Some(appName))
+    val (finalSubFeeds, stats) = sdlb.startSimulation(configStart, Seq(SparkSubFeed(Some(dfSrc1), srcDO.id, Seq())))
+
+    // check results
+    assert(finalSubFeeds.size == 1)
+    assert(stats == Map(RuntimeEventState.SUCCEEDED -> 2))
+    assert(finalSubFeeds.head.dataFrame.get.select(dfSrc1.columns.map(col):_*).symmetricDifference(dfSrc1).isEmpty)
+  }
 }
 
 class FailTransformer extends CustomDfTransformer {

--- a/src/test/scala/io/smartdatalake/config/TestAction.scala
+++ b/src/test/scala/io/smartdatalake/config/TestAction.scala
@@ -51,6 +51,7 @@ case class TestAction(override val id: ActionObjectId,
   private[config] val output = instanceRegistry.get[TransactionalSparkTableDataObject](outputId)
   override val inputs: Seq[DataObject with CanCreateDataFrame] = Seq(input)
   override val outputs: Seq[TransactionalSparkTableDataObject] = Seq(output)
+  override val recursiveInputs:Seq[DataObject with CanCreateDataFrame] = Seq()
 
   /**
    * @inheritdoc

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
@@ -22,6 +22,7 @@ package io.smartdatalake.workflow
 import java.time.{Duration, LocalDateTime}
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.config.SdlConfigObject._
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.{ResultRuntimeInfo, RuntimeEventState, RuntimeInfo}
@@ -36,9 +37,8 @@ class ActionDAGRunTest extends FunSuite {
   test("convert ActionDAGRunState to json and back") {
     val df = Seq(("a",1)).toDF("txt", "value")
     val infoA = RuntimeInfo(RuntimeEventState.SUCCEEDED, startTstmp = Some(LocalDateTime.now()), duration = Some(Duration.ofMinutes(5)), msg = Some("test"), results = Seq(ResultRuntimeInfo(SparkSubFeed(Some(df), "do1", partitionValues = Seq(PartitionValues(Map("test"->1)))),Map("test"->1, "test2"->"abc"))))
-    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, Map("a" -> infoA), isFinal = false)
+    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, Map(("a", infoA)), isFinal = false)
     val json = state.toJson
-    //println(json)
     // remove DataFrame from SparkSubFeed, it should not be serialized
     val expectedState = state.copy(actionsState = state.actionsState
       .mapValues(actionState => actionState

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
@@ -37,7 +37,7 @@ class ActionDAGRunTest extends FunSuite {
   test("convert ActionDAGRunState to json and back") {
     val df = Seq(("a",1)).toDF("txt", "value")
     val infoA = RuntimeInfo(RuntimeEventState.SUCCEEDED, startTstmp = Some(LocalDateTime.now()), duration = Some(Duration.ofMinutes(5)), msg = Some("test"), results = Seq(ResultRuntimeInfo(SparkSubFeed(Some(df), "do1", partitionValues = Seq(PartitionValues(Map("test"->1)))),Map("test"->1, "test2"->"abc"))))
-    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, Map(("a", infoA)), isFinal = false)
+    val state = ActionDAGRunState(SmartDataLakeBuilderConfig(), 1, 1, LocalDateTime.now, LocalDateTime.now, Map(ActionObjectId("a") -> infoA), isFinal = false)
     val json = state.toJson
     // remove DataFrame from SparkSubFeed, it should not be serialized
     val expectedState = state.copy(actionsState = state.actionsState

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -24,7 +24,7 @@ import java.time.{Instant, LocalDateTime}
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.{PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
+import io.smartdatalake.definitions.{ExecutionModeFailedException, PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
@@ -392,7 +392,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
   }
 
 
-  test("action dag with 2 actions and positive top-level partition values filter") {
+  test("action dag with 2 actions and positive top-level partition values filter, ignoring executionMode=PartitionDiffMode") {
 
     // setup DataObjects
     val feed = "actiondag"
@@ -419,13 +419,13 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     val dfSrc = Seq(("20180101", "person", "doe","john",5) // partition 20180101 is included in partition values filter
       ,("20190101", "company", "olmo","-",10)) // partition 20190101 is not included
       .toDF("dt", "type", "lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, dfSrc, Seq("dt","type"))
+    srcDO.writeDataFrame(dfSrc, Seq())
 
     // prepare DAG
     val refTimestamp1 = LocalDateTime.now()
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val actions = Seq(
-      DeduplicateAction("a", srcDO.id, tgt1DO.id),
+      DeduplicateAction("a", srcDO.id, tgt1DO.id, executionMode=Some(PartitionDiffMode())), // PartitionDiffMode is ignored because partition values are given below as parameter
       CopyAction("b", tgt1DO.id, tgt2DO.id)
     )
     val dag = ActionDAGRun(actions, 1, 1, partitionValues = Seq(PartitionValues(Map("dt"->"20180101"))))
@@ -556,7 +556,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     assert(action2MainMetrics("num_tasks")==1)
   }
 
-  test("action dag with 2 actions in sequence and initExecutionMode=PartitionDiffMode") {
+  test("action dag with 2 actions in sequence and executionMode=PartitionDiffMode") {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
@@ -582,7 +582,58 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     val expectedPartitions = Seq(PartitionValues(Map("lastname"->"doe")))
     srcDO.writeDataFrame(df1, expectedPartitions)
     val actions: Seq[SparkSubFeedAction] = Seq(
-      DeduplicateAction("a", srcDO.id, tgt1DO.id, initExecutionMode = Some(PartitionDiffMode()))
+      DeduplicateAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(applyCondition = Some("isStartNode"), failCondition = Some("size(selectedPartitionValues) = 0 and size(outputPartitionValues) = 0"))))
+      , CopyAction("b", tgt1DO.id, tgt2DO.id)
+    )
+    val dag: ActionDAGRun = ActionDAGRun(actions, 1, 1)
+
+    // first dag run
+    dag.prepare
+    dag.init
+    dag.exec
+
+    // check
+    val r1 = tgt2DO.getDataFrame()
+      .select($"rating")
+      .as[Int].collect().toSeq
+    assert(r1.size == 1)
+    assert(r1.head == 5)
+    assert(tgt2DO.listPartitions == expectedPartitions)
+
+    // second dag run - skip action execution because there are no new partitions to process
+    dag.prepare
+    intercept[NoDataToProcessWarning](dag.init)
+  }
+
+  test("action dag with 2 actions in sequence and executionMode=PartitionDiffMode alternativeOutputId") {
+    // setup DataObjects
+    val feed = "actionpipeline"
+    val srcTable = Table(Some("default"), "ap_input")
+    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
+    val srcPath = tempPath+s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
+    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
+    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
+    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    instanceRegistry.register(tgt1DO)
+    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
+    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
+    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), table = tgt2Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    instanceRegistry.register(tgt2DO)
+
+    // prepare DAG
+    // prepare data in srcDO and tgt1DO. Because of alternativeOutputId in action~a it should be processed again.
+    val refTimestamp1 = LocalDateTime.now()
+    implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val df1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val expectedPartitions = Seq(PartitionValues(Map("lastname"->"doe")))
+    srcDO.writeDataFrame(df1, expectedPartitions)
+    tgt1DO.writeDataFrame(df1, expectedPartitions)
+    val actions: Seq[SparkSubFeedAction] = Seq(
+      CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(alternativeOutputId = Some(tgt2DO.id))))
       , CopyAction("b", tgt1DO.id, tgt2DO.id)
     )
     val dag: ActionDAGRun = ActionDAGRun(actions, 1, 1)
@@ -883,6 +934,31 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     dag.init
     val ex = intercept[TaskFailedException](dag.exec)
     assert(ex.cause.isInstanceOf[MetricsCheckFailed])
+  }
+
+  test("action dag failes because of executionMode=PartitionDiffMode failCondition") {
+    // setup DataObjects
+    val feed = "actionpipeline"
+    val tempDir = Files.createTempDirectory(feed)
+    val schema = DataType.fromDDL("lastname string, firstname string, rating int, tstmp timestamp").asInstanceOf[StructType]
+    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(schema), partitions = Seq("lastname"))
+    instanceRegistry.register(srcDO)
+    val tgt1DO = ParquetFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), partitions = Seq("lastname"), saveMode = SaveMode.Append)
+    instanceRegistry.register(tgt1DO)
+
+    // prepare DAG
+    val refTimestamp1 = LocalDateTime.now()
+    implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val df1 = Seq(("doe","john",5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    srcDO.writeDataFrame(df1, Seq())
+
+    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode=Some(PartitionDiffMode(failCondition = Some("year(runStartTime) > 2000"))))
+    val dag: ActionDAGRun = ActionDAGRun(Seq(action1), 1, 1)
+
+    // first dag run, first file processed
+    dag.prepare
+    val ex = intercept[TaskFailedException](dag.init)
+    assert(ex.cause.isInstanceOf[ExecutionModeFailedException])
   }
 
 }

--- a/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -210,8 +210,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // prepare action
     val refTimestamp = LocalDateTime.now()
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
-    val action = CopyAction("a1", srcDO.id, tgtDO.id, initExecutionMode = Some(PartitionDiffMode()))
-    val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
+    val action = CopyAction("a1", srcDO.id, tgtDO.id, executionMode = Some(PartitionDiffMode()))
+    val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test executionMode!
 
     // prepare & start first load
     val l1 = Seq(("A","doe","john",5)).toDF("type", "lastname", "firstname", "rating")

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
@@ -111,7 +111,7 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
     // prepare & start load
     implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
     val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Map("test"->"true"))
-    val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, false, 1, initExecutionMode = Some(PartitionDiffMode()))
+    val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, false, 1, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", srcPartitionValues) // InitSubFeed needed to test initExecutionMode!
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -29,7 +29,7 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.action.customlogic.{CustomDfsTransformer, CustomDfsTransformerConfig}
-import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
+import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
@@ -103,6 +103,57 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
       .as[Int].collect().toSeq
     assert(r2.size == 1)
     assert(r2.head == 6)
+  }
+
+  test("spark action with recursive input") {
+    // setup DataObjects
+    val feed = "recursive_inputs"
+
+    val srcTable1 = Table(Some("default"), "copy_input1")
+    HiveUtil.dropTable(session, srcTable1.db.get, srcTable1.name)
+    val srcPath1 = tempPath + s"/${srcTable1.fullName}"
+    val srcDO1 = TickTockHiveTableDataObject("src1", Some(srcPath1), table = srcTable1, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO1)
+
+    val tgtTable1 = Table(Some("default"), "copy_output1", None, Some(Seq("lastname", "firstname")))
+    HiveUtil.dropTable(session, tgtTable1.db.get, tgtTable1.name)
+    val tgtPath1 = tempPath + s"/${tgtTable1.fullName}"
+    val tgtDO1 = TickTockHiveTableDataObject("tgt1", Some(tgtPath1), table = tgtTable1, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(tgtDO1)
+
+    // prepare & start load
+    val refTimestamp1 = LocalDateTime.now()
+    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerRecursive"))
+
+    // first action to create output table as it does not exist yet
+    val action1 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig)(context1.instanceRegistry)
+
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    TestUtil.prepareHiveTable(srcTable1, srcPath1, l1)
+
+    val tgtSubFeedsNonRecursive = action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))
+    assert(tgtSubFeedsNonRecursive.size == 1)
+    assert(tgtSubFeedsNonRecursive.map(_.dataObjectId) == Seq(tgtDO1.id))
+
+    val r1 = session.table(s"${tgtTable1.fullName}")
+      .select($"rating")
+      .as[Int].collect().toSeq
+    assert(r1.size == 1)
+    assert(r1.head == 6) // should be increased by 1 through TestDfTransformer
+
+    // second action to test recursive inputs
+    val action2 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig, recursiveInputIds = List(tgtDO1.id))(context1.instanceRegistry)
+
+    val tgtSubFeedsRecursive = action2.exec(Seq(SparkSubFeed(None, "src1", Seq()), SparkSubFeed(None, "tgt1", Seq())))
+    assert(tgtSubFeedsRecursive.size == 1) // still 1 as recursive inputs are handled separately
+
+    val r2 = session.table(s"${tgtTable1.fullName}")
+      .select($"rating")
+      .as[Int].collect().toSeq
+    assert(r2.size == 1)
+    assert(r2.head == 11) // Record should be updated a second time with data from tgt1
+
   }
 
   test("copy with partition diff execution mode 2 iterations") {
@@ -259,6 +310,25 @@ class TestDfsTransformerIncrement extends CustomDfsTransformer {
       "tgt1" -> dfs("src1").withColumn("rating", $"rating"+1)
     , "tgt2" -> dfs("src2").withColumn("rating", $"rating"+1)
     )
+  }
+}
+
+class TestDfsTransformerRecursive extends CustomDfsTransformer {
+  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String,DataFrame]): Map[String,DataFrame] = {
+    import session.implicits._
+    if(!dfs.contains("tgt1")) {
+      // first run without recursive inputs
+      Map(
+        "tgt1" -> dfs("src1").withColumn("rating", $"rating"+1)
+      )
+    }
+    else {
+      // second run with recursive inputs
+      Map(
+        "tgt1" -> dfs("tgt1").withColumn("rating", $"rating"+5)
+      )
+    }
+
   }
 }
 

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -175,7 +175,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     val refTimestamp = LocalDateTime.now()
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
-    val action = CustomSparkAction("a1", Seq(srcDO.id), Seq(tgtDO.id), transformer = customTransformerConfig, initExecutionMode = Some(PartitionDiffMode()))
+    val action = CustomSparkAction("a1", Seq(srcDO.id), Seq(tgtDO.id), transformer = customTransformerConfig, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
 
     // prepare & start first load
@@ -234,7 +234,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
     val action = CustomSparkAction("a1", Seq(srcDO.id, srcDO2.id), Seq(tgtDO.id, tgtDO2.id), transformer = customTransformerConfig
-      , initExecutionMode = Some(PartitionDiffMode(mainInputId = Some("src1"), mainOutputId = Some("tgt1"))))
+      , mainInputId = Some("src1"), mainOutputId = Some("tgt1"), executionMode = Some(PartitionDiffMode()))
     val srcSubFeed1 = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
     val srcSubFeed2 = InitSubFeed("src2", Seq())
 

--- a/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
@@ -1,0 +1,100 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject
+import java.nio.file.Files
+import java.time.LocalDateTime
+
+import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.definitions.PartitionDiffMode
+import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.hive.HiveUtil
+import io.smartdatalake.workflow.action.CustomSparkAction
+import io.smartdatalake.workflow.action.customlogic.{CustomDfsTransformer, CustomDfsTransformerConfig}
+import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
+import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+
+class TickTockHiveTableDataObjectTest extends FunSuite with BeforeAndAfter {
+  protected implicit val session: SparkSession = TestUtil.sessionHiveCatalog
+  import session.implicits._
+
+  private val tempDir = Files.createTempDirectory("test")
+  private val tempPath = tempDir.toAbsolutePath.toString
+
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+
+  before {
+    instanceRegistry.clear()
+  }
+
+  test("Empty dataframe is created if schemaMin is provided") {
+
+    val feed = "autocreate"
+    val schemaMin: StructType = StructType(StructField("id", IntegerType, nullable = false) :: StructField("name", StringType, nullable=false) :: StructField("rating", IntegerType, nullable=false) :: Nil)
+
+    // create source dataobject
+    val srcTable = Table(Some("default"), "input")
+    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name)
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = TickTockHiveTableDataObject("input", Some(srcPath), table = srcTable, partitions = Seq(), numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+
+    // create target
+    val tgtTable = Table(Some("default"),"output")
+    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name)
+    val tgtPath = tempPath + s"/${tgtTable.fullName}"
+    val tgtDO = TickTockHiveTableDataObject("output", Some(tgtPath), table = tgtTable, partitions = Seq(), numInitialHdfsPartitions = 1, schemaMin=Some(schemaMin))
+    instanceRegistry.register(tgtDO)
+
+    val refTimestamp1 = LocalDateTime.now()
+    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.dataobject.TestDfsTransformerEmptyDf"))
+
+    val action = CustomSparkAction("action", List(srcDO.id), List(tgtDO.id), transformer = customTransformerConfig, recursiveInputIds = List(tgtDO.id))(context1.instanceRegistry)
+
+    // write test files
+    val l1 = Seq((1, "john", 5)).toDF("id", "name", "rating")
+    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+
+    val tgtSubFeeds = action.exec(Seq(SparkSubFeed(None, "input", Seq()), SparkSubFeed(None, "output", Seq())))
+
+    val r = session.table(s"${tgtTable.fullName}")
+      .select($"rating")
+      .as[Int].collect().toSeq
+    assert(r.size == 1)
+    assert(r.head == 6) // should be increased by 1 through TestDfTransformer
+  }
+}
+
+class TestDfsTransformerEmptyDf extends CustomDfsTransformer {
+  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String,DataFrame]): Map[String,DataFrame] = {
+    import session.implicits._
+
+    Map(
+      "output" -> dfs("input").withColumn("rating", $"rating"+1)
+    )
+
+  }
+}

--- a/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
@@ -22,15 +22,11 @@ import java.time.LocalDateTime
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.config.SdlConfigObject.DataObjectId
-import io.smartdatalake.definitions.PartitionDiffMode
 import io.smartdatalake.testutils.TestUtil
-import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.action.CustomSparkAction
 import io.smartdatalake.workflow.action.customlogic.{CustomDfsTransformer, CustomDfsTransformerConfig}
-import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}


### PR DESCRIPTION
### What changes are included in the pull request?
New features:
- Allow recursive inputs to CustomSparkAction (#150)
- Create empty DataFrame according to schemaMin if table does not exist (#153)
- Refactor executionmode (see PR #147 for details)
- Refine Kafka schema registry conversion (see PR #154 for details)
- Support config validation and dry-runs, support to start simulation run programmatically (Part of #120)
- new StateListener interface for custom handler of current state/metrics (#156)

Breaking changes
- removal of initExecutionMode attribute on Actions. This can now be achieved by applyCondition = "isNodeStart" (Part of PR #147)

### Why are the changes needed?
Releasing 1.1.0