### PR TITLE
Explode input and output ids...

### DIFF
--- a/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
@@ -25,6 +25,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.ProductUtil._
 import io.smartdatalake.workflow.action.{Action, ActionMetadata}
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions.{split,explode}
 
 /**
  * Exports a util [[DataFrame]] that contains properties and metadata extracted from all [[io.smartdatalake.workflow.action.Action]]s
@@ -127,6 +128,10 @@ case class ActionsExporterDataObject(id: DataObjectId,
       "breakDataFrameLineage",
       "persist"
     )
+    .withColumn("inputId", split($"inputId",","))
+    .withColumn("inputId", explode($"inputId"))
+    .withColumn("outputId", split($"outputId", ","))
+    .withColumn("outputId", explode($"outputId"))
   }
 
   /**


### PR DESCRIPTION
... so you get one line for each input and output dependency

### What changes are included in the pull request?
Insert explode function in action exporter

### Why are the changes needed?
In the exporter, CustomSparkActions with multiple inputs and / or multiple outputs are in the exported files only once. 
To build the lineage graph, we probably want one line per input/output dependency, not one line per action.