### PR TITLE
improve detection of main input/output

### DIFF
--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -239,7 +239,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     appConfig.validate()
 
     // log start parameters
-    logger.info(s"Starting run: runId=$runId attemptId=$attemptId feedSel=${appConfig.feedSel} appName=${appConfig.appName} test=${appConfig.test}")
+    logger.info(s"Starting run: runId=$runId attemptId=$attemptId feedSel=${appConfig.feedSel} appName=${appConfig.appName} test=${appConfig.test} givenPartitionValues=${appConfig.getPartitionValues.map(x => "("+x.mkString(",")+")").getOrElse("None")}")
     logger.debug(s"Environment: " + sys.env.map(x => x._1 + "=" + x._2).mkString(" "))
     logger.debug(s"System properties: " + sys.props.toMap.map(x => x._1 + "=" + x._2).mkString(" "))
 

--- a/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -128,15 +128,21 @@ private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
   }
 
   def getMainDataObject[T <: DataObject](mainId: Option[DataObjectId], dataObjects: Seq[T], inputOutput: String, mainNeeded: Boolean, actionId: ActionObjectId): T = {
-    val (partitionedDataObjects,unpartitionedDataObjects) = dataObjects.collect{ case x: T @unchecked with CanHandlePartitions => x }.partition(_.partitions.nonEmpty)
+    // split dataObjects into dataObjects with partition columns defined and others
+    val partitionedDataObjects = dataObjects.collect{ case x: T @unchecked with CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
+    val unpartitionedDataObjects = dataObjects.filterNot(partitionedDataObjects.contains(_))
     mainId.map {
+      // 1. mainInput is defined
       id => dataObjects.find(_.id == id).getOrElse(throw ConfigurationException(s"($actionId) main${inputOutput}Id $id not found in ${inputOutput}s"))
     }.orElse {
+      // 2. there is only one partitioned dataObject
       if (partitionedDataObjects.size==1) partitionedDataObjects.headOption
       else None
     }.orElse {
+      // 3. there is only one dataObject in total
       if (dataObjects.size==1) dataObjects.headOption else None
     }.getOrElse {
+      // 4. mainInput is not unique, we log a warning and favor partitioned dataObjects over others.
       if (mainNeeded) logger.warn(s"($actionId) Could not determine unique main $inputOutput but execution mode might need it. Decided for ${dataObjects.head.id}.")
       (partitionedDataObjects ++ unpartitionedDataObjects).head
     }


### PR DESCRIPTION
### What changes are included in the pull request?
If detection of main input/output is not unique, the first DataObject is choosen.
The change favors partitioned DataObjects over unpartitioned DataObjects.

### Why are the changes needed?
Currently partitioned DataObjects are not favored in case of main input/output is not unique.