### PR TITLE
Bugfix: implement early validation of metricsFailCondition

### DIFF
--- a/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -95,8 +95,10 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
     val duplicateNames = context.instanceRegistry.getDataObjects.map {
       dataObj => ActionHelper.replaceSpecialCharactersWithUnderscore(dataObj.id.id)
     }.groupBy(identity).collect { case (x, List(_,_,_*)) => x }.toList
-
     require(duplicateNames.isEmpty, s"The names of your DataObjects are not unique when replacing special characters with underscore. Duplicates: ${duplicateNames.mkString(",")}")
+
+    // validate metricsFailCondition
+    metricsFailCondition.foreach(c => evaluateMetricsFailCondition(c, onlySyntaxCheck = true))
   }
 
   /**
@@ -137,7 +139,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    */
   def postExec(inputSubFeed: Seq[SubFeed], outputSubFeed: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     // evaluate metrics fail condition if defined
-    metricsFailCondition.foreach(evaluateMetricsFailCondition)
+    metricsFailCondition.foreach( c => evaluateMetricsFailCondition(c))
     // process postRead/Write hooks
     inputs.foreach( input => input.postRead(findSubFeedPartitionValues(input.id, inputSubFeed)))
     outputs.foreach( output => output.postWrite(findSubFeedPartitionValues(output.id, outputSubFeed)))
@@ -146,16 +148,20 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
   /**
    * Evaluates a condition against latest metrics and throws an MetricsCheckFailed if there is a match.
    */
-  private def evaluateMetricsFailCondition(condition: String)(implicit session: SparkSession): Unit = {
+  private def evaluateMetricsFailCondition(condition: String, onlySyntaxCheck: Boolean = false)(implicit session: SparkSession): Unit = {
     import session.implicits._
-    val metrics = getAllLatestMetrics.flatMap{
-      case (dataObjectId, Some(metrics)) => metrics.getMainInfos.map{ case (k,v) => (dataObjectId.id, Some(k), Some(v.toString))}.toSeq
-      case (dataObjectId, _) => Seq((dataObjectId.id, None, None))
-    }.toSeq
-    val failedMetrics = metrics.toDF("dataObjectId", "key", "value")
+    val metrics = if (!onlySyntaxCheck) {
+      getAllLatestMetrics.flatMap{
+        case (dataObjectId, Some(metrics)) => metrics.getMainInfos.map{ case (k,v) => (dataObjectId.id, Some(k), Some(v.toString))}.toSeq
+        case (dataObjectId, _) => Seq((dataObjectId.id, None, None))
+      }.toSeq
+    } else Seq()
+    val dfFailedMetrics = metrics.toDF("dataObjectId", "key", "value")
       .where(condition)
-      .collect
-    if (failedMetrics.nonEmpty) throw MetricsCheckFailed(s"""($id) metrics check failed: ${failedMetrics.mkString(", ")} matched condition "$condition"""")
+    if (!onlySyntaxCheck) {
+      val failedMetrics = dfFailedMetrics.collect
+      if (failedMetrics.nonEmpty) throw MetricsCheckFailed(s"""($id) metrics check failed: ${failedMetrics.mkString(", ")} matched condition "$condition"""")
+    }
   }
 
   /**


### PR DESCRIPTION
### What changes are included in the pull request?
implement early validation of metricsFailCondition

### Why are the changes needed?
configuration problems should be detected as soon as possible. In the current implementation a syntax error in metricsFailCondition will only fail at exec-phase.