### PR TITLE
Release 1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@ data/output
 .cache-*
 lib
 target
+venv
 /.externalToolBuilders/
 *.html
-*.iml
 *.js
 *.log
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -56,6 +56,7 @@ The following is a list of implemented and planned (Future) features of Smart Da
 ##### Metrics
 * Number of rows written per DataObject
 * Execution duration per Action
+* StateListener interface to get notified about progress & metrics
 
 ##### Data Catalog
 * Report all DataObjects attributes (incl. foreign keys if defined) for visualisation of data catalog in BI tool
@@ -70,3 +71,11 @@ The following is a list of implemented and planned (Future) features of Smart Da
 * Check & report primary key violations by executing primary key checker action
 * Future: Metadata support for arbitrary data quality checks
 * Future: Report data quality (foreign key matching & arbitrary data quality checks) by executing data quality reporter action
+
+##### Testing
+* Support for CI
+  * Config validation
+  * Custom transformation unit tests
+  * Spark data pipeline simulation (acceptance tests)
+* Support for Deployment
+  * Dry-run

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -29,11 +29,11 @@ The following is a list of implemented and planned (Future) features of Smart Da
 
 ##### Customizable Transformations
 * Spark Transformations: 
-  * Languages: SQL, Scala (Class, compile from config), Future: Python
+  * Languages: SQL, Scala (Class, compile from config), Python
   * Many input DataFrames to many outputs DataFrames (but only one output recommended normally, in order to define dependencies as detailed as possible (lineage))
 * File Transformations: 
   * Language: Scala
-  * Only one to one (one Input Stream to one OutputStream)
+  * Only one to one (one InputStream to one OutputStream)
 
 ##### Early Validation
 * Execution in 3 phases before execution

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -165,4 +165,6 @@ Sample log message:
 
 A fail condition can be specified on Actions to fail execution if a certain condition is not met.
 The condition must be specified as spark sql expression, which is evaluated as where-clause against a dataframe of metrics. Available columns are dataObjectId, key, value. 
-To fail above sample log in case there are no records written, specify `"dataObjectId = 'tgt1' and key = 'records_written' and value = 0"`. 
+To fail above sample log in case there are no records written, specify `"dataObjectId = 'tgt1' and key = 'records_written' and value = 0"`.
+
+By implementing interface StateListener  you can get notified about action results & metrics. To configure state listeners set config attribute `global.stateListeners = [{className = ...}]`.

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -168,3 +168,21 @@ The condition must be specified as spark sql expression, which is evaluated as w
 To fail above sample log in case there are no records written, specify `"dataObjectId = 'tgt1' and key = 'records_written' and value = 0"`.
 
 By implementing interface StateListener  you can get notified about action results & metrics. To configure state listeners set config attribute `global.stateListeners = [{className = ...}]`.
+
+## Custom Spark Transformations
+
+### Scala
+TODO
+
+### SQL
+TODO
+
+### Python
+It's possible to use Python to define a custom Spark transformation. Input is a PySpark DataFrame and the transformation must return again a PySpark DataFrame.
+
+Requirements: Python version >= 3.4 an <= 3.7 (for Spark 2.4), PySpark package.
+See Readme of [sdl-examples](https://github.com/smart-data-lake/sdl-examples) for a working example and instructions to setup environment for IntelliJ  
+
+How it works: under the hood a PySpark DataFrame is a proxy for a Java Spark DataFrame. PySpark uses Py4j to access Java objects in the JVM.
+
+  

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -12,6 +12,19 @@ Note that the binary files need to be located at %HADOOP_HOME%\bin!
 ## Windows: `/tmp/hive` is not writable
 Solution: Change to `%HADOOP_HOME%\bin` and execute `winutils chmod 777 /tmp/hive`.
 
+## Windows: winutils.exe is not working correctly
+Error:  
+`winutils.exe - System Error The code execution cannot proceed because MSVCR100.dll was not found. Reinstalling the program may fix this problem.`  
+Other errors are also possible:
+- Similar error message when double clicking on winutils.exe (Popup)
+- Errors when providing a path to the configuration instead of a single configuration file
+- ExitCodeException exitCode=-1073741515 when executing SDL even though everything ran without errors
+
+Solution: 
+Install VC++ Redistributable Package from Microsoft:  
+http://www.microsoft.com/en-us/download/details.aspx?id=5555 (x86)  
+http://www.microsoft.com/en-us/download/details.aspx?id=14632 (x64)
+
 ## Resources not copied
 Symptom: Tests fail due to missing or outdated resources or the execution starts but can not find the feeds specified. IntelliJ might not copy the resource files to the target directory. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>smartdatalake_${scala.minor.version}</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<licenses>

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -305,8 +305,8 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
       }
     } catch {
       // don't fail on not severe exceptions like having no data to process
-      case ex: DAGException if (ex.severity == ExceptionSeverity.SKIPPED) =>
-        logger.warn(s"Some actions are skipped because of ${ex.getClass.getSimpleName}: ${ex.getMessage}")
+      case ex: DAGException if (ex.severity >= ExceptionSeverity.SKIPPED) =>
+        logger.warn(s"At least one action is ${ex.severity}")
         Seq()
     }
 

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -185,6 +185,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
         val latestRunState = stateStore.recoverRunState(latestStateFile)
         if (latestRunState.isFailed) {
           // start recovery
+          assert(appConfig == latestRunState.appConfig, s"There is a failed run to be recovered. Either you clean-up this state fail or the command line parameters given must match the parameters of the run to be recovered (${latestRunState.appConfig}")
           recoverRun(appConfig, stateStore, latestRunState)._2
         } else {
           startRun(appConfig, runId = latestRunState.runId+1, stateStore = Some(stateStore))._2

--- a/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -239,7 +239,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     appConfig.validate()
 
     // log start parameters
-    logger.info(s"Starting run: runId=$runId attemptId=$attemptId feedSel=${appConfig.feedSel} appName=${appConfig.appName} test=${appConfig.test}")
+    logger.info(s"Starting run: runId=$runId attemptId=$attemptId feedSel=${appConfig.feedSel} appName=${appConfig.appName} test=${appConfig.test} givenPartitionValues=${appConfig.getPartitionValues.map(x => "("+x.mkString(",")+")").getOrElse("None")}")
     logger.debug(s"Environment: " + sys.env.map(x => x._1 + "=" + x._2).mkString(" "))
     logger.debug(s"System properties: " + sys.props.toMap.map(x => x._1 + "=" + x._2).mkString(" "))
 

--- a/src/main/scala/io/smartdatalake/app/StateListener.scala
+++ b/src/main/scala/io/smartdatalake/app/StateListener.scala
@@ -23,6 +23,12 @@ import io.smartdatalake.config.ConfigurationException
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.{ActionDAGRunState, ActionPipelineContext}
 
+/**
+ * Configuration to notify interested parties about action results & metric
+ *
+ * @param className fully qualified class name of class implementing StateListener interface. The class needs a constructor with one parameter `options: Map[String,String]`.
+ * @param options Options are passed to StateListener constructor.
+ */
 case class StateListenerConfig(className: String, options: Option[Map[String,String]] = None) {
   // instantiate listener
   private[smartdatalake] val listener: StateListener = try {
@@ -35,10 +41,13 @@ case class StateListenerConfig(className: String, options: Option[Map[String,Str
   }
 }
 
+/**
+ * Interface to notify interested parties about action results & metric
+ */
 trait StateListener {
 
   /**
-   * Notify State
+   * notifyState is called whenever an action is finished (succeeded or failed)
    */
   def notifyState(state: ActionDAGRunState, context: ActionPipelineContext): Unit
 }

--- a/src/main/scala/io/smartdatalake/app/StateListener.scala
+++ b/src/main/scala/io/smartdatalake/app/StateListener.scala
@@ -47,6 +47,11 @@ case class StateListenerConfig(className: String, options: Option[Map[String,Str
 trait StateListener {
 
   /**
+   * Called on initialization to check environment
+   */
+  def init(): Unit = Unit
+
+  /**
    * notifyState is called whenever an action is finished (succeeded or failed)
    */
   def notifyState(state: ActionDAGRunState, context: ActionPipelineContext): Unit

--- a/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -24,7 +24,10 @@ import io.smartdatalake.config.ConfigurationException
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{SmartDataLakeLogger, SparkExpressionUtil}
-import io.smartdatalake.workflow.{ActionPipelineContext, SubFeed}
+import io.smartdatalake.workflow.DAGHelper.NodeId
+import io.smartdatalake.workflow.ExceptionSeverity.ExceptionSeverity
+import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
+import io.smartdatalake.workflow._
 import io.smartdatalake.workflow.action.ActionHelper.{getOptionalDataFrame, searchCommonInits}
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, DataObject}
@@ -120,7 +123,7 @@ case class PartitionDiffMode(partitionColNb: Option[Int] = None, override val al
               // evaluate fail condition
               val data = PartitionDiffModeExpressionData.from(context).copy(inputPartitionValues = inputPartitionValues.map(_.getMapString), outputPartitionValues = outputPartitionValues.map(_.getMapString), selectedPartitionValues = selectedPartitionValues.map(_.getMapString))
               val doFail = failCondition.exists(c => SparkExpressionUtil.evaluateBoolean(actionId, Some("failCondition"), c, data)) // default is to not fail
-              if (doFail) throw ExecutionModeFailedException(s"($actionId) Execution mode failed because of failCondition '${failCondition.get}' for $data")
+              if (doFail) throw ExecutionModeFailedException(actionId.id, context.phase, s"($actionId) Execution mode failed because of failCondition '${failCondition.get}' for $data")
               // stop processing if no new data
               if (partitionValuesToBeProcessed.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No partitions to process found for ${input.id}")
               //return
@@ -217,7 +220,7 @@ object SparkIncrementalMode {
 case class FailIfNoPartitionValuesMode() extends ExecutionMode {
   override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
     // check if partition values present
-    if (subFeed.partitionValues.isEmpty) throw ExecutionModeFailedException(s"($actionId) Partition values are empty")
+    if (subFeed.partitionValues.isEmpty) throw new IllegalStateException(s"($actionId) Partition values are empty for mainInput ${subFeed.dataObjectId.id}")
     // return
     None
   }
@@ -239,5 +242,9 @@ private[smartdatalake] object DefaultExecutionModeExpressionData {
   }
 }
 
-private[smartdatalake] case class ExecutionModeFailedException(msg: String) extends Exception(msg)
+private[smartdatalake] case class ExecutionModeFailedException(id: NodeId, phase: ExecutionPhase, msg: String) extends DAGException(msg) {
+  // don't fail in init phase, but skip action to continue with exec phase
+  override def severity: ExceptionSeverity = if (phase==ExecutionPhase.Init) ExceptionSeverity.SKIPPED else ExceptionSeverity.FAILED
+  override def getDAGRootExceptions: Seq[DAGException] = Seq(this)
+}
 

--- a/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
+++ b/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
@@ -63,8 +63,6 @@ private[smartdatalake] case class SparkStageMetrics(jobInfo: JobInfo, stageId: I
   lazy val resultSerializationTime: Duration = Duration.millis(resultSerializationTimeInMillis)
   lazy val shuffleFetchWaitTime: Duration = Duration.millis(shuffleFetchWaitTimeInMillis)
   lazy val shuffleWriteTime: Duration = Duration.millis(shuffleWriteTimeInNanos / 1000000)
-  // for some sources (Kafka, Jdbc) recordsWritten is always 0, but there is an accumulator which has "number of output rows" set...
-  lazy val recordsWrittenCons: Long = if (recordsWritten>0) recordsWritten else accumulables.find(_.name.contains("number of output rows")).flatMap(_.value).map(_.asInstanceOf[Long]).getOrElse(0L)
 
   /**
    * Formats [[Duration]]s as human readable strings.
@@ -118,7 +116,6 @@ private[smartdatalake] case class SparkStageMetrics(jobInfo: JobInfo, stageId: I
        |    ${keyValueStringWithSeparator("bytes_written", bytesWritten.toString)} B
        |    ${keyValueStringWithSeparator("records_read", recordsRead.toString)}
        |    ${keyValueStringWithSeparator("records_written", recordsWritten.toString)}
-       |    ${keyValueStringWithSeparator("records_written consolidated", recordsWrittenCons.toString)}
        |    ${durationStringWithSeparator("shuffle_fetch_waittime", shuffleFetchWaitTime)}
        |    ${keyValueStringWithSeparator("shuffle_remote_blocks_fetched", shuffleRemoteBlocksFetched.toString)}
        |    ${keyValueStringWithSeparator("shuffle_local_blocks_fetched", shuffleLocalBlocksFetched.toString)}
@@ -135,7 +132,7 @@ private[smartdatalake] case class SparkStageMetrics(jobInfo: JobInfo, stageId: I
   def getId: String = jobInfo.toString
   def getOrder: Long = stageId
   def getMainInfos: Map[String, Any] = {
-    Map("duration" -> stageRuntime, "records_written" -> recordsWrittenCons, "bytes_written" -> bytesWritten, "num_tasks" -> numTasks.toLong, "stage" -> stageName.split(' ').head )
+    Map("stageDuration" -> stageRuntime, "records_written" -> recordsWritten, "bytes_written" -> bytesWritten, "num_tasks" -> numTasks.toLong, "stage" -> stageName.split(' ').head )
   }
 }
 private[smartdatalake] case class JobInfo(id: Int, group: String, description: String)

--- a/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
+++ b/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
@@ -22,7 +22,7 @@ package io.smartdatalake.metrics
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.ActionMetrics
-import org.apache.spark.scheduler.{AccumulableInfo, SparkListener, SparkListenerJobStart, SparkListenerStageCompleted, SparkListenerTaskEnd}
+import org.apache.spark.scheduler.{AccumulableInfo, SparkListener, SparkListenerJobStart, SparkListenerStageCompleted}
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter, PeriodFormatter, PeriodFormatterBuilder}
 import org.joda.time.{Duration, Instant}
 

--- a/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
@@ -23,9 +23,11 @@ import java.net.URI
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import scala.io.Source
 
 /**
  * Provides utility functions for HDFS.
@@ -221,5 +223,12 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
 
   def getHadoopPartitionLayout(partitionCols: Seq[String], separator: Char): String = {
     partitionCols.map(col => s"$col=%$col%$separator").mkString
+  }
+
+  def readHadoopFile( file: String ): String = {
+    val path = addHadoopDefaultSchemaAuthority(new Path(file))
+    val fileSystem: FileSystem = getHadoopFs(path)
+    val is = fileSystem.open(path)
+    Source.fromInputStream(is).getLines.mkString(sys.props("line.separator"))
   }
 }

--- a/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
@@ -35,15 +35,13 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
   /**
    * Returns size information about existing files in HDFS
    *
-   * @param parquetPath Path to files in HDFS
+   * @param path Path to files in HDFS
    * @return Amount of files, total size of files in Bytes, average size of files in bytes
    */
-  def sizeInfo(parquetPath: String, sc: SparkContext): (Long, Long, Long) = {
+  def sizeInfo(path: Path, fs: FileSystem): (Long, Long, Long) = {
     try {
-      val hdfs: FileSystem = FileSystem.get(sc.hadoopConfiguration)
-      val hadoopPath = new Path(parquetPath)
       val recursive = false
-      val ri = hdfs.listFiles(hadoopPath, recursive)
+      val ri = fs.listFiles(path, recursive)
       val it = new Iterator[org.apache.hadoop.fs.LocatedFileStatus]() {
         override def hasNext = ri.hasNext
 
@@ -78,7 +76,7 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
    * @param session
    * @return
    */
-  def desiredFileSize(session:SparkSession): Long = {
+  def desiredFileSize(implicit session:SparkSession): Long = {
     session.sparkContext.hadoopConfiguration.getLong("dfs.blocksize", DefaultBlocksize)
   }
 
@@ -100,47 +98,37 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
    *                         small and Spark can't use up the configured boundaries.
    * @return repartitioned [[DataFrame]] (or Input [[DataFrame]] if partitioning is untouched)
    */
-  def repartitionForHdfsFileSize(df: DataFrame, existingFilePath: String, reducePartitions: Boolean = false): DataFrame = {
+  def repartitionForHdfsFileSize(df: DataFrame, existingFilePath: Path, reducePartitions: Boolean = false)(implicit session:SparkSession): DataFrame = {
 
     // Use the HDFS blocksize as target size or use the default if it can't be evaluated
     val desiredSize = desiredFileSize(df.sparkSession)
 
-    val (numFiles, sumSize, avgSize) = HdfsUtil.sizeInfo(existingFilePath, df.sparkSession.sparkContext)
+    val fs = getHadoopFsFromSpark(existingFilePath)
+    val (numFiles, sumSize, avgSize) = HdfsUtil.sizeInfo(existingFilePath, fs)
     val reduceBy = if(reducePartitions) 2 else 1
     val numPartitionsRequired = Math.max(1,Math.ceil(sumSize.toDouble/desiredSize.toDouble).toInt) / reduceBy
     val currentPartitionNum = df.rdd.getNumPartitions
 
-    logger.info(s"Current Parquet files: ${numFiles} with a size of ${sumSize}. Requiring ${numPartitionsRequired} partitions now.")
+    logger.debug(s"Current Parquet files: ${numFiles} with a size of ${sumSize}. Requiring ${numPartitionsRequired} partitions now.")
 
     // Repartition is only done if files exist, otherwise you always end up with one partition
     val dfRepartitioned = if (sumSize > 0 && numPartitionsRequired > currentPartitionNum) {
-      logger.info(s"Executing repartition to ${numPartitionsRequired}")
+      logger.debug(s"Executing repartition to ${numPartitionsRequired}")
       df.repartition(numPartitionsRequired)
     } else if(sumSize > 0 && numPartitionsRequired < currentPartitionNum) {
-      logger.info(s"Executing coalesce to ${numPartitionsRequired}")
+      logger.debug(s"Executing coalesce to ${numPartitionsRequired}")
       df.coalesce(numPartitionsRequired)
     }
     else df
 
     val adjustedPartitionNum = dfRepartitioned.rdd.getNumPartitions
-    logger.info(s"Number of RDD partitions before repartition: ${currentPartitionNum}.")
-    logger.info(s"Number of RDD partitions after repartition: ${adjustedPartitionNum}.")
+    logger.debug(s"Repartitioning: Number of RDD partitions before=$currentPartitionNum after=$adjustedPartitionNum")
     dfRepartitioned
   }
 
-  def deletePath( path:String, sc:SparkContext, doWarn:Boolean ) : Unit = {
-    val hdfs = FileSystem.get(sc.hadoopConfiguration)
+  def deletePath( path: Path, fs:FileSystem, doWarn:Boolean ) : Unit = {
     try {
-      hdfs.delete(new Path(path), true) // recursive=true
-      logger.info(s"Hadoop path ${path} deleted.")
-    } catch {
-      case e: Exception => if (doWarn) logger.warn(s"Hadoop path ${path} couldn't be deleted (${e.getMessage})")
-    }
-  }
-
-  def deletePath( path:String, fs:FileSystem, doWarn:Boolean ) : Unit = {
-    try {
-      fs.delete(new Path(path), true) // recursive=true
+      fs.delete(path, true) // recursive=true
       logger.info(s"Hadoop path ${path} deleted.")
     } catch {
       case e: Exception => if (doWarn) logger.warn(s"Hadoop path ${path} couldn't be deleted (${e.getMessage})")
@@ -150,9 +138,9 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
   /**
    * In contrast to deletePath this supports "globs"
    */
-  def deleteFiles( path:String, fs:FileSystem, doWarn:Boolean ) : Unit = {
+  def deleteFiles( path: Path, fs:FileSystem, doWarn:Boolean ) : Unit = {
     try {
-      val deletePaths = fs.globStatus(new Path(path)).map(_.getPath)
+      val deletePaths = fs.globStatus(path).map(_.getPath)
       deletePaths.foreach{ path => fs.delete(path, true) }
       logger.info(s"${deletePaths.size} files delete for hadoop path ${path}.")
     } catch {
@@ -175,7 +163,7 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
    * @param path path to be extended with authority
    * @return Hadoop Path with authority
    */
-  def addHadoopDefaultSchemaAuthority(path: org.apache.hadoop.fs.Path): org.apache.hadoop.fs.Path = {
+  def addHadoopDefaultSchemaAuthority(path: Path): Path = {
     if (path.isAbsoluteAndSchemeAuthorityNull) path.makeQualified(HdfsUtil.getHadoopDefaultSchemeAuthority, null)
     else path
   }
@@ -191,11 +179,10 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
    * @param prefix prefix to be added if path doesn't contain schema and authority
    * @return Hadoop Path with schema and authority
    */
-  def prefixHadoopPath(path: String, prefix: Option[String]): org.apache.hadoop.fs.Path = {
-    import org.apache.hadoop.fs.Path
+  def prefixHadoopPath(path: String, prefix: Option[String]): Path = {
     val hadoopPath = new Path(path)
     if (hadoopPath.isAbsoluteAndSchemeAuthorityNull || !hadoopPath.isAbsolute) {
-      val hadoopPathPrefixed = prefix.map( p => new Path(p + HdfsUtil.addLeadingSeparator(path,Environment.defaultPathSeparator)))
+      val hadoopPathPrefixed = prefix.map( p => new Path(p + HdfsUtil.addLeadingSeparator(path, Environment.defaultPathSeparator)))
         .getOrElse(hadoopPath)
       HdfsUtil.addHadoopDefaultSchemaAuthority( hadoopPathPrefixed )
     }
@@ -210,8 +197,8 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
    * @param path
    * @return
    */
-  def getHadoopFs(path: org.apache.hadoop.fs.Path): FileSystem = {
-    path.getFileSystem(new org.apache.hadoop.conf.Configuration())
+  def getHadoopFs(path: Path): FileSystem = {
+    path.getFileSystem(new Configuration())
   }
 
   /**
@@ -220,14 +207,15 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
    * @param path
    * @return
    */
-  def getHadoopFsFromSpark(path: org.apache.hadoop.fs.Path)(implicit session: SparkSession): FileSystem = {
+  def getHadoopFsFromSpark(path: Path)(implicit session: SparkSession): FileSystem = {
     path.getFileSystem(session.sparkContext.hadoopConfiguration)
   }
-  def getHadoopFsWithConf(path: org.apache.hadoop.fs.Path, hadoopConf: Configuration)(implicit session: SparkSession): FileSystem = {
+
+  def getHadoopFsWithConf(path: Path, hadoopConf: Configuration)(implicit session: SparkSession): FileSystem = {
     path.getFileSystem(hadoopConf)
   }
 
-  def addLeadingSeparator(path:String, separator: Char): String = {
+  def addLeadingSeparator(path: String, separator: Char): String = {
     if (path.startsWith(separator.toString)) path else separator + path
   }
 

--- a/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
@@ -41,44 +41,37 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * Creates a String by concatenating all column names of a table. 
    * Columns are seperated by ','.
    *
-   * @param session [[SparkSession]] used
-   * @param tableName Name of table
-   * @return
+   * @param table Hive table
    */
-  def tableColumnsString(session: SparkSession, dbName: String, tableName: String): String = {
+  def tableColumnsString(table: Table)(implicit session: SparkSession): String = {
     import session.implicits._ // Workaround for
-    val tableSchema = execSqlStmt(session, s"show columns in $dbName.$tableName")
+    val tableSchema = execSqlStmt(s"show columns in ${table.fullName}")
     tableSchema.map(c => c(0).toString.replace(" ","").toLowerCase).collect.mkString(",")
   }
 
   /**
    * Deletes a Hive table
    *
-   * @param session [[SparkSession]] used
-   * @param hiveDb Hive DB to use
-   * @param tableName Name of table
+   * @param table Hive table
    * @param doPurge Flag to indicate if PURGE should be used when deleting (don't delete to HDFS trash). Default: true
    * @param existingOnly Flag if check "if exists" should be executed. Default: true
    */
-  def dropTable(session: SparkSession, hiveDb: String, tableName: String, doPurge: Boolean = true,
-                existingOnly: Boolean = true): Unit = {
+  def dropTable(table: Table, doPurge: Boolean = true, existingOnly: Boolean = true)(implicit session: SparkSession): Unit = {
     val existsClause = if (existingOnly) "if exists " else ""
     val purgeClause = if (doPurge) " purge" else ""
-    val stmt = s"drop table $existsClause$hiveDb.$tableName$purgeClause"
-    execSqlStmt(session, stmt)
+    val stmt = s"drop table $existsClause${table.fullName}$purgeClause"
+    execSqlStmt(stmt)
   }
 
   /**
    * Collects table-level statistics
    *
-   * @param session [[SparkSession]] to use
-   * @param hiveDb Hive DB to use
-   * @param hiveTable Hive table for which statistics should get collected
+   * @param table Hive table
    */
-  def analyzeTable(session: SparkSession, hiveDb: String, hiveTable: String): Unit = {
-    val stmt = s"ANALYZE TABLE $hiveDb.$hiveTable COMPUTE STATISTICS"
-    Try(execSqlStmt(session, stmt)) match {
-      case Success(_) => logger.info(s"Gathered table-level statistics on table $hiveDb.$hiveTable")
+  def analyzeTable(table: Table)(implicit session: SparkSession): Unit = {
+    val stmt = s"ANALYZE TABLE ${table.fullName} COMPUTE STATISTICS"
+    Try(execSqlStmt(stmt)) match {
+      case Success(_) => logger.info(s"Gathered table-level statistics on table ${table.fullName}")
       case Failure(throwable) => logger.error(throwable.getMessage)
         throw new AnalyzeTableException(s"Error running: $stmt")
     }
@@ -87,15 +80,13 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
   /**
    * Collects column-level statistics
    *
-   * @param session [[SparkSession]] to use
-   * @param hiveDb Hive DB to use
-   * @param hiveTable  Hive table for which statistics should get collected
-   * @param columns The column list of the Hive table
+   * @param table Hive table
+   * @param columns Columns to collect statistics from
    */
-  def analyzeTableColumns(session: SparkSession, hiveDb: String, hiveTable: String, columns: String): Unit = {
-    val stmt = s"ANALYZE TABLE $hiveDb.$hiveTable COMPUTE STATISTICS FOR COLUMNS $columns"
-    Try(execSqlStmt(session, stmt)) match {
-      case Success(_) => logger.info(s"Gathered column-level statistics on table $hiveDb.$hiveTable")
+  def analyzeTableColumns(table: Table, columns: String)(implicit session: SparkSession): Unit = {
+    val stmt = s"ANALYZE TABLE ${table.fullName} COMPUTE STATISTICS FOR COLUMNS $columns"
+    Try(execSqlStmt(stmt)) match {
+      case Success(_) => logger.info(s"Gathered column-level statistics on table ${table.fullName}")
       case Failure(throwable) => logger.error(throwable.getMessage)
         throw new AnalyzeTableException(s"Error running: $stmt")
     }
@@ -108,47 +99,42 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * We will reduce the number by 2%: If the number is too low, the block is not filled optimally. On the other hand,
    * if the number is too high we end up with an additional (very small) block which is worse.
    *
-   * @param session
-   * @param hiveDb
-   * @param hiveTable
+   * @param table Hive Table
    * @return Desired number of records per file if it can be determined, None otherwise
    */
-  def calculateMaxRecordsPerFileFromStatistics(session: SparkSession, hiveDb: String, hiveTable: String): Option[BigInt] = {
+  def calculateMaxRecordsPerFileFromStatistics(table: Table)(implicit session: SparkSession): Option[BigInt] = {
     val desiredSizePerFile = HdfsUtil.desiredFileSize(session)
     logger.debug("Desired filesize for session is " +desiredSizePerFile +" bytes.")
 
-    session.sharedState.externalCatalog.getTable(hiveDb, hiveTable).stats.flatMap(s =>
+    session.sharedState.externalCatalog.getTable(table.db.get, table.name).stats.flatMap(s =>
       s.rowCount.map(rCount => (desiredSizePerFile / (s.sizeInBytes / rCount))*98/100))
   }
 
   /**
    * Collects column-level statistics for partitions
    *
-   * @param session [[SparkSession]] to use
-   * @param hiveDb  Hive DB to use
-   * @param hiveTable  Hive table for which statistics should get collected
-   * @param partitions Partitions to collect statistics for
-   * @param partitionValues Seq of PartitionValues of hiveTable (mapping col->value)
+   * @param table Hive table
+   * @param partitionCols Partitioned columns
+   * @param partitionValues Partition values
    */
-  def analyzeTablePartitions(session: SparkSession, hiveDb: String, hiveTable: String
-                           , partitions: Seq[String], partitionValues: Seq[PartitionValues]): Unit = {
+  def analyzeTablePartitions(table: Table, partitionCols: Seq[String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
 
     val preparedPartitionValues = if (partitionValues.nonEmpty) {
       partitionValues.map{
         partitionValue =>
           // extend PartitionValue with defaults for missing partition colums
-          partitionValue.elements.mapValues(Some(_)) ++ partitions.diff(partitionValue.keys.toSeq).map( c => (c, None))
+          partitionValue.elements.mapValues(Some(_)) ++ partitionCols.diff(partitionValue.keys.toSeq).map( c => (c, None))
       }
     } else {
       // create a default entry for every partition column to compute statistics for all partition values existing on the storage
-      Seq(partitions.map(c => (c, None)).toMap)
+      Seq(partitionCols.map(c => (c, None)).toMap)
     }
     preparedPartitionValues.foreach{ p =>
       val partitionSpec = p.map{ case (col, value) => if(value.isDefined) s"$col='${value.get}'" else col}
         .mkString(",")
-      val stmt = s"ANALYZE TABLE $hiveDb.$hiveTable PARTITION($partitionSpec) COMPUTE STATISTICS"
-      Try(execSqlStmt(session, stmt)) match {
-        case Success(_) => logger.info(s"Gathered partition-level statistics for $partitionSpec on table $hiveDb.$hiveTable")
+      val stmt = s"ANALYZE TABLE ${table.fullName} PARTITION($partitionSpec) COMPUTE STATISTICS"
+      Try(execSqlStmt(stmt)) match {
+        case Success(_) => logger.info(s"Gathered partition-level statistics for $partitionSpec on table ${table.fullName}")
         case Failure(throwable) => logger.error(throwable.getMessage)
           throw new AnalyzeTableException(s"Error running: $stmt")
       }
@@ -156,7 +142,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
   }
 
   // get Partitions for specified table from catalog
-  def getTablePartitions(hiveDb:String, tableName:String) (implicit session: SparkSession) : Seq[Map[String,String]] = {
+  def getTablePartitions(table: Table) (implicit session: SparkSession) : Seq[Map[String,String]] = {
     import session.implicits._
 
     // Parse HDFS partitionname into Map
@@ -168,15 +154,15 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
         throw ex
     }
 
-    session.sql(s"show partitions $hiveDb.$tableName").as[String].collect.map( parseHDFSPartitionString).toSeq
+    session.sql(s"show partitions ${table.fullName}").as[String].collect.map( parseHDFSPartitionString).toSeq
   }
 
   // get partition columns for specified table from DDL
-  def getTablePartitionCols(hiveDb:String, tableName:String) (implicit session: SparkSession) : Option[Seq[String]] = {
+  def getTablePartitionCols(table: Table) (implicit session: SparkSession) : Option[Seq[String]] = {
     import session.implicits._
 
     // get ddl and concat into one string without newlines
-    val tableDDL = session.sql(s"show create table $hiveDb.$tableName").as[String].collect.mkString(" ").replace("\n"," ")
+    val tableDDL = session.sql(s"show create table ${table.fullName}").as[String].collect.mkString(" ").replace("\n"," ")
 
     // extract partition by declaration
     val regexPartitionBy = raw"PARTITIONED BY\s+\(([^\)]+)\)".r.unanchored
@@ -208,37 +194,34 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * @param session SparkSession
    * @param dfNew DataFrame to write
    * @param outputDir Directory to store files for Table
-   * @param hiveTable Tablename
-   * @param hiveDb Hive database name
+   * @param table Table
    * @param partitions Partition column names
    * @param hdfsOutputType tables underlying file format, default = parquet
    * @param numInitialHdfsPartitions the initial number of files created if table does not exist yet, default = -1. Note: the number of files created is controlled by the number of Spark partitions.
    */
-  def writeDfToHive(session: SparkSession, dfNew: DataFrame, outputDir: String, hiveTable: String,
-                    hiveDb: String, partitions: Seq[String], saveMode: SaveMode,
-                    hdfsOutputType: OutputType = OutputType.Parquet, numInitialHdfsPartitions: Int = -1): Unit = {
-    implicit val sss = session
-    logger.info(s"writeDfToHive: starting for table $hiveDb.$hiveTable, outputDir: $outputDir, partitions:$partitions")
+  def writeDfToHive(dfNew: DataFrame, outputDir: String, table: Table, partitions: Seq[String], saveMode: SaveMode,
+                    hdfsOutputType: OutputType = OutputType.Parquet, numInitialHdfsPartitions: Int = -1)(implicit session: SparkSession): Unit = {
+    logger.info(s"writeDfToHive: starting for table ${table.fullName}, outputDir: $outputDir, partitions:$partitions")
 
     // check if all partition cols are present in DataFrame
     val missingPartitionCols = partitions.diff(dfNew.columns)
     require( missingPartitionCols.isEmpty, s"""Partition column(s) ${missingPartitionCols.mkString(",")} are missing in DataFrame columns (${dfNew.columns.mkString(",")}).""" )
 
     // check if table exists and location is correct
-    val tableExists = isHiveTableExisting(hiveTable,session,hiveDb)
-    if (!tableExists) logger.info(s"writeDfToHive: table $hiveDb.$hiveTable doesnt exist yet")
+    val tableExists = isHiveTableExisting(table)
+    if (!tableExists) logger.info(s"writeDfToHive: table ${table.fullName} doesnt exist yet")
 
     // check if partitionsOpt match with existing table definition
     if (tableExists) {
       val configuredCols = partitions.toSet
-      val existingCols = getTablePartitionCols(hiveDb,hiveTable).getOrElse(Seq()).toSet
+      val existingCols = getTablePartitionCols(table).getOrElse(Seq()).toSet
       require( configuredCols==existingCols, s"writeDfToHive: configured are different from tables existing partition columns: configured=$configuredCols, existing=$existingCols" )
     }
 
     // check if this run is with SchemaEvolution and sort columns (partition columns last)
     val (df_newColsSorted, withSchemaEvolution) = if (tableExists) {
       // check if schema evolution
-      val df_existing = session.table(s"$hiveDb.$hiveTable")
+      val df_existing = session.table(table.fullName)
       val withSchemaEvolution = !SchemaEvolution.hasSameColNamesAndTypes(df_existing, dfNew)
       if (withSchemaEvolution) {
         logger.info("writeDfToHive: schema evolution detected")
@@ -273,18 +256,15 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
     // Schema evolution with Partitions can only be done with Tick-Tock
     require( !(withSchemaEvolution && partitions.nonEmpty), "Schema evolution with partitions only works with TickTock! Use writeDfToHiveWithTickTock instead." )
 
-    // define table
-    val table = s"$hiveDb.$hiveTable"
-
-    val originalMaxRecordsPerFile = session.conf.get("spark.sql.files.maxRecordsPerFile")
 
     // write to table
+    val originalMaxRecordsPerFile = session.conf.get("spark.sql.files.maxRecordsPerFile")
     if (tableExists && !withSchemaEvolution) {
       // insert into existing table
-      logger.info(s"writeDfToHive: insert into $table")
+      logger.info(s"writeDfToHive: insert into ${table.fullName}")
 
       // Try to determine maximum number of records according to catalog statistics
-      val maxRecordsPerFile: Option[BigInt] = calculateMaxRecordsPerFileFromStatistics(session, hiveDb, hiveTable)
+      val maxRecordsPerFile: Option[BigInt] = calculateMaxRecordsPerFileFromStatistics(table)
       val df_partitioned = if(maxRecordsPerFile.isDefined) {
         // if exact number of records could be determined from Hive statistics, use it to split files
         logger.info(s"writing with maxRecordsPerFile " +maxRecordsPerFile.get.toLong)
@@ -300,7 +280,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
       // Write file
       df_partitioned.write
         .mode(saveMode)
-        .insertInto(table)
+        .insertInto(table.fullName)
 
     } else {
       // for new tables:
@@ -311,22 +291,22 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
 
       // create and write to table
       if (partitions.nonEmpty) { // with partitions
-        logger.info(s"writeDfToHive: creating external partitioned table $table at location $outputDir")
+        logger.info(s"writeDfToHive: creating external partitioned table ${table.fullName} at location $outputDir")
         HdfsUtil.deletePath(outputDir, session.sparkContext, doWarn=false) // delete existing data, as all partitions need to be written when table is created.
         df_partitioned.write
           .partitionBy(partitions:_*)
           .format(hdfsOutputType.toString)
           .option("path", outputDir)
           .mode("overwrite")
-          .saveAsTable(table)
+          .saveAsTable(table.fullName)
 
       } else { // without partitions
-        logger.info(s"writeDfToHive: creating table $table at location $outputDir")
+        logger.info(s"writeDfToHive: creating table ${table.fullName} at location $outputDir")
         df_partitioned.write
           .format(hdfsOutputType.toString)
           .option("path", outputDir)
           .mode("overwrite")
-          .saveAsTable(table)
+          .saveAsTable(table.fullName)
       }
     }
     session.conf.set("spark.sql.files.maxRecordsPerFile", originalMaxRecordsPerFile.toLong)
@@ -342,36 +322,33 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * @param session SparkSession
    * @param df_new DataFrame to write
    * @param outputDir Directory to store files for Table
-   * @param hiveTable Tablename
-   * @param hiveDb Hive database name
+   * @param table Table
    * @param partitions Partitions column name
    * @param hdfsOutputType tables underlying file format, default = parquet
    */
-  def writeDfToHiveWithTickTock(session: SparkSession, df_new: DataFrame, outputDir: String, hiveTable: String,
-                    hiveDb: String, partitions: Seq[String], saveMode: SaveMode,
-                    hdfsOutputType: OutputType = OutputType.Parquet): Unit = {
-    implicit val sss = session
-    logger.info(s"writeDfToHiveWithTickTock: starting for table $hiveDb.$hiveTable, outputDir: $outputDir, partitions:$partitions")
+  def writeDfToHiveWithTickTock(df_new: DataFrame, outputDir: String, table: Table, partitions: Seq[String], saveMode: SaveMode,
+                    hdfsOutputType: OutputType = OutputType.Parquet)(implicit session: SparkSession): Unit = {
+    logger.info(s"writeDfToHiveWithTickTock: starting for table ${table.fullName}, outputDir: $outputDir, partitions:$partitions")
 
     // check if all partition cols are present in DataFrame
     val missingPartitionCols = partitions.diff(df_new.columns)
     require( missingPartitionCols.isEmpty, s"""partition columns ${missingPartitionCols.mkString(",")} not present in DataFrame""" )
 
     // check if table exists and location is correct
-    val tableExists = isHiveTableExisting(hiveTable,session,hiveDb)
-    if (!tableExists) logger.info(s"writeDfToHive: table $hiveDb.$hiveTable doesn't exist yet")
+    val tableExists = isHiveTableExisting(table)
+    if (!tableExists) logger.info(s"writeDfToHive: table ${table.fullName} doesn't exist yet")
 
     // check if partitionsOpt match with existing table definition
     if (tableExists) {
       val configuredCols = partitions.toSet
-      val existingCols = getTablePartitionCols(hiveDb,hiveTable).getOrElse(Seq()).toSet
+      val existingCols = getTablePartitionCols(table).getOrElse(Seq()).toSet
       require( configuredCols==existingCols, s"writeDfToHive: configured are different from tables existing partition columns: configured=$configuredCols, existing=$existingCols" )
     }
 
     // check if this run is with SchemaEvolution and sort columns (partition columns last)
     val (df_newColsSorted, withSchemaEvolution) = if (tableExists) {
       // check if schema evolution
-      val df_existing = session.table(s"$hiveDb.$hiveTable")
+      val df_existing = session.table(table.fullName)
       val withSchemaEvolution = !SchemaEvolution.hasSameColNamesAndTypes(df_existing, df_new)
       if (withSchemaEvolution) {
         logger.info("writeDfToHive: schema evolution detected")
@@ -409,73 +386,71 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
     val doTickTock = (partitions.isEmpty || withSchemaEvolution) && tableExists
 
     // define location: use tick-tock path
-    val location = alternatingTickTockLocation2(hiveDb, session, hiveTable, outputDir)
+    val location = alternatingTickTockLocation2(table, outputDir)
 
     // define table: use tmp-table if we need to *do* a tick-tock
-    val table = if (doTickTock) {
+    val tableName = if (doTickTock) {
       logger.info(s"writeDfToHive: tick-tock needed")
-      s"$hiveDb.${hiveTable}_tmp"
-    } else s"$hiveDb.$hiveTable"
+      s"${table.fullName}_tmp"
+    } else table.fullName
 
     // write to table
     if (tableExists && !doTickTock && !withSchemaEvolution) {
       // insert into existing table
-      logger.info(s"writeDfToHive: insert into $table")
-      df_newColsSorted.write.mode(saveMode).insertInto(table)
+      logger.info(s"writeDfToHive: insert into $tableName")
+      df_newColsSorted.write.mode(saveMode).insertInto(tableName)
 
     } else {
       // create and write to table
       if (partitions.nonEmpty) { // with partitions
-        logger.info(s"writeDfToHive: creating external partitioned table $table at location $location")
+        logger.info(s"writeDfToHive: creating external partitioned table $tableName at location $location")
         HdfsUtil.deletePath(location, session.sparkContext, doWarn=false) // delete existing data, as all partitions need to be written when table is created.
         df_newColsSorted.write
           .partitionBy(partitions:_*)
           .format(hdfsOutputType.toString)
           .option("path", location)
           .mode("overwrite")
-          .saveAsTable(table)
+          .saveAsTable(tableName)
 
       } else { // without partitions
-        logger.info(s"writeDfToHive: creating table $table at location $location")
+        logger.info(s"writeDfToHive: creating table $tableName at location $location")
         df_newColsSorted.write
           .format(hdfsOutputType.toString)
           .option("path", location)
           .mode("overwrite")
-          .saveAsTable(table)
+          .saveAsTable(tableName)
       }
     }
 
     // point hiveTable to new data for Tick-Tock table
     if (doTickTock) {
-      val existingTable = s"$hiveDb.$hiveTable"
+      val existingTable = table.fullName
       // drop existing table (schema is outdated), rename tmp table (new schema)
       // Attention: this table is potentially missing for some milliseconds...
       // Note: we could also change location of existing table, but this get's complicated for partitioned tables as all partition locations need to be changed as well, maybe even with multiple partition cols.
-      logger.info(s"writeDfToHive: droping table $existingTable, renaming table $table to $existingTable" )
+      logger.info(s"writeDfToHive: droping table $existingTable, renaming table $tableName to $existingTable" )
       session.sql(s"DROP TABLE IF EXISTS $existingTable")
-      session.sql(s"ALTER TABLE $table RENAME TO $existingTable")
+      session.sql(s"ALTER TABLE $tableName RENAME TO $existingTable")
     }
   }
 
   /**
    * Collects table statistics for table or table with partitions
    *
-   * @param session [[SparkSession]] to use
-   * @param hiveDb Target Hive DB
-   * @param hiveTable Target Hive table
-   * @param partitions Seq of partitions of hiveTable
-   * @param partitionValues Seq of PartitionValues of hiveTable (mapping col->value)
+   * @param table Hive table
+   * @param partitionCols Partitioned columns
+   * @param partitionValues Partition values
    */
-  def analyze(session: SparkSession, hiveDb: String, hiveTable: String, partitions: Seq[String], partitionValues: Seq[PartitionValues] = Seq()): Unit = {
+  def analyze(table: Table, partitionCols: Seq[String], partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession): Unit = {
     // If partitions are present, statistics can't be collected for the table itself
     // only for partitions or columns
-    val columns = tableColumnsString(session, hiveDb, hiveTable)
-    if (partitions.isEmpty){
-      analyzeTableColumns(session, hiveDb, hiveTable, columns)
-      analyzeTable(session, hiveDb, hiveTable)
+    val columns = tableColumnsString(table)
+    if (partitionCols.isEmpty){
+      analyzeTableColumns(table, columns)
+      analyzeTable(table)
     } else {
-      analyzeTablePartitions(session, hiveDb, hiveTable, partitions, partitionValues)
-      analyzeTableColumns(session, hiveDb, hiveTable, columns)
+      analyzeTablePartitions(table, partitionCols, partitionValues)
+      analyzeTableColumns(table, columns)
     }
   }
 
@@ -486,7 +461,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * @param stmt statement to be executed
    * @return result DataFrame
    */
-  def execSqlStmt(session: SparkSession, stmt: String): DataFrame = {
+  def execSqlStmt(stmt: String)(implicit session: SparkSession): DataFrame = {
     try {
       logger.info(s"Executing SQL statement: $stmt")
       session.sql(stmt)
@@ -533,17 +508,15 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
   /**
    * Checks if a Hive table exists
    *
-   * @param tableName Name of table
-   * @param session [[SparkSession]] to use
-   * @param hiveDb Hive DB to use
    * @return true if a table exists, otherwise false
    */
-  def isHiveTableExisting(tableName: String, session: SparkSession, hiveDb: String): Boolean = {
-    session.catalog.tableExists(hiveDb, tableName)
+  def isHiveTableExisting(table: Table)(implicit session: SparkSession): Boolean = {
+    if (table.db.isDefined) session.catalog.tableExists(table.db.get, table.name)
+    else session.catalog.tableExists(table.name)
   }
 
-  def hiveTableLocation(dbName: String, session: SparkSession, tableName: String): String = {
-    val extendedDescribe = session.sql(s"describe extended $dbName.$tableName")
+  def hiveTableLocation(table: Table)(implicit session: SparkSession): String = {
+    val extendedDescribe = session.sql(s"describe extended ${table.fullName}")
       .cache
 
     // Spark 2.2, 2.3: Location is found as row with col_name == "Location",
@@ -573,19 +546,19 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
       case _ => None
     }
 
-    location22.orElse(location21).getOrElse( throw new TableInformationException( s"Location for table $dbName.$tableName not found"))
+    location22.orElse(location21).getOrElse( throw new TableInformationException( s"Location for table ${table.fullName} not found"))
   }
 
   def existingTableLocation(table: Table)(implicit session: SparkSession): URI = {
     session.sharedState.externalCatalog.getTable(table.db.get,table.name).location
   }
 
-  def existingTickTockLocation(dbName: String, session: SparkSession, tableName: String): String = {
-    hiveTableLocation(dbName, session, tableName)
+  def existingTickTockLocation(table: Table)(implicit session: SparkSession): String = {
+    hiveTableLocation(table)
   }
 
-  def getCurrentTickTockLocationSuffix(dbName: String, session: SparkSession, tableName: String): HiveTableLocationSuffix.Value = {
-    val currentLocation = hiveTableLocation(dbName, session, tableName)
+  def getCurrentTickTockLocationSuffix(table: Table)(implicit session: SparkSession): HiveTableLocationSuffix.Value = {
+    val currentLocation = hiveTableLocation(table)
     logger.debug(s"currentLocation: $currentLocation")
     HiveTableLocationSuffix.withName(currentLocation.split('/').last)
   }
@@ -604,17 +577,17 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
     }
   }
 
-  def alternatingTickTockLocation(dbName: String, session: SparkSession, tableName: String): String = {
-    val currentLocation = hiveTableLocation(dbName, session, tableName)
+  def alternatingTickTockLocation(table: Table)(implicit session: SparkSession): String = {
+    val currentLocation = hiveTableLocation(table)
     logger.debug(s"currentLocation: $currentLocation")
     val newLocation = alternateTickTockLocation(currentLocation)
     logger.debug(s"newLocation: $currentLocation")
     newLocation
   }
 
-  def alternatingTickTockLocation2(dbName: String, session: SparkSession, tableName: String, outputDir:String): String = {
-    if (isHiveTableExisting(tableName,session,dbName)) {
-      alternateTickTockLocation(hiveTableLocation(dbName, session, tableName))
+  def alternatingTickTockLocation2(table: Table, outputDir:String)(implicit session: SparkSession): String = {
+    if (isHiveTableExisting(table)) {
+      alternateTickTockLocation(hiveTableLocation(table))
     } else {
       // If the table doesn't exist yet, start with tick
       s"$outputDir/${HiveTableLocationSuffix.Tick.toString}"
@@ -649,6 +622,6 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
 
   def createEmptyPartition(table: Table, partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {
     val partitionDef = partitionValues.elements.map{ case (k,v) => s"$k='$v'"}.mkString(", ")
-    execSqlStmt(session, s"ALTER TABLE ${table.fullName} ADD IF NOT EXISTS PARTITION ($partitionDef)")
+    execSqlStmt(s"ALTER TABLE ${table.fullName} ADD IF NOT EXISTS PARTITION ($partitionDef)")
   }
 }

--- a/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.util.evolution.SchemaEvolution
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionLayout, PartitionValues}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.dataobject.Table
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions.{array, col}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
@@ -623,5 +624,13 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
   def createEmptyPartition(table: Table, partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {
     val partitionDef = partitionValues.elements.map{ case (k,v) => s"$k='$v'"}.mkString(", ")
     execSqlStmt(s"ALTER TABLE ${table.fullName} ADD IF NOT EXISTS PARTITION ($partitionDef)")
+  }
+
+  def dropPartition(table: Table, tablePath: Path, partition: PartitionValues)(implicit session: SparkSession): Unit = {
+    val partitionLayout = HdfsUtil.getHadoopPartitionLayout(partition.keys.toSeq, Environment.defaultPathSeparator)
+    val partitionPath = new Path(tablePath, partition.getPartitionString(partitionLayout))
+    HdfsUtil.deletePath(partitionPath.toString, session.sparkContext, false)
+    val partitionDef = partition.elements.map{ case (k,v) => s"$k='$v'"}.mkString(", ")
+    execSqlStmt(s"ALTER TABLE ${table.fullName} DROP IF EXISTS PARTITION ($partitionDef)")
   }
 }

--- a/src/main/scala/io/smartdatalake/util/misc/PythonUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/misc/PythonUtil.scala
@@ -1,0 +1,65 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.misc
+
+import org.apache.spark.python.PythonHelper
+import org.apache.spark.python.PythonHelper.SparkEntryPoint
+import org.apache.spark.sql.SparkSession
+
+private[smartdatalake] object PythonUtil {
+
+  /**
+   * Execute python code within a given Spark context/session.
+   *
+   * @param code python code as string.
+   *                   The SparkContext is available as "sc" and SparkSession as "session".
+   * @param entryPointObj py4j gateway entrypoint java object available in python code as gateway.entry_point.
+   *                      This is used to transfer SparkContext to python and can hold additional custom parameters.
+   *                      entryPointObj must at least implement trait SparkEntryPoint.
+   */
+  def execPythonTransform[T<:SparkEntryPoint](entryPointObj: T, code: String): Unit = {
+    PythonHelper.exec(entryPointObj, mainInitCode + sys.props("line.separator") + code)
+  }
+
+  // python spark gateway init code
+  val mainInitCode =
+    """
+      |from pyspark.java_gateway import launch_gateway
+      |from pyspark.context import SparkContext
+      |from pyspark.conf import SparkConf
+      |from pyspark.sql.session import SparkSession
+      |from pyspark.sql import SQLContext
+      |from pyspark.sql import DataFrame
+      |
+      |# Initialize python spark session from java spark context.
+      |# The java spark context is set as entrypoint for the py4j gateway.
+      |gateway = launch_gateway()
+      |entryPoint = gateway.entry_point
+      |javaSparkContext = entryPoint.getJavaSparkContext()
+      |sparkConf = SparkConf(_jvm=gateway.jvm, _jconf=javaSparkContext.getConf())
+      |sc = SparkContext(conf=sparkConf, gateway=gateway, jsc=javaSparkContext)
+      |session = SparkSession(sc, entryPoint.session())
+      |sqlContext = SQLContext(sc, session, entryPoint.getSQLContext())
+      |print("python spark session initialized (sc, session, sqlContext)")
+      |""".stripMargin
+}
+
+class DfTransformerSparkEntryPoint(override val session: SparkSession, options: Map[String,String] = Map()) extends SparkEntryPoint
+

--- a/src/main/scala/io/smartdatalake/util/misc/SparkExpressionUtil.scala
+++ b/src/main/scala/io/smartdatalake/util/misc/SparkExpressionUtil.scala
@@ -130,11 +130,12 @@ private[smartdatalake] object SparkExpressionUtil {
   }
 }
 
-case class DefaultExpressionData( feed: String, application: String, runId: Int, attemptId: Int, referenceTimestamp: Option[Timestamp]
-                                , runStartTime: Timestamp, attemptStartTime: Timestamp, partitionValues: Seq[Map[String,String]])
+case class DefaultExpressionData( feed: String, application: String, runId: Int, attemptId: Int, executionPhase:String, referenceTimestamp: Option[Timestamp]
+                                  , runStartTime: Timestamp, attemptStartTime: Timestamp, partitionValues: Seq[Map[String,String]])
 object DefaultExpressionData {
   def from(context: ActionPipelineContext, partitionValues: Seq[PartitionValues]): DefaultExpressionData = {
-    DefaultExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
-      , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), partitionValues.map(_.elements.mapValues(_.toString)))
+    DefaultExpressionData(context.feed, context.application, context.runId, context.attemptId, context.phase.toString
+      , context.referenceTimestamp.map(Timestamp.valueOf), Timestamp.valueOf(context.runStartTime)
+      , Timestamp.valueOf(context.attemptStartTime), partitionValues.map(_.elements.mapValues(_.toString)))
   }
 }

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -114,8 +114,8 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
   }
 
   def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    // run prepare for every node
     context.phase = ExecutionPhase.Prepare
+    // run prepare for every node
     run[DummyDAGResult](context.phase, parallelism) {
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => DummyDAGResult(dataObjectId))
@@ -127,8 +127,10 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
   }
 
   def init(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
-    // run init for every node
     context.phase = ExecutionPhase.Init
+    // initialize state listeners
+    stateListeners.foreach(_.init)
+    // run init for every node
     val t = run[SubFeed](context.phase) {
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))

--- a/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -116,7 +116,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
   def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     context.phase = ExecutionPhase.Prepare
     // run prepare for every node
-    run[DummyDAGResult](context.phase, parallelism) {
+    run[DummyDAGResult](context.phase) {
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => DummyDAGResult(dataObjectId))
       case (node: Action, _) =>
@@ -149,7 +149,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], runId: Int, att
     session.sparkContext.addSparkListener(stageMetricsListener)
     val result = try {
       context.phase = ExecutionPhase.Exec
-      run[SubFeed](context.phase) {
+      run[SubFeed](context.phase, parallelism) {
         case (node: InitDAGNode, _) =>
           node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
         case (node: Action, subFeeds) =>

--- a/src/main/scala/io/smartdatalake/workflow/DAG.scala
+++ b/src/main/scala/io/smartdatalake/workflow/DAG.scala
@@ -153,10 +153,12 @@ case class DAG[N <: DAGNode : ClassTag] private(sortedNodes: Seq[DAGNode],
       case Success(r) =>
         notify(node, eventListener.onNodeSuccess(r))
         resultRaw
-      case Failure(ex: TaskSkippedWarning) =>
+      case Failure(ex: DAGException) if ex.severity >= ExceptionSeverity.SKIPPED =>
+        // notify only if severity is low
         notify(node, eventListener.onNodeSkipped(ex))
         resultRaw
       case Failure(ex) =>
+        // pass Failure if severity is high
         notify(node, eventListener.onNodeFailure(ex))
         logger.error(s"Task ${node.nodeId} failed: $ex")
         Failure(TaskFailedException(node.nodeId, ex))

--- a/src/main/scala/io/smartdatalake/workflow/DAGException.scala
+++ b/src/main/scala/io/smartdatalake/workflow/DAGException.scala
@@ -24,6 +24,7 @@ import io.smartdatalake.workflow.DAGHelper.NodeId
 private[smartdatalake] abstract class DAGException(msg: String, cause: Throwable = null) extends Exception(msg, cause) {
   def severity: ExceptionSeverity.ExceptionSeverity
   def getDAGRootExceptions: Seq[DAGException]
+  def getMessageWithCause: String = msg + Option(getDAGRootExceptions.head.getCause).map(t => ": " + t.getMessage).getOrElse("")
 }
 
 private[smartdatalake] case class TaskFailedException(id: NodeId, cause: Throwable) extends DAGException(id, cause) {

--- a/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -140,6 +140,9 @@ case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
     val updatedPartitionValues = partitionValues.map( pvs => PartitionValues(pvs.elements.filterKeys(partitions.contains))).filter(_.nonEmpty)
     this.copy(partitionValues = updatedPartitionValues)
   }
+  def checkPartitionValuesColsExisting(partitions: Set[String]): Boolean = {
+    partitionValues.forall( pvs => partitions.diff(pvs.keys).isEmpty)
+  }
   override def clearDAGStart(): FileSubFeed = {
     this.copy(isDAGStart = false)
   }

--- a/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -212,6 +212,11 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
   }
 
   /**
+   * get latest runtime state
+   */
+  def getLatestRuntimeState = runtimeEvents.lastOption.map(_.state)
+
+  /**
    * get latest runtime information for this action
    */
   def getRuntimeInfo: Option[RuntimeInfo] = {
@@ -318,7 +323,7 @@ case class ActionMetadata(
 private[smartdatalake] case class RuntimeEvent(tstmp: LocalDateTime, phase: ExecutionPhase, state: RuntimeEventState, msg: Option[String], results: Seq[SubFeed])
 private[smartdatalake] object RuntimeEventState extends Enumeration {
   type RuntimeEventState = Value
-  val STARTED, SUCCEEDED, FAILED, SKIPPED, PENDING = Value
+  val STARTED, PREPARED, INITIALIZED, SUCCEEDED, FAILED, SKIPPED, PENDING = Value
 }
 private[smartdatalake] case class RuntimeInfo(state: RuntimeEventState, startTstmp: Option[LocalDateTime] = None, duration: Option[Duration] = None, msg: Option[String] = None, results: Seq[ResultRuntimeInfo] = Seq()) {
   override def toString: String = {

--- a/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -95,8 +95,10 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
     val duplicateNames = context.instanceRegistry.getDataObjects.map {
       dataObj => ActionHelper.replaceSpecialCharactersWithUnderscore(dataObj.id.id)
     }.groupBy(identity).collect { case (x, List(_,_,_*)) => x }.toList
-
     require(duplicateNames.isEmpty, s"The names of your DataObjects are not unique when replacing special characters with underscore. Duplicates: ${duplicateNames.mkString(",")}")
+
+    // validate metricsFailCondition
+    metricsFailCondition.foreach(c => evaluateMetricsFailCondition(c, onlySyntaxCheck = true))
   }
 
   /**
@@ -137,7 +139,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    */
   def postExec(inputSubFeed: Seq[SubFeed], outputSubFeed: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     // evaluate metrics fail condition if defined
-    metricsFailCondition.foreach(evaluateMetricsFailCondition)
+    metricsFailCondition.foreach( c => evaluateMetricsFailCondition(c))
     // process postRead/Write hooks
     inputs.foreach( input => input.postRead(findSubFeedPartitionValues(input.id, inputSubFeed)))
     outputs.foreach( output => output.postWrite(findSubFeedPartitionValues(output.id, outputSubFeed)))
@@ -146,16 +148,20 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
   /**
    * Evaluates a condition against latest metrics and throws an MetricsCheckFailed if there is a match.
    */
-  private def evaluateMetricsFailCondition(condition: String)(implicit session: SparkSession): Unit = {
+  private def evaluateMetricsFailCondition(condition: String, onlySyntaxCheck: Boolean = false)(implicit session: SparkSession): Unit = {
     import session.implicits._
-    val metrics = getAllLatestMetrics.flatMap{
-      case (dataObjectId, Some(metrics)) => metrics.getMainInfos.map{ case (k,v) => (dataObjectId.id, Some(k), Some(v.toString))}.toSeq
-      case (dataObjectId, _) => Seq((dataObjectId.id, None, None))
-    }.toSeq
-    val failedMetrics = metrics.toDF("dataObjectId", "key", "value")
+    val metrics = if (!onlySyntaxCheck) {
+      getAllLatestMetrics.flatMap{
+        case (dataObjectId, Some(metrics)) => metrics.getMainInfos.map{ case (k,v) => (dataObjectId.id, Some(k), Some(v.toString))}.toSeq
+        case (dataObjectId, _) => Seq((dataObjectId.id, None, None))
+      }.toSeq
+    } else Seq()
+    val dfFailedMetrics = metrics.toDF("dataObjectId", "key", "value")
       .where(condition)
-      .collect
-    if (failedMetrics.nonEmpty) throw MetricsCheckFailed(s"""($id) metrics check failed: ${failedMetrics.mkString(", ")} matched condition "$condition"""")
+    if (!onlySyntaxCheck) {
+      val failedMetrics = dfFailedMetrics.collect
+      if (failedMetrics.nonEmpty) throw MetricsCheckFailed(s"""($id) metrics check failed: ${failedMetrics.mkString(", ")} matched condition "$condition"""")
+    }
   }
 
   /**

--- a/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -128,17 +128,23 @@ private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
   }
 
   def getMainDataObject[T <: DataObject](mainId: Option[DataObjectId], dataObjects: Seq[T], inputOutput: String, mainNeeded: Boolean, actionId: ActionObjectId): T = {
+    // split dataObjects into dataObjects with partition columns defined and others
+    val partitionedDataObjects = dataObjects.collect{ case x: T @unchecked with CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
+    val unpartitionedDataObjects = dataObjects.filterNot(partitionedDataObjects.contains(_))
     mainId.map {
+      // 1. mainInput is defined
       id => dataObjects.find(_.id == id).getOrElse(throw ConfigurationException(s"($actionId) main${inputOutput}Id $id not found in ${inputOutput}s"))
     }.orElse {
-      val partitionedDataObjects = dataObjects.collect{ case x: T @unchecked with CanHandlePartitions => x }.filter(_.partitions.nonEmpty)
+      // 2. there is only one partitioned dataObject
       if (partitionedDataObjects.size==1) partitionedDataObjects.headOption
       else None
     }.orElse {
+      // 3. there is only one dataObject in total
       if (dataObjects.size==1) dataObjects.headOption else None
     }.getOrElse {
+      // 4. mainInput is not unique, we log a warning and favor partitioned dataObjects over others.
       if (mainNeeded) logger.warn(s"($actionId) Could not determine unique main $inputOutput but execution mode might need it. Decided for ${dataObjects.head.id}.")
-      dataObjects.head
+      (partitionedDataObjects ++ unpartitionedDataObjects).head
     }
   }
 }

--- a/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -36,7 +36,11 @@ import scala.util.{Failure, Success, Try}
  * @param inputId inputs DataObject
  * @param outputId output DataObject
  * @param deleteDataAfterRead a flag to enable deletion of input partitions after copying.
- * @param transformer a custom transformation that is applied to each SubFeed separately
+ * @param transformer optional custom transformation to apply
+ * @param columnBlacklist Remove all columns on blacklist from dataframe
+ * @param columnWhitelist Keep only columns on whitelist in dataframe
+ * @param additionalColumns optional tuples of [column name, spark sql expression] to be added as additional columns to the dataframe.
+ *                          The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  * @param executionMode optional execution mode for this Action
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
@@ -48,6 +52,7 @@ case class CopyAction(override val id: ActionObjectId,
                       transformer: Option[CustomDfTransformerConfig] = None,
                       columnBlacklist: Option[Seq[String]] = None,
                       columnWhitelist: Option[Seq[String]] = None,
+                      additionalColumns: Option[Map[String,String]] = None,
                       filterClause: Option[String] = None,
                       standardizeDatatypes: Boolean = false,
                       override val breakDataFrameLineage: Boolean = false,
@@ -69,7 +74,7 @@ case class CopyAction(override val id: ActionObjectId,
   }
 
   override def transform(subFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
-    applyTransformations(subFeed, transformer, columnBlacklist, columnWhitelist, standardizeDatatypes, output, None, filterClauseExpr)
+    applyTransformations(subFeed, transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, Seq(), filterClauseExpr)
   }
 
   override def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {

--- a/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.ExecutionMode
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
-import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, CanWriteDataFrame, DataObject}
+import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, CanWriteDataFrame, DataObject, FileRefDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed, SubFeed}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.expr
@@ -73,11 +73,14 @@ case class CopyAction(override val id: ActionObjectId,
   }
 
   override def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    // delete input partitions if desired
-    if (deleteDataAfterRead) (input, inputSubFeed) match {
-      case (partitionInput: CanHandlePartitions, sparkSubFeed: SparkSubFeed) =>
-        if (sparkSubFeed.partitionValues.nonEmpty) partitionInput.deletePartitions(sparkSubFeed.partitionValues)
-      case x => throw new IllegalStateException(s"Unmatched case $x")
+    if (deleteDataAfterRead) input match {
+      // delete input partitions if applicable
+      case (partitionInput: CanHandlePartitions) if partitionInput.partitions.nonEmpty && inputSubFeed.partitionValues.nonEmpty =>
+        partitionInput.deletePartitions(inputSubFeed.partitionValues)
+      // otherwise delete all
+      case (fileInput: FileRefDataObject) =>
+        fileInput.deleteAll
+      case x => throw new IllegalStateException(s"($id) input ${input.id} doesn't support deleting data")
     }
   }
 

--- a/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -79,7 +79,8 @@ abstract class FileSubFeedAction extends Action {
     }
     // validate partition values existing for input
     if (subFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || subFeed.isDAGStart)) {
-      val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(input.listPartitions, subFeed.partitionValues)
+      val expectedPartitions = input.filterExpectedPartitionValues(subFeed.partitionValues)
+      val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(input.listPartitions, expectedPartitions)
       assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
     }
     // break lineage if requested

--- a/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -19,9 +19,10 @@
 package io.smartdatalake.workflow.action
 
 import io.smartdatalake.definitions.ExecutionMode
+import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.PerformanceUtils
-import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, FileRefDataObject}
-import io.smartdatalake.workflow.{ActionMetrics, ActionPipelineContext, FileSubFeed, GenericMetrics, SubFeed}
+import io.smartdatalake.workflow.dataobject._
+import io.smartdatalake.workflow._
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
 abstract class FileSubFeedAction extends Action {
@@ -64,12 +65,7 @@ abstract class FileSubFeedAction extends Action {
     executionMode.foreach(_.prepare(id))
   }
 
-  /**
-   * Action.init implementation
-   */
-  override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
-    assert(subFeeds.size == 1, s"Only one subfeed allowed for FileSubFeedAction (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}")
-    val subFeed = subFeeds.head
+  private def prepareSubFeed(subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
     // convert subfeeds to FileSubFeed type or initialize if not yet existing
     var preparedSubFeed = FileSubFeed.fromSubFeed(subFeed)
     // apply execution mode
@@ -81,12 +77,42 @@ abstract class FileSubFeedAction extends Action {
         }
       case _ => preparedSubFeed
     }
+    // validate partition values existing for input
+    if (subFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || subFeed.isDAGStart)) {
+      val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(input.listPartitions, subFeed.partitionValues)
+      assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
+    }
     // break lineage if requested
-    preparedSubFeed = if (breakFileRefLineage) preparedSubFeed.breakLineage else preparedSubFeed
-    // transform
+    if (breakFileRefLineage) preparedSubFeed.breakLineage else preparedSubFeed
+  }
+
+  /**
+   * Updates the partition values of a SubFeed to the partition columns of an output, removing not existing columns from the partition values.
+   *
+   * @param output output DataObject
+   * @param subFeed transformed SubFeed
+   * @return SubFeed with updated partition values.
+   */
+  private def validateAndUpdateSubFeed(output: DataObject, subFeed: FileSubFeed )(implicit session: SparkSession): FileSubFeed = {
+    val updatedSubFeed = output match {
+      case partitionedDO: CanHandlePartitions =>
+        // remove superfluous partitionValues
+        subFeed.updatePartitionValues(partitionedDO.partitions)
+      case _ => subFeed.clearPartitionValues()
+    }
+    updatedSubFeed.clearDAGStart().copy(dataObjectId = output.id)
+  }
+
+  /**
+   * Action.init implementation
+   */
+  override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
+    assert(subFeeds.size == 1, s"Only one subfeed allowed for FileSubFeedAction (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}")
+    val preparedSubFeed = prepareSubFeed(subFeeds.head)
+    // transform (file transformation is limited to initialization in init phase)
     val transformedSubFeed = initSubFeed(preparedSubFeed)
-    // update partition values to output's partition columns and update dataObjectId
-    Seq(transformedSubFeed.updatePartitionValues(output.partitions).copy(dataObjectId = output.id))
+    // update subFeed
+    Seq(validateAndUpdateSubFeed(output,transformedSubFeed))
   }
 
   /**
@@ -94,20 +120,7 @@ abstract class FileSubFeedAction extends Action {
    */
   override final def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for FileSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
-    val subFeed = subFeeds.head
-    // convert subfeeds to FileSubFeed type or initialize if not yet existing
-    var preparedSubFeed = FileSubFeed.fromSubFeed(subFeed)
-    // apply init execution mode if there are no partition values given in command line
-    preparedSubFeed = executionMode match {
-      case Some(mode) =>
-        mode.apply(id, input, output, preparedSubFeed) match {
-          case Some((partitionValues, _)) => preparedSubFeed.copy(partitionValues = partitionValues)
-          case None => preparedSubFeed
-        }
-      case _ => preparedSubFeed
-    }
-    // break lineage if requested
-    preparedSubFeed = if (breakFileRefLineage) preparedSubFeed.breakLineage else preparedSubFeed
+    val preparedSubFeed = prepareSubFeed(subFeeds.head)
     // delete existing files on overwrite
     if (output.saveMode == SaveMode.Overwrite) {
       if (output.partitions.nonEmpty)
@@ -124,8 +137,8 @@ abstract class FileSubFeedAction extends Action {
     logger.info(s"($id) finished writing files to ${output.id}: duration=$d files_written=$filesWritten")
     // send metric to action (for file subfeeds this has to be done manually while spark subfeeds get's the metrics via a spark events listener)
     onRuntimeMetrics(Some(output.id), GenericMetrics(s"$id-${output.id}", 1, Map("duration"->d, "files_written"->filesWritten)))
-    // update partition values to output's partition columns and update dataObjectId
-    Seq(transformedSubFeed.updatePartitionValues(output.partitions).copy(dataObjectId = output.id))
+    // update subFeed
+    Seq(validateAndUpdateSubFeed(output,transformedSubFeed))
   }
 
   override final def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {

--- a/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -54,7 +54,6 @@ case class FileTransferAction(override val id: ActionObjectId,
   override val outputs: Seq[FileRefDataObject] = Seq(output)
 
   // initialize FileTransfer
-  // TODO: move deleteDataAfterRead to postExecSubFeed
   private val fileTransfer = FileTransfer(input, output, deleteDataAfterRead, overwrite)
 
   override def initSubFeed(subFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -22,7 +22,7 @@ package io.smartdatalake.workflow.action
 import java.time.LocalDateTime
 
 import io.smartdatalake.config.ConfigurationException
-import io.smartdatalake.definitions.{ExecutionMode, FailIfNoPartitionValuesMode, PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
+import io.smartdatalake.definitions._
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.DataFrameUtil
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
@@ -31,7 +31,7 @@ import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.action.ActionHelper.{filterBlacklist, filterWhitelist}
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
 import io.smartdatalake.workflow.dataobject._
-import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed, SubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -87,12 +87,11 @@ private[smartdatalake] abstract class SparkAction extends Action {
         if (phase==ExecutionPhase.Exec && (subFeed.dataFrame.isEmpty || subFeed.isDummy || subFeed.isStreaming.contains(true))) {
           // validate partition values existing for input
           input match {
-            case partitionedInput: DataObject with CanHandlePartitions if subFeed.partitionValues.nonEmpty =>
+            case partitionedInput: DataObject with CanHandlePartitions if subFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || subFeed.isDAGStart) =>
               val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(partitionedInput.listPartitions, subFeed.partitionValues)
               assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
             case _ => Unit
           }
-          if (subFeed.partitionValues.nonEmpty)
           // recreate DataFrame from DataObject
           logger.info(s"($id) getting DataFrame for ${input.id}" + (if (subFeed.partitionValues.nonEmpty) s" filtered by partition values ${subFeed.partitionValues.mkString(" ")}" else ""))
           val df = input.getDataFrame(subFeed.partitionValues)

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -88,7 +88,8 @@ private[smartdatalake] abstract class SparkAction extends Action {
           // validate partition values existing for input
           input match {
             case partitionedInput: DataObject with CanHandlePartitions if subFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || subFeed.isDAGStart) =>
-              val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(partitionedInput.listPartitions, subFeed.partitionValues)
+              val expectedPartitions = partitionedInput.filterExpectedPartitionValues(subFeed.partitionValues)
+              val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(partitionedInput.listPartitions, expectedPartitions)
               assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
             case _ => Unit
           }

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -19,20 +19,19 @@
 
 package io.smartdatalake.workflow.action
 
-import java.time.LocalDateTime
-
 import io.smartdatalake.config.ConfigurationException
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.definitions._
 import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.util.misc.DataFrameUtil
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+import io.smartdatalake.util.misc.{DataFrameUtil, DefaultExpressionData, SparkExpressionUtil}
 import io.smartdatalake.util.streaming.DummyStreamProvider
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import io.smartdatalake.workflow.action.ActionHelper.{filterBlacklist, filterWhitelist}
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
 import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.streaming.Trigger
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
@@ -144,21 +143,6 @@ private[smartdatalake] abstract class SparkAction extends Action {
     }
   }
 
-  /**
-   * transform sequence of subfeeds
-   */
-  def transformSubfeeds(subFeeds: Seq[SparkSubFeed], transformer: DataFrame => DataFrame): Seq[SparkSubFeed] = {
-    subFeeds.map( subFeed => subFeed.copy( dataFrame = Some(transformer(subFeed.dataFrame.get))))
-  }
-
-  /**
-   * applies multiple transformations to a sequence of subfeeds
-   */
-  def multiTransformSubfeeds( subFeeds: Seq[SparkSubFeed], transformers: Seq[DataFrame => DataFrame]): Seq[SparkSubFeed] = {
-    transformers.foldLeft( subFeeds ){
-      case (subFeed, transform) => transformSubfeeds( subFeed, transform )
-    }
-  }
 
   /**
    * applies multiple transformations to a sequence of subfeeds
@@ -170,82 +154,57 @@ private[smartdatalake] abstract class SparkAction extends Action {
   }
 
   /**
-   * applies the transformers
+   * apply custom transformation
    */
-  def applyCustomTransformation(inputSubFeed: SparkSubFeed, transformer: Option[CustomDfTransformerConfig])(implicit session: SparkSession): SparkSubFeed = transformer.map {
-    transformer =>
-      val transformedDf = transformer.transform(inputSubFeed.dataFrame.get, inputSubFeed.dataObjectId)
-      inputSubFeed.copy(dataFrame = Some(transformedDf))
-  }.getOrElse( inputSubFeed )
+  def applyCustomTransformation(transformer: CustomDfTransformerConfig, dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues])(df: DataFrame)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+    transformer.transform(id, partitionValues, df, dataObjectId)
+  }
 
   /**
-   * applies columnBlackList and columnWhitelist
+   * applies additionalColumns
    */
-  def applyBlackWhitelists(subFeed: SparkSubFeed, columnBlacklist: Option[Seq[String]], columnWhitelist: Option[Seq[String]]): SparkSubFeed = {
-    val blackWhiteDfTransforms: Seq[DataFrame => DataFrame] = Seq(
-      columnBlacklist.map(l => filterBlacklist(l) _),
-      columnWhitelist.map(l => filterWhitelist(l) _)
-    ).flatten
-    multiTransformSubfeed(subFeed, blackWhiteDfTransforms)
+  def applyAdditionalColumns(additionalColumns: Map[String,String], partitionValues: Seq[PartitionValues])(df: DataFrame)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+    val data = DefaultExpressionData.from(context, partitionValues)
+    additionalColumns.foldLeft(df){
+      case (df, (colName, expr)) =>
+        val value = SparkExpressionUtil.evaluateAny(id, Some("additionalColumns"), expr, data)
+        df.withColumn(colName, lit(value.orNull))
+    }
   }
 
   /**
    * applies filterClauseExpr
    */
-  def applyFilter(subFeed: SparkSubFeed, filterClauseExpr: Option[Column]): SparkSubFeed = {
-    val filterDfTransform = filterClauseExpr.map( expr => (df: DataFrame) => df.where(expr))
-    multiTransformSubfeed(subFeed, filterDfTransform.toSeq)
-  }
+  def applyFilter(filterClauseExpr: Column)(df: DataFrame): DataFrame = df.where(filterClauseExpr)
 
   /**
    * applies type casting decimal -> integral/float
    */
-  def applyCastDecimal2IntegralFloat(subFeed: SparkSubFeed): SparkSubFeed = multiTransformSubfeed(subFeed, Seq(_.castAllDecimal2IntegralFloat))
-
-  /**
-   * applies an optional additional transformation
-   */
-  def applyAdditional(subFeed: SparkSubFeed,
-                      additional: (SparkSubFeed,Option[DataFrame],Seq[String],LocalDateTime) => SparkSubFeed,
-                      output: TableDataObject)(implicit session: SparkSession,
-                                               context: ActionPipelineContext): SparkSubFeed = {
-    val timestamp = context.referenceTimestamp.getOrElse(LocalDateTime.now)
-    val table = output.table
-    val pks = table.primaryKey
-      .getOrElse( throw new ConfigurationException(s"There is no <primary-keys> defined for table ${table.name}."))
-    val existingDf = if (output.isTableExisting) {
-      Some(output.getDataFrame())
-    } else None
-    additional(subFeed, existingDf, pks, timestamp)
-  }
+  def applyCastDecimal2IntegralFloat(df: DataFrame): DataFrame = df.castAllDecimal2IntegralFloat
 
   /**
    * applies all the transformations above
    */
   def applyTransformations(inputSubFeed: SparkSubFeed,
-                           transformer: Option[CustomDfTransformerConfig],
+                           transformation: Option[CustomDfTransformerConfig],
                            columnBlacklist: Option[Seq[String]],
                            columnWhitelist: Option[Seq[String]],
+                           additionalColumns: Option[Map[String,String]],
                            standardizeDatatypes: Boolean,
-                           output: DataObject,
-                           additional: Option[(SparkSubFeed,Option[DataFrame],Seq[String],LocalDateTime) => SparkSubFeed],
-                           filterClauseExpr: Option[Column] = None)(
-                            implicit session: SparkSession,
-                            context: ActionPipelineContext): SparkSubFeed = {
+                           additionalTransformers: Seq[(DataFrame => DataFrame)],
+                           filterClauseExpr: Option[Column] = None)
+                          (implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+    val transformers = Seq(
+      transformation.map( t => applyCustomTransformation(t, inputSubFeed.dataObjectId, inputSubFeed.partitionValues) _),
+      columnBlacklist.map(filterBlacklist),
+      columnWhitelist.map(filterWhitelist),
+      additionalColumns.map( m => applyAdditionalColumns(m, inputSubFeed.partitionValues) _),
+      filterClauseExpr.map(applyFilter),
+      if (standardizeDatatypes) Some(applyCastDecimal2IntegralFloat _) else None // currently we cast decimals away only but later we may add further type casts
+    ).flatten ++ additionalTransformers
 
-    var transformedSubFeed : SparkSubFeed = applyBlackWhitelists(applyCustomTransformation(inputSubFeed, transformer)(session),
-      columnBlacklist: Option[Seq[String]],
-      columnWhitelist: Option[Seq[String]]
-    )
-
-    if (filterClauseExpr.isDefined) transformedSubFeed = applyFilter(inputSubFeed, filterClauseExpr)
-
-    if (standardizeDatatypes) transformedSubFeed = applyCastDecimal2IntegralFloat(transformedSubFeed) // currently we cast decimals away only but later we may add further type casts
-    if (additional.isDefined && output.isInstanceOf[TableDataObject]) {
-      transformedSubFeed = applyAdditional(transformedSubFeed, additional.get, output.asInstanceOf[TableDataObject])(session,context)
-    }
     // return
-    transformedSubFeed
+    multiTransformSubfeed(inputSubFeed, transformers)
   }
 
   /**

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -18,7 +18,6 @@
  */
 package io.smartdatalake.workflow.action
 
-import io.smartdatalake.definitions.ExecutionMode
 import io.smartdatalake.util.misc.PerformanceUtils
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed, SubFeed}

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedAction.scala
@@ -105,7 +105,7 @@ abstract class SparkSubFeedAction extends SparkAction {
     setSparkJobMetadata()
     val metricsLog = if (noData) ", no data found"
     else getFinalMetrics(output.id).map(_.getMainInfos).map(" "+_.map( x => x._1+"="+x._2).mkString(" ")).getOrElse("")
-    logger.info(s"($id) finished writing DataFrame to ${output.id}: duration=$d" + metricsLog)
+    logger.info(s"($id) finished writing DataFrame to ${output.id}: jobDuration=$d" + metricsLog)
     // return
     Seq(updateSubFeedAfterWrite(transformedSubFeed))
   }

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
@@ -118,7 +118,7 @@ abstract class SparkSubFeedsAction extends SparkAction {
       setSparkJobMetadata()
       val metricsLog = if (noData) ", no data found"
       else getFinalMetrics(output.id).map(_.getMainInfos).map(" "+_.map( x => x._1+"="+x._2).mkString(" ")).getOrElse("")
-      logger.info(s"($id) finished writing DataFrame to ${output.id}: duration=$d" + metricsLog)
+      logger.info(s"($id) finished writing DataFrame to ${output.id}: jobDuration=$d" + metricsLog)
     }
     // return
     transformedSubFeeds.map( transformedSubFeed => updateSubFeedAfterWrite(transformedSubFeed))

--- a/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/SparkSubFeedsAction.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.ConfigurationException
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
-import io.smartdatalake.definitions.{ExecutionMode, ExecutionModeWithMainInputOutput}
+import io.smartdatalake.definitions.ExecutionModeWithMainInputOutput
 import io.smartdatalake.util.misc.PerformanceUtils
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed, SubFeed}

--- a/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfCreator.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfCreator.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.workflow.action.customlogic
 
+import io.smartdatalake.util.hdfs.HdfsUtil
 import io.smartdatalake.util.misc.CustomCodeUtil
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -48,7 +49,7 @@ case class CustomDfCreatorConfig(className: Option[String] = None,
   }.orElse{
     scalaFile.map {
       file =>
-        val fnTransform = CustomCodeUtil.compileFromFile[(SparkSession, Map[String, String]) => DataFrame](file)
+        val fnTransform = CustomCodeUtil.compileCode[(SparkSession, Map[String, String]) => DataFrame](HdfsUtil.readHadoopFile(file))
         new CustomDfCreatorWrapper(fnTransform)
     }
   }.orElse{

--- a/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfTransformer.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfTransformer.scala
@@ -20,10 +20,11 @@ package io.smartdatalake.workflow.action.customlogic
 
 import io.smartdatalake.config.SdlConfigObject
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
-import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.util.misc.{CustomCodeUtil, DefaultExpressionData, SparkExpressionUtil}
+import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
+import io.smartdatalake.util.misc.{CustomCodeUtil, DefaultExpressionData, PythonUtil, SparkExpressionUtil}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.ActionHelper
+import org.apache.spark.python.PythonHelper.SparkEntryPoint
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -47,56 +48,67 @@ trait CustomDfTransformer extends Serializable {
 /**
  * Configuration of a custom Spark-DataFrame transformation between one input and one output (1:1)
  *
+ * Note about Python transformation: Environment with Python and PySpark needed.
+ * PySpark session is initialize and available under variables `sc`, `session`, `sqlContext`.
+ * Input DataFrame is available as `inputDf`. Output DataFrame must be set with `setOutputDf(df)`.
+ *
  * @param className Optional class name to load transformer code from
  * @param scalaFile Optional file where scala code for transformation is loaded from
  * @param scalaCode Optional scala code for transformation
  * @param sqlCode Optional SQL code for transformation.
  *                Use tokens %{<key>} to replace with runtimeOptions in SQL code.
  *                Example: "select * from test where run = %{runId}"
+ * @param pythonFile Optional pythonFile to use for python transformation
+ * @param pythonCode Optional pythonCode to user for python transformation
  * @param options Options to pass to the transformation
  * @param runtimeOptions optional tuples of [key, spark sql expression] to be added as additional options when executing transformation.
  *                       The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  */
-case class CustomDfTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, sqlCode: Option[String] = None, options: Map[String,String] = Map(), runtimeOptions: Map[String,String] = Map()) {
-  require(className.isDefined || scalaFile.isDefined || scalaCode.isDefined || sqlCode.isDefined, "Either className, scalaFile, scalaCode or sqlCode must be defined for CustomDfTransformer")
+case class CustomDfTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, sqlCode: Option[String] = None, pythonFile: Option[String] = None, pythonCode: Option[String] = None, options: Map[String,String] = Map(), runtimeOptions: Map[String,String] = Map()) {
+  require(className.isDefined || scalaFile.isDefined || scalaCode.isDefined || sqlCode.isDefined || pythonFile.isDefined || pythonCode.isDefined, "Either className, scalaFile, scalaCode, sqlCode, pythonFile or code must be defined for CustomDfTransformer")
 
   val impl : Option[CustomDfTransformer] = className.map {
     clazz => CustomCodeUtil.getClassInstanceByName[CustomDfTransformer](clazz)
-  }.orElse{
+  }.orElse {
     scalaFile.map {
       file =>
-        val fnTransform = CustomCodeUtil.compileFromFile[(SparkSession, Map[String,String], DataFrame, String) => DataFrame](file)
+        val fnTransform = CustomCodeUtil.compileCode[(SparkSession, Map[String,String], DataFrame, String) => DataFrame](HdfsUtil.readHadoopFile(file))
         new CustomDfTransformerWrapper( fnTransform )
     }
-  }.orElse{
+  }.orElse {
     scalaCode.map {
       code =>
         val fnTransform = CustomCodeUtil.compileCode[(SparkSession, Map[String,String], DataFrame, String) => DataFrame](code)
         new CustomDfTransformerWrapper( fnTransform )
     }
-  }.orElse{
+  }.orElse {
     sqlCode.map {
       sql =>
-        def sqlTransform (session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectIdStr: String): DataFrame = {
-          val dataObjectId = DataObjectId(dataObjectIdStr)
-          val objectId = ActionHelper.replaceSpecialCharactersWithUnderscore(dataObjectIdStr)
-          val preparedSql = SparkExpressionUtil.substituteOptions( dataObjectId, Some("transform.sqlCode"), sql, options)
-          try {
-            df.createOrReplaceTempView(s"$objectId")
-            session.sql(preparedSql)
-          } catch {
-            case e : Throwable => throw new SQLTransformationException(s"(transformation for $dataObjectId) Could not execute SQL query. Check your query and remember that special characters are replaced by underscores (name of the temp view used was: ${objectId}). Error: ${e.getMessage}")
-          }
-        }
-        new CustomDfTransformerWrapper( sqlTransform )
+        val fnTransform = createSqlFnTransform(sql)
+        new CustomDfTransformerWrapper( fnTransform )
+    }
+  }.orElse {
+    pythonFile.map {
+      file =>
+        val fnTransform = createPythonFnTransform(HdfsUtil.readHadoopFile(file))
+        new CustomDfTransformerWrapper( fnTransform )
+    }
+  }.orElse {
+    pythonCode.map {
+      code =>
+        val fnTransform = createPythonFnTransform(code.stripMargin)
+        new CustomDfTransformerWrapper( fnTransform )
     }
   }
 
   override def toString: String = {
-    if(className.isDefined)       "className: "+className.get
-    else if(scalaFile.isDefined)  "scalaFile: "+scalaFile.get
-    else if(scalaCode.isDefined)  "scalaCode: "+scalaCode.get
-    else                          "sqlCode: "+sqlCode.get
+    if (className.isDefined)      "className: " +className.get
+    else if(scalaFile.isDefined)  "scalaFile: " +scalaFile.get
+    else if(scalaCode.isDefined)  "scalaCode: " +scalaCode.get
+    else if(sqlCode.isDefined)    "sqlCode: "   +sqlCode.get
+    else if(pythonCode.isDefined) "code: "+pythonCode.get
+    else if(pythonFile.isDefined) "pythonFile: "+pythonFile.get
+    else throw new IllegalStateException("transformation undefined!")
   }
 
   def transform(actionId: ActionObjectId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext) : DataFrame = {
@@ -107,5 +119,52 @@ case class CustomDfTransformerConfig( className: Option[String] = None, scalaFil
     }.filter(_._2.isDefined).mapValues(_.get)
     // transform
     impl.get.transform(session, options ++ runtimeOptionsReplaced, df, dataObjectId.id)
+  }
+
+  private def createSqlFnTransform(sql: String): (SparkSession, Map[String, String], DataFrame, String) => DataFrame = {
+    (session: SparkSession, options: Map[String, String], df: DataFrame, dataObjectIdStr: String) => {
+      val dataObjectId = DataObjectId(dataObjectIdStr)
+      val objectId = ActionHelper.replaceSpecialCharactersWithUnderscore(dataObjectIdStr)
+      val preparedSql = SparkExpressionUtil.substituteOptions( dataObjectId, Some("transform.sqlCode"), sql, options)
+      try {
+        df.createOrReplaceTempView(s"$objectId")
+        session.sql(preparedSql)
+      } catch {
+        case e : Throwable => throw new SQLTransformationException(s"(transformation for $dataObjectId) Could not execute SQL query. Check your query and remember that special characters are replaced by underscores (name of the temp view used was: ${objectId}). Error: ${e.getMessage}")
+      }
+    }
+  }
+
+  private def createPythonFnTransform(code: String): (SparkSession, Map[String, String], DataFrame, String) => DataFrame = {
+    (session: SparkSession, options: Map[String, String], df: DataFrame, dataObjectId: String) => {
+      // python transformation is executed by passing options and input/output DataFrame through entry point
+      val objectId = ActionHelper.replaceSpecialCharactersWithUnderscore(dataObjectId)
+      try {
+        val entryPoint = new DfTransformerPySparkEntryPoint(session, options, df, objectId)
+        val additionalInitCode = """
+          |# prepare input parameters
+          |options = entryPoint.options
+          |inputDf = DataFrame(entryPoint.getInputDf(), sqlContext) # convert input dataframe to pyspark
+          |dataObjectId = entryPoint.getDataObjectId()
+          |# helper function to return output dataframe
+          |def setOutputDf( df ):
+          |    entryPoint.setOutputDf(df._jdf)
+          """.stripMargin
+        PythonUtil.execPythonTransform( entryPoint, additionalInitCode + sys.props("line.separator") + code)
+        entryPoint.outputDf.getOrElse(throw new IllegalStateException("Python transformation must set output DataFrame (call setOutputDf(df))"))
+      } catch {
+        case e: Throwable => throw new PythonTransformationException(s"Could not execute Python code. Error: ${e.getMessage}", e)
+      }
+    }
+  }
+}
+
+private[smartdatalake] class DfTransformerPySparkEntryPoint(override val session: SparkSession, options: Map[String,String], inputDf: DataFrame, dataObjectId: String, var outputDf: Option[DataFrame] = None) extends SparkEntryPoint {
+  // it seems that py4j can handle functions but not pure attributes -> wrapper functions needed...
+  def getOptions: Map[String,String] = options
+  def getInputDf: DataFrame = inputDf
+  def getDataObjectId: String = dataObjectId
+  def setOutputDf(df: DataFrame): Unit = {
+    outputDf = Some(df)
   }
 }

--- a/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfsTransformer.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfsTransformer.scala
@@ -18,8 +18,10 @@
  */
 package io.smartdatalake.workflow.action.customlogic
 
-import io.smartdatalake.config.SdlConfigObject.DataObjectId
-import io.smartdatalake.util.misc.CustomCodeUtil
+import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.misc.{CustomCodeUtil, DefaultExpressionData, SparkExpressionUtil}
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.ActionHelper
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -47,10 +49,14 @@ trait CustomDfsTransformer extends Serializable {
  * @param className Optional class name to load transformer code from
  * @param scalaFile Optional file where scala code for transformation is loaded from
  * @param scalaCode Optional scala code for transformation
- * @param sqlCode Optional map of DataObjectId and corresponding SQL Code
+ * @param sqlCode Optional map of DataObjectId and corresponding SQL Code.
+ *                Use tokens %{<key>} to replace with runtimeOptions in SQL code.
+ *                Example: "select * from test where run = %{runId}"
  * @param options Options to pass to the transformation
+ * @param runtimeOptions optional tuples of [key, spark sql expression] to be added as additional options when executing transformation.
+ *                       The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  */
-case class CustomDfsTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, sqlCode: Map[DataObjectId,String] = Map(), options: Map[String,String] = Map()) {
+case class CustomDfsTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, sqlCode: Map[DataObjectId,String] = Map(), options: Map[String,String] = Map(), runtimeOptions: Map[String,String] = Map()) {
   require(className.isDefined || scalaFile.isDefined || scalaCode.isDefined || sqlCode.nonEmpty, "Either className, scalaFile, scalaCode or sqlCode must be defined for CustomDfsTransformer")
 
   // Load Transformer code from appropriate location
@@ -68,6 +74,31 @@ case class CustomDfsTransformerConfig( className: Option[String] = None, scalaFi
         val fnTransform = CustomCodeUtil.compileCode[(SparkSession, Map[String,String], Map[String,DataFrame]) => Map[String,DataFrame]](code)
         new CustomDfsTransformerWrapper( fnTransform )
     }
+  }.orElse{
+    if (sqlCode.nonEmpty) {
+      def sqlTransform(session: SparkSession, options: Map[String,String], dfs: Map[String,DataFrame]): Map[String,DataFrame] = {
+        // register all input DataObjects as temporary table
+        dfs.foreach {
+          case (dataObjectId,df) =>
+            val objectId =  ActionHelper.replaceSpecialCharactersWithUnderscore(dataObjectId)
+            // Using createTempView does not work because the same data object might be created more than once
+            df.createOrReplaceTempView(objectId)
+        }
+        // execute all queries and return them under corresponding dataObjectId
+        sqlCode.map {
+          case (dataObjectId,sql) => {
+            val df = try {
+              val preparedSql = SparkExpressionUtil.substituteOptions(dataObjectId, Some("transformation.sqlCode"), sql, options)
+              session.sql(preparedSql)
+            } catch {
+              case e : Throwable => throw new SQLTransformationException(s"(transformation for $dataObjectId) Could not execute SQL query. Check your query and remember that special characters are replaced by underscores. Error: ${e.getMessage}")
+            }
+            (dataObjectId.id, df)
+          }
+        }
+      }
+      Some(new CustomDfsTransformerWrapper( sqlTransform ))
+    } else None
   }
 
   override def toString: String = {
@@ -75,34 +106,15 @@ case class CustomDfsTransformerConfig( className: Option[String] = None, scalaFi
     else if(scalaFile.isDefined)  "scalaFile: "+scalaFile.get
     else if(scalaCode.isDefined)  "scalaCode: "+scalaCode.get
     else                          "sqlCode: "+sqlCode
-
   }
 
-  def transform(dfs: Map[String,DataFrame])(implicit session: SparkSession) : Map[String,DataFrame] = {
-    if(className.isDefined || scalaFile.isDefined || scalaCode.isDefined) {
-      impl.get.transform(session, options, dfs)
-    }
-    // Work with SQL Transformations
-    else {
-      // register all input DataObjects as temporary table
-      for( (dataObjectId,df) <- dfs) {
-        val objectId =  ActionHelper.replaceSpecialCharactersWithUnderscore(dataObjectId)
-        // Using createTempView does not work because the same data object might be created more than once
-        df.createOrReplaceTempView(objectId)
-      }
-
-      // execute all queries and return them under corresponding dataObjectId
-      sqlCode.map {
-        case (dataObjectId,sqlCode) => {
-          val df = try {
-            session.sql(sqlCode)
-          } catch {
-            case e : Throwable => throw new SQLTransformationException(s"Could not execute SQL query. Check your query and remember that special characters are replaced by underscores. Error: ${e.getMessage}")
-          }
-          (dataObjectId.id, df)
-        }
-      }
-
-    }
+  def transform(actionId: ActionObjectId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame])(implicit session: SparkSession, context: ActionPipelineContext) : Map[String,DataFrame] = {
+    // replace runtime options
+    lazy val data = DefaultExpressionData.from(context, partitionValues)
+    val runtimeOptionsReplaced = runtimeOptions.mapValues {
+      expr => SparkExpressionUtil.evaluateString(actionId, Some("transformation.runtimeObjects"), expr, data)
+    }.filter(_._2.isDefined).mapValues(_.get)
+    // transform
+    impl.get.transform(session, options ++ runtimeOptionsReplaced, dfs)
   }
 }

--- a/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfsTransformer.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomDfsTransformer.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.workflow.action.customlogic
 
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
-import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.misc.{CustomCodeUtil, DefaultExpressionData, SparkExpressionUtil}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.ActionHelper
@@ -65,7 +65,7 @@ case class CustomDfsTransformerConfig( className: Option[String] = None, scalaFi
   }.orElse{
     scalaFile.map {
       file =>
-        val fnTransform = CustomCodeUtil.compileFromFile[(SparkSession, Map[String,String], Map[String,DataFrame]) => Map[String,DataFrame]](file)
+        val fnTransform = CustomCodeUtil.compileCode[(SparkSession, Map[String,String], Map[String,DataFrame]) => Map[String,DataFrame]](HdfsUtil.readHadoopFile(file))
         new CustomDfsTransformerWrapper( fnTransform )
     }
   }.orElse{

--- a/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.workflow.action.customlogic
 
+import io.smartdatalake.util.hdfs.HdfsUtil
 import io.smartdatalake.util.misc.{CustomCodeUtil, SmartDataLakeLogger}
 import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream}
 import org.slf4j.Logger
@@ -54,7 +55,7 @@ case class CustomFileTransformerConfig( className: Option[String] = None, scalaF
   }.orElse{
     scalaFile.map {
       file =>
-        val fnTransform = CustomCodeUtil.compileFromFile[(Map[String,String], FSDataInputStream, FSDataOutputStream, Logger) => Option[Exception]](file)
+        val fnTransform = CustomCodeUtil.compileCode[(Map[String,String], FSDataInputStream, FSDataOutputStream, Logger) => Option[Exception]](HdfsUtil.readHadoopFile(file))
         new CustomFileTransformerWrapper( fnTransform )
     }
   }.orElse{

--- a/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
@@ -73,7 +73,6 @@ case class CustomFileTransformerConfig( className: Option[String] = None, scalaF
 class CustomFileTransformerWrapper(val fnExec: (Map[String,String], FSDataInputStream, FSDataOutputStream, Logger) => Option[Exception])
 extends CustomFileTransformer with SmartDataLakeLogger {
   override def transform(options: Map[String,String], input: FSDataInputStream, output: FSDataOutputStream): Option[Exception] = {
-    // TODO: This used to be logger.underlying, is it OK to use logger ?
     fnExec(options, input, output, logger)
   }
 }

--- a/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonTransformationException.scala
+++ b/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonTransformationException.scala
@@ -1,0 +1,25 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.customlogic
+
+/**
+ * Exception is thrown if the Python transformation can not be executed correctly
+ */
+private[smartdatalake] class PythonTransformationException(msg: String, throwable: Throwable) extends RuntimeException(msg, throwable)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.AclDef
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types.StructType
@@ -39,6 +39,9 @@ import org.apache.spark.sql.types.StructType
  * @param schema An optional schema for the spark data frame used when writing new Avro files. Note: Existing Avro files
  *               contain a source schema. Therefore, this schema is ignored when reading from existing Avro files.
  * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  *
  * @see [[org.apache.spark.sql.DataFrameReader]]
  * @see [[org.apache.spark.sql.DataFrameWriter]]
@@ -53,6 +56,7 @@ case class AvroFileDataObject( override val id: DataObjectId,
                                override val acl: Option[AclDef] = None,
                                override val connectionId: Option[ConnectionId] = None,
                                override val filenameColumn: Option[String] = None,
+                               override val expectedPartitionsCondition: Option[String] = None,
                                override val metadata: Option[DataObjectMetadata] = None
                              )(@transient implicit override val instanceRegistry: InstanceRegistry)
   extends SparkFileDataObjectWithEmbeddedSchema with CanCreateDataFrame with CanWriteDataFrame {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
@@ -32,6 +32,15 @@ private[smartdatalake] trait CanHandlePartitions {
   def partitions: Seq[String]
 
   /**
+   * Definition of partitions that are expected to exists.
+   * This is used to validate that partitions being read exists and don't return no data.
+   * Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+   * example: "elements['yourColName'] > 2017"
+   * @return true if partition is expected to exist.
+   */
+  def expectedPartitionsCondition: Option[String]
+
+  /**
    * Delete given partitions. This is used to cleanup partitions after they are processed.
    */
   def deletePartitions(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = throw new RuntimeException(s"deletePartitions not implemented")
@@ -54,5 +63,18 @@ private[smartdatalake] trait CanHandlePartitions {
     partitionValues.diff(listPartitions.map(_.filterKeys(partitionValuesCols)))
       .foreach(createEmptyPartition)
   }
-}
 
+  /**
+   * Filter list of partition values by expected partitions condition
+   */
+  final def filterExpectedPartitionValues(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Seq[PartitionValues] = {
+    import org.apache.spark.sql.functions.expr
+    import session.implicits._
+    expectedPartitionsCondition.map{ condition =>
+      // partition values value type is any, we need to convert it to string and keep the hashCode for filtering afterwards
+      val partitionsValuesStringWithHashCode = partitionValues.map( pv => (pv.elements.mapValues(_.toString), pv.hashCode))
+      val expectedHashCodes = partitionsValuesStringWithHashCode.toDF("elements","hashCode").where(expr(condition)).select($"hashCode").as[Int].collect.toSet
+      partitionValues.filter( pv => expectedHashCodes.contains(pv.hashCode))
+    }.getOrElse(partitionValues)
+  }
+}

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
@@ -33,7 +33,7 @@ private[smartdatalake] trait CanWriteDataFrame {
    */
   def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = Unit
 
-  def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit
+  def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)(implicit session: SparkSession): Unit
 
   /**
    * Write Spark structured streaming DataFrame

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.DateColumnType
 import io.smartdatalake.definitions.DateColumnType.DateColumnType
-import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import org.apache.spark.sql.types.{DateType, StringType, StructType}
@@ -63,6 +63,10 @@ import org.apache.spark.sql.{DataFrame, SaveMode}
  * @param csvOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
  * @param dateColumnType Specifies the string format used for writing date typed data.
  * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
+ *
  **/
 case class CsvFileDataObject( override val id: DataObjectId,
                               override val path: String,
@@ -76,6 +80,7 @@ case class CsvFileDataObject( override val id: DataObjectId,
                               override val acl: Option[AclDef] = None,
                               override val connectionId: Option[ConnectionId] = None,
                               override val filenameColumn: Option[String] = None,
+                              override val expectedPartitionsCondition: Option[String] = None,
                               override val metadata: Option[DataObjectMetadata] = None
                             )(@transient implicit override val instanceRegistry: InstanceRegistry)
   extends SparkFileDataObject with CanCreateDataFrame with CanWriteDataFrame {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -49,6 +49,9 @@ import scala.collection.JavaConverters._
  * @param saveMode spark [[SaveMode]] to use when writing files, default is "overwrite"
  * @param retentionPeriod DeltaLake table retention period of old transactions for time travel feature in hours
  * @param acl override connections permissions for files created tables hadoop directory with this connection
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  * @param connectionId optional id of [[io.smartdatalake.workflow.connection.HiveTableConnection]]
  * @param metadata meta data
  */
@@ -63,6 +66,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
                                     retentionPeriod: Int = 7*24, // hours
                                     acl: Option[AclDef] = None,
                                     connectionId: Option[ConnectionId] = None,
+                                    override val expectedPartitionsCondition: Option[String] = None,
                                     override val metadata: Option[DataObjectMetadata] = None)
                                    (@transient implicit val instanceRegistry: InstanceRegistry)
   extends TransactionalSparkTableDataObject with CanHandlePartitions {
@@ -84,6 +88,11 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   table = table.overrideDb(connection.map(_.db))
   if (table.db.isEmpty) {
     throw ConfigurationException(s"($id) db is not defined in table and connection for dataObject.")
+  }
+
+  override def prepare(implicit session: SparkSession): Unit = {
+    super.prepare
+    filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
 
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession): DataFrame = {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -109,7 +109,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     }
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
                              (implicit session: SparkSession): Unit = {
     validateSchemaMin(df)
     writeDataFrame(df, createTableOnly=false, partitionValues)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.{AclDef, DataFrameUtil}
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SaveMode}
@@ -50,6 +50,9 @@ import org.apache.spark.sql.{DataFrame, Row, SaveMode}
  * @param excelOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
  * @param schema An optional data object schema. If defined, any automatic schema inference is avoided.
  * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop. Default is numberOfTasksPerPartition = 1.
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  */
 case class ExcelFileDataObject(override val id: DataObjectId,
                                override val path: String,
@@ -62,6 +65,7 @@ case class ExcelFileDataObject(override val id: DataObjectId,
                                override val acl: Option[AclDef] = None,
                                override val connectionId: Option[ConnectionId] = None,
                                override val filenameColumn: Option[String] = None,
+                               override val expectedPartitionsCondition: Option[String] = None,
                                override val metadata: Option[DataObjectMetadata] = None
                               )(@transient implicit override val instanceRegistry: InstanceRegistry)
   extends SparkFileDataObject with CanCreateDataFrame with CanWriteDataFrame {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
@@ -19,6 +19,7 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.definitions.Environment
+import org.apache.spark.sql.SparkSession
 
 private[smartdatalake] trait FileDataObject extends DataObject with CanHandlePartitions {
 
@@ -31,4 +32,9 @@ private[smartdatalake] trait FileDataObject extends DataObject with CanHandlePar
     * default separator for paths
     */
   protected val separator = Environment.defaultPathSeparator
+
+  override def prepare(implicit session: SparkSession): Unit = {
+    super.prepare
+    filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
+  }
 }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -111,12 +111,12 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
   /**
    * Delete given files. This is used to cleanup files after they are processed.
    */
-  def deleteFileRefs(fileRefs: Seq[FileRef])(implicit session: SparkSession): Unit = throw new RuntimeException(s"deleteFileRefs not implemented for $id")
+  def deleteFileRefs(fileRefs: Seq[FileRef])(implicit session: SparkSession): Unit = throw new RuntimeException(s"($id) deleteFileRefs not implemented")
 
   /**
    * Delete all data. This is used to implement SaveMode.Overwrite.
    */
-  def deleteAll(implicit session: SparkSession): Unit = throw new RuntimeException(s"deleteAll not implemented for $id")
+  def deleteAll(implicit session: SparkSession): Unit = throw new RuntimeException(s"($id) deleteAll not implemented")
 
   /**
    * Overwrite or Append new data.

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -181,6 +181,10 @@ case class HiveTableDataObject(override val id: DataObjectId,
     else Seq()
   }
 
+  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+    partitionValues.foreach( pv => HiveUtil.dropPartition(table, hadoopPath, pv))
+  }
+
   override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {
     if (partitionValues.keys == partitions.toSet) HiveUtil.createEmptyPartition(table, partitionValues)
     else logger.warn(s"($id) No empty partition was created for $partitionValues because there are not all partition columns defined")

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -153,12 +153,12 @@ case class HiveTableDataObject(override val id: DataObjectId,
     val dfPrepared = if (createTableOnly) session.createDataFrame(List[Row]().asJava, df.schema) else df
 
     // write table and fix acls
-    HiveUtil.writeDfToHive( session, dfPrepared, hadoopPath.toString, table.name, table.db.get, partitions, saveMode, numInitialHdfsPartitions=numInitialHdfsPartitions )
+    HiveUtil.writeDfToHive( dfPrepared, hadoopPath.toString, table, partitions, saveMode, numInitialHdfsPartitions=numInitialHdfsPartitions )
     val aclToApply = acl.orElse(connection.flatMap(_.acl))
     if (aclToApply.isDefined) AclUtil.addACLs(aclToApply.get, hadoopPath)(filesystem)
     if (analyzeTableAfterWrite && !createTableOnly) {
       logger.info(s"Analyze table ${table.fullName}.")
-      HiveUtil.analyze(session, table.db.get, table.name, partitions, partitionValues)
+      HiveUtil.analyze(table, partitions, partitionValues)
     }
 
     // make sure empty partitions are created as well
@@ -187,7 +187,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
   }
 
   override def dropTable(implicit session: SparkSession): Unit = {
-    HiveUtil.dropTable(session, table.db.get, table.name)
+    HiveUtil.dropTable(table)
   }
 
   /**

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -143,9 +143,8 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   }
   private def preparedAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext) = {
     sqlOpt.foreach { sql =>
-      val params = DefaultExpressionData(context.feed, context.application, context.runId, context.attemptId, context.referenceTimestamp.map(Timestamp.valueOf)
-        , Timestamp.valueOf(context.runStartTime), Timestamp.valueOf(context.attemptStartTime), partitionValues.map(_.elements.mapValues(_.toString)))
-      val preparedSql = SparkExpressionUtil.substitute(id, configName, sql, params)
+      val data = DefaultExpressionData.from(context, partitionValues)
+      val preparedSql = SparkExpressionUtil.substitute(id, configName, sql, data)
       logger.info(s"($id) ${configName.getOrElse("SQL")} is being executed: $preparedSql")
       connection.execJdbcStatement(preparedSql, logging = false)
     }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -109,7 +109,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
     df.colNamesLowercase
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)(implicit session: SparkSession): Unit = {
     require(table.query.isEmpty, s"($id) Cannot write to jdbc DataObject defined by a query.")
     validateSchemaMin(df)
     // write table

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import org.apache.spark.sql.types.StructType
@@ -40,6 +40,9 @@ import org.apache.spark.sql.{DataFrame, SaveMode}
  * @param jsonOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *                    [[org.apache.spark.sql.DataFrameWriter]].
  * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  *
  * @note By default, the JSON option `multiline` is enabled.
  *
@@ -58,6 +61,7 @@ case class JsonFileDataObject( override val id: DataObjectId,
                                override val acl: Option[AclDef] = None,
                                override val connectionId: Option[ConnectionId] = None,
                                override val filenameColumn: Option[String] = None,
+                               override val expectedPartitionsCondition: Option[String] = None,
                                override val metadata: Option[DataObjectMetadata] = None
                              )(implicit override val instanceRegistry: InstanceRegistry)
   extends SparkFileDataObject with CanCreateDataFrame with CanWriteDataFrame {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
@@ -267,7 +267,7 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
     )
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)(implicit session: SparkSession): Unit = {
     convertToWriteDataFrame(df)
       .write
       .format("kafka")

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
@@ -116,6 +116,7 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
   extends DataObject with CanCreateDataFrame with CanCreateStreamingDataFrame with CanWriteDataFrame with CanHandlePartitions with SchemaValidation {
 
   override val partitions: Seq[String] = datePartitionCol.map(_.colName).toSeq
+  override val expectedPartitionsCondition: Option[String] = None // expect all partitions to exist
   private val udfFormatPartition = udf((ts:Timestamp) => ts.toLocalDateTime.truncatedTo(datePartitionCol.get.chronoUnit).format(datePartitionCol.get.formatter))
 
   private val connection = getConnection[KafkaConnection](connectionId)
@@ -138,11 +139,12 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
   }
 
   override def prepare(implicit session: SparkSession): Unit = {
+    super.prepare
     // test schema registry connection
     connection.testSchemaRegistry()
     // test kafka connection and topic existing
-    // TODO: einkommentieren!
-    //require(connection.topicExists(topicName), s"($id) topic $topicName doesn't exist")
+    require(connection.topicExists(topicName), s"($id) topic $topicName doesn't exist")
+    filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
 
   override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import org.apache.spark.sql.streaming.Trigger
@@ -52,6 +52,9 @@ import org.apache.spark.sql.{DataFrame, SaveMode}
  * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
  * @param acl override connections permissions for files created with this connection
  * @param connectionId optional id of [[io.smartdatalake.workflow.connection.HadoopFileConnection]]
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  * @param metadata Metadata describing this data object.
  */
 case class ParquetFileDataObject( override val id: DataObjectId,
@@ -64,6 +67,7 @@ case class ParquetFileDataObject( override val id: DataObjectId,
                                   override val acl: Option[AclDef] = None,
                                   override val connectionId: Option[ConnectionId] = None,
                                   override val filenameColumn: Option[String] = None,
+                                  override val expectedPartitionsCondition: Option[String] = None,
                                   override val metadata: Option[DataObjectMetadata] = None
                                 )(@transient implicit override val instanceRegistry: InstanceRegistry)
   extends SparkFileDataObjectWithEmbeddedSchema with CanCreateDataFrame with CanWriteDataFrame{

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
@@ -21,6 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.AclDef
 import org.apache.spark.sql.SaveMode
 
@@ -29,7 +30,9 @@ import org.apache.spark.sql.SaveMode
  * Provides details to an Action to access raw files.
  * @param fileName Definition of fileName. This is concatenated with path and partition layout to search for files. Default is an asterix to match everything.
  * @param saveMode Overwrite or Append new data.
- *
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  */
 case class RawFileDataObject( override val id: DataObjectId,
                               override val path: String,
@@ -38,6 +41,7 @@ case class RawFileDataObject( override val id: DataObjectId,
                               override val saveMode: SaveMode = SaveMode.Overwrite,
                               override val acl: Option[AclDef] = None,
                               override val connectionId: Option[ConnectionId] = None,
+                              override val expectedPartitionsCondition: Option[String] = None,
                               override val metadata: Option[DataObjectMetadata] = None
                             )(@transient implicit override val instanceRegistry: InstanceRegistry)
   extends HadoopFileDataObject {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -46,6 +46,9 @@ import scala.util.{Failure, Success, Try}
  *                        if there is no char to delimit the last token from the rest of the path or also between
  *                        two tokens.
  * @param saveMode Overwrite or Append new data.
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  */
 case class SFtpFileRefDataObject(override val id: DataObjectId,
                                  override val path: String,
@@ -53,6 +56,7 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
                                  override val partitions: Seq[String] = Seq(),
                                  override val partitionLayout: Option[String] = None,
                                  override val saveMode: SaveMode = SaveMode.Overwrite,
+                                 override val expectedPartitionsCondition: Option[String] = None,
                                  override val metadata: Option[DataObjectMetadata] = None)
                                 (@transient implicit val instanceRegistry: InstanceRegistry)
   extends FileRefDataObject with CanCreateInputStream with CanCreateOutputStream with SmartDataLakeLogger {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -125,7 +125,7 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
             val pattern = PartitionLayout.replaceTokens(partitionLayout, PartitionValues(Map()))
             // list directories and extract partition values
             SshUtil.sftpListFiles(path + separator + pattern)(sftp)
-              .map( f => PartitionLayout.extractPartitionValues(partitionLayout, "", f + separator))
+              .map( f => PartitionLayout.extractPartitionValues(partitionLayout, "", f.stripPrefix(path+separator) + separator))
         }
     }.getOrElse(Seq())
   }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -161,7 +161,8 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
    * @param partitionValues The partition layout to write.
    * @param session the current [[SparkSession]].
    */
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)(implicit session: SparkSession): Unit = {
+    require(!isRecursiveInput, "($id) SparkFileDataObject cannot write dataframe when dataobject is also used as recursive input ")
 
     // prepare data
     var dfPrepared = beforeWrite(df)

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -183,6 +183,10 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     else logger.warn(s"($id) No empty partition was created for $partitionValues because there are not all partition columns defined")
   }
 
+  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+    partitionValues.foreach( pv => HiveUtil.dropPartition(table, hadoopPath, pv))
+  }
+
   override def dropTable(implicit session: SparkSession): Unit = {
     HiveUtil.dropTable(table)
   }

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -68,7 +68,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
 
     if (hadoopPathHolder == null) {
       hadoopPathHolder = {
-        if (thisIsTableExisting) new Path(HiveUtil.existingTableLocation(table))
+        if (thisIsTableExisting) HiveUtil.removeTickTockFromLocation(new Path(HiveUtil.existingTableLocation(table)))
         else HdfsUtil.prefixHadoopPath(path.get, connection.map(_.pathPrefix))
       }
 
@@ -77,7 +77,6 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
         // Normalize both paths before comparing them (remove tick / tock folder and trailing slash)
         val hadoopPathNormalized = HiveUtil.normalizePath(hadoopPathHolder.toString)
         val definedPathNormalized = HiveUtil.normalizePath(path.get)
-
 
         if (definedPathNormalized != hadoopPathNormalized)
           logger.warn(s"Table ${table.fullName} exists already with different path. The table will be written with new path definition ${hadoopPathHolder}!")
@@ -123,10 +122,10 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     }
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
                              (implicit session: SparkSession): Unit = {
     validateSchemaMin(df)
-    writeDataFrame(df, createTableOnly=false, partitionValues)
+    writeDataFrameInternal(df, createTableOnly=false, partitionValues, isRecursiveInput)
 
     // make sure empty partitions are created as well
     createMissingPartitions(partitionValues)
@@ -137,8 +136,8 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
    * DataFrames are repartitioned in order not to write too many small files
    * or only a few HDFS files that are too large.
    */
-  def writeDataFrame(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues])
-                    (implicit session: SparkSession): Unit = {
+  def writeDataFrameInternal(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues], isRecursiveInput: Boolean)
+                            (implicit session: SparkSession): Unit = {
     val dfPrepared = if (createTableOnly) {
       // create empty df with existing df's schema
       session.createDataFrame(List.empty[Row].asJava, df.schema)
@@ -148,12 +147,12 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
       // estimate number of partitions from existing data, otherwise use numInitialHdfsPartitions
       else if (isTableExisting) {
         val currentHdfsPath = HdfsUtil.prefixHadoopPath(HiveUtil.existingTickTockLocation(table), None)
-        HdfsUtil.repartitionForHdfsFileSize(df, currentHdfsPath.toString)
+        HdfsUtil.repartitionForHdfsFileSize(df, currentHdfsPath)
       } else df.repartition(numInitialHdfsPartitions)
     }
 
     // write table and fix acls
-    HiveUtil.writeDfToHiveWithTickTock(dfPrepared, hadoopPath.toString, table, partitions, saveMode)
+    HiveUtil.writeDfToHiveWithTickTock(dfPrepared, hadoopPath, table, partitions, saveMode, forceTickTock = isRecursiveInput)
     val aclToApply = acl.orElse(connection.flatMap(_.acl))
     if (aclToApply.isDefined) AclUtil.addACLs(aclToApply.get, hadoopPath)(filesystem)
     if (analyzeTableAfterWrite && !createTableOnly) {

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -61,6 +61,7 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
   override val saveMode: SaveMode = SaveMode.Overwrite
 
   override def partitions: Seq[String] = partitionDefs.map(_.name)
+  override def expectedPartitionsCondition: Option[String] = None // all partitions are expected to exist
 
   /**
    * Get Access Token through Keycloak

--- a/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
+++ b/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.json.DefaultFlatteningParser
 import io.smartdatalake.util.misc.AclDef
 import org.apache.spark.sql.types.StructType
@@ -40,6 +40,9 @@ import org.apache.spark.sql.{DataFrame, SaveMode}
  * @param xmlOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *                    [[org.apache.spark.sql.DataFrameWriter]].
  * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  *
  * @see [[org.apache.spark.sql.DataFrameReader]]
  * @see [[org.apache.spark.sql.DataFrameWriter]]
@@ -57,6 +60,7 @@ case class XmlFileDataObject(override val id: DataObjectId,
                              override val acl: Option[AclDef] = None,
                              override val connectionId: Option[ConnectionId] = None,
                              override val filenameColumn: Option[String] = None,
+                             override val expectedPartitionsCondition: Option[String] = None,
                              override val metadata: Option[DataObjectMetadata] = None)
                             (@transient implicit override val instanceRegistry: InstanceRegistry)
   extends SparkFileDataObject with CanCreateDataFrame with CanWriteDataFrame {

--- a/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -298,4 +298,5 @@ class TestStateListener(options: Map[String,String]) extends StateListener {
     if (firstState.isEmpty) firstState = Some(state)
     finalState = Some(state)
   }
+
 }

--- a/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -281,7 +281,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check results
     assert(finalSubFeeds.size == 1)
-    assert(stats == Map(RuntimeEventState.SUCCEEDED -> 2))
+    assert(stats == Map(RuntimeEventState.INITIALIZED -> 2))
     assert(finalSubFeeds.head.dataFrame.get.select(dfSrc1.columns.map(col):_*).symmetricDifference(dfSrc1).isEmpty)
   }
 }

--- a/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -59,7 +59,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     val appName = "sdlb-recovery"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(statePath, filesystem, false)
+    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
 
@@ -158,7 +158,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     val appName = "sdlb-runId"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(s"$statePath", filesystem, false)
+    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
 
@@ -243,7 +243,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     val appName = "sdlb-simulation"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(s"$statePath", filesystem, false)
+    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
 

--- a/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -65,22 +65,19 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
     // source table has partitions columns dt and type
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgt1Table = Table(Some("default"), "ap_copy1", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = TickTockHiveTableDataObject( "tgt1", Some(tgt1Path), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
     val tgt2Table = Table(Some("default"), "ap_copy2", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
-    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
     // second table has partition columns dt only (reduced)
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare data
@@ -167,16 +164,14 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
     // source table has partitions columns dt and type
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgt1Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = TickTockHiveTableDataObject( "tgt1", Some(tgt1Path), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
 
     // fill src table with first partition

--- a/src/test/scala/io/smartdatalake/config/TestDataObject.scala
+++ b/src/test/scala/io/smartdatalake/config/TestDataObject.scala
@@ -44,7 +44,7 @@ case class TestDataObject( id: DataObjectId,
 
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession): DataFrame = null
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {}
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)(implicit session: SparkSession): Unit = {}
 
   override var table: Table = Table(db=Some("testdb"), name="testtable")
 

--- a/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -90,7 +90,7 @@ object TestUtil extends SmartDataLakeLogger {
     val table = Table(db=db,name=tableName,primaryKey=primaryKeyColumns)
     val path = dirPath+s"$tableName"
     val hTabDo = HiveTableDataObject(id=s"${tableName}DO",path=Some(path),schemaMin=schemaMin,table=table)
-    dropTable(session,db.get,tableName)
+    hTabDo.dropTable
     instanceRegistry.register(hTabDo)
     prepareHiveTable(table,path,df,partitionCols)
     hTabDo

--- a/src/test/scala/io/smartdatalake/util/hive/HiveUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/hive/HiveUtilTest.scala
@@ -22,6 +22,7 @@ import java.nio.file.{Files, Path, Paths}
 
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.dataobject.Table
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
@@ -36,11 +37,11 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
   implicit lazy val session: SparkSession = TestUtil.sessionHiveCatalog
   import session.implicits._
 
-  val hiveDBName = "default"
-  val hiveTableName = "unittesttable"
+  private val hiveTable = Table(Some("default"), "unittesttable")
+  private val hiveTableTmp = Table(Some("default"), "unittesttable_tmp")
 
   val tmpDirOnFS: Path = Files.createTempDirectory("sdl_test")
-  val tableDirOnFS: Path = Paths.get(tmpDirOnFS.toString, hiveTableName)
+  val tableDirOnFS: Path = Paths.get(tmpDirOnFS.toString, hiveTable.name)
   val hdfsTablePath: String = tableDirOnFS.toUri.toString // we use local filesystem and hive catalog for testing
 
   before {
@@ -55,8 +56,8 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
   private def cleanup(): Unit = {
     logger.info("cleanup!")
     // cleanup tables
-    Try(HiveUtil.execSqlStmt(session, s"Drop table if exists $hiveDBName.$hiveTableName"))
-    Try(HiveUtil.execSqlStmt(session, s"Drop table if exists $hiveDBName.${hiveTableName}_tmp"))
+    HiveUtil.dropTable(hiveTable)
+    HiveUtil.dropTable(hiveTableTmp)
     // cleanup existing files
     FileUtils.deleteDirectory(tmpDirOnFS.toFile)
   }
@@ -72,8 +73,8 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     (3, "C", "A", "Y"),
     (4, "C", "A", "Y"))).toDF( "id", "data1", "data2", "part" )
 
-  def checkPartitionsExpected( hiveDb:String, tableName:String, expectedPartitions:Seq[Map[String,String]] ) : Boolean = {
-    val tablePartitions = HiveUtil.getTablePartitions(hiveDb, tableName)
+  def checkPartitionsExpected( table: Table, expectedPartitions:Seq[Map[String,String]] ) : Boolean = {
+    val tablePartitions = HiveUtil.getTablePartitions(table)
     tablePartitions.toSet.equals(expectedPartitions.toSet)
   }
 
@@ -81,16 +82,16 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     val partitions = Seq()
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHive(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
+    HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
     intercept[AnalysisException]{
       // AnalysisException expected because table is not partitioned
-      HiveUtil.getTablePartitions(hiveDBName, hiveTableName).isEmpty
+      HiveUtil.getTablePartitions(hiveTable).isEmpty
     }
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
 
     logger.info("Overwriting data in existing table")
-    HiveUtil.writeDfToHive(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
   }
 
   test("Create unpartitioned external table and overwrite data with schema evolution without Tick-Tock") {
@@ -98,16 +99,16 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     val useTickTock = false
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHive(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
+    HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
     intercept[AnalysisException] {
       // AnalysisException expected because table is not partitioned
-      HiveUtil.getTablePartitions(hiveDBName, hiveTableName).isEmpty
+      HiveUtil.getTablePartitions(hiveTable).isEmpty
     }
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
 
     logger.info("Overwriting data in existing table with modified schema without Tick-Tock")
-    HiveUtil.writeDfToHive(session, testDataB, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataB ))
+    HiveUtil.writeDfToHive(testDataB, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataB ))
   }
 
   test("Create unpartitioned external table and overwrite data with schema evolution with TickTock") {
@@ -115,57 +116,57 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     val useTickTock = true
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
+    HiveUtil.writeDfToHiveWithTickTock(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
     intercept[AnalysisException]{
       // AnalysisException expected because table is not partitioned
-      HiveUtil.getTablePartitions(hiveDBName, hiveTableName).isEmpty
+      HiveUtil.getTablePartitions(hiveTable).isEmpty
     }
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
 
     logger.info("Overwriting data in existing table with modified schema with Tick-Tock")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataB, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataB ))
+    HiveUtil.writeDfToHiveWithTickTock(testDataB, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataB ))
   }
 
   test("Create partitioned external table and overwrite data") {
     val partitions = Seq("part")
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHive(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(checkPartitionsExpected(hiveDBName, hiveTableName, Seq(Map( "part" -> "X"), Map("part" -> "Y"))))
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(checkPartitionsExpected(hiveTable, Seq(Map( "part" -> "X"), Map("part" -> "Y"))))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
 
     logger.info("Overwriting data in existing table with modified schema with Tick-Tock")
-    HiveUtil.writeDfToHive(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(checkPartitionsExpected(hiveDBName, hiveTableName, Seq(Map( "part" -> "X"), Map("part" -> "Y"))))
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(checkPartitionsExpected(hiveTable, Seq(Map( "part" -> "X"), Map("part" -> "Y"))))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
   }
 
   test("Create partitioned table and overwrite data with schema evolution with TickTock") {
     val partitions = Seq("part")
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(HiveUtil.getTablePartitions(hiveDBName, hiveTableName).toSet.equals(Set(Map( "part" -> "X"), Map("part" -> "Y"))))
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    HiveUtil.writeDfToHiveWithTickTock(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(HiveUtil.getTablePartitions(hiveTable).toSet.equals(Set(Map( "part" -> "X"), Map("part" -> "Y"))))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
 
     logger.info("Overwriting data in existing table with modified schema and Tick-Tock")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataB, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(HiveUtil.getTablePartitions(hiveDBName, hiveTableName).toSet.equals(Set(Map( "part" -> "Y"), Map("part" -> "Z"))))
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataB ))
+    HiveUtil.writeDfToHiveWithTickTock(testDataB, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(HiveUtil.getTablePartitions(hiveTable).toSet.equals(Set(Map( "part" -> "Y"), Map("part" -> "Z"))))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataB ))
   }
 
   test("Creating a partitioned table and overwriting data with schema evolution with TickTock aborts") {
     val partitions = Seq("part")
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHive(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    assert(HiveUtil.getTablePartitions(hiveDBName, hiveTableName).toSet.equals(Set(Map( "part" -> "X"), Map("part" -> "Y"))))
-    assert(TestUtil.isDataFrameEqual( session.table(hiveTableName), testDataA ))
+    HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    assert(HiveUtil.getTablePartitions(hiveTable).toSet.equals(Set(Map( "part" -> "X"), Map("part" -> "Y"))))
+    assert(TestUtil.isDataFrameEqual( session.table(hiveTable.fullName), testDataA ))
 
     logger.info("Overwriting data in existing table with modified schema and Tick-Tock")
     intercept[IllegalArgumentException] {
-      HiveUtil.writeDfToHiveWithTickTock(session, testDataB, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
+      HiveUtil.writeDfToHiveWithTickTock(testDataB, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
     }
   }
 
@@ -173,12 +174,12 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     val partitions = Seq()
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    val suffix1 = HiveUtil.getCurrentTickTockLocationSuffix( hiveDBName, session, hiveTableName )
+    HiveUtil.writeDfToHiveWithTickTock(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    val suffix1 = HiveUtil.getCurrentTickTockLocationSuffix(hiveTable)
 
     logger.info("Overwriting data in existing table with modified schema and Tick-Tock")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    val suffix2 = HiveUtil.getCurrentTickTockLocationSuffix( hiveDBName, session, hiveTableName )
+    HiveUtil.writeDfToHiveWithTickTock(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    val suffix2 = HiveUtil.getCurrentTickTockLocationSuffix(hiveTable)
 
     assert(suffix1 != suffix2)
   }
@@ -187,12 +188,12 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     val partitions = Seq("part")
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    val suffix1 = HiveUtil.getCurrentTickTockLocationSuffix( hiveDBName, session, hiveTableName )
+    HiveUtil.writeDfToHiveWithTickTock(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    val suffix1 = HiveUtil.getCurrentTickTockLocationSuffix(hiveTable)
 
     logger.info("Overwriting data in existing table with modified schema and Tick-Tock")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    val suffix2 = HiveUtil.getCurrentTickTockLocationSuffix( hiveDBName, session, hiveTableName )
+    HiveUtil.writeDfToHiveWithTickTock(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    val suffix2 = HiveUtil.getCurrentTickTockLocationSuffix(hiveTable)
 
     assert(suffix1 == suffix2)
   }
@@ -201,12 +202,12 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     val partitions = Seq("part")
 
     logger.info("Creating table")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataA, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    val suffix1 = HiveUtil.getCurrentTickTockLocationSuffix( hiveDBName, session, hiveTableName )
+    HiveUtil.writeDfToHiveWithTickTock(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    val suffix1 = HiveUtil.getCurrentTickTockLocationSuffix(hiveTable)
 
     logger.info("Overwriting data in existing table with modified schema and Tick-Tock")
-    HiveUtil.writeDfToHiveWithTickTock(session, testDataB, hdfsTablePath, hiveTableName, hiveDBName, partitions, SaveMode.Overwrite)
-    val suffix2 = HiveUtil.getCurrentTickTockLocationSuffix( hiveDBName, session, hiveTableName )
+    HiveUtil.writeDfToHiveWithTickTock(testDataB, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
+    val suffix2 = HiveUtil.getCurrentTickTockLocationSuffix(hiveTable)
 
     assert(suffix1 != suffix2)
   }

--- a/src/test/scala/io/smartdatalake/util/hive/HiveUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/hive/HiveUtilTest.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.workflow.dataobject.Table
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.apache.hadoop.fs.{Path => HadoopPath}
 
 import scala.util.Try
 
@@ -42,7 +43,7 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
 
   val tmpDirOnFS: Path = Files.createTempDirectory("sdl_test")
   val tableDirOnFS: Path = Paths.get(tmpDirOnFS.toString, hiveTable.name)
-  val hdfsTablePath: String = tableDirOnFS.toUri.toString // we use local filesystem and hive catalog for testing
+  val hdfsTablePath: HadoopPath = new HadoopPath(tableDirOnFS.toUri) // we use local filesystem and hive catalog for testing
 
   before {
     // make sure directory exists for Tick-Tock mode in Windows

--- a/src/test/scala/io/smartdatalake/util/misc/SparkExpressionUtilTest.scala
+++ b/src/test/scala/io/smartdatalake/util/misc/SparkExpressionUtilTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.misc
+
+import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.definitions.DefaultExecutionModeExpressionData
+import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.workflow.ActionPipelineContext
+import org.apache.spark.sql.SparkSession
+import org.scalatest.FunSuite
+
+class SparkExpressionUtilTest extends FunSuite {
+
+  protected implicit val session: SparkSession = TestUtil.sessionHiveCatalog
+
+  private val registry = new InstanceRegistry
+  private val context = ActionPipelineContext("testFeed", "testApp", 1, 1, registry, None, SmartDataLakeBuilderConfig())
+  private val data = DefaultExecutionModeExpressionData.from(context)
+
+  test("evaluate boolean") {
+    val result = SparkExpressionUtil.evaluateBoolean(DataObjectId("test"), Some("testCondition"), "runId + attemptId = 2", data)
+    // result should be true
+    assert(result)
+  }
+
+  test("evaluate string") {
+    val result = SparkExpressionUtil.evaluateString(DataObjectId("test"), Some("testCondition"), "concat(feed, '-', application)", data)
+    assert(result.contains("testFeed-testApp"))
+  }
+
+  test("substitute tokens") {
+    val result = SparkExpressionUtil.substitute(DataObjectId("test"), Some("testCondition"), "hello %{concat(feed, '-', application)}, lets make %{runId + attemptId}", data)
+    assert(result.contains("hello testFeed-testApp, lets make 2"))
+  }
+
+  test("substitute options") {
+    val result = SparkExpressionUtil.substituteOptions(DataObjectId("test"), Some("testCondition"), "hello %{key1}, lets make %{key2}", Map("key1"->"tester", "key2"->"tests"))
+    assert(result.contains("hello tester, lets make tests"))
+  }
+}

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -56,19 +56,16 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
-    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
     val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
-    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
@@ -77,7 +74,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     val appName = "test"
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, appName, 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val action1 = DeduplicateAction("a", srcDO.id, tgt1DO.id, metricsFailCondition = Some(s"dataObjectId = '${tgt1DO.id.id}' and key = 'records_written' and value = 0"))
     val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id)
     val actions: Seq[SparkSubFeedAction] = Seq(action1, action2)
@@ -119,19 +116,16 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
-    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
     val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
-    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
@@ -139,7 +133,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     val appName = "test"
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, appName, 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val action1 = DeduplicateAction("a", srcDO.id, tgt1DO.id)
     val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id, breakDataFrameLineage = true)
     val actions: Seq[SparkSubFeedAction] = Seq(action1, action2)
@@ -285,19 +279,16 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable1 = Table(Some("default"), "input1")
-    HiveUtil.dropTable(session, srcTable1.db.get, srcTable1.name )
-    val srcPath1 = tempPath+s"/${srcTable1.fullName}"
-    val srcDO1 = HiveTableDataObject( "src1", Some(srcPath1), table = srcTable1, numInitialHdfsPartitions = 1)
+    val srcDO1 = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable1.fullName}"), table = srcTable1, numInitialHdfsPartitions = 1)
+    srcDO1.dropTable
     instanceRegistry.register(srcDO1)
     val srcTable2 = Table(Some("default"), "input2")
-    HiveUtil.dropTable(session, srcTable2.db.get, srcTable2.name )
-    val srcPath2 = tempPath+s"/${srcTable2.fullName}"
-    val srcDO2 = HiveTableDataObject( "src2", Some(srcPath2), table = srcTable2, numInitialHdfsPartitions = 1)
+    val srcDO2 = HiveTableDataObject( "src2", Some(tempPath+s"/${srcTable2.fullName}"), table = srcTable2, numInitialHdfsPartitions = 1)
+    srcDO2.dropTable
     instanceRegistry.register(srcDO2)
     val tgtTable = Table(Some("default"), "output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = HiveTableDataObject("tgt1", Some(tgtPath), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare DAG
@@ -329,33 +320,28 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "A", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "A", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
 
     val tgtATable = Table(Some("default"), "tgt_a", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtATable.db.get, tgtATable.name )
-    val tgtAPath = tempPath+s"/${tgtATable.fullName}"
-    val tgtADO = TickTockHiveTableDataObject("tgt_A", Some(tgtAPath), table = tgtATable, numInitialHdfsPartitions = 1)
+    val tgtADO = TickTockHiveTableDataObject("tgt_A", Some(tempPath+s"/${tgtATable.fullName}"), table = tgtATable, numInitialHdfsPartitions = 1)
+    tgtADO.dropTable
     instanceRegistry.register(tgtADO)
 
     val tgtBTable = Table(Some("default"), "tgt_b", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtBTable.db.get, tgtBTable.name )
-    val tgtBPath = tempPath+s"/${tgtBTable.fullName}"
-    val tgtBDO = HiveTableDataObject( "tgt_B", Some(tgtBPath), table = tgtBTable, numInitialHdfsPartitions = 1)
+    val tgtBDO = HiveTableDataObject( "tgt_B", Some(tempPath+s"/${tgtBTable.fullName}"), table = tgtBTable, numInitialHdfsPartitions = 1)
+    tgtBDO.dropTable
     instanceRegistry.register(tgtBDO)
 
     val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtCTable.db.get, tgtCTable.name )
-    val tgtCPath = tempPath+s"/${tgtCTable.fullName}"
-    val tgtCDO = HiveTableDataObject( "tgt_C", Some(tgtCPath), table = tgtCTable, numInitialHdfsPartitions = 1)
+    val tgtCDO = HiveTableDataObject( "tgt_C", Some(tempPath+s"/${tgtCTable.fullName}"), table = tgtCTable, numInitialHdfsPartitions = 1)
+    tgtCDO.dropTable
     instanceRegistry.register(tgtCDO)
 
     val tgtDTable = Table(Some("default"), "tgt_d", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtDTable.db.get, tgtDTable.name )
-    val tgtDPath = tempPath+s"/${tgtDTable.fullName}"
-    val tgtDDO = HiveTableDataObject( "tgt_D", Some(tgtDPath), table = tgtDTable, numInitialHdfsPartitions = 1)
+    val tgtDDO = HiveTableDataObject( "tgt_D", Some(tempPath+s"/${tgtDTable.fullName}"), table = tgtDTable, numInitialHdfsPartitions = 1)
+    tgtDDO.dropTable
     instanceRegistry.register(tgtDDO)
 
     // prepare DAG
@@ -363,7 +349,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransfomer = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.TestActionDagTransformer"))
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val actions = Seq(
       DeduplicateAction("A", srcDO.id, tgtADO.id),
       CopyAction("B", tgtADO.id, tgtBDO.id),
@@ -403,22 +389,19 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     // setup DataObjects
     val feed = "actiondag"
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
     // source table has partitions columns dt and type
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = TickTockHiveTableDataObject( "tgt1", Some(tgt1Path), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
     val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
-    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
     // second table has partition columns dt only (reduced)
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare data
@@ -478,9 +461,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
 
     // setup tgt2 Hive DataObject
     val tgt2Table = Table(Some("default"), "ap_copy")
-    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
-    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare ActionPipeline
@@ -521,9 +503,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
 
     // setup tgt1 Hive DataObject
     val tgt1Table = Table(Some("default"), "ap_copy")
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
-    val tgt1DO = HiveTableDataObject( "tgt1", Some(tgt1Path), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
 
     // setup tgt2 CSV DataObject
@@ -566,19 +547,16 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
-    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1, expectedPartitionsCondition = Some("elements['lastname'] != 'xyz'"))
+    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1, expectedPartitionsCondition = Some("elements['lastname'] != 'xyz'"))
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
     val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
-    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), table = tgt2Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
@@ -614,15 +592,16 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
   test( "validate expected partitions") {
 
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
     val srcPath = tempPath+s"/${srcTable.fullName}"
     val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1, expectedPartitionsCondition = Some("elements['lastname'] != 'xyz'"))
+    srcDO.dropTable
+
     instanceRegistry.register(srcDO)
 
     val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
     val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
     val tgt1DO = HiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
 
     val refTimestamp1 = LocalDateTime.now()
@@ -649,19 +628,16 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt1Table.db.get, tgt1Table.name )
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
-    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
     val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgt2Table.db.get, tgt2Table.name )
-    val tgt2Path = tempPath+s"/${tgt2Table.fullName}"
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tgt2Path), table = tgt2Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -210,8 +210,9 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
       assert(r1 == Seq("5"))
 
       // check metrics
-      val action2MainMetrics = action2.getFinalMetrics(action2.outputId).get.getMainInfos
-      assert(action2MainMetrics("records_written") == 1)
+      // note: metrics don't work for KafkaTopicDataObject
+      //val action2MainMetrics = action2.getFinalMetrics(action2.outputId).get.getMainInfos
+      //assert(action2MainMetrics("records_written") == 1)
     }
   }
 

--- a/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -22,14 +22,14 @@ import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.{Instant, LocalDateTime}
 
-import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, SmartDataLakeBuilderConfig}
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.{ExecutionModeFailedException, PartitionDiffMode, SparkIncrementalMode, SparkStreamingOnceMode}
+import io.smartdatalake.definitions._
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
-import io.smartdatalake.workflow.action._
 import io.smartdatalake.workflow.action.customlogic.{CustomDfTransformerConfig, CustomDfsTransformer, CustomDfsTransformerConfig}
+import io.smartdatalake.workflow.action.{CopyAction, _}
 import io.smartdatalake.workflow.connection.KafkaConnection
 import io.smartdatalake.workflow.dataobject._
 import net.manub.embeddedkafka.EmbeddedKafka
@@ -175,9 +175,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
       val kafkaConnection = KafkaConnection("kafkaCon1", "localhost:6000")
       instanceRegistry.register(kafkaConnection)
       val srcTable = Table(Some("default"), "ap_input")
-      HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-      val srcPath = tempPath+s"/${srcTable.fullName}"
-      val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+      val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+      srcDO.dropTable
       instanceRegistry.register(srcDO)
       createCustomTopic("topic1", Map(), 1, 1)
       val tgt1DO = KafkaTopicDataObject("kafka1", topicName = "topic1", connectionId = "kafkaCon1", valueType = KafkaColumnType.String, selectCols = Seq("value", "timestamp"), schemaMin = Some(StructType(Seq(StructField("timestamp", TimestampType)))))
@@ -191,7 +190,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
       val appName = "test"
       implicit val context: ActionPipelineContext = ActionPipelineContext(feed, appName, 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
       val l1 = Seq(("doe-john", 5)).toDF("key", "value")
-      TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+      srcDO.writeDataFrame(l1, Seq())
       val action1 = CopyAction("a", srcDO.id, tgt1DO.id)
       val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id, transformer = Some(CustomDfTransformerConfig(sqlCode = Some("select 'test' as key, value from kafka1"))))
       val dag: ActionDAGRun = ActionDAGRun(Seq(action1, action2), 1, 1)
@@ -210,68 +209,74 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
       assert(r1 == Seq("5"))
 
       // check metrics
-      // note: metrics don't work for KafkaTopicDataObject
+      // note: metrics don't work for Kafka sink in Spark 2.4
       //val action2MainMetrics = action2.getFinalMetrics(action2.outputId).get.getMainInfos
       //assert(action2MainMetrics("records_written") == 1)
     }
   }
 
-  test("action dag with 2 dependent actions from same predecessor") {
+  test("action dag with 2 dependent actions from same predecessor, PartitionDiffMode and another action with no data to process") {
     // Action B and C depend on Action A
 
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTableA = Table(Some("default"), "ap_input")
-    HiveUtil.dropTable(session, srcTableA.db.get, srcTableA.name )
-    val srcPath = tempPath+s"/${srcTableA.fullName}"
-    val srcDO = HiveTableDataObject( "A", Some(srcPath), table = srcTableA, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "A", Some(tempPath+s"/${srcTableA.fullName}"), table = srcTableA, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtATable = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtATable.db.get, tgtATable.name )
-    val tgtAPath = tempPath+s"/${tgtATable.fullName}"
-    val tgtADO = TickTockHiveTableDataObject("tgt_A", Some(tgtAPath), table = tgtATable, numInitialHdfsPartitions = 1)
+    val tgtADO = TickTockHiveTableDataObject("tgt_A", Some(tempPath+s"/${tgtATable.fullName}"), table = tgtATable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    tgtADO.dropTable
     instanceRegistry.register(tgtADO)
 
-    val tgtBTable = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtBTable.db.get, tgtBTable.name )
-    val tgtBPath = tempPath+s"/${tgtBTable.fullName}"
-    val tgtBDO = HiveTableDataObject( "tgt_B", Some(tgtBPath), table = tgtBTable, numInitialHdfsPartitions = 1)
+    val tgtBTable = Table(Some("default"), "ap_copy1", None, Some(Seq("lastname","firstname")))
+    val tgtBDO = HiveTableDataObject( "tgt_B", Some(tempPath+s"/${tgtBTable.fullName}"), table = tgtBTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    tgtBDO.dropTable
     instanceRegistry.register(tgtBDO)
 
-    val tgtCTable = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtCTable.db.get, tgtCTable.name )
-    val tgtCPath = tempPath+s"/${tgtCTable.fullName}"
-    val tgtCDO = HiveTableDataObject( "tgt_C", Some(tgtCPath), table = tgtCTable, numInitialHdfsPartitions = 1)
+    val tgtCTable = Table(Some("default"), "ap_copy2", None, Some(Seq("lastname","firstname")))
+    val tgtCDO = HiveTableDataObject( "tgt_C", Some(tempPath+s"/${tgtCTable.fullName}"), table = tgtCTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    tgtCDO.dropTable
     instanceRegistry.register(tgtCDO)
+
+    val tgtDTable = Table(Some("default"), "ap_copy3", None, Some(Seq("lastname","firstname")))
+    val tgtDDO = HiveTableDataObject( "tgt_D", Some(tempPath+s"/${tgtDTable.fullName}"), table = tgtDTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    tgtDDO.dropTable
+    instanceRegistry.register(tgtDDO)
 
     // prepare DAG
     val refTimestamp1 = LocalDateTime.now()
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTableA, srcPath, l1)
-    val actions = Seq(
-      DeduplicateAction("a", srcDO.id, tgtADO.id),
-      CopyAction("b", tgtADO.id, tgtBDO.id),
-      CopyAction("c", tgtADO.id, tgtCDO.id)
-    )
-    val dag = ActionDAGRun(actions, 1, 1)
+    srcDO.writeDataFrame(l1, Seq())
+    tgtDDO.writeDataFrame(l1, Seq()) // we populate tgtD so there should be no partitions to process
+    instanceRegistry.register(DeduplicateAction("a", srcDO.id, tgtADO.id, executionMode = Some(PartitionDiffMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
+    instanceRegistry.register(CopyAction("b", tgtADO.id, tgtBDO.id, executionMode = Some(FailIfNoPartitionValuesMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
+    instanceRegistry.register(CopyAction("c", tgtADO.id, tgtCDO.id, metadata = Some(ActionMetadata(feed = Some(feed)))))
+    instanceRegistry.register(CopyAction("d", srcDO.id, tgtDDO.id, executionMode = Some(PartitionDiffMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
 
     // exec dag
-    dag.prepare
-    dag.init
-    dag.exec
+    val sdlb = new DefaultSmartDataLakeBuilder
+    val appConfig = SmartDataLakeBuilderConfig(feedSel=feed)
+    sdlb.exec(appConfig, 1, 1, LocalDateTime.now(), LocalDateTime.now(), Seq(), Seq(), None, Seq(), simulation = false)
 
-    val r1 = session.table(s"${tgtBTable.fullName}")
+    val r1 = tgtBDO.getDataFrame()
       .select($"rating")
       .as[Int].collect.toSeq
     assert(r1.size == 1)
     assert(r1.head == 5)
 
-    val r2 = session.table(s"${tgtCTable.fullName}")
+    val r2 = tgtCDO.getDataFrame()
       .select($"rating")
       .as[Int].collect.toSeq
     assert(r2.size == 1)
     assert(r2.head == 5)
+
+    val r3 = tgtDDO.getDataFrame()
+      .select($"rating")
+      .as[Int].collect.toSeq
+    assert(r3.size == 1)
+    assert(r3.head == 5)
   }
 
   test("action dag where first actions has multiple input subfeeds") {
@@ -958,8 +963,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
 
     // first dag run, first file processed
     dag.prepare
-    val ex = intercept[TaskFailedException](dag.init)
-    assert(ex.cause.isInstanceOf[ExecutionModeFailedException])
+    val ex = intercept[ExecutionModeFailedException](dag.init)
   }
 
 }

--- a/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -52,14 +52,12 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tgtPath), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
@@ -68,7 +66,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val customTransformerConfig = CustomDfTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfTransformer"))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")),PartitionValues(Map("lastname" -> "jonson"))))
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
@@ -97,14 +95,12 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), analyzeTableAfterWrite=true, table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), analyzeTableAfterWrite=true, table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tgtPath), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
@@ -112,7 +108,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig))
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.exec(Seq(srcSubFeed))
 
@@ -128,14 +124,12 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tgtPath), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
@@ -144,7 +138,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val customTransformerConfig = CustomDfTransformerConfig(sqlCode = Some("select * from copy_input where rating = 5"))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
@@ -165,14 +159,12 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "notransform"
     val srcTable = Table(Some("default"), "copy_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tgtPath), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
@@ -180,7 +172,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val action1 = CopyAction("a1", srcDO.id, tgtDO.id, transformer = None)
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
@@ -197,15 +189,13 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "partitiondiff"
     val srcTable = Table(Some("default"), "copy_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("type","lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tgtPath), table = tgtTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     instanceRegistry.register(tgtDO)
+    tgtDO.dropTable
 
     // prepare action
     val refTimestamp = LocalDateTime.now()
@@ -244,14 +234,12 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tgtPath), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
@@ -260,7 +248,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val customTransformerConfig = CustomDfTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfTransformer"))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig), filterClause = Some("lastname='jonson'"))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomDfToHiveTableTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomDfToHiveTableTest.scala
@@ -52,9 +52,8 @@ class CustomDfToHiveTableTest extends FunSuite with BeforeAndAfter {
     val feed = "customDf2Hive"
     val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some("io.smartdatalake.config.TestCustomDfCreator")))
     val targetTable = Table(db = Some("default"), name = "custom_df_copy", query = None, primaryKey = Some(Seq("line")))
-    HiveUtil.dropTable(session, targetTable.db.get, targetTable.name )
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = HiveTableDataObject(id="target", Some(targetTablePath), table = targetTable, numInitialHdfsPartitions = 1)
+    val targetDO = HiveTableDataObject(id="target", Some(tempPath+s"/${targetTable.fullName}"), table = targetTable, numInitialHdfsPartitions = 1)
+    targetDO.dropTable
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
 
@@ -79,9 +78,8 @@ class CustomDfToHiveTableTest extends FunSuite with BeforeAndAfter {
     val feed = "customDf2Hive_dfManyTypes"
     val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some("io.smartdatalake.config.TestCustomDfManyTypes")))
     val targetTable = Table(db = Some("default"), name = "custom_dfManyTypes_copy")
-    HiveUtil.dropTable(session, targetTable.db.get, targetTable.name )
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = HiveTableDataObject(id="target", Some(targetTablePath), table = targetTable, numInitialHdfsPartitions = 1)
+    val targetDO = HiveTableDataObject(id="target", Some(tempPath+s"/${targetTable.fullName}"), table = targetTable, numInitialHdfsPartitions = 1)
+    targetDO.dropTable
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
 

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -113,7 +113,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(srcDO1)
 
     val tgtTable1 = Table(Some("default"), "copy_output1", None, Some(Seq("lastname", "firstname")))
-    val tgtDO1 = TickTockHiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable1.fullName}"), table = tgtTable1, numInitialHdfsPartitions = 1)
+    val tgtDO1 = TickTockHiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable1.fullName}"), table = tgtTable1, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     tgtDO1.dropTable
     instanceRegistry.register(tgtDO1)
 
@@ -205,40 +205,55 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val srcTable2 = Table(Some("default"), "dummy")
+    val srcTable2 = Table(Some("default"), "dummy1")
     val srcDO2 = HiveTableDataObject( "src2", Some(tempPath+s"/${srcTable2.fullName}"), table = srcTable2, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     srcDO2.dropTable
     instanceRegistry.register(srcDO2)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("type","lastname","firstname")))
+    val srcTable3 = Table(Some("default"), "dummy2")
+    val srcDO3 = HiveTableDataObject( "src3", Some(tempPath+s"/${srcTable3.fullName}"), table = srcTable3, numInitialHdfsPartitions = 1)
+    srcDO3.dropTable
+    instanceRegistry.register(srcDO3)
+    val tgtTable = Table(Some("default"), "copy_output1", None, Some(Seq("type","lastname","firstname")))
     val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
-    val tgtTable2 = Table(Some("default"), "copy_output", None, Some(Seq("type","lastname","firstname")))
+    val tgtTable2 = Table(Some("default"), "copy_output2", None, Some(Seq("type","lastname","firstname")))
     val tgtDO2 = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgtTable2.fullName}"), table = tgtTable2, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     tgtDO2.dropTable
     instanceRegistry.register(tgtDO2)
+    val tgtTable3 = Table(Some("default"), "copy_output3", None, Some(Seq("type","lastname","firstname")))
+    val tgtDO3 = HiveTableDataObject( "tgt3", Some(tempPath+s"/${tgtTable3.fullName}"), table = tgtTable3, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    tgtDO3.dropTable
+    instanceRegistry.register(tgtDO3)
 
     // prepare action
     val refTimestamp = LocalDateTime.now()
     implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
-    val action = CustomSparkAction("a1", Seq(srcDO.id, srcDO2.id), Seq(tgtDO.id, tgtDO2.id), transformer = customTransformerConfig
+    val action = CustomSparkAction("a1", Seq(srcDO.id, srcDO2.id, srcDO3.id), Seq(tgtDO.id, tgtDO2.id, tgtDO3.id), transformer = customTransformerConfig
       , mainInputId = Some("src1"), mainOutputId = Some("tgt1"), executionMode = Some(PartitionDiffMode()))
-    val srcSubFeed1 = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
+    val srcSubFeed1 = InitSubFeed("src1", Seq())
     val srcSubFeed2 = InitSubFeed("src2", Seq())
+    val srcSubFeed3 = InitSubFeed("src3", Seq())
 
     // prepare & start first load
     val l1 = Seq(("A","doe","john",5)).toDF("type", "lastname", "firstname", "rating")
+    val l2 = Seq(("A","doe","john",5),("B","doe","john",5)).toDF("type", "lastname", "firstname", "rating")
     val l1PartitionValues = Seq(PartitionValues(Map("type"->"A")))
-    srcDO.writeDataFrame(l1, l1PartitionValues) // prepare testdata
-    srcDO2.writeDataFrame(l1, l1PartitionValues)
-    val tgtSubFeed1 = action.exec(Seq(srcSubFeed1, srcSubFeed2)).head
+    val l2PartitionValues = Seq(PartitionValues(Map("type"->"A")),PartitionValues(Map("type"->"B")))
+    srcDO.writeDataFrame(l1, l1PartitionValues)
+    srcDO2.writeDataFrame(l2, l2PartitionValues)
+    srcDO3.writeDataFrame(l2, Seq()) // src3 is not partitioned
+    val tgtSubFeed1 = action.exec(Seq(srcSubFeed1, srcSubFeed2, srcSubFeed3)).head
 
     // check load
     assert(tgtSubFeed1.dataObjectId == tgtDO.id)
     assert(tgtSubFeed1.partitionValues.toSet == l1PartitionValues.toSet)
-    assert(tgtDO.getDataFrame().count == 1)
+    assert(tgtDO.getDataFrame().count == 1) // partition type=A is missing
     assert(tgtDO.listPartitions.toSet == l1PartitionValues.toSet)
+    assert(tgtDO2.getDataFrame().count == 1) // only partitions according to srcDO1 read
+    assert(tgtDO2.listPartitions.toSet == l1PartitionValues.toSet)
+    assert(tgtDO3.getDataFrame().count == 2) // all records read because not partitioned
   }
 
   test("copy load with 2 transformations from sql code") {

--- a/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -74,7 +74,10 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     // prepare & start load
     val refTimestamp1 = LocalDateTime.now()
     implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
-    val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerIncrement"))
+    val customTransformerConfig = CustomDfsTransformerConfig(
+      className = Some("io.smartdatalake.workflow.action.TestDfsTransformerIncrement"),
+      options = Map("increment1" -> "1"), runtimeOptions = Map("increment2" -> "runId")
+    )
 
     val action1 = CustomSparkAction("action1", List(srcDO1.id, srcDO2.id), List(tgtDO1.id, tgtDO2.id), transformer = customTransformerConfig)(context1.instanceRegistry)
 
@@ -86,14 +89,14 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     assert(tgtSubFeeds.size == 2)
     assert(tgtSubFeeds.map(_.dataObjectId) == Seq(tgtDO1.id, tgtDO2.id))
 
-    val r1 = session.table(s"${tgtTable1.fullName}")
+    val r1 = tgtDO1.getDataFrame()
       .select($"rating")
       .as[Int].collect().toSeq
     assert(r1.size == 1)
     assert(r1.head == 6) // should be increased by 1 through TestDfTransformer
 
     // same for the second dataframe
-    val r2 = session.table(s"${tgtTable2.fullName}")
+    val r2 = tgtDO2.getDataFrame()
       .select($"rating")
       .as[Int].collect().toSeq
     assert(r2.size == 1)
@@ -290,8 +293,8 @@ class TestDfsTransformerIncrement extends CustomDfsTransformer {
   override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String,DataFrame]): Map[String,DataFrame] = {
     import session.implicits._
     Map(
-      "tgt1" -> dfs("src1").withColumn("rating", $"rating"+1)
-    , "tgt2" -> dfs("src2").withColumn("rating", $"rating"+1)
+      "tgt1" -> dfs("src1").withColumn("rating", $"rating" + options("increment1").toInt)
+    , "tgt2" -> dfs("src2").withColumn("rating", $"rating" + options("increment2").toInt)
     )
   }
 }

--- a/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
@@ -50,14 +50,12 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "deduplicate"
     val srcTable = Table(Some("default"), "deduplicate_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath),  table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"),  table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tgtPath), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
@@ -65,7 +63,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id)
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
@@ -81,7 +79,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     val context2 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig())
     val action2 = DeduplicateAction("dda2", srcDO.id, tgtDO.id)
     val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l2)
+    srcDO.writeDataFrame(l2, Seq())
     action2.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
 
     val r2 = session.table(s"${tgtTable.fullName}")
@@ -112,14 +110,12 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "deduplicate"
     val srcTable = Table(Some("default"), "deduplicate_input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    HiveUtil.dropTable(session, tgtTable.db.get, tgtTable.name )
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tgtPath), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
@@ -127,7 +123,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, filterClause = Some("lastname='jonson'"))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)

--- a/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
@@ -27,7 +27,7 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.connection.SftpFileRefConnection
 import io.smartdatalake.workflow.dataobject._
-import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, FileSubFeed}
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.apache.sshd.server.SshServer
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
@@ -151,13 +151,10 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
+    implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
     val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id)
     val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date"->"00010101"))))
-    action1.exec(Seq(srcSubFeed))
-
-    val r1 = tgtDO.getFileRefs(Seq())
-    assert(r1.isEmpty)
+    intercept[AssertionError](action1.exec(Seq(srcSubFeed)))
   }
 
   test("copy file from sftp to hadoop with partitions and positive top-level partition filter") {
@@ -186,7 +183,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
+    implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
     val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id)
     val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date"->datePartitionVal))))
     action1.exec(Seq(srcSubFeed))

--- a/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
@@ -36,9 +36,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
   test("write and analyze table without partitions") {
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    srcDO.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq())
     // check table statistics
@@ -51,9 +50,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
   test("write and analyze table with partitions and partition values") {
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    srcDO.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq(PartitionValues(Map("type"->"ext")),PartitionValues(Map("type"->"int"))))
     // check table statistics
@@ -73,9 +71,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
   test("write and analyze table with partitions without partition values") {
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    srcDO.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq())
     // check table statistics
@@ -95,9 +92,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
   test("write and analyze table with multi partition layout and partial partition values") {
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("type","lastname"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type","lastname"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    srcDO.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq(PartitionValues(Map("type"->"ext"))))
     // check table statistics
@@ -121,9 +117,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
   test("write and analyze table with multi partition layout and full partition values") {
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("type","lastname"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type","lastname"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
+    srcDO.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq(PartitionValues(Map("type"->"ext", "lastname"->"doe")),PartitionValues(Map("type"->"ext", "lastname"->"smith"))))
     // check table statistics
@@ -149,9 +144,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
     // create data object
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("p"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("p"), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
 
     // write test data 1 - create partition A and B
     val partitionValuesCreated = Seq( PartitionValues(Map("p"->"A")), PartitionValues(Map("p"->"B")))
@@ -175,9 +169,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
     // create data object
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("p"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("p"), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
 
     // write test files
     val partitionValuesCreated = Seq(PartitionValues(Map("p"->"A")), PartitionValues(Map("p"->"B")))
@@ -192,9 +185,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
     // create data object
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("p1","p2"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("p1","p2"), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
 
     // write test files
     val partitionValuesCreated = Seq( PartitionValues(Map("p1"->"A","p2"->"L2A")), PartitionValues(Map("p1"->"A","p2"->"L2B"))
@@ -210,9 +202,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
     // create data object
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name )
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "input", Some(srcPath), table = srcTable, partitions = Seq("p1","p2"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("p1","p2"), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
 
     // write test files
     val partitionValuesCreated = Seq( PartitionValues(Map("p1"->"A","p2"->"L2A")), PartitionValues(Map("p1"->"X","p2"->"L2X")))
@@ -252,9 +243,8 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     try {
       // create data object
       val srcTable = Table(Some("default"), "input")
-      HiveUtil.dropTable(testSession, srcTable.db.get, srcTable.name)
-      val srcPath = tempPath + s"/${srcTable.fullName}"
-      val srcDO = HiveTableDataObject("input", Some(srcPath), table = srcTable, partitions = Seq("p1", "p2"), numInitialHdfsPartitions = 1)
+      val srcDO = HiveTableDataObject("input", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("p1", "p2"), numInitialHdfsPartitions = 1)
+      srcDO.dropTable
 
       // write test files
       val df = Seq(("A", "L2A", 1), ("A", "L2B", 2), ("B", "L2B", 3), ("B", "L2C", 4)).toDF("p1", "p2", "value")

--- a/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
+++ b/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
@@ -52,16 +52,14 @@ class TickTockHiveTableDataObjectTest extends FunSuite with BeforeAndAfter {
 
     // create source dataobject
     val srcTable = Table(Some("default"), "input")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name)
-    val srcPath = tempPath + s"/${srcTable.fullName}"
-    val srcDO = TickTockHiveTableDataObject("input", Some(srcPath), table = srcTable, partitions = Seq(), numInitialHdfsPartitions = 1)
+    val srcDO = TickTockHiveTableDataObject("input", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq(), numInitialHdfsPartitions = 1)
+    srcDO.dropTable
     instanceRegistry.register(srcDO)
 
     // create target
     val tgtTable = Table(Some("default"),"output")
-    HiveUtil.dropTable(session, srcTable.db.get, srcTable.name)
-    val tgtPath = tempPath + s"/${tgtTable.fullName}"
-    val tgtDO = TickTockHiveTableDataObject("output", Some(tgtPath), table = tgtTable, partitions = Seq(), numInitialHdfsPartitions = 1, schemaMin=Some(schemaMin))
+    val tgtDO = TickTockHiveTableDataObject("output", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq(), numInitialHdfsPartitions = 1, schemaMin=Some(schemaMin))
+    tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     val refTimestamp1 = LocalDateTime.now()
@@ -72,7 +70,7 @@ class TickTockHiveTableDataObjectTest extends FunSuite with BeforeAndAfter {
 
     // write test files
     val l1 = Seq((1, "john", 5)).toDF("id", "name", "rating")
-    TestUtil.prepareHiveTable(srcTable, srcPath, l1)
+    srcDO.writeDataFrame(l1, Seq())
 
     val tgtSubFeeds = action.exec(Seq(SparkSubFeed(None, "input", Seq()), SparkSubFeed(None, "output", Seq())))
 


### PR DESCRIPTION
### What changes are included in the pull request?
Major bugfixes and enhancements:
- Python Transformations (#130)
- Partition values on initSubfeed (#161)
- Abort run if failed run with different parameters exists (#163)
- Do not stop after init if some actions are skipped (#168)
- Fix unmatched case exception on deleteDataAfterRead (#173)
- Dynamically add runId as DataFrame column / PartitionValue (#102, #187)
- Filter partition values for other subFeeds to dataObjects partition columns (#180)
- Fix TickTockHiveTable for recursiveInputs (#181)
- Fix parallelism (#184)

Minor bugfixes and correction:
See the following Pull Requests:
#164 check partitions existing
#167 improve detection of main input/output
#177 early validation of metricsFailCondition
#178 add initialization hook to StateListener

### Why are the changes needed?
Release 1.1.1