### PR TITLE
Update libraries due to security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -620,13 +620,13 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>14.0.1</version>
+				<version>24.1.1-jre</version>
 				<scope>${spark.deps.scope}</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.jpmml</groupId>
 				<artifactId>pmml-model</artifactId>
-				<version>1.2.15</version>
+				<version>1.4.3</version>
 				<scope>provided</scope>
 				<exclusions>
 					<exclusion>
@@ -2108,7 +2108,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.4.1</version>
+				<version>1.18</version>
 			</dependency>
 			<dependency>
 				<groupId>com.typesafe</groupId>


### PR DESCRIPTION
### What changes are included in the pull request?
Library updates:
com.google.guava:guava:14.0.1 -> 24.1.1-jre (CVE-2018-10237)
org.jpmml:pmml-model:1.2.15 -> 1.4.3 (WS-2019-0065)
org.apache.commons:commons-compress:1.4.1 -> 1.18 (CVE-2018-11771)

### Why are the changes needed?
Github Dependabot reported 3 vulnerabilities in our dependencies