### PR TITLE
Use JdbcDialects' implementation of getTableExistsQuery

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/JdbcTableConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/JdbcTableConnection.scala
@@ -157,7 +157,7 @@ private[smartdatalake] class DefaultSQLCatalog(connection: JdbcTableConnection) 
     connection.execJdbcQuery(cntTableInCatalog, evalRecordExists )
   }
   override def isTableExisting(db: String, table: String)(implicit session: SparkSession): Boolean = {
-    val dbPrefix = if(table.equals("")) "" else table+"."
+    val dbPrefix = if(db.equals("")) "" else db+"."
     val existsQuery = JdbcDialects.get(connection.url).getTableExistsQuery(dbPrefix+table)
     connection.execJdbcStatement(existsQuery)
   }


### PR DESCRIPTION
### What changes are included in the pull request?
Special characters, reserved words or case sensitive schema names in JDBC configurations could not be handled correctly. 
See #158 for details. Problems were seen in Postgres and MSSQL databases.

### Why are the changes needed?
The following schemas don't work without this fix:

- Postgres schema called XyZ
- Postgres called schema-with-dash
- MSSQL schema called "AS" (reserved words)

### Additional information
In the fix, I ignore the Environment variable enableJdbcCaseSensitivity because I don't see an easy way to use JdbcDialects' implementation AND check for case sensitivity.
I would even argue, that we don't need the Environment variable. If a database like MSSQL is NOT case sensitive, it doesn't matter what you configure. For a schema called "AB", both "ab" and "AB" will work no matter what you use for enableJdbcCaseSensitivity.
In environment with case sensitivity like MySQL on Linux, I think the variable enableJdbcCaseSensitivity either doesn't work correctly or is very confusing. If you have two tables called "sample" and "Sample" and you insert data into "SAMPLE", where should your data go?

I propose to get rid of the variable and leave it to the JDBC driver and database if your config has to be case sensitive or not. 