### PR TITLE
Implement basic POST method for webservices ...

### DIFF
--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -301,7 +301,12 @@
 			<version>2.25.1</version>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
+			<version>1.24.1</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/sdl-core/src/main/scala/io/smartdatalake/util/webservice/DefaultWebserviceClient.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/webservice/DefaultWebserviceClient.scala
@@ -52,6 +52,20 @@ private[smartdatalake] class DefaultWebserviceClient(httpRequest: HttpRequest) e
   }
 
   /**
+   * Sends a POST request with a body in the given mimetype
+   * @param body body
+   * @param mimeType mimetype to use for the body
+   * @return
+   */
+  override def post(body: Array[Byte], mimeType: String): Try[Array[Byte]] = {
+    logger.info("Sending POST request with content-type: " +mimeType)
+     Try(httpRequest.method("POST").header("content-type",mimeType).postData(body).asBytes) match {
+       case Success(httpResponse) => checkResponse(httpResponse)
+       case Failure(exception) => Failure(exception)
+     }
+  }
+
+  /**
    *
    * Check response of webservice call
    *

--- a/sdl-core/src/main/scala/io/smartdatalake/util/webservice/Webservice.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/webservice/Webservice.scala
@@ -30,4 +30,7 @@ private[smartdatalake] trait Webservice {
     */
   def get(): Try[Array[Byte]]
 
+
+  def post(body: Array[Byte], mimeType: String): Try[Array[Byte]]
+
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -172,7 +172,7 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
         postResponse(webserviceOptions.url, bytes)
       } match {
         case Success(s) => s
-        case Failure(e) => throw new RuntimeException(s"Can't create OutputStream for $id and $path: ${e.getClass.getSimpleName} - ${e.getMessage}", e)
+        case Failure(e) => throw new RuntimeException(s"Could not post to webservice for $id - ${e.getMessage}", e)
       }
     }
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -132,15 +132,19 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
     // Try to extract Mime Type
     // JSON is detected as text/plain, try to parse it as JSON to more precisely define it as
     // application/json
-    val mimetype:String = tika.detect(body) match {
-      case "text/plain" => try {
-        new ObjectMapper().readTree(body)
-        "application/json"
-      } catch {
-        case _ : Throwable => "text/plain"
+    val mimetype:String =
+    if(webserviceOptions.mimeType.isDefined)
+      webserviceOptions.mimeType.get
+    else
+      tika.detect(body) match {
+        case "text/plain" => try {
+          new ObjectMapper().readTree(body)
+          "application/json"
+        } catch {
+          case _ : Throwable => "text/plain"
+        }
+        case s => s
       }
-      case s => s
-    }
     webserviceClient.post(body, mimetype) match {
       case Success(c) => c
       case Failure(e) => logger.error(e.getMessage, e)
@@ -311,5 +315,6 @@ case class WebserviceOptions (url: String,
                               keycloakAuth: Option[KeycloakConfig] = None,
                               userVariable: Option[String] = None,
                               passwordVariable: Option[String] = None,
-                              token: Option[String] = None)
+                              token: Option[String] = None,
+                              mimeType: Option[String] = None)
 

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -27,12 +27,10 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.util.hive.HiveUtil.dropTable
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
 import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.sshd.common.NamedFactory
@@ -153,11 +151,15 @@ object TestUtil extends SmartDataLakeLogger {
           .port(port)
           .httpsPort(httpsPort)
           .bindAddress(host)
-          .keystorePath("src/test/resources/test_keystore.pkcs12")
+          .keystorePath("sdl-core/src/test/resources/test_keystore.pkcs12")
           .keystorePassword("mytruststorepassword")
       )
     wireMockServer
       .start()
+
+    stubFor(post(urlEqualTo("/good/post/no_auth"))
+      .willReturn(aResponse().withBody("{{request.path.[0]}}"))
+    )
 
     stubFor(get(urlEqualTo("/good/no_auth/"))
       .willReturn(aResponse().withStatus(200))

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -151,7 +151,7 @@ object TestUtil extends SmartDataLakeLogger {
           .port(port)
           .httpsPort(httpsPort)
           .bindAddress(host)
-          .keystorePath("sdl-core/src/test/resources/test_keystore.pkcs12")
+          .keystorePath("src/test/resources/test_keystore.pkcs12")
           .keystorePassword("mytruststorepassword")
       )
     wireMockServer

--- a/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
@@ -120,4 +120,13 @@ class WebserviceClientTest extends FunSuite with BeforeAndAfterEach  {
     assert(check.isFailure)
   }
 
+  test("Check posting JSON") {
+    val webserviceClient = DefaultWebserviceClient(Some(s"http://$host:$port/good/post/no_auth"))
+    val testJson = s"""{name: "Samantha", age: 31, city: "San Francisco"};""".getBytes
+    webserviceClient.post(testJson, "application/json")
+    val response = HttpResponse(body=testJson, code = 200, headers= Map())
+    val check = webserviceClient.checkResponse(response)
+    assert(check.isSuccess)
+  }
+
 }


### PR DESCRIPTION
... including automatic detection of mime-type through Apache Tika

### What changes are included in the pull request?
So far, only GET requests could be sent to Webservices so these DataObjects could only be used as Source DataObject.
This PR changes that by implementing POST calls to webservices which allow you to send arbitrary data to a Webservice. 
The type of data and therefore the chosen content-type for the webservice call are detected by Tika which is why I added tika-core as dependency (< 1MB)

### Why are the changes needed?
To write to WebserviceFileDataObject.
