### PR TITLE
use information catalog to check if table exists if noop dialect

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/JdbcTableConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/JdbcTableConnection.scala
@@ -130,6 +130,7 @@ object JdbcTableConnection extends FromConfigFactory[Connection] {
 private[smartdatalake] abstract class SQLCatalog(connection: JdbcTableConnection) {
   // get spark jdbc dialect definitions
   protected val jdbcDialect: JdbcDialect = JdbcDialects.get(connection.url)
+  protected val isNoopDialect: Boolean = jdbcDialect.getClass.getSimpleName.startsWith("NoopDialect") // The default implementation is used for unknown url types
   def isDbExisting(db: String)(implicit session: SparkSession): Boolean
   def isTableExisting(db: String, table: String)(implicit session: SparkSession): Boolean
   protected def evalRecordExists( rs:ResultSet ) : Boolean = {
@@ -159,9 +160,17 @@ private[smartdatalake] class DefaultSQLCatalog(connection: JdbcTableConnection) 
     connection.execJdbcQuery(cntTableInCatalog, evalRecordExists )
   }
   override def isTableExisting(db: String, table: String)(implicit session: SparkSession): Boolean = {
-    val dbPrefix = if(db.equals("")) "" else db+"."
-    val existsQuery = jdbcDialect.getTableExistsQuery(dbPrefix+table)
-    connection.execJdbcStatement(existsQuery)
+    if (!isNoopDialect) {
+      val dbPrefix = if (db.equals("")) "" else db + "."
+      val existsQuery = jdbcDialect.getTableExistsQuery(dbPrefix + table)
+      connection.execJdbcStatement(existsQuery)
+    } else {
+      val cntTableInCatalog = if (Environment.enableJdbcCaseSensitivity)
+        s"select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME='$table' and TABLE_SCHEMA='$db'"
+      else
+        s"select count(*) from INFORMATION_SCHEMA.TABLES where upper(TABLE_NAME)=upper('$table') and upper(TABLE_SCHEMA)=upper('$db')"
+      connection.execJdbcQuery(cntTableInCatalog, evalRecordExists)
+    }
   }
 }
 
@@ -180,9 +189,9 @@ private[smartdatalake] class OracleSQLCatalog(connection: JdbcTableConnection) e
   override def isTableExisting(db: String, table: String)(implicit session: SparkSession): Boolean = {
     val cntTableInCatalog =
       if (Environment.enableJdbcCaseSensitivity)
-        s"select count(*) from ALL_TABLES where TABLE_NAME='$table' and OWNER='$db'"
+        s"select count(*) from ((select TABLE_NAME as name from ALL_TABLES where TABLE_NAME='$table' and OWNER='$db') union all (select VIEW_NAME as name from ALL_VIEWS where VIEW_NAME='$table' and OWNER='$db'))"
       else
-        s"select count(*) from ALL_TABLES where upper(TABLE_NAME)=upper('$table') and upper(OWNER)=upper('$db')"
+        s"select count(*) from ((select TABLE_NAME as name from ALL_TABLES where TABLE_NAME=upper('$table') and OWNER=upper('$db')) union all (select VIEW_NAME as name from ALL_VIEWS where VIEW_NAME=upper('$table') and OWNER=upper('$db')))"
     connection.execJdbcQuery( cntTableInCatalog, evalRecordExists )
   }
 }


### PR DESCRIPTION
### What changes are included in the pull request?
1) sdl-example doesnt work anymore because isTableExisting throws exception for hsqldb if table doesnt exist. Reason: The noop jdbc dialect returns a query that throws an exception if the table doesn't exists.
-> use information_schema if noop dialect.
2) fix lost changes in OracleSQLCatalog to check for tables and views in isTableExisting
