### PR TITLE
avoid duplicate test class

### DIFF
--- a/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
+++ b/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{StructField, StructType, TimestampType}
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
-class ActionDAGTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
+class ActionDAGKafkaTest extends FunSuite with BeforeAndAfter with EmbeddedKafka {
 
   protected implicit val session: SparkSession = TestUtil.sessionHiveCatalog
   import session.implicits._


### PR DESCRIPTION
### What changes are included in the pull request?
make test class names unique across modules.

### Why
sdl-kafka:ActionDAGTest has the same package and name as sdl-core:ActionDAGTest. In IntelliJ if you start sdl-kafka:ActionDAGTest the sdl-core:ActionDAGTest, but when debugging in sdl-core:ActionDAGTest it opens sdl-kafka:ActionDAGTest.
