### PR TITLE
Release version 1.2.1

### DIFF
--- a/.github/workflows/release-spark3.yml
+++ b/.github/workflows/release-spark3.yml
@@ -104,7 +104,9 @@ jobs:
         current-version: ${{ env.MVN_RELEASE_VERSION }}
         version-fragment: bug
     - name: Develop-spark3 Set Next Snapshot version
-      run: sed -i "/${MVN_RELEASE_VERSION}/{s//${{ steps.bump_version.outputs.next-version }}-SNAPSHOT/;:p;n;bp}" pom.xml
+      run: |
+        sed -i "/${MVN_RELEASE_VERSION}/{s//${{ steps.bump_version.outputs.next-version }}-SNAPSHOT/;:p;n;bp}" pom.xml
+        sed -i "/${MVN_RELEASE_VERSION}/{s//${{ steps.bump_version.outputs.next-version }}-SNAPSHOT/;:p;n;bp}" */pom.xml
     - name: Develop-spark3 Git Commit Snapshot
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,9 @@ jobs:
         current-version: ${{ env.MVN_RELEASE_VERSION }}
         version-fragment: bug
     - name: Develop Set Next Snapshot version
-      run: sed -i "/${MVN_RELEASE_VERSION}/{s//${{ steps.bump_version.outputs.next-version }}-SNAPSHOT/;:p;n;bp}" pom.xml
+      run: |
+        sed -i "/${MVN_RELEASE_VERSION}/{s//${{ steps.bump_version.outputs.next-version }}-SNAPSHOT/;:p;n;bp}" pom.xml
+        sed -i "/${MVN_RELEASE_VERSION}/{s//${{ steps.bump_version.outputs.next-version }}-SNAPSHOT/;:p;n;bp}" */pom.xml
     - name: Develop Git Commit Snapshot
       run: |
         git config --local user.email "action@github.com"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>sdl-parent</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-jms/pom.xml
+++ b/sdl-jms/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-kafka/pom.xml
+++ b/sdl-kafka/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-splunk/pom.xml
+++ b/sdl-splunk/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>1.2.0-SNAPSHOT</version>
+		<version>1.2.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Seems version 1.2.0 is bricked on bintray from all my experiments. I propose to retry with version 1.2.1. There will be no release with version 1.2.0 in consequence...

Error on bintray:
Error:  Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy (default-deploy) on project sdl-core_2.11: Failed to deploy artifacts: Could not transfer artifact io.smartdatalake:sdl-core_2.11:pom:1.2.0 from/to bintray-smart-data-lake-smart-data-lake (https://api.bintray.com/maven/smart-data-lake/smart-data-lake/smart-data-lake/;publish=1): Transfer failed for https://api.bintray.com/maven/smart-data-lake/smart-data-lake/smart-data-lake/;publish=1/io/smartdatalake/sdl-core_2.11/1.2.0/sdl-core_2.11-1.2.0.pom 409 Conflict