### PR TITLE
created separate profile for release to sonatype

### DIFF
--- a/.github/workflows/release-spark3.yml
+++ b/.github/workflows/release-spark3.yml
@@ -49,7 +49,7 @@ jobs:
         gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         nexus_username: ${{ secrets.SONATYPE_USERNAME }}
         nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-        maven_profiles: scala-2.12,scala-doc-nolinkwarnings
+        maven_profiles: scala-2.12,scala-doc-nolinkwarnings,release-sonatype
         maven_args: -B -f pom.xml
 
     - name: Git Commit and Tag Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         nexus_username: ${{ secrets.SONATYPE_USERNAME }}
         nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-        maven_profiles: scala-2.11,scala-doc-nolinkwarnings
+        maven_profiles: scala-2.11,scala-doc-nolinkwarnings,release-sonatype
         maven_args: -B -f pom.xml
 
     - name: Maven deploy to sonatype for Scala 2.12
@@ -59,7 +59,7 @@ jobs:
         gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         nexus_username: ${{ secrets.SONATYPE_USERNAME }}
         nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-        maven_profiles: scala-2.12,scala-doc-nolinkwarnings
+        maven_profiles: scala-2.12,scala-doc-nolinkwarnings,release-sonatype
         # exclude sdl-parent as it is already uploaded with previous deploy, stays the same and cannot be replaced in remote repository
         maven_args: -B -pl '!.' -f pom.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,54 @@
 				<curator.version>2.13.0</curator.version>
 			</properties>
 		</profile>
+		<profile>
+			<id>release-sonatype</id>
+			<distributionManagement>
+				<repository>
+					<id>ossrh</id>
+					<name>Central Repository OSSRH</name>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
+			<build>
+				<plugins>
+					<!-- sign artifacts with gpg -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<!-- Prevent `gpg` from using pinentry programs -->
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<!-- deploy to sonatype / maven central -->
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.6.7</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<properties>
@@ -272,14 +320,6 @@
 		<sshd.test.version>2.3.0</sshd.test.version>
 
 	</properties>
-
-	<distributionManagement>
-		<repository>
-			<id>ossrh</id>
-			<name>Central Repository OSSRH</name>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
 
 	<scm>
 		<connection>scm:git:git://github.com/smart-data-lake/smart-data-lake.git</connection>
@@ -617,42 +657,6 @@
 				<version>2.12.4</version>
 				<configuration>
 					<skip>true</skip>
-				</configuration>
-			</plugin>
-
-			<!-- sign artifacts with gpg -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.6</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-						<configuration>
-							<!-- Prevent `gpg` from using pinentry programs -->
-							<gpgArguments>
-								<arg>--pinentry-mode</arg>
-								<arg>loopback</arg>
-							</gpgArguments>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<!-- deploy to sonatype / maven central -->
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>false</autoReleaseAfterClose>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
### What changes are included in the pull request?
use maven profile for deploy/release to sonatype/maven central

### Why are the changes needed?
Background is that plugins are inherited by projects using sdl-parent as parent. These project probably dont want release to sonatype, if they have no gpg configured, their deploy will fail.

