### PR TITLE
Enable private auth headers in WebserviceFileDataObject

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -52,6 +52,7 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
                                    (@transient implicit val instanceRegistry: InstanceRegistry)
   extends FileRefDataObject with CanCreateInputStream with CanCreateOutputStream with SmartDataLakeLogger {
 
+  private val authHeader: Option[String] = webserviceOptions.authHeader.map(CredentialsUtil.getCredentials)
   private val webServiceClientId = webserviceOptions.clientIdVariable.map(CredentialsUtil.getCredentials)
   private val webServiceClientSecret = webserviceOptions.clientSecretVariable.map(CredentialsUtil.getCredentials)
   private val webServiceUser = webserviceOptions.userVariable.map(CredentialsUtil.getCredentials)
@@ -91,15 +92,14 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
 
       // Call webservice with token
       initWebservice(webserviceOptions.url + query, webserviceOptions.connectionTimeoutMs, webserviceOptions.readTimeoutMs
-        , webserviceOptions.authHeader, webServiceClientId, webServiceClientSecret, webServiceUser
+        , authHeader, webServiceClientId, webServiceClientSecret, webServiceUser
         , webServicePassword, Some(token.getToken))
     }
     // Call webservice without token
     else {
       initWebservice(webserviceOptions.url + query, webserviceOptions.connectionTimeoutMs, webserviceOptions.readTimeoutMs
-        , webserviceOptions.authHeader, None, None, webServiceUser, webServicePassword, None)
+        , authHeader, None, None, webServiceUser, webServicePassword, None)
     }
-
   }
 
   /**


### PR DESCRIPTION
### What changes are included in the pull request?
Similar to the other credentials used in WebserviceFileDataObject, also pass authHeader through the CredentialsUtil, so that the ENV#MY_SECRET_AUTH_HEADER format works for auth headers.

### Why are the changes needed?
I have a hardcoded auth header for a webservice that I don't want to hardcode into a config file and check in to source control.
