### PR TITLE
fix rewriting pom on release-sonatype

### DIFF
--- a/.github/workflows/release-spark3.yml
+++ b/.github/workflows/release-spark3.yml
@@ -49,7 +49,7 @@ jobs:
         gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         nexus_username: ${{ secrets.SONATYPE_USERNAME }}
         nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-        maven_profiles: scala-2.12,scala-doc-nolinkwarnings,release-sonatype
+        maven_profiles: scala-2.12,release-sonatype
         maven_args: -B -f pom.xml
 
     - name: Git Commit and Tag Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         nexus_username: ${{ secrets.SONATYPE_USERNAME }}
         nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-        maven_profiles: scala-2.11,scala-doc-nolinkwarnings,release-sonatype
+        maven_profiles: scala-2.11,release-sonatype
         maven_args: -B -f pom.xml
 
     - name: Maven deploy to sonatype for Scala 2.12
@@ -59,7 +59,7 @@ jobs:
         gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
         nexus_username: ${{ secrets.SONATYPE_USERNAME }}
         nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-        maven_profiles: scala-2.12,scala-doc-nolinkwarnings,release-sonatype
+        maven_profiles: scala-2.12,release-sonatype
         # exclude sdl-parent as it is already uploaded with previous deploy, stays the same and cannot be replaced in remote repository
         maven_args: -B -pl '!.' -f pom.xml
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,9 @@
 									<goal>sign</goal>
 								</goals>
 								<configuration>
+									<!-- Prevent `gpg` from using pinentry programs -->
 									<gpgArguments>
-										<arg>pinentry-mode</arg>
+										<arg>--pinentry-mode</arg>
 										<arg>loopback</arg>
 									</gpgArguments>
 								</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -92,15 +92,6 @@
 			</build>
 		</profile>
 		<profile>
-			<!-- do not use this profile if you want to see warnings about missing links
-            it makes sense to check warnings about internal (public) members, but we will always have
-            warnings for external libraries which is why we deactivate them -->
-			<id>scala-doc-nolinkwarnings</id>
-			<properties>
-				<scaladoc.nolinkwarnings>-no-link-warnings</scaladoc.nolinkwarnings>
-			</properties>
-		</profile>
-		<profile>
 			<id>scala-2.12</id>
 			<properties>
 				<scala.minor.version>2.12</scala.minor.version>
@@ -117,6 +108,11 @@
 		<profile>
 			<id>release-sonatype</id>
 			<distributionManagement>
+				<snapshotRepository>
+					<id>ossrh</id>
+					<name>Central Repository OSSRH</name>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</snapshotRepository>
 				<repository>
 					<id>ossrh</id>
 					<name>Central Repository OSSRH</name>
@@ -125,6 +121,25 @@
 			</distributionManagement>
 			<build>
 				<plugins>
+					<!-- create scala-doc -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<version>4.3.1</version>
+						<executions>
+							<execution>
+								<id>scala-doc</id>
+								<goals>
+									<goal>doc-jar</goal>
+								</goals>
+								<configuration>
+									<args>
+										<arg>-no-link-warnings</arg>
+									</args>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 					<!-- sign artifacts with gpg -->
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -138,9 +153,8 @@
 									<goal>sign</goal>
 								</goals>
 								<configuration>
-									<!-- Prevent `gpg` from using pinentry programs -->
 									<gpgArguments>
-										<arg>--pinentry-mode</arg>
+										<arg>pinentry-mode</arg>
 										<arg>loopback</arg>
 									</gpgArguments>
 								</configuration>
@@ -166,7 +180,6 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<scaladoc.nolinkwarnings>-unchecked</scaladoc.nolinkwarnings>
 		<license.header.file>src/license/gplv3-header.txt</license.header.file>
 
 		<maven.compiler.source>1.8</maven.compiler.source>
@@ -328,17 +341,6 @@
 								<goal>compile</goal>
 								<goal>testCompile</goal>
 							</goals>
-						</execution>
-						<execution>
-							<id>scala-doc</id>
-							<goals>
-								<goal>doc-jar</goal>
-							</goals>
-							<configuration>
-								<args>
-									<arg>${scaladoc.nolinkwarnings}</arg>
-								</args>
-							</configuration>
 						</execution>
 					</executions>
 					<configuration>


### PR DESCRIPTION
### What changes are included in the pull request?
Properties ${scala.minor.version} are not replaced in pom on maven central for release 1.2.0/2.0.0.
Reason is a conflict between scala-cross-maven-plugin and scala-doc-nolinkwarnings profile.
This PR fixes it.

Background:
scala-cross-maven-plugin searchs for an active profile starting with "scala-" to replace properties in the pom. Unfortunately during deploy scala-doc-nolinkwarnings was enabled and choosen. As a result no expressions ${scala.minor.version} were replaced in the pom.
This fix removes scala-doc-nolinkwarnings completely and configures execution for creation of scala-doc directly in the release-sonatype profile, including "-no-link-warnings" argument.