### PR TITLE
Release 1.2.1 - increase nexus staging timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
 							<serverId>ossrh</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
 							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+							<stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
Default is 5min, we got errors "Warning: TIMEOUT after 303.8 s" while deployment...