### PR TITLE
refactor transform partition values

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -111,7 +111,7 @@ private[smartdatalake] trait ExecutionModeWithMainInputOutput {
  *                     Set stopIfNoData=false if you want to run further actions nevertheless. They will receive output dataObject unfiltered as input.
  * @param selectExpression          optional expression to define or refine the list of selected output partitions. Define a spark sql expression working with the attributes of [[PartitionDiffModeExpressionData]] returning a list<map<string,string>>.
  *                                  Default is to return the originally selected output partitions found in attribute selectedPartitionValues.
- * @param applyPartitionValuesTransform If true applies the partition values transform of custom transformations on input partition values before comparision with output partition values.
+ * @param applyPartitionValuesTransform If true applies the partition values transform of custom transformations on input partition values before comparison with output partition values.
  *                                  If enabled input and output partition columns can be different. Default is to disable the transformation of partition values.
  * @param selectAdditionalInputExpression optional expression to refine the list of selected input partitions. Note that primarily output partitions are selected by PartitionDiffMode.
  *                                  The selected output partitions are then transformed back to the input partitions needed to create the selected output partitions. This is one-to-one except if applyPartitionValuesTransform=true.
@@ -393,4 +393,3 @@ private[smartdatalake] case class ExecutionModeFailedException(id: NodeId, phase
   override val severity: ExceptionSeverity = if (phase == ExecutionPhase.Init) ExceptionSeverity.FAILED_DONT_STOP else ExceptionSeverity.FAILED
   override def getDAGRootExceptions: Seq[DAGException] = Seq(this)
 }
-

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -54,7 +54,9 @@ sealed trait ExecutionMode extends SmartDataLakeLogger {
     // validate apply conditions
     applyConditionsDef.foreach(_.syntaxCheck[DefaultExecutionModeExpressionData](actionId, Some("applyCondition")))
   }
-  private[smartdatalake] def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = None
+  private[smartdatalake] def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
+                                  , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
+                                  (implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Seq[PartitionValues], Option[String])] = None
   private[smartdatalake] def mainInputOutputNeeded: Boolean = false
   private[smartdatalake] val applyConditionsDef: Seq[Condition] = Seq()
   private[smartdatalake] val failConditionsDef: Seq[Condition] = Seq()
@@ -105,8 +107,10 @@ private[smartdatalake] trait ExecutionModeWithMainInputOutput {
  * @param failConditions            List of conditions to fail application of execution mode if true. Define as spark sql expressions working with attributes of [[PartitionDiffModeExpressionData]] returning a boolean.
  *                                  Default is that the application of the PartitionDiffMode does not fail the action. If there is no data to process, the following actions are skipped.
  *                                  Multiple conditions are evaluated individually and every condition may fail the execution mode (or-logic)
- * @param selectExpression          optional expression to define or refine the list of selected partitions. Define a spark sql expression working with the attributes of [[PartitionDiffModeExpressionData]] returning a list<map<string,string>>.
+ * @param selectExpression          optional expression to define or refine the list of selected output partitions. Define a spark sql expression working with the attributes of [[PartitionDiffModeExpressionData]] returning a list<map<string,string>>.
  *                                  Default is to return the originally selected partitions found in attribute selectedPartitions.
+ * @param applyPartitionValuesTransform If true applies the partition values transform of custom transformations on input partition values before comparision with output partition values.
+ *                                  If enabled input and output partition columns can be different. Default is to disable the transformation of partition values.
  */
 case class PartitionDiffMode( partitionColNb: Option[Int] = None
                             , override val alternativeOutputId: Option[DataObjectId] = None
@@ -115,6 +119,7 @@ case class PartitionDiffMode( partitionColNb: Option[Int] = None
                             , failCondition: Option[String] = None
                             , failConditions: Seq[Condition] = Seq()
                             , selectExpression: Option[String] = None
+                            , applyPartitionValuesTransform: Boolean = false
                             ) extends ExecutionMode with ExecutionModeWithMainInputOutput {
   private[smartdatalake] override val applyConditionsDef = applyCondition.toSeq.map(Condition(_))
   private[smartdatalake] override val failConditionsDef = failCondition.toSeq.map(Condition(_)) ++ failConditions
@@ -128,7 +133,9 @@ case class PartitionDiffMode( partitionColNb: Option[Int] = None
     // check alternativeOutput exists
     alternativeOutput
   }
-  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
+                                           , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
+                                           (implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Seq[PartitionValues], Option[String])] = {
     val doApply = evaluateApplyConditions(actionId, subFeed)
       .getOrElse(subFeed.partitionValues.isEmpty) // default is to apply PartitionDiffMode if no partition values are given
     if (doApply) {
@@ -139,42 +146,54 @@ case class PartitionDiffMode( partitionColNb: Option[Int] = None
           if (partitionInput.partitions.nonEmpty) {
             if (partitionOutput.partitions.nonEmpty) {
               // prepare common partition columns
-              val commonInits = searchCommonInits(partitionInput.partitions, partitionOutput.partitions)
-              require(commonInits.nonEmpty, s"$actionId has set executionMode = 'PartitionDiffMode' but no common init was found in partition columns for $input and $output")
-              val commonPartitions = if (partitionColNb.isDefined) {
-                commonInits.find(_.size == partitionColNb.get).getOrElse(throw ConfigurationException(s"$actionId has set executionMode = 'PartitionDiffMode' but no common init with ${partitionColNb.get} was found in partition columns of $input and $output from $commonInits!"))
-              } else {
-                commonInits.maxBy(_.size)
+              val (inputPartitions, outputPartitions) = if (applyPartitionValuesTransform) (partitionInput.partitions, partitionOutput.partitions)
+              else {
+                val commonInits = searchCommonInits(partitionInput.partitions, partitionOutput.partitions)
+                if (commonInits.nonEmpty) {
+                  val commonInit = if (partitionColNb.isDefined) {
+                    commonInits.find(_.size == partitionColNb.get).getOrElse(throw ConfigurationException(s"$actionId has set executionMode = 'PartitionDiffMode' but no common init with ${partitionColNb.get} was found in partition columns of ${input.id} and ${output.id} from $commonInits!"))
+                  } else {
+                    commonInits.maxBy(_.size)
+                  }
+                  (commonInit, commonInit)
+                } else {
+                  throw new ConfigurationException(s"$actionId has set executionMode = 'PartitionDiffMode' but no common init was found in partition columns for ${input.id} and ${output.id}. Enable applyPartitionValuesTransform to transform partition values.")
+                }
               }
               // calculate missing partition values
-              val inputPartitionValues = partitionInput.listPartitions.map(_.filterKeys(commonPartitions))
-              val outputPartitionValues = partitionOutput.listPartitions.map(_.filterKeys(commonPartitions))
-              val partitionValuesToBeProcessed = inputPartitionValues.toSet.diff(outputPartitionValues.toSet).toSeq
+              val filteredInputPartitionValues = partitionInput.listPartitions.map(_.filterKeys(inputPartitions))
+              val filteredOutputPartitionValues = partitionOutput.listPartitions.map(_.filterKeys(outputPartitions))
+              val inputOutputPartitionValuesMap = if (applyPartitionValuesTransform) partitionValuesTransform(filteredInputPartitionValues) else PartitionValues.oneToOneMapping(filteredInputPartitionValues) // normally this transformation is 1:1, but it can be implemented in custom transformations for aggregations
+              val outputInputPartitionValuesMap = inputOutputPartitionValuesMap.toSeq.map{ case (k,v) => (v,k)}.groupBy(_._1).mapValues(_.map(_._2))
+              val outputPartitionValuesToBeProcessed = inputOutputPartitionValuesMap.values.toSet.diff(filteredOutputPartitionValues.toSet).toSeq
               // sort and limit number of partitions processed
-              val ordering = PartitionValues.getOrdering(commonPartitions)
-              val selectedPartitionValues = nbOfPartitionValuesPerRun match {
-                case Some(n) => partitionValuesToBeProcessed.sorted(ordering).take(n)
-                case None => partitionValuesToBeProcessed.sorted(ordering)
+              val ordering = PartitionValues.getOrdering(outputPartitions)
+              val selectedOutputPartitionValues = nbOfPartitionValuesPerRun match {
+                case Some(n) => outputPartitionValuesToBeProcessed.sorted(ordering).take(n)
+                case None => outputPartitionValuesToBeProcessed.sorted(ordering)
               }
               // apply optional select expression
-              val data = PartitionDiffModeExpressionData.from(context).copy(givenPartitionValues = subFeed.partitionValues.map(_.getMapString), inputPartitionValues = inputPartitionValues.map(_.getMapString), outputPartitionValues = outputPartitionValues.map(_.getMapString), selectedPartitionValues = selectedPartitionValues.map(_.getMapString))
+              val data = PartitionDiffModeExpressionData.from(context).copy(givenPartitionValues = subFeed.partitionValues.map(_.getMapString), inputPartitionValues = filteredInputPartitionValues.map(_.getMapString), outputPartitionValues = filteredOutputPartitionValues.map(_.getMapString), selectedPartitionValues = selectedOutputPartitionValues.map(_.getMapString))
               val refinedSelectedPartitionValues = if (selectExpression.isDefined) {
                 SparkExpressionUtil.evaluate[PartitionDiffModeExpressionData, Seq[Map[String, String]]](actionId, Some("selectExpression"), selectExpression.get, data)
                   .map(_.map(PartitionValues(_)))
-                  .getOrElse(selectedPartitionValues)
-              } else selectedPartitionValues
+                  .getOrElse(selectedOutputPartitionValues)
+              } else selectedOutputPartitionValues
               // evaluate fail conditions
               val refinedData = data.copy(selectedPartitionValues = refinedSelectedPartitionValues.map(_.getMapString))
               evaluateFailConditions(actionId, refinedData) // throws exception on failed condition
               // skip processing if no new data
               if (refinedSelectedPartitionValues.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No partitions to process found for ${input.id}")
+              // reverse lookup input partitions as selection of output partitions might have changed
+              val inputPartitionValuesToBeProcessed = refinedSelectedPartitionValues.flatMap(outputInputPartitionValuesMap)
               //return
-              logger.info(s"($actionId) PartitionDiffMode selected partition values ${refinedSelectedPartitionValues.mkString(", ")} to process")
-              Some((refinedSelectedPartitionValues, None))
-            } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $output has no partition columns defined!")
-          } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $input has no partition columns defined!")
-        case (_: CanHandlePartitions, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $output does not support partitions!")
-        case (_, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but $input does not support partitions!")
+              val inputPartitionLog = if (inputPartitionValuesToBeProcessed != refinedSelectedPartitionValues) s" by using input partitions ${inputPartitionValuesToBeProcessed.mkString(", ")}" else ""
+              logger.info(s"($actionId) PartitionDiffMode selected output partition values ${refinedSelectedPartitionValues.mkString(", ")} to process$inputPartitionLog.")
+              Some((inputPartitionValuesToBeProcessed, refinedSelectedPartitionValues, None))
+            } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but ${output.id} has no partition columns defined!")
+          } else throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but ${input.id} has no partition columns defined!")
+        case (_: CanHandlePartitions, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but ${output.id} does not support partitions!")
+        case (_, _) => throw ConfigurationException(s"$actionId has set executionMode = PartitionDiffMode but ${input.id} does not support partitions!")
       }
     } else None
   }
@@ -219,7 +238,9 @@ case class SparkIncrementalMode(compareCol: String, override val alternativeOutp
     // check alternativeOutput exists
     alternativeOutput
   }
-  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
+                                           , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
+                                           (implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Seq[PartitionValues], Option[String])] = {
     val doApply = evaluateApplyConditions(actionId, subFeed)
       .getOrElse(true) // default is to apply SparkIncrementalMode
     if (doApply) {
@@ -260,11 +281,11 @@ case class SparkIncrementalMode(compareCol: String, override val alternativeOutp
                 logger.info(s"($actionId) SparkIncrementalMode selected all data for writing to ${output.id}: output table is currently empty")
                 None
               }
-              Some((Seq(), dataFilter))
+              Some((Seq(), Seq(), dataFilter))
             // select all if output is empty
             case (Some(_),None) =>
               logger.info(s"($actionId) SparkIncrementalMode selected all records for writing to ${output.id}, because output DataObject is still empty.")
-              Some((Seq(), None))
+              Some((Seq(), Seq(), None))
             // otherwise no data to process
             case _ =>
               logger.info(s"($actionId) SparkIncrementalMode selected all records for writing to ${output.id}, because output DataObject is still empty.")
@@ -286,7 +307,9 @@ private[smartdatalake] object SparkIncrementalMode {
  * Note: For start nodes of the DAG partition values can be defined by command line, for subsequent nodes partition values are passed on from previous nodes.
  */
 case class FailIfNoPartitionValuesMode() extends ExecutionMode {
-  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
+                                           , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
+                                           (implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Seq[PartitionValues], Option[String])] = {
     // check if partition values present
     if (subFeed.partitionValues.isEmpty) throw new IllegalStateException(s"($actionId) Partition values are empty for mainInput ${subFeed.dataObjectId.id}")
     // return
@@ -307,15 +330,17 @@ case class CustomPartitionMode(className: String, override val alternativeOutput
 extends ExecutionMode with ExecutionModeWithMainInputOutput {
   private[smartdatalake] override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
   private val impl = CustomCodeUtil.getClassInstanceByName[CustomPartitionModeLogic](className)
-  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Option[String])] = {
+  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
+                                           , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
+                                           (implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Seq[PartitionValues], Option[String])] = {
     val output = alternativeOutput.getOrElse(mainOutput)
     (mainInput, output) match {
       case (input: CanHandlePartitions, output: CanHandlePartitions) =>
         val partitionValuesOpt = impl.apply(session, options, actionId, input, output, subFeed.partitionValues.map(_.getMapString), context)
           .map(_.map( pv => PartitionValues(pv)))
-        partitionValuesOpt.map(pvs => (pvs, None))
+        partitionValuesOpt.map(pvs => (pvs, pvs, None))
       case (_: CanHandlePartitions, _) =>
-        throw ConfigurationException(s"$actionId has set executionMode = CustomPartitionMode but $output does not support partitions!")
+        throw ConfigurationException(s"$actionId has set executionMode = CustomPartitionMode but ${output.id} does not support partitions!")
       case (_, _) =>
         throw ConfigurationException(s"$actionId has set executionMode = CustomPartitionMode but $mainInput does not support partitions!")
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.util.hdfs
 
+import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
 
@@ -34,11 +35,12 @@ private[smartdatalake] object Partition {
  * A partition is defined by values for its partition columns.
  * It can be represented by a Map. The key of the Map are the partition column names.
  */
-private[smartdatalake] case class PartitionValues(elements: Map[String, Any]) {
-  def getPartitionString(partitionLayout: String): String= {
+@DeveloperApi
+case class PartitionValues(elements: Map[String, Any]) {
+  private[smartdatalake] def getPartitionString(partitionLayout: String): String= {
     PartitionLayout.replaceTokens(partitionLayout, this)
   }
-  def getSparkExpr: Column = {
+  private[smartdatalake] def getSparkExpr: Column = {
     // "and" filter concatenation of each element
     elements.map {case (k,v) => col(k) === lit(v)}.reduce( (a,b) => a and b)
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -128,6 +128,8 @@ private[smartdatalake] object PartitionValues {
     }
     diffPartitionValues(existingPartitionValues, expectedPartitionValues, partitionColCombinations)
   }
+
+  def oneToOneMapping(partitionValues: Seq[PartitionValues]): Map[PartitionValues,PartitionValues] = partitionValues.map(x => (x,x)).toMap
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -47,9 +47,11 @@ trait SubFeed extends DAGResult {
 
   def clearPartitionValues(): SubFeed
 
-  def updatePartitionValues(partitions: Seq[String]): SubFeed
+  def updatePartitionValues(partitions: Seq[String], newPartitionValues: Option[Seq[PartitionValues]] = None): SubFeed
 
   def clearDAGStart(): SubFeed
+
+  def toOutput(dataObjectId: DataObjectId): SubFeed
 
   override def resultId: String = dataObjectId.id
 }
@@ -75,13 +77,14 @@ case class SparkSubFeed(@transient dataFrame: Option[DataFrame],
   override def breakLineage(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     // in order to keep the schema but truncate spark logical plan, a dummy DataFrame is created.
     // dummy DataFrames must be exchanged to real DataFrames before reading in exec-phase.
-    if(dataFrame.isDefined && !context.simulation) convertToDummy(dataFrame.get.schema) else this
+    if(dataFrame.isDefined && !isDummy && !context.simulation) convertToDummy(dataFrame.get.schema) else this
   }
   override def clearPartitionValues(): SparkSubFeed = {
     this.copy(partitionValues = Seq())
   }
-  override def updatePartitionValues(partitions: Seq[String]): SparkSubFeed = {
-    val updatedPartitionValues = partitionValues.map( pvs => PartitionValues(pvs.elements.filterKeys(partitions.contains))).filter(_.nonEmpty)
+  override def updatePartitionValues(partitions: Seq[String], newPartitionValues: Option[Seq[PartitionValues]] = None): SparkSubFeed = {
+    val updatedPartitionValues = newPartitionValues.getOrElse(partitionValues)
+      .map( pvs => PartitionValues(pvs.elements.filterKeys(partitions.contains))).filter(_.nonEmpty)
     this.copy(partitionValues = updatedPartitionValues)
   }
   def movePartitionColumnsLast(partitions: Seq[String]): SparkSubFeed = {
@@ -90,8 +93,11 @@ case class SparkSubFeed(@transient dataFrame: Option[DataFrame],
   override def clearDAGStart(): SparkSubFeed = {
     this.copy(isDAGStart = false)
   }
+  override def toOutput(dataObjectId: DataObjectId): SparkSubFeed = {
+    this.copy(dataFrame = None, filter=None, isDAGStart = false, isDummy = false, dataObjectId = dataObjectId)
+  }
   def clearFilter(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
-    // if filter is removed, also the DataFrame must be removed so that the next action get's an unfiltered DataFrame
+    // if filter is removed, also the DataFrame must be removed so that the next action get's a fresh unfiltered DataFrame
     if (filter.isDefined) this.copy(filter = None).breakLineage else this
   }
   def persist: SparkSubFeed = {
@@ -111,9 +117,9 @@ case class SparkSubFeed(@transient dataFrame: Option[DataFrame],
   }
 }
 object SparkSubFeed {
-  def fromSubFeed( subFeed: SubFeed ): SparkSubFeed = {
+  def fromSubFeed( subFeed: SubFeed )(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     subFeed match {
-      case sparkSubFeed: SparkSubFeed => sparkSubFeed
+      case sparkSubFeed: SparkSubFeed => sparkSubFeed.clearFilter // make sure there is no filter, as filter can not be passed between actions.
       case _ => SparkSubFeed(None, subFeed.dataObjectId, subFeed.partitionValues, subFeed.isDAGStart)
     }
   }
@@ -135,13 +141,14 @@ case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
                       )
   extends SubFeed {
   override def breakLineage(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
-    this.copy(fileRefs = None)
+    this.copy(fileRefs = None, processedInputFileRefs = None)
   }
   override def clearPartitionValues(): FileSubFeed = {
     this.copy(partitionValues = Seq())
   }
-  override def updatePartitionValues(partitions: Seq[String]): FileSubFeed = {
-    val updatedPartitionValues = partitionValues.map( pvs => PartitionValues(pvs.elements.filterKeys(partitions.contains))).filter(_.nonEmpty)
+  override def updatePartitionValues(partitions: Seq[String], newPartitionValues: Option[Seq[PartitionValues]] = None): FileSubFeed = {
+    val updatedPartitionValues = newPartitionValues.getOrElse(partitionValues)
+      .map( pvs => PartitionValues(pvs.elements.filterKeys(partitions.contains))).filter(_.nonEmpty)
     this.copy(partitionValues = updatedPartitionValues)
   }
   def checkPartitionValuesColsExisting(partitions: Set[String]): Boolean = {
@@ -149,6 +156,9 @@ case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
   }
   override def clearDAGStart(): FileSubFeed = {
     this.copy(isDAGStart = false)
+  }
+  override def toOutput(dataObjectId: DataObjectId): FileSubFeed = {
+    this.copy(fileRefs = None, processedInputFileRefs = None, isDAGStart = false, dataObjectId = dataObjectId)
   }
 }
 object FileSubFeed {
@@ -173,9 +183,11 @@ case class InitSubFeed(override val dataObjectId: DataObjectId, override val par
   override def clearPartitionValues(): InitSubFeed = {
     this.copy(partitionValues = Seq())
   }
-  override def updatePartitionValues(partitions: Seq[String]): InitSubFeed = {
-    val updatedPartitionValues = partitionValues.map( pvs => PartitionValues(pvs.elements.filterKeys(partitions.contains))).filter(_.nonEmpty)
+  override def updatePartitionValues(partitions: Seq[String], newPartitionValues: Option[Seq[PartitionValues]] = None): InitSubFeed = {
+    val updatedPartitionValues = newPartitionValues.getOrElse(partitionValues)
+      .map( pvs => PartitionValues(pvs.elements.filterKeys(partitions.contains))).filter(_.nonEmpty)
     this.copy(partitionValues = updatedPartitionValues)
   }
   override def clearDAGStart(): InitSubFeed = throw new NotImplementedException() // calling clearDAGStart makes no sense on InitSubFeed
+  override def toOutput(dataObjectId: DataObjectId): FileSubFeed = throw new NotImplementedException()
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -22,6 +22,7 @@ import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.ExecutionMode
+import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, CanWriteDataFrame, DataObject, FileRefDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed, SubFeed}
@@ -73,8 +74,14 @@ case class CopyAction(override val id: ActionObjectId,
     case Failure(e) => throw new ConfigurationException(s"(${id}) Error parsing filterClause parameter as Spark expression: ${e.getClass.getSimpleName}: ${e.getMessage}")
   }
 
-  override def transform(subFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
-    applyTransformations(subFeed, transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, Seq(), filterClauseExpr)
+  override def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+    val transformedDf = applyTransformations(inputSubFeed, transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, Seq(), filterClauseExpr)
+    outputSubFeed.copy(dataFrame = Some(transformedDf))
+  }
+
+  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
+    if (transformer.isDefined) transformer.get.transformPartitionValues(id, partitionValues)
+    else PartitionValues.oneToOneMapping(partitionValues)
   }
 
   override def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -22,6 +22,7 @@ import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.{ExecutionMode, SparkStreamingOnceMode}
+import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.customlogic.CustomDfsTransformerConfig
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
@@ -65,23 +66,24 @@ case class CustomSparkAction ( override val id: ActionObjectId,
   if (executionMode.exists(_.isInstanceOf[SparkStreamingOnceMode]) && transformer.sqlCode.nonEmpty)
     logger.warn("Defining custom stateful streaming operations with sqlCode is not well supported by Spark and can create strange errors or effects. Use scalaCode to be safe.")
 
-  /**
-   * @inheritdoc
-   */
-  override def transform(subFeeds: Seq[SparkSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
-    val mainInputSubFeed = subFeeds.find(_.dataObjectId==mainInput.id)
+  override def transform(inputSubFeeds: Seq[SparkSubFeed], outputSubFeeds: Seq[SparkSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
+    val mainInputSubFeed = inputSubFeeds.find(_.dataObjectId==mainInput.id)
 
     // Apply custom transformation to all subfeeds
     val partitionValues = mainInputSubFeed.map(_.partitionValues).getOrElse(Seq())
-    val (outputDfs, outputPartitionValues) = transformer.transform(id, partitionValues, subFeeds.map( subFeed => (subFeed.dataObjectId.id, subFeed.dataFrame.get)).toMap)
+    val outputDfs = transformer.transform(id, partitionValues, inputSubFeeds.map( subFeed => (subFeed.dataObjectId.id, subFeed.dataFrame.get)).toMap)
+    // create output subfeeds from transformed dataframes
     outputDfs.map {
-      // create output subfeeds from transformed dataframes
       case (dataObjectId, dataFrame) =>
-        val output = outputs.find(_.id.id == dataObjectId)
+        val outputSubFeed = outputSubFeeds.find(_.dataObjectId.id == dataObjectId)
           .getOrElse(throw ConfigurationException(s"($id) No output found for result ${dataObjectId}. Configured outputs are ${outputs.map(_.id.id).mkString(", ")}."))
         // get partition values from main input
-        SparkSubFeed(Some(dataFrame),dataObjectId, outputPartitionValues)
+        outputSubFeed.copy(dataFrame = Some(dataFrame))
     }.toSeq
+  }
+
+  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
+    transformer.transformPartitionValues(id, partitionValues)
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.{ExecutionMode, TechnicalTableColumn}
 import io.smartdatalake.util.evolution.SchemaEvolution
+import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanHandlePartitions, DataObject, TransactionalSparkTableDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
@@ -90,7 +91,7 @@ case class DeduplicateAction(override val id: ActionObjectId,
     case Failure(e) => throw new ConfigurationException(s"(${id}) Error parsing filterClause parameter as Spark expression: ${e.getClass.getSimpleName}: ${e.getMessage}")
   }
 
-  override def transform(subFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  override def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
     val timestamp = context.referenceTimestamp.getOrElse(LocalDateTime.now)
     val pks = output.table.primaryKey.get // existance is validated earlier
     // get existing data
@@ -98,7 +99,13 @@ case class DeduplicateAction(override val id: ActionObjectId,
     val existingDf = if (output.isTableExisting) Some(output.getDataFrame())
     else None
     val deduplicateTransformer = DeduplicateAction.deduplicateDataFrame(existingDf, pks, timestamp, ignoreOldDeletedColumns, ignoreOldDeletedNestedColumns) _
-    applyTransformations(subFeed, transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, Seq(deduplicateTransformer), filterClauseExpr)
+    val transformedDf = applyTransformations(inputSubFeed, transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, Seq(deduplicateTransformer), filterClauseExpr)
+    outputSubFeed.copy(dataFrame = Some(transformedDf))
+  }
+
+  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
+    if (transformer.isDefined) transformer.get.transformPartitionValues(id, partitionValues)
+    else PartitionValues.oneToOneMapping(partitionValues)
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -44,64 +44,47 @@ abstract class FileSubFeedAction extends Action {
   override def recursiveInputs: Seq[FileRefDataObject with CanCreateInputStream] = Seq()
 
   /**
-   * Initialize Action with a given [[FileSubFeed]]
-   * Note that this only checks the prerequisits to do the processing and simulates the output FileRef's that would be created.
+   * "Transformes" a given [[FileSubFeed]]
+   * Note usage of doExec to choose between initialization or actual execution.
    *
-   * @param subFeed subFeed to be processed (referencing files to be read)
-   * @return processed subFeed (referencing files that would be written by this action)
+   * @param inputSubFeed subFeed to be processed (referencing files to be read)
+   * @param outputSubFeed prepared output subFeed
+   * @param doExec true if action should be executed. If false this only checks the prerequisits to do the processing and simulates the output FileRef's that would be created.
+   * @return processed output subFeed (referencing files written by this action)
    */
-  def initSubFeed(subFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed
-
-  /**
-   * Executes Action for a given [[FileSubFeed]]
-   *
-   * @param subFeed subFeed to be processed (referencing files to be read)
-   * @return processed subFeed (referencing files written by this action)
-   */
-  def execSubFeed(subFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed
+  def doTransform(inputSubFeed: FileSubFeed, outputSubFeed: FileSubFeed, doExec: Boolean)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed
 
   override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.prepare
     executionMode.foreach(_.prepare(id))
   }
 
-  private def prepareSubFeed(subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
+  private def prepareSubFeed(subFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): (FileSubFeed,FileSubFeed) = {
     // convert subfeeds to FileSubFeed type or initialize if not yet existing
-    var preparedSubFeed = FileSubFeed.fromSubFeed(subFeed)
-    // apply execution mode
-    preparedSubFeed = executionMode match {
+    var inputSubFeed = ActionHelper.updatePartitionValues(input, FileSubFeed.fromSubFeed(subFeed))
+    // create output subfeed
+    var outputSubFeed = ActionHelper.updatePartitionValues(output, inputSubFeed.toOutput(output.id))
+    // apply execution mode & prepare output partitions
+    executionMode match {
       case Some(mode) =>
-        mode.apply(id, input, output, preparedSubFeed) match {
-          case Some((partitionValues, _)) => preparedSubFeed.copy(partitionValues = partitionValues)
-          case None => preparedSubFeed
+        mode.apply(id, input, output, inputSubFeed, PartitionValues.oneToOneMapping) match {
+          case Some((inputPartitionValues, outputPartitionValues, _)) =>
+            inputSubFeed = inputSubFeed.copy(partitionValues = inputPartitionValues).breakLineage
+            outputSubFeed = outputSubFeed.copy(partitionValues = outputPartitionValues).breakLineage
+          case None => Unit
         }
-      case _ => preparedSubFeed
+      case _ => Unit
     }
     // validate partition values existing for input
-    if (subFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || subFeed.isDAGStart)) {
-      val expectedPartitions = input.filterExpectedPartitionValues(subFeed.partitionValues)
+    if (inputSubFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || inputSubFeed.isDAGStart)) {
+      val expectedPartitions = input.filterExpectedPartitionValues(inputSubFeed.partitionValues)
       val missingPartitionValues = if (expectedPartitions.nonEmpty) PartitionValues.checkExpectedPartitionValues(input.listPartitions, expectedPartitions) else Seq()
       assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
     }
     // break lineage if requested
-    if (breakFileRefLineage) preparedSubFeed.breakLineage else preparedSubFeed
-  }
-
-  /**
-   * Updates the partition values of a SubFeed to the partition columns of an output, removing not existing columns from the partition values.
-   *
-   * @param output output DataObject
-   * @param subFeed transformed SubFeed
-   * @return SubFeed with updated partition values.
-   */
-  private def validateAndUpdateSubFeed(output: DataObject, subFeed: FileSubFeed )(implicit session: SparkSession): FileSubFeed = {
-    val updatedSubFeed = output match {
-      case partitionedDO: CanHandlePartitions =>
-        // remove superfluous partitionValues
-        subFeed.updatePartitionValues(partitionedDO.partitions)
-      case _ => subFeed.clearPartitionValues()
-    }
-    updatedSubFeed.clearDAGStart().copy(dataObjectId = output.id)
+    if (breakFileRefLineage) inputSubFeed = inputSubFeed.breakLineage
+    // return
+    (inputSubFeed,outputSubFeed)
   }
 
   /**
@@ -109,11 +92,11 @@ abstract class FileSubFeedAction extends Action {
    */
   override final def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for FileSubFeedAction (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")}")
-    val preparedSubFeed = prepareSubFeed(subFeeds.head)
+    val (inputSubFeed, outputSubFeed) = prepareSubFeed(subFeeds.head)
     // transform (file transformation is limited to initialization in init phase)
-    val transformedSubFeed = initSubFeed(preparedSubFeed)
+    val transformedSubFeed = doTransform(inputSubFeed, outputSubFeed, doExec = false)
     // update subFeed
-    Seq(validateAndUpdateSubFeed(output,transformedSubFeed))
+    Seq(transformedSubFeed)
   }
 
   /**
@@ -121,25 +104,25 @@ abstract class FileSubFeedAction extends Action {
    */
   override final def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = {
     assert(subFeeds.size == 1, s"Only one subfeed allowed for FileSubFeedActions (Action $id, inputSubfeed's ${subFeeds.map(_.dataObjectId).mkString(",")})")
-    val preparedSubFeed = prepareSubFeed(subFeeds.head)
+    var (inputSubFeed,outputSubFeed) = prepareSubFeed(subFeeds.head)
     // delete existing files on overwrite
     if (output.saveMode == SaveMode.Overwrite) {
       if (output.partitions.nonEmpty)
-        if (preparedSubFeed.partitionValues.nonEmpty) output.deletePartitions(preparedSubFeed.partitionValues)
+        if (outputSubFeed.partitionValues.nonEmpty) output.deletePartitions(outputSubFeed.partitionValues)
         else logger.warn(s"($id) Cannot delete data from partitioned data object ${output.id} as no partition values are given but saveMode=overwrite")
       else output.deleteAll
     }
     // transform
-    logger.info( s"($id) start writing files to ${output.id}" + (if (preparedSubFeed.partitionValues.nonEmpty) s", partitionValues ${preparedSubFeed.partitionValues.mkString(" ")}" else ""))
+    logger.info( s"($id) start writing files to ${output.id}" + (if (outputSubFeed.partitionValues.nonEmpty) s", partitionValues ${outputSubFeed.partitionValues.mkString(" ")}" else ""))
     val (transformedSubFeed,d) = PerformanceUtils.measureDuration {
-      execSubFeed(preparedSubFeed)
+      doTransform(inputSubFeed, outputSubFeed, doExec = true)
     }
     val filesWritten = transformedSubFeed.fileRefs.get.size.toLong
     logger.info(s"($id) finished writing files to ${output.id}: duration=$d files_written=$filesWritten")
     // send metric to action (for file subfeeds this has to be done manually while spark subfeeds get's the metrics via a spark events listener)
     onRuntimeMetrics(Some(output.id), GenericMetrics(s"$id-${output.id}", 1, Map("duration"->d, "files_written"->filesWritten)))
     // update subFeed
-    Seq(validateAndUpdateSubFeed(output,transformedSubFeed))
+    Seq(transformedSubFeed)
   }
 
   override final def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -44,7 +44,7 @@ abstract class FileSubFeedAction extends Action {
   override def recursiveInputs: Seq[FileRefDataObject with CanCreateInputStream] = Seq()
 
   /**
-   * "Transformes" a given [[FileSubFeed]]
+   * "Transforms" a given [[FileSubFeed]]
    * Note usage of doExec to choose between initialization or actual execution.
    *
    * @param inputSubFeed subFeed to be processed (referencing files to be read)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileSubFeedAction.scala
@@ -80,7 +80,7 @@ abstract class FileSubFeedAction extends Action {
     // validate partition values existing for input
     if (subFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || subFeed.isDAGStart)) {
       val expectedPartitions = input.filterExpectedPartitionValues(subFeed.partitionValues)
-      val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(input.listPartitions, expectedPartitions)
+      val missingPartitionValues = if (expectedPartitions.nonEmpty) PartitionValues.checkExpectedPartitionValues(input.listPartitions, expectedPartitions) else Seq()
       assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
     }
     // break lineage if requested

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -24,7 +24,7 @@ import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.ExecutionMode
 import io.smartdatalake.util.filetransfer.FileTransfer
 import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, FileRefDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed, SubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed}
 import org.apache.spark.sql.SparkSession
 
 /**
@@ -56,18 +56,12 @@ case class FileTransferAction(override val id: ActionObjectId,
   // initialize FileTransfer
   private val fileTransfer = FileTransfer(input, output, deleteDataAfterRead, overwrite)
 
-  override def initSubFeed(subFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
-    val inputFileRefs = subFeed.fileRefs.getOrElse( input.getFileRefs(subFeed.partitionValues))
+  override def doTransform(inputSubFeed: FileSubFeed, outputSubFeed: FileSubFeed, doExec: Boolean)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
+    // recreate FileRefs if needed
+    val inputFileRefs = inputSubFeed.fileRefs.getOrElse(input.getFileRefs(inputSubFeed.partitionValues))
     val fileRefPairs = fileTransfer.init(inputFileRefs)
-    subFeed.copy(fileRefs = Some(fileRefPairs.map(_._2)), dataObjectId = output.id, processedInputFileRefs = Some(inputFileRefs))
-  }
-
-  override def execSubFeed(subFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
-    // recreate FileRefs is desired
-    val inputFileRefs = subFeed.fileRefs.getOrElse( input.getFileRefs(subFeed.partitionValues))
-    val fileRefPairs = fileTransfer.init(inputFileRefs)
-    fileTransfer.exec(fileRefPairs)
-    subFeed.copy(fileRefs = Some(fileRefPairs.map(_._2)), dataObjectId = output.id, processedInputFileRefs = Some(inputFileRefs))
+    if (doExec) fileTransfer.exec(fileRefPairs)
+    outputSubFeed.copy(fileRefs = Some(fileRefPairs.map(_._2)), processedInputFileRefs = Some(inputFileRefs))
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -88,7 +88,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
           input match {
             case partitionedInput: DataObject with CanHandlePartitions if subFeed.partitionValues.nonEmpty && (context.phase==ExecutionPhase.Exec || subFeed.isDAGStart) =>
               val expectedPartitions = partitionedInput.filterExpectedPartitionValues(subFeed.partitionValues)
-              val missingPartitionValues = PartitionValues.checkExpectedPartitionValues(partitionedInput.listPartitions, expectedPartitions)
+              val missingPartitionValues = if (expectedPartitions.nonEmpty) PartitionValues.checkExpectedPartitionValues(partitionedInput.listPartitions, expectedPartitions) else Seq()
               assert(missingPartitionValues.isEmpty, s"($id) partitions $missingPartitionValues missing for ${input.id}")
             case _ => Unit
           }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -133,7 +133,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
         if (noData) logger.info(s"($id) no data to process for ${output.id} in streaming mode")
         // return
         noData
-      case None | Some(_: PartitionDiffMode) | Some(_: SparkIncrementalMode) | Some(_: FailIfNoPartitionValuesMode) =>
+      case None | Some(_: PartitionDiffMode) | Some(_: SparkIncrementalMode) | Some(_: FailIfNoPartitionValuesMode) | Some(_: CustomPartitionMode) =>
         // Write in batch mode
         assert(!subFeed.dataFrame.get.isStreaming, s"($id) Input from ${subFeed.dataObjectId} is a streaming DataFrame, but executionMode!=${SparkStreamingOnceMode.getClass.getSimpleName}")
         output.writeDataFrame(subFeed.dataFrame.get, subFeed.partitionValues, isRecursiveInput)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -234,8 +234,12 @@ case class JdbcTableDataObject(override val id: DataObjectId,
       val partitionsColss = partitionValues.map(_.keys).distinct
       assert(partitionsColss.size == 1, "All partition values must have the same set of partition columns defined!")
       val partitionCols = partitionsColss.head
-      val partitionValuesStr = partitionValues.map(pv => s"(${partitionCols.map(pv(_).toString).mkString(",")})")
-      val deletePartitionQuery = s"delete from ${table.fullName} where (${partitionCols.mkString(",")}) in (${partitionValuesStr.mkString(",")})"
+      val deletePartitionQuery = if (partitionCols.size == 1) {
+        s"delete from ${table.fullName} where ${partitionCols.head} in (${partitionValues.map(pv => pv(partitionCols.head)).mkString(",")})"
+      } else {
+        val partitionValuesStr = partitionValues.map(pv => s"(${partitionCols.map(pv(_).toString).mkString(",")})")
+        s"delete from ${table.fullName} where (${partitionCols.mkString(",")}) in (${partitionValuesStr.mkString(",")})"
+      }
       connection.execJdbcStatement(deletePartitionQuery)
     }
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/DataObjectTestSuite.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/DataObjectTestSuite.scala
@@ -22,20 +22,21 @@ import java.nio.file.Files
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql._
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 
 trait DataObjectTestSuite extends FunSuite with Matchers with BeforeAndAfter {
 
-  protected implicit lazy val testSession: SparkSession = TestUtil.sessionHiveCatalog
+  protected implicit lazy val session: SparkSession = TestUtil.sessionHiveCatalog
 
 
   protected val escapedFilePath: String => String = (path: String) => path.replaceAll("\\\\", "\\\\\\\\")
   protected val convertFilePath: String => String = (path: String) => path.replaceAll("\\\\", "/")
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
-  implicit val testContext: ActionPipelineContext = ActionPipelineContext("testFeed", "testSource", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
+  implicit val contextInit: ActionPipelineContext = ActionPipelineContext("testFeed", "testSource", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Init)
+  val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
 
   protected def createTempDir = Files.createTempDirectory("test")
 

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -22,14 +22,16 @@ import java.io.File
 import java.math.BigDecimal
 import java.nio.file.Files
 import java.sql.{Date, Timestamp}
-import java.time.Instant
+import java.time.{Instant, LocalDateTime}
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.types._
@@ -73,6 +75,10 @@ object TestUtil extends SmartDataLakeLogger {
   // create SparkSession if needed
   lazy val sessionHiveCatalog : SparkSession = sparkSessionBuilder(withHive = true).getOrCreate
   lazy val sessionWithoutHive : SparkSession = sparkSessionBuilder().getOrCreate
+
+  def getDefaultActionPipelineContext(implicit instanceRegistry: InstanceRegistry): ActionPipelineContext = {
+    ActionPipelineContext("feedTest", "appTest", 1, 1, instanceRegistry, Some(LocalDateTime.now()), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Init)
+  }
 
   // write DataFrame to table
   def prepareHiveTable( table: Table, path: String, df: DataFrame, partitionCols: Seq[String] = Seq() ): Unit = {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/SubFeedTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/SubFeedTest.scala
@@ -18,10 +18,16 @@
  */
 package io.smartdatalake.workflow
 
+import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.definitions.Environment.instanceRegistry
+import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import org.scalatest.FunSuite
 
 class SubFeedTest extends FunSuite {
+
+  implicit val session = TestUtil.sessionHiveCatalog
+  implicit val context1: ActionPipelineContext = ActionPipelineContext("testfeed", "testapp", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
 
   test("FileSubFeed to SparkSubFeed") {
     val fileSubFeed = FileSubFeed(None, "test1", Seq(PartitionValues(Map("dt"->"20190101"))))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -29,7 +29,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.action.customlogic.{CustomDfTransformer, CustomDfTransformerConfig}
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
-import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, InitSubFeed, SparkSubFeed}
 import org.apache.spark.sql.functions.{lit, substring}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
@@ -43,6 +43,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
   private val tempPath = tempDir.toAbsolutePath.toString
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
 
   before {
     instanceRegistry.clear()
@@ -62,14 +64,12 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfTransformer"))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")),PartitionValues(Map("lastname" -> "jonson"))))
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     val r1 = session.table(s"${tgtTable.fullName}")
@@ -105,13 +105,11 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig))
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    action1.exec(Seq(srcSubFeed))
+    action1.exec(Seq(srcSubFeed))(session,contextExec)
 
     val r1 = session.table(s"${tgtTable.fullName}")
       .select($"rating")
@@ -134,14 +132,12 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfTransformerConfig(sqlCode = Some("select * from copy_input where rating = 5"))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     session.table(s"${tgtTable.fullName}").show
@@ -169,13 +165,11 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val action1 = CopyAction("a1", srcDO.id, tgtDO.id, transformer = None)
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     val r1 = session.table(s"${tgtTable.fullName}")
@@ -199,8 +193,6 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     tgtDO.dropTable
 
     // prepare action
-    val refTimestamp = LocalDateTime.now()
-    implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val action = CopyAction("a1", srcDO.id, tgtDO.id, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test executionMode!
 
@@ -209,7 +201,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l1PartitionValues = Seq(PartitionValues(Map("type"->"A")))
     srcDO.writeDataFrame(l1, l1PartitionValues) // prepare testdata
     val initOutputSubFeeds = action.init(Seq(srcSubFeed))
-    val tgtSubFeed1 = action.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed1 = action.exec(Seq(srcSubFeed))(session,contextExec).head
 
     // check first load
     assert(initOutputSubFeeds.head.asInstanceOf[SparkSubFeed].dataFrame.get.columns.last == "type", "partition columns must be moved last already in init phase")
@@ -223,7 +215,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l2PartitionValues = Seq(PartitionValues(Map("type"->"B")))
     srcDO.writeDataFrame(l2, l2PartitionValues) // prepare testdata
     assert(srcDO.getDataFrame().count == 2) // note: this needs spark.sql.sources.partitionOverwriteMode=dynamic, otherwise the whole table is overwritten
-    val tgtSubFeed2 = action.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed2 = action.exec(Seq(srcSubFeed))(session,contextExec).head
 
     // check 2nd load
     assert(tgtSubFeed2.dataObjectId == tgtDO.id)
@@ -246,23 +238,21 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestOptionsDfTransformer"), options = Map("test" -> "test"), runtimeOptions = Map("appName" -> "application"))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig), filterClause = Some("lastname='jonson'"), additionalColumns = Some(Map("run_id" -> "runId")))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     val r1 = tgtDO.getDataFrame()
       .select($"rating", $"test", $"run_id")
       .as[(Int,String,Int)].collect().toSeq
-    assert(r1 == Seq((6, "test-test", 1)))
+    assert(r1 == Seq((6, "test-appTest", 1)))
   }
 
-  test("date to month aggregation with partition value transformation") {
+  test("date to month aggregation with partition value transformation and PartitionDiffMode") {
 
     // setup DataObjects
     val feed = "copy"
@@ -275,21 +265,28 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
-    // prepare & simulate load (init only)
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    // prepare, simulate
+    val contextExec = contextInit.copy(phase = ExecutionPhase.Exec)
     val customTransformerConfig = CustomDfTransformerConfig(className = Some(classOf[TestAggDfTransformer].getName))
-    val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig))
+    val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig), executionMode = Some(PartitionDiffMode(applyPartitionValuesTransform=true)))
     val l1 = Seq(("20100101","jonson","rob",5),("20100103","doe","bob",3)).toDF("dt", "lastname", "firstname", "rating")
-    val srcPartitionValues = Seq(PartitionValues(Map("dt" -> "20100101")), PartitionValues(Map("dt" -> "20100103")))
     srcDO.writeDataFrame(l1, Seq())
-    val srcSubFeed = SparkSubFeed(None, "src1", srcPartitionValues)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.init(Seq(srcSubFeed)).head.asInstanceOf[SparkSubFeed]
-    assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
+    // check simulate
+    assert(tgtSubFeed.dataObjectId == tgtDO.id)
     val expectedPartitionValues = Seq(PartitionValues(Map("mt" -> "201001")))
     assert(tgtSubFeed.partitionValues == expectedPartitionValues)
     assert(tgtSubFeed.dataFrame.get.columns.contains("mt"))
+
+    // run
+    action1.exec(Seq(srcSubFeed))(session,contextExec)
+    assert(tgtDO.getDataFrame().count == 2)
+
+    // simulate next run
+    action1.reset
+    intercept[NoDataToProcessWarning](action1.init(Seq(srcSubFeed)).head.asInstanceOf[SparkSubFeed])
   }
 
 }
@@ -315,7 +312,7 @@ class TestAggDfTransformer extends CustomDfTransformer {
     import session.implicits._
     df.withColumn("mt", substring($"dt",1,6))
   }
-  override def transformPartitionValues(options: Map[String, String], partitionValues: Seq[PartitionValues]): Seq[PartitionValues] = {
-    partitionValues.map(pv => PartitionValues(Map("mt" -> pv("dt").toString.take(6)))).distinct
+  override def transformPartitionValues(options: Map[String, String], partitionValues: Seq[PartitionValues]): Map[PartitionValues,PartitionValues] = {
+    partitionValues.map(pv => (pv,PartitionValues(Map("mt" -> pv("dt").toString.take(6))))).toMap
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDfToDeltaTableTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDfToDeltaTableTest.scala
@@ -28,7 +28,7 @@ import io.smartdatalake.testutils.TestUtil._
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import io.smartdatalake.workflow.action.customlogic.CustomDfCreatorConfig
 import io.smartdatalake.workflow.dataobject.{CustomDfDataObject, DeltaLakeTableDataObject, Table}
-import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
@@ -40,6 +40,8 @@ class CustomDfToDeltaTableTest extends FunSuite with BeforeAndAfter {
   val tempPath: String = tempDir.toAbsolutePath.toString
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
 
   before { instanceRegistry.clear() }
 
@@ -55,11 +57,9 @@ class CustomDfToDeltaTableTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(targetDO)
 
     // prepare & start load
-    val startTime = LocalDateTime.now()
-    implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(startTime), SmartDataLakeBuilderConfig())
     val testAction = CopyAction(id = s"${feed}Action", inputId = sourceDO.id, outputId = targetDO.id)
     val srcSubFeed = SparkSubFeed(None, "source", partitionValues = Seq())
-    testAction.exec(Seq(srcSubFeed))
+    testAction.exec(Seq(srcSubFeed))(session, contextExec)
 
     val expected = sourceDO.getDataFrame()
     val actual = targetDO.getDataFrame()
@@ -80,11 +80,9 @@ class CustomDfToDeltaTableTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(targetDO)
 
     // prepare & start load
-    val startTime = LocalDateTime.now()
-    implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(startTime), SmartDataLakeBuilderConfig())
     val testAction = CopyAction(id = s"${feed}Action", inputId = sourceDO.id, outputId = targetDO.id)
     val srcSubFeed = SparkSubFeed(None, "source", partitionValues = Seq())
-    testAction.exec(Seq(srcSubFeed))
+    testAction.exec(Seq(srcSubFeed))(session, contextExec)
 
     val expected = sourceDO.getDataFrame()
     val actual = targetDO.getDataFrame()

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -30,7 +30,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.action.customlogic.{CustomDfsTransformer, CustomDfsTransformerConfig}
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, InitSubFeed, SparkSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, InitSubFeed, SparkSubFeed}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
@@ -42,6 +42,8 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
   private val tempPath = tempDir.toAbsolutePath.toString
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
 
   before {
     instanceRegistry.clear()
@@ -72,20 +74,18 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO2)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(
       className = Some("io.smartdatalake.workflow.action.TestDfsTransformerIncrement"),
       options = Map("increment1" -> "1"), runtimeOptions = Map("increment2" -> "runId")
     )
 
-    val action1 = CustomSparkAction("action1", List(srcDO1.id, srcDO2.id), List(tgtDO1.id, tgtDO2.id), transformer = customTransformerConfig)(context1.instanceRegistry)
+    val action1 = CustomSparkAction("action1", List(srcDO1.id, srcDO2.id), List(tgtDO1.id, tgtDO2.id), transformer = customTransformerConfig)
 
     val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO1.writeDataFrame(l1, Seq())
     srcDO2.writeDataFrame(l1, Seq())
 
-    val tgtSubFeeds = action1.exec(Seq(SparkSubFeed(None, "src1", Seq()), SparkSubFeed(None, "src2", Seq())))
+    val tgtSubFeeds = action1.exec(Seq(SparkSubFeed(None, "src1", Seq()), SparkSubFeed(None, "src2", Seq())))(session,contextExec)
     assert(tgtSubFeeds.size == 2)
     assert(tgtSubFeeds.map(_.dataObjectId) == Seq(tgtDO1.id, tgtDO2.id))
 
@@ -118,16 +118,14 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO1)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerRecursive"))
 
     // first action to create output table as it does not exist yet
-    val action1 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig)(context1.instanceRegistry)
+    val action1 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig)
     val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO1.writeDataFrame(l1, Seq())
 
-    val tgtSubFeedsNonRecursive = action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))
+    val tgtSubFeedsNonRecursive = action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, contextExec)
     assert(tgtSubFeedsNonRecursive.size == 1)
     assert(tgtSubFeedsNonRecursive.map(_.dataObjectId) == Seq(tgtDO1.id))
 
@@ -138,9 +136,9 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     assert(r1.head == 6) // should be increased by 1 through TestDfTransformer
 
     // second action to test recursive inputs
-    val action2 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig, recursiveInputIds = List(tgtDO1.id))(context1.instanceRegistry)
+    val action2 = CustomSparkAction("action1", List(srcDO1.id), List(tgtDO1.id), transformer = customTransformerConfig, recursiveInputIds = List(tgtDO1.id))
 
-    val tgtSubFeedsRecursive = action2.exec(Seq(SparkSubFeed(None, "src1", Seq()), SparkSubFeed(None, "tgt1", Seq())))
+    val tgtSubFeedsRecursive = action2.exec(Seq(SparkSubFeed(None, "src1", Seq()), SparkSubFeed(None, "tgt1", Seq())))(session, contextExec)
     assert(tgtSubFeedsRecursive.size == 1) // still 1 as recursive inputs are handled separately
 
     val r2 = session.table(s"${tgtTable1.fullName}")
@@ -154,7 +152,6 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
   test("copy with partition diff execution mode 2 iterations") {
 
     // setup DataObjects
-    val feed = "partitiondiff"
     val srcTable = Table(Some("default"), "copy_input")
     val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
@@ -165,8 +162,6 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare action
-    val refTimestamp = LocalDateTime.now()
-    implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
     val action = CustomSparkAction("a1", Seq(srcDO.id), Seq(tgtDO.id), transformer = customTransformerConfig, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test initExecutionMode!
@@ -175,7 +170,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq(("A","doe","john",5)).toDF("type", "lastname", "firstname", "rating")
     val l1PartitionValues = Seq(PartitionValues(Map("type"->"A")))
     srcDO.writeDataFrame(l1, l1PartitionValues) // prepare testdata
-    val tgtSubFeed1 = action.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed1 = action.exec(Seq(srcSubFeed))(session,contextExec).head
 
     // check first load
     assert(tgtSubFeed1.dataObjectId == tgtDO.id)
@@ -188,7 +183,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     val l2PartitionValues = Seq(PartitionValues(Map("type"->"B")))
     srcDO.writeDataFrame(l2, l2PartitionValues) // prepare testdata
     assert(srcDO.getDataFrame().count == 2) // note: this needs spark.sql.sources.partitionOverwriteMode=dynamic, otherwise the whole table is overwritten
-    val tgtSubFeed2 = action.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed2 = action.exec(Seq(srcSubFeed))(session,contextExec).head
 
     // check 2nd load
     assert(tgtSubFeed2.dataObjectId == tgtDO.id)
@@ -227,9 +222,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO3)
 
     // prepare action
-    val refTimestamp = LocalDateTime.now()
-    implicit val context: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp), SmartDataLakeBuilderConfig())
-    val customTransformerConfig = CustomDfsTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestDfsTransformerDummy"))
+    val customTransformerConfig = CustomDfsTransformerConfig(className = Some(classOf[TestDfsTransformerDummy].getName))
     val action = CustomSparkAction("a1", Seq(srcDO.id, srcDO2.id, srcDO3.id), Seq(tgtDO.id, tgtDO2.id, tgtDO3.id), transformer = customTransformerConfig
       , mainInputId = Some("src1"), mainOutputId = Some("tgt1"), executionMode = Some(PartitionDiffMode()))
     val srcSubFeed1 = InitSubFeed("src1", Seq())
@@ -244,7 +237,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     srcDO.writeDataFrame(l1, l1PartitionValues)
     srcDO2.writeDataFrame(l2, l2PartitionValues)
     srcDO3.writeDataFrame(l2, Seq()) // src3 is not partitioned
-    val tgtSubFeed1 = action.exec(Seq(srcSubFeed1, srcSubFeed2, srcSubFeed3)).head
+    val tgtSubFeed1 = action.exec(Seq(srcSubFeed1, srcSubFeed2, srcSubFeed3))(session, contextExec).head
 
     // check load
     assert(tgtSubFeed1.dataObjectId == tgtDO.id)
@@ -276,14 +269,12 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO2)
 
     // prepare & start load
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(sqlCode = Map(DataObjectId("tgt1")->"select * from copy_input where rating = 5", DataObjectId("tgt2")->"select * from copy_input where rating = 3"))
     val action1 = CustomSparkAction("ca", List(srcDO.id), List(tgtDO1.id,tgtDO2.id), transformer = customTransformerConfig)
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, contextExec).head
 
     val r1 = session.table(s"${tgtTable1.fullName}")
       .select($"lastname")
@@ -314,15 +305,13 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO1)
 
     // prepare & simulate load (init only)
-    val refTimestamp1 = LocalDateTime.now()
-    implicit val context1: ActionPipelineContext = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
     val customTransformerConfig = CustomDfsTransformerConfig(className = Some(classOf[TestDfsTransformerPartitionValues].getName))
     val action1 = CustomSparkAction("ca", List(srcDO.id), List(tgtDO1.id), transformer = customTransformerConfig)
     val l1 = Seq(("20100101","jonson","rob",5),("20100103","doe","bob",3)).toDF("dt", "lastname", "firstname", "rating")
     val srcPartitionValues = Seq(PartitionValues(Map("dt" -> "20100101")), PartitionValues(Map("dt" -> "20100103")))
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", srcPartitionValues)
-    val tgtSubFeed = action1.init(Seq(srcSubFeed)).head.asInstanceOf[SparkSubFeed]
+    val tgtSubFeed = action1.init(Seq(srcSubFeed))(session,contextExec).head.asInstanceOf[SparkSubFeed]
 
     val expectedPartitionValues = Seq(PartitionValues(Map("mt" -> "201001")))
     assert(tgtSubFeed.partitionValues == expectedPartitionValues)
@@ -375,8 +364,8 @@ class TestDfsTransformerPartitionValues extends CustomDfsTransformer {
     val dfTgt = dfs("src1").withColumn("mt", substring($"dt",1,6))
     Map("tgt1" -> dfTgt)
   }
-  override def transformPartitionValues(options: Map[String, String], partitionValues: Seq[PartitionValues]): Seq[PartitionValues] = {
-    partitionValues.map(pv => PartitionValues(Map("mt" -> pv("dt").toString.take(6)))).distinct
+  override def transformPartitionValues(options: Map[String, String], partitionValues: Seq[PartitionValues]): Map[PartitionValues,PartitionValues] = {
+    partitionValues.map(pv => (pv, PartitionValues(Map("mt" -> pv("dt").toString.take(6))))).toMap
   }
 }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
@@ -20,7 +20,8 @@ package io.smartdatalake.workflow.action
 
 import java.nio.file.Files
 import java.sql.Timestamp
-import java.time.{LocalDateTime, Month}
+import java.time.temporal.ChronoUnit
+import java.time.{LocalDateTime, Month, ZoneOffset}
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
@@ -28,7 +29,7 @@ import io.smartdatalake.definitions.TechnicalTableColumn
 import io.smartdatalake.testutils.DataFrameTestHelper._
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
@@ -62,7 +63,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id)
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
@@ -74,22 +75,21 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
       .select($"rating", $"dl_ts_captured")
       .as[(Int,Timestamp)].collect().toSeq
     assert(r1.size == 1)
-    assert(r1.head._2.toLocalDateTime == refTimestamp1)
+    assert(ChronoUnit.MILLIS.between(r1.head._2.toLocalDateTime,refTimestamp1) == 0)
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig())
-    val action2 = DeduplicateAction("dda2", srcDO.id, tgtDO.id)
+    val context2 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
     val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l2, Seq())
-    action2.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
 
     val r2 = session.table(s"${tgtTable.fullName}")
       .select($"rating", $"dl_ts_captured").orderBy($"dl_ts_captured")
       .as[(Int,Timestamp)].collect().toSeq
     assert(r2.size == 1)
     assert(r2.head._1 == 10) // rating should be the second one
-    assert(r2.head._2.toLocalDateTime == refTimestamp2)
+    assert(ChronoUnit.MILLIS.between(r2.head._2.toLocalDateTime,refTimestamp2) == 0)
   }
 
   test("early validation that output primary key exists") {
@@ -121,8 +121,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
-    val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val context1 = TestUtil.getDefaultActionPipelineContext
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, filterClause = Some("lastname='jonson'"))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
@@ -21,13 +21,14 @@
 import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
@@ -60,7 +61,7 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig())
+    val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id)
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
@@ -72,11 +73,11 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
       .select($"rating", $"dl_ts_captured", $"dl_ts_delimited")
       .as[(Int,Timestamp,Timestamp)].collect().toSeq
     assert(r1.size == 1)
-    assert(r1.head._2.toLocalDateTime == refTimestamp1)
+    assert(ChronoUnit.MILLIS.between(r1.head._2.toLocalDateTime,refTimestamp1) == 0)
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig())
+    val context2 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id)
     val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l2, Seq())
@@ -88,9 +89,9 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
       .as[(Int,Timestamp,Timestamp)].collect().toSeq
     assert(r2.size == 2)
     assert(r2.head._1 == 5) // check first rating
-    assert(r2.head._2.toLocalDateTime == refTimestamp1)
+    assert(ChronoUnit.MILLIS.between(r2.head._2.toLocalDateTime,refTimestamp1) == 0)
     assert(r2(1)._1 == 10) // check second rating
-    assert(r2(1)._2.toLocalDateTime == refTimestamp2)
+    assert(ChronoUnit.MILLIS.between(r2(1)._2.toLocalDateTime,refTimestamp2) == 0)
   }
 
   test("early validation that output primary key exists") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.{DataFrame, Row, SaveMode}
  */
 class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObjectSchemaBehavior {
 
-  import testSession.implicits._
+  import session.implicits._
 
   test("Reading from an empty file with header=true and inferSchema=false results in an empty, schema-less data frame.") {
     val tempFile = File.createTempFile("temp", "csv")
@@ -116,7 +116,7 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     tempFile.deleteOnExit()
 
 
-    testSession.createDataFrame(testSession.sparkContext.makeRDD(Seq(
+    session.createDataFrame(session.sparkContext.makeRDD(Seq(
       Row.fromTuple("A", "B"),
       Row.fromTuple("B", "1")
     )),
@@ -165,7 +165,7 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     tempFile.deleteOnExit()
 
 
-    testSession.createDataFrame(testSession.sparkContext.makeRDD(Seq(
+    session.createDataFrame(session.sparkContext.makeRDD(Seq(
       Row.fromTuple("A", "B"),
       Row.fromTuple("B", "1")
     )),

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObjectTest.scala
@@ -39,7 +39,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
       ActionPipelineContext("testFeed", "testApp", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Init)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(testSession, context)
+    val df = customDfDataObject.getDataFrame(Seq())(session, context)
 
     // check
     assert(df.schema.equals(customDfDataObject.creator.schema.get))
@@ -53,7 +53,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
       ActionPipelineContext("testFeed", "testApp", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(testSession, context)
+    val df = customDfDataObject.getDataFrame(Seq())(session, context)
 
     // check
     assert(df.schema.equals(customDfDataObject.creator.exec.schema))
@@ -67,7 +67,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
       ActionPipelineContext("testFeed", "testApp", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Init)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(testSession, context)
+    val df = customDfDataObject.getDataFrame(Seq())(session, context)
 
     // check
     assert(df.count() == 0)
@@ -81,7 +81,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
       ActionPipelineContext("testFeed", "testApp", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(testSession, context)
+    val df = customDfDataObject.getDataFrame(Seq())(session, context)
 
     // check
     assert(df.count() == 2)
@@ -95,7 +95,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
       ActionPipelineContext("testFeed", "testApp", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Init)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(testSession, context)
+    val df = customDfDataObject.getDataFrame(Seq())(session, context)
 
     // check
     assert(df.count() == 2)
@@ -109,7 +109,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
       ActionPipelineContext("testFeed", "testApp", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(testSession, context)
+    val df = customDfDataObject.getDataFrame(Seq())(session, context)
 
     // check
     assert(df.count() == 2)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObjectTest.scala
@@ -30,7 +30,7 @@ import scala.util.Try
  * Unit tests for [[HadoopFileDataObjectTest]].
  */
 class HadoopFileDataObjectTest extends DataObjectTestSuite {
-  import testSession.implicits._
+  import session.implicits._
 
   test("overwrite only one partition") {
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
@@ -33,7 +33,7 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
   private val tempDir = createTempDir
   private val tempPath = tempDir.toAbsolutePath.toString
 
-  import testSession.implicits._
+  import session.implicits._
 
   test("write and analyze table without partitions") {
     val srcTable = Table(Some("default"), "input")
@@ -42,7 +42,7 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq())
     // check table statistics
-    val statsStr = testSession.sql(s"describe extended ${srcTable.fullName}")
+    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
       .where($"col_name"==="Statistics").head.getAs[String](1)
     assert(statsStr.contains("3 rows"))
     // check table contents
@@ -56,14 +56,14 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq(PartitionValues(Map("type"->"ext")),PartitionValues(Map("type"->"int"))))
     // check table statistics
-    val statsStr = testSession.sql(s"describe extended ${srcTable.fullName}")
+    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
       .where($"col_name"==="Statistics").head.getAs[String](1)
     assert(statsStr.contains("3 rows"))
     // check partition statistics
-    val statsPart1Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='ext')")
+    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart1Str.contains("2 rows"))
-    val statsPart2Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='int')")
+    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart2Str.contains("1 rows"))
     // check table contents
@@ -77,14 +77,14 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq())
     // check table statistics
-    val statsStr = testSession.sql(s"describe extended ${srcTable.fullName}")
+    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
       .where($"col_name"==="Statistics").head.getAs[String](1)
     assert(statsStr.contains("3 rows"))
     // check partition statistics
-    val statsPart1Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='ext')")
+    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart1Str.contains("2 rows"))
-    val statsPart2Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='int')")
+    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart2Str.contains("1 rows"))
     // check table contents
@@ -98,18 +98,18 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq(PartitionValues(Map("type"->"ext"))))
     // check table statistics
-    val statsStr = testSession.sql(s"describe extended ${srcTable.fullName}")
+    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
       .where($"col_name"==="Statistics").head.getAs[String](1)
     assert(statsStr.contains("3 rows"))
     // check partition statistics -> only partition type=ext,name=doe and type=ext,lastname=smith should have been analyzed
-    val statsPart1Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='doe')")
+    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='doe')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart1Str.contains("1 rows"))
-    val statsPart2Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='smith')")
+    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='smith')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart2Str.contains("1 rows"))
     // check no partition statistics for type=int,lastname=emma
-    val statsPart3Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='int',lastname='emma')")
+    val statsPart3Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int',lastname='emma')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(!statsPart3Str.contains("1 rows"))
     // check table contents
@@ -123,18 +123,18 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(df, Seq(PartitionValues(Map("type"->"ext", "lastname"->"doe")),PartitionValues(Map("type"->"ext", "lastname"->"smith"))))
     // check table statistics
-    val statsStr = testSession.sql(s"describe extended ${srcTable.fullName}")
+    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
       .where($"col_name"==="Statistics").head.getAs[String](1)
     assert(statsStr.contains("3 rows"))
     // check partition statistics -> only partition type=ext,name=doe and type=ext,lastname=smith should have been analyzed
-    val statsPart1Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='doe')")
+    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='doe')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart1Str.contains("1 rows"))
-    val statsPart2Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='smith')")
+    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='smith')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(statsPart2Str.contains("1 rows"))
     // check no partition statistics for type=int,lastname=emma
-    val statsPart3Str = testSession.sql(s"describe extended ${srcTable.fullName} partition(type='int',lastname='emma')")
+    val statsPart3Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int',lastname='emma')")
       .where($"col_name"==="Partition Statistics").head.getAs[String](1)
     assert(!statsPart3Str.contains("1 rows"))
     // check table contents

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
@@ -25,7 +25,7 @@ import io.smartdatalake.workflow.connection.{DefaultSQLCatalog, JdbcTableConnect
 
 class JdbcTableDataObjectTest extends DataObjectTestSuite {
 
-  import testSession.implicits._
+  import session.implicits._
 
   private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb", "org.hsqldb.jdbcDriver")
 
@@ -69,7 +69,7 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id)
     val srcSubFeed = SparkSubFeed(None, srcDO.id, Seq())
     action1.preExec(Seq(srcSubFeed))
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
     action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed))
 
     val dfSrcExpected = Seq(("ext", "doe", "john", 5)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObjectTest.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types._
 
 class JsonFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObjectSchemaBehavior {
 
-  val hdfs = FileSystem.get(testSession.sparkContext.hadoopConfiguration)
+  val hdfs = FileSystem.get(session.sparkContext.hadoopConfiguration)
 
   case class Data(name: String, age: Int)
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObjectTest.scala
@@ -29,7 +29,7 @@ class ParquetFileDataObjectTest extends DataObjectTestSuite with SparkFileDataOb
   private val tempDir = createTempDir
   private val tempPath = tempDir.toAbsolutePath.toString
 
-  import testSession.implicits._
+  import session.implicits._
 
   private val testDf = Seq(
     ("string1",1,Seq(1,2,3)),

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
@@ -29,7 +29,7 @@ import org.apache.commons.io.FileUtils
 class SparkFileDataObjectTest extends DataObjectTestSuite {
 
   test("read partitioned data and filter expected partitions") {
-    import testSession.implicits._
+    import session.implicits._
 
     // create data object
     val tempDir = Files.createTempDirectory("tempHadoopDO")
@@ -52,7 +52,7 @@ class SparkFileDataObjectTest extends DataObjectTestSuite {
   }
 
   test("append filename") {
-    import testSession.implicits._
+    import session.implicits._
 
     // create data object
 

--- a/sdl-kafka/src/test/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObjectTest.scala
+++ b/sdl-kafka/src/test/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObjectTest.scala
@@ -32,7 +32,7 @@ import org.scalatest.FunSuite
 class KafkaTopicDataObjectTest extends FunSuite with EmbeddedKafka with DataObjectTestSuite with SmartDataLakeLogger {
 
   import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
-  import testSession.implicits._
+  import session.implicits._
 
   private val kafkaConnection = KafkaConnection("kafkaCon1", "localhost:6000")
 


### PR DESCRIPTION
see #264, improvements are:
- refactoring of transformation of partition values to support: 
  - use Seq[Map[PartitionValues,PartitionValues]] as return type of CustomDfTransformer.transformPartitionValues to make define rename & aggregation of partition values precisely,
  - keep input & outputSubFeed seperated in SparkAction
- implement PartitionDiffMode selectAdditionalInputExpression(#264)
- implement PartitionDiffMode stopIfNoData
