### PR TITLE
fix Kafka Avro with schemaregistry NotSerializableException for Gener…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
 		<scala.version>${scala.minor.version}.12</scala.version>
 
 		<spark.version>3.0.1</spark.version>
+		<spark-extensions.version>2.0.7</spark-extensions.version>
 
 		<!-- SPARK-PARENT start: properties copied from spark-parent pom version 2.4.7 for spark-parent import in dependencyManagement -->
 		<!-- attention - manually adapted are: zookeeper, scala.version, scala.binary.version -->
@@ -2456,6 +2457,11 @@
 				<groupId>org.tukaani</groupId>
 				<artifactId>xz</artifactId>
 				<version>1.5</version>
+			</dependency>
+			<dependency>
+				<groupId>io.smartdatalake</groupId>
+				<artifactId>spark-extensions_${scala.minor.version}</artifactId>
+				<version>${spark-extensions.version}</version>
 			</dependency>
 
 			<!-- TEST dependencies -->

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>io.smartdatalake</groupId>
 			<artifactId>spark-extensions_${scala.minor.version}</artifactId>
-			<version>2.0.6</version>
+			<version>${spark-extensions.version}</version>
 		</dependency>
 
 		<dependency>

--- a/sdl-kafka/pom.xml
+++ b/sdl-kafka/pom.xml
@@ -122,7 +122,7 @@
 		<dependency>
 			<groupId>io.smartdatalake</groupId>
 			<artifactId>spark-extensions_${scala.minor.version}</artifactId>
-			<version>1.0.0</version>
+			<version>${spark-extensions.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
See #198:
Found another NotSerializableException for GenericDatumReader when reading Avro from Kafka with schema registry. 
Details see https://github.com/smart-data-lake/spark-extensions/commit/3ed7694254b156a6c6fdd762ef58eaf15b562534.
