### PR TITLE
Feature/104 fail on configuration objects defined in multiple locations

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
@@ -47,22 +47,31 @@ private[smartdatalake] object ConfigParser extends SmartDataLakeLogger {
   def parse(config: Config, instanceRegistry: InstanceRegistry = new InstanceRegistry): InstanceRegistry = {
     implicit val registry: InstanceRegistry = instanceRegistry
 
-    val connections: Map[ConnectionId, Connection] = config.get[Map[String, Config]]("connections")
-      .valueOrElse(Map.empty)
+    val connections: Map[ConnectionId, Connection] = getConnectionConfigMap(config)
       .map{ case (id, config) => (ConnectionId(id), parseConfigObject[Connection](id, config))}
     registry.register(connections)
 
-    val dataObjects: Map[DataObjectId, DataObject] = config.get[Map[String, Config]]("dataObjects")
-      .valueOrElse(Map.empty)
+    val dataObjects: Map[DataObjectId, DataObject] = getDataObjectConfigMap(config)
       .map{ case (id, config) => (DataObjectId(id), parseConfigObject[DataObject](id, config))}
     registry.register(dataObjects)
 
-    val actions: Map[ActionObjectId, Action] = config.get[Map[String, Config]]("actions")
-      .valueOrElse(Map.empty)
+    val actions: Map[ActionObjectId, Action] = getActionConfigMap(config)
       .map{ case (id, config) => (ActionObjectId(id), parseConfigObject[Action](id, config))}
     registry.register(actions)
 
     registry
+  }
+
+  def getConnectionConfigMap(config: Config) = {
+    config.get[Map[String, Config]]("connections").valueOrElse(Map.empty)
+  }
+
+  def getDataObjectConfigMap(config: Config) = {
+    config.get[Map[String, Config]]("dataObjects").valueOrElse(Map.empty)
+  }
+
+  def getActionConfigMap(config: Config) = {
+    config.get[Map[String, Config]]("actions").valueOrElse(Map.empty)
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -97,6 +97,15 @@ object Environment {
   }
 
   /**
+   * Set to true to enable check for duplicate first class object definitions when loading configuration (default=true).
+   * The check fails if Connections, DataObjects or Actions are defined in multiple locations.
+   */
+  var enableCheckConfigDuplicates: Boolean = {
+    EnvironmentUtil.getSdlParameter("enableCheckConfigDuplicates")
+      .map(_.toBoolean).getOrElse(true)
+  }
+
+  /**
    * ordering of columns in SchemaEvolution result
    * - true: result schema is ordered according to existing schema, new columns are appended
    * - false: result schema is ordered according to new schema, deleted columns are appended

--- a/sdl-core/src/test/resources/configWithDuplicates/config.conf
+++ b/sdl-core/src/test/resources/configWithDuplicates/config.conf
@@ -1,0 +1,33 @@
+#
+# Smart Data Lake - Build your data lake the smart way.
+#
+# Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+config = config
+overwrite = original
+
+dataObjects = {
+  testDataObjectFromConfig = {
+    type = io.smartdatalake.config.TestDataObject
+    arg1 = Foo
+    args = [Bar]
+    metadata = {
+      name = Test DataObject From Config
+      description = Loaded from a Test Config
+    }
+  }
+}

--- a/sdl-core/src/test/resources/configWithDuplicates/configDuplicate.conf
+++ b/sdl-core/src/test/resources/configWithDuplicates/configDuplicate.conf
@@ -1,0 +1,30 @@
+#
+# Smart Data Lake - Build your data lake the smart way.
+#
+# Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+dataObjects = {
+  testDataObjectFromConfig = {
+    type = io.smartdatalake.config.TestDataObject
+    arg1 = Foo
+    args = [Bar]
+    metadata = {
+      name = Test DataObject From Config
+      description = Loaded from a Test Config
+    }
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -49,13 +49,17 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
 
   it must "not parse a file that is not a config file" in {
     val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory/file.txt").toString))
-    an [ConfigException] should be thrownBy config.getString("noconfig")
+    a [ConfigException] should be thrownBy config.getString("noconfig")
   }
 
   it must "only parse config files in directories" in {
     val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString))
     config.getString("foo") shouldBe "foo"
     config.getString("config2") shouldBe "config2"
-    an [ConfigException] should be thrownBy config.getString("noconfig")
+    a [ConfigException] should be thrownBy config.getString("noconfig")
+  }
+
+  it should "fail on duplicate configuration object IDs" in {
+    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/configWithDuplicates").toString))
   }
 }


### PR DESCRIPTION
see #104: if a configuration objects are defined in multiple locations, a ConfigurationException is thrown.

To be discussed if an exception is the desired behaviour, or if we just want to log a Warning/Error. 
In my opinion we can be strict here, as it's really confusing to define the same configuration object in different locations and have it merged by Hocon.