### PR TITLE
implement automatic caching/release of DataFrames that are used multiple times

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -79,3 +79,7 @@ The following is a list of implemented and planned (Future) features of Smart Da
   * Spark data pipeline simulation (acceptance tests)
 * Support for Deployment
   * Dry-run
+
+##### Spark Performance
+* Execute multiple Spark jobs in parallel within the same Spark Session to save resources
+* Automatically cache and release intermediate results (DataFrames)

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -138,6 +138,14 @@ object Environment {
       .map(_.toBoolean).getOrElse(false)
   }
 
+  /**
+   * Set to true if you want to enable automatic caching of DataFrames that are used multiple times (default=true).
+   */
+  var enableAutomaticDataFrameCaching: Boolean = {
+    EnvironmentUtil.getSdlParameter("enableAutomaticDataFrameCaching")
+      .map(_.toBoolean).getOrElse(true)
+  }
+
   // static configurations
   val configPathsForLocalSubstitution: Seq[String] = Seq(
       "path", "table.name"

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -22,8 +22,13 @@ import java.time.LocalDateTime
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.config.SdlConfigObject.{ActionObjectId, DataObjectId}
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
 import org.apache.spark.annotation.DeveloperApi
+
+import scala.collection.mutable
 
 /**
  * ActionPipelineContext contains start and runtime information about a SmartDataLake run.
@@ -39,20 +44,37 @@ import org.apache.spark.annotation.DeveloperApi
  * @param attemptStartTime start time of attempt
  * @param simulation true if this is a simulation run
  * @param phase current execution phase
+ * @param dataFrameReuseStatistics Counter how many times a DataFrame of a SparkSubFeed is reused by an Action later in the pipeline.
+ *                                 The counter is increased during ExecutionPhase.Init when preparing the SubFeeds for an Action and it is
+ *                                 decreased in ExecutionPhase.Exec to unpersist the DataFrame after there is no need for it anymore.
  */
 @DeveloperApi
-case class ActionPipelineContext(
-                                                         feed: String,
-                                                         application: String,
-                                                         runId: Int,
-                                                         attemptId: Int,
-                                                         instanceRegistry: InstanceRegistry,
-                                                         referenceTimestamp: Option[LocalDateTime] = None,
-                                                         appConfig: SmartDataLakeBuilderConfig, // application config is needed to persist action dag state for recovery
-                                                         runStartTime: LocalDateTime = LocalDateTime.now(),
-                                                         attemptStartTime: LocalDateTime = LocalDateTime.now(),
-                                                         simulation: Boolean = false,
-                                                         var phase: ExecutionPhase = ExecutionPhase.Prepare
-) {
+case class ActionPipelineContext (
+                                  feed: String, application: String, runId: Int, attemptId: Int,
+                                  instanceRegistry: InstanceRegistry,
+                                  referenceTimestamp: Option[LocalDateTime] = None,
+                                  appConfig: SmartDataLakeBuilderConfig, // application config is needed to persist action dag state for recovery
+                                  runStartTime: LocalDateTime = LocalDateTime.now(),
+                                  attemptStartTime: LocalDateTime = LocalDateTime.now(),
+                                  simulation: Boolean = false,
+                                  var phase: ExecutionPhase = ExecutionPhase.Prepare,
+                                  dataFrameReuseStatistics: mutable.Map[(DataObjectId, Seq[PartitionValues]), Seq[ActionObjectId]] = mutable.Map()
+) extends SmartDataLakeLogger {
   private[smartdatalake] def getReferenceTimestampOrNow: LocalDateTime = referenceTimestamp.getOrElse(LocalDateTime.now)
+  private[smartdatalake] def rememberDataFrameReuse(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], actionId: ActionObjectId): Int = dataFrameReuseStatistics.synchronized {
+    val key = (dataObjectId, partitionValues)
+    val newValue = dataFrameReuseStatistics.getOrElse(key, Seq()) :+ actionId
+    dataFrameReuseStatistics.update(key, newValue)
+    newValue.size
+  }
+  private[smartdatalake] def forgetDataFrameReuse(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], actionId: ActionObjectId): Option[Int] = dataFrameReuseStatistics.synchronized {
+    val key = (dataObjectId, partitionValues)
+    val existingValue = dataFrameReuseStatistics.get(key)
+    existingValue.map { v =>
+      val newValue = v.diff(Seq(actionId))
+      if (v.size == newValue.size) logger.warn(s"Could not find $actionId in dataFrame reuse list!")
+      dataFrameReuseStatistics.update(key, newValue)
+      newValue.size
+    }
+  }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -104,6 +104,7 @@ case class SparkSubFeed(@transient dataFrame: Option[DataFrame],
     this.copy(dataFrame = this.dataFrame.map(_.persist))
   }
   def isStreaming: Option[Boolean] = dataFrame.map(_.isStreaming)
+  def hasReusableDataFrame: Boolean = dataFrame.isDefined && !isDummy && !isStreaming.getOrElse(false)
   def getFilterCol: Option[Column] = {
     filter.map(functions.expr)
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -137,7 +137,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
 
   /**
    * Executes operations needed after executing an action.
-   * In this step any phase on Input- or Output-DataObjects needed after the main task is executed,
+   * In this step any task on Input- or Output-DataObjects needed after the main task is executed,
    * e.g. JdbcTableDataObjects postWriteSql or CopyActions deleteInputData.
    */
   def postExec(inputSubFeed: Seq[SubFeed], outputSubFeed: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {


### PR DESCRIPTION
See #112:
The implementation counts DataFrames reused in subsequent actions in init-phase, so that we can "persist/cache" them before the write operation in exec-phase.
It also tracks when postExec function when no Action needs the cached DataFrame anymore, and releases it automatically.
In my opinion the "persist" property of Actions to manually control caching isn't needed anymore, but we can leave it for the moment for backward as it is no problem if the same DataFrame is cached multiple times.

