### PR TITLE
fix compilation of module fat-jars with scala-2.11 (#269)

### DIFF
--- a/sdl-jms/pom.xml
+++ b/sdl-jms/pom.xml
@@ -39,6 +39,16 @@
 				<!-- do not include sdl-core into fat-jar for this module, as sdl-core is normally put into classpath separately -->
 				<sdl-core.scope>provided</sdl-core.scope>
 			</properties>
+			<dependencies>
+				<!-- spark-tags needs to have compile scope; if it's runtime it doesnt compile anymore with scala 2.11. There is a bug about annotations missing in classpath. -->
+				<!-- this is an unused declared dependency, but it's needed to override scope -->
+				<dependency>
+					<groupId>org.apache.spark</groupId>
+					<artifactId>spark-tags_${scala.minor.version}</artifactId>
+					<version>${spark.version}</version>
+					<scope>compile</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 	</profiles>
 

--- a/sdl-kafka/pom.xml
+++ b/sdl-kafka/pom.xml
@@ -39,6 +39,16 @@
 				<!-- do not include sdl-core into fat-jar for this module, as sdl-core is normally put into classpath separately -->
 				<sdl-core.scope>provided</sdl-core.scope>
 			</properties>
+			<dependencies>
+				<!-- spark-tags needs to have compile scope; if it's runtime it doesnt compile anymore with scala 2.11. There is a bug about annotations missing in classpath. -->
+				<!-- this is an unused declared dependency, but it's needed to override scope -->
+				<dependency>
+					<groupId>org.apache.spark</groupId>
+					<artifactId>spark-tags_${scala.minor.version}</artifactId>
+					<version>${spark.version}</version>
+					<scope>compile</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 	</profiles>
 

--- a/sdl-splunk/pom.xml
+++ b/sdl-splunk/pom.xml
@@ -39,6 +39,16 @@
 				<!-- do not include sdl-core into fat-jar for this module, as sdl-core is normally put into classpath separately -->
 				<sdl-core.scope>provided</sdl-core.scope>
 			</properties>
+			<dependencies>
+				<!-- spark-tags needs to have compile scope; if it's runtime it doesnt compile anymore with scala 2.11. There is a bug about annotations missing in classpath. -->
+				<!-- this is an unused declared dependency, but it's needed to override scope -->
+				<dependency>
+					<groupId>org.apache.spark</groupId>
+					<artifactId>spark-tags_${scala.minor.version}</artifactId>
+					<version>${spark.version}</version>
+					<scope>compile</scope>
+				</dependency>
+			</dependencies>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
### What changes are included in the pull request?
artifact spark-tags needs to have compile scope for compilation of fat-jar for modules with scala-2.11

### Why are the changes needed?
Through profile fat-jar scope of sdl-core is set to provided in modules. 
Although artifacts with scope compile are available for compile, compiling with scala-2.11 fails because of missing annotations defined in spark-tags. Setting scope of spark-tags to compile helps.

The error doesnt exist with spark-2.12. This fixed is therefore not needed on SDL 2.x.

@pgruetter: @MarkusRothSBB would like to have a 1.2.x release including this fix asap if possible