### PR TITLE
implement ProcessAllMode

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -333,8 +333,21 @@ case class FailIfNoPartitionValuesMode() extends ExecutionMode {
                                            (implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Seq[PartitionValues], Option[String])] = {
     // check if partition values present
     if (subFeed.partitionValues.isEmpty) throw new IllegalStateException(s"($actionId) Partition values are empty for mainInput ${subFeed.dataObjectId.id}")
-    // return
+    // return: no change of given partition values and filter
     None
+  }
+}
+
+/**
+ * An execution mode which forces processing all data from it's inputs.
+ */
+case class ProcessAllMode() extends ExecutionMode {
+  private[smartdatalake] override def apply(actionId: ActionObjectId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
+                                            , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
+                                           (implicit session: SparkSession, context: ActionPipelineContext): Option[(Seq[PartitionValues], Seq[PartitionValues], Option[String])] = {
+    // return: reset given partition values and filter
+    logger.info(s"($actionId) ProcessModeAll reset partition values")
+    Some(Seq(),Seq(),None)
   }
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -136,7 +136,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
         if (noData) logger.info(s"($id) no data to process for ${output.id} in streaming mode")
         // return
         noData
-      case None | Some(_: PartitionDiffMode) | Some(_: SparkIncrementalMode) | Some(_: FailIfNoPartitionValuesMode) | Some(_: CustomPartitionMode) =>
+      case None | Some(_: PartitionDiffMode) | Some(_: SparkIncrementalMode) | Some(_: FailIfNoPartitionValuesMode) | Some(_: CustomPartitionMode) | Some(_: ProcessAllMode) =>
         // Auto persist if dataFrame is reused later
         val preparedSubFeed = if (context.dataFrameReuseStatistics.contains((output.id, subFeed.partitionValues))) {
           val partitionValuesStr = if (subFeed.partitionValues.nonEmpty) s" and partitionValues ${subFeed.partitionValues.mkString(", ")}" else ""


### PR DESCRIPTION
### What changes are included in the pull request?
implement ProcessAllMode: this execution mode resets partition values and filter so that all data is read from input DataObjects.

### Why are the changes needed?
If you want to switch from an incremental processing to full processing in the middle of a data pipeline, reset of partition values is needed.
