### PR TITLE
Bugfix/positive number of partitions required

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -169,7 +169,7 @@ object Environment {
     , "create-sql", "createSql", "pre-read-sql", "preReadSql", "post-read-sql", "postReadSql", "pre-write-sql", "preWriteSql", "post-write-sql", "postWriteSql"
     , "executionMode.checkpointLocation", "execution-mode.checkpoint-location")
   val defaultPathSeparator: Char = '/'
-  val runIdPartitionColumnName = "_run_id"
+  val runIdPartitionColumnName = "run_id"
 
   // dynamically shared environment for custom code (see also #106)
   def sparkSession: SparkSession = _sparkSession

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
@@ -108,7 +108,7 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
     val fs = getHadoopFsFromSpark(existingFilePath)
     val (numFiles, sumSize, avgSize) = HdfsUtil.sizeInfo(existingFilePath, fs)
     val reduceBy = if(reducePartitions) 2 else 1
-    val numPartitionsRequired = Math.max(1,Math.ceil(sumSize.toDouble/desiredSize.toDouble).toInt) / reduceBy
+    val numPartitionsRequired = Math.max(1,Math.ceil(sumSize.toDouble / desiredSize / reduceBy).toInt)
     val currentPartitionNum = df.rdd.getNumPartitions
 
     logger.debug(s"Current Parquet files: ${numFiles} with a size of ${sumSize}. Requiring ${numPartitionsRequired} partitions now.")


### PR DESCRIPTION
Change:
- change _run_id partition column name to run_id

Fix:
- dont automatically repartition if numInitialHdfsPartitions = -1
- make sure numPartitionsRequired is not equal to 0

Note that these changes didn't resolve the bug we where facing, nevertheless they are good improvements.
