### PR TITLE
Added and implemented AtlasExportable trait

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/AtlasExportable.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/AtlasExportable.scala
@@ -1,0 +1,25 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2021 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow
+
+trait AtlasExportable {
+  def atlasQualifiedName(prefix: String): String = s"$prefix.$atlasName"
+  def atlasName: String
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -42,7 +42,7 @@ import scala.util.{Success, Try}
  * An action defines a [[DAGNode]], that is, a transformation from input [[DataObject]]s to output [[DataObject]]s in
  * the DAG of actions.
  */
-private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNode with SmartDataLakeLogger {
+private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNode with SmartDataLakeLogger with AtlasExportable {
 
   /**
    * A unique identifier for this instance.
@@ -320,6 +320,8 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
     val outputStr = outputs.map( _.toStringShort).mkString(", ")
     s"$toStringShort Inputs: $inputStr Outputs: $outputStr"
   }
+
+  override def atlasName: String = id.id
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/Connection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/Connection.scala
@@ -20,8 +20,9 @@ package io.smartdatalake.workflow.connection
 
 import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{ParsableFromConfig, SdlConfigObject}
+import io.smartdatalake.workflow.AtlasExportable
 
-private[smartdatalake] trait Connection extends SdlConfigObject with ParsableFromConfig[Connection] {
+private[smartdatalake] trait Connection extends SdlConfigObject with ParsableFromConfig[Connection] with AtlasExportable {
 
   /**
    * A unique identifier for this instance.
@@ -36,6 +37,8 @@ private[smartdatalake] trait Connection extends SdlConfigObject with ParsableFro
   def toStringShort: String = {
     s"$id[${this.getClass.getSimpleName}]"
   }
+
+  override def atlasName: String = id.id
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
@@ -22,7 +22,7 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, InstanceRegistry, ParsableFromConfig, SdlConfigObject}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.{ActionPipelineContext, AtlasExportable}
 import io.smartdatalake.workflow.connection.Connection
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.SparkSession
@@ -34,7 +34,7 @@ import scala.reflect.runtime.universe._
  * This is the root trait for every DataObject.
  */
 @DeveloperApi
-trait DataObject extends SdlConfigObject with ParsableFromConfig[DataObject] with SmartDataLakeLogger {
+trait DataObject extends SdlConfigObject with ParsableFromConfig[DataObject] with SmartDataLakeLogger with AtlasExportable {
 
   /**
    * A unique identifier for this instance.
@@ -101,6 +101,8 @@ trait DataObject extends SdlConfigObject with ParsableFromConfig[DataObject] wit
   def toStringShort: String = {
     s"$id[${this.getClass.getSimpleName}]"
   }
+
+  override def atlasName: String = id.id
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
@@ -53,4 +53,8 @@ private[smartdatalake] trait TableDataObject extends DataObject with CanCreateDa
   def isPKcandidateKey(implicit session: SparkSession, context: ActionPipelineContext): Boolean =  {
     table.primaryKey.isEmpty || getDataFrame().isCandidateKey(table.primaryKey.get.toArray)
   }
+
+  override def atlasQualifiedName(prefix: String): String = s"${table.db.getOrElse("default")}.${table.name}"
+
+  override def atlasName: String = id.id
 }


### PR DESCRIPTION
### What changes are included in the pull request?
Trait to provide name and qualified name for classes that are to be exported to Atlas.

### Why are the changes needed?
Atlas entities require a name and a qualified name. The qualified name is used as a unique identifier between entities of the same type. In order to avoid unwanted ambiguity (different qualified names) or overlap (same qualified name), each exportable class needs to determine how the qualified name of its instances is composed.