### PR TITLE
implement support to register python UDFs for Spark SQL transformations

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -27,7 +27,7 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.misc.{MemoryUtils, SmartDataLakeLogger}
 import io.smartdatalake.util.secrets.{SecretProviderConfig, SecretsUtil}
-import io.smartdatalake.workflow.action.customlogic.SparkUDFCreatorConfig
+import io.smartdatalake.workflow.action.customlogic.{PythonUDFCreatorConfig, SparkUDFCreatorConfig}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.custom.ExpressionEvaluator
 
@@ -42,6 +42,8 @@ import org.apache.spark.sql.custom.ExpressionEvaluator
  * @param stateListeners Define state listeners to be registered for receiving events of the execution of SmartDataLake job
  * @param sparkUDFs      Define UDFs to be registered in spark session. The registered UDFs are available in Spark SQL transformations
  *                       and expression evaluation, e.g. configuration of ExecutionModes.
+ * @param pythonUDFs     Define UDFs in python to be registered in spark session. The registered UDFs are available in Spark SQL transformations
+ *                       but not for expression evaluation.
  * @param secretProviders Define SecretProvider's to be registered.
  * @param allowOverwriteAllPartitionsWithoutPartitionValues Configure a list of exceptions for partitioned DataObject id's,
  *                       which are allowed to overwrite the all partitions of a table if no partition values are set.
@@ -55,6 +57,7 @@ case class GlobalConfig( kryoClasses: Option[Seq[String]] = None
                        , shutdownHookLogger: Boolean = false
                        , stateListeners: Seq[StateListenerConfig] = Seq()
                        , sparkUDFs: Option[Map[String,SparkUDFCreatorConfig]] = None
+                       , pythonUDFs: Option[Map[String,PythonUDFCreatorConfig]] = None
                        , secretProviders: Option[Map[String,SecretProviderConfig]] = None
                        , allowOverwriteAllPartitionsWithoutPartitionValues: Seq[DataObjectId] = Seq()
                        )
@@ -82,16 +85,20 @@ extends SmartDataLakeLogger {
     // prepare additional spark options
     // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
     val executorPlugins = (sparkOptions.flatMap(_.get("spark.executor.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq()))
-    // config for MemoryLoggerExecutorPlugin can only be transfered to Executor by spark-options
+    // config for MemoryLoggerExecutorPlugin can only be transferred to Executor by spark-options
     val memoryLogOptions = memoryLogTimer.map(_.getAsMap).getOrElse(Map())
     val sparkOptionsExtended = sparkOptions.getOrElse(Map()) ++ memoryLogOptions ++ (if (executorPlugins.nonEmpty) Map("spark.executor.plugins" -> executorPlugins.mkString(",")) else Map())
     Environment._sparkSession = AppUtil.createSparkSession(appName, master, deployMode, kryoClasses, sparkOptionsExtended, enableHive)
-    sparkUDFs.getOrElse(Map()).foreach { case (name,creator) =>
-      val udf = creator.get
+    sparkUDFs.getOrElse(Map()).foreach { case (name,config) =>
+      val udf = config.getUDF
       // register in SDL spark session
       Environment._sparkSession.udf.register(name, udf)
       // register for use in expression evaluation
       ExpressionEvaluator.registerUdf(name, udf)
+    }
+    pythonUDFs.getOrElse(Map()).foreach { case (name,config) =>
+      // register in SDL spark session
+      config.registerUDF(name, Environment._sparkSession)
     }
     // return
     Environment._sparkSession

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonUDFCreatorConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonUDFCreatorConfig.scala
@@ -1,0 +1,52 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2021 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.customlogic
+
+import io.smartdatalake.config.ConfigurationException
+import io.smartdatalake.util.hdfs.HdfsUtil
+import io.smartdatalake.util.misc.{PythonSparkEntryPoint, PythonUtil}
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Configuration to register a Python UDF in the spark session of SmartDataLake.
+ * Define a python function with type hints i python code and register it in global configuration.
+ * The name of the function must match the name you use to declare it in GlobalConf.
+ * The Python function can then be used in Spark SQL expressions.
+ *
+ * @param pythonFile Optional pythonFile to use for python UDF.
+ * @param pythonCode Optional pythonCode to use for python UDF.
+ * @param options Options are available in your python code as variable options.
+ */
+case class PythonUDFCreatorConfig(pythonFile: Option[String] = None, pythonCode: Option[String] = None, options: Map[String,String] = Map()) {
+  require(pythonFile.isDefined || pythonCode.isDefined, "Either pythonFile or pythonCode must be defined for SparkUDFCreatorConfig")
+
+  private val functionCode = pythonFile.map(HdfsUtil.readHadoopFile).orElse(pythonCode.map(_.stripMargin)).get
+
+  private[smartdatalake] def registerUDF(functionName: String, session: SparkSession): Unit = {
+    val entryPoint = new PythonSparkEntryPoint(session, options)
+    val registrationCode =
+      s"""
+         |session.udf.register("$functionName", $functionName)
+         |print()
+         |print("python udf $functionName registered")
+         |""".stripMargin
+    PythonUtil.execPythonSparkCode( entryPoint, functionCode + sys.props("line.separator") + registrationCode)
+  }
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
@@ -39,7 +39,7 @@ case class SparkUDFCreatorConfig(className: String, options: Map[String,String] 
     case e: NoSuchMethodException => throw ConfigurationException(s"SparkUDFCreatorConfig class $className needs constructor without parameters: ${e.getMessage}", Some("globalConfig.sparkUDFs"), e)
     case e: Exception => throw ConfigurationException(s"Cannot instantiate SparkUDFCreatorConfig class $className: ${e.getMessage}", Some("globalConfig.sparkUDFs"), e)
   }
-  private[smartdatalake] def get: UserDefinedFunction = creator.get(options)
+  private[smartdatalake] def getUDF: UserDefinedFunction = creator.get(options)
 }
 
 /**

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
@@ -123,7 +123,7 @@ class ExecutionModeTest extends FunSuite with BeforeAndAfter {
 
   test("PartitionDiffMode selectAdditionalInputExpression with udf") {
     val udfConfig = SparkUDFCreatorConfig(classOf[TestUdfAddLastnameEinstein].getName)
-    ExpressionEvaluator.registerUdf("testUdfAddLastNameEinstein", udfConfig.get)
+    ExpressionEvaluator.registerUdf("testUdfAddLastNameEinstein", udfConfig.getUDF)
     val executionMode = PartitionDiffMode(selectAdditionalInputExpression = Some("testUdfAddLastNameEinstein(selectedInputPartitionValues,inputPartitionValues)"))
     executionMode.prepare(ActionId("test"))
     val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())


### PR DESCRIPTION
### What changes are included in the pull request?
Support to register python udfs in global config, which can then be used in Spark SQL.

### Why are the changes needed?
nice feature