### PR TITLE
validate partition columns existing on write and read

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
@@ -19,14 +19,15 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.SchemaViolationException
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
  * A trait to be implemented by DataObjects which store partitioned data
  */
 @DeveloperApi
-trait CanHandlePartitions {
+trait CanHandlePartitions { this: DataObject =>
 
   /**
    * Definition of partition columns
@@ -78,5 +79,17 @@ trait CanHandlePartitions {
       val expectedHashCodes = partitionsValuesStringWithHashCode.toDF("elements","hashCode").where(expr(condition)).select($"hashCode").as[Int].collect.toSet
       partitionValues.filter( pv => expectedHashCodes.contains(pv.hashCode))
     }.getOrElse(partitionValues)
+  }
+
+  /**
+   * Validate the schema of a given Spark Data Frame `df` that it contains the specified partition columns
+   *
+   * @param df The data frame to validate.
+   * @param role role used in exception message. Set to read or write.
+   * @throws SchemaViolationException if the partitions columns are not included.
+   */
+  def validateSchemaHasPartitionCols(df: DataFrame, role: String): Unit = {
+    val missingCols = partitions.diff(df.columns)
+    if (missingCols.nonEmpty) throw new SchemaViolationException(s"($id) DataFrame is missing partition cols ${missingCols.mkString(", ")} on $role")
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -129,6 +129,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
     val df = session.table(s"${table.fullName}")
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     df
   }
 
@@ -140,6 +141,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
   override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.init(df, partitionValues)
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     // validate against hive table schema if existing
     if (isTableExisting && !isOverwriteSchemaAllowed) validateSchema(df, session.table(table.fullName).schema, "write")
   }
@@ -156,6 +158,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     require(!isRecursiveInput, "($id) HiveTableDataObject cannot write dataframe when dataobject is also used as recursive input ")
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     writeDataFrameInternal(df, createTableOnly = false, partitionValues)
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -65,6 +65,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
    */
   def beforeWrite(df: DataFrame)(implicit session: SparkSession): DataFrame = {
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     schema.foreach(schemaExpected => validateSchema(df, schemaExpected, "write"))
     df
   }
@@ -76,6 +77,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
    */
   def afterRead(df: DataFrame)(implicit session: SparkSession): DataFrame = {
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     schema.map(createReadSchema).foreach(schemaExpected => validateSchema(df, schemaExpected, "read"))
     df
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -108,6 +108,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
   override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.init(df, partitionValues)
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
   }
 
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
@@ -120,6 +121,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     }
 
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     df
   }
 
@@ -134,6 +136,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     writeDataFrameInternal(df, createTableOnly=false, partitionValues, isRecursiveInput)
 
     // make sure empty partitions are created as well

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -97,9 +97,16 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
 
+  override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.init(df, partitionValues)
+    validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
+  }
+
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
     val df = session.read.format("delta").load(hadoopPath.toString)
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     df
   }
 
@@ -114,6 +121,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     writeDataFrame(df, createTableOnly=false, partitionValues)
   }
 


### PR DESCRIPTION
### What changes are included in the pull request?
Validate that partition columns are existing in DataFrame, when writing or reading from "DataObjects with CanHandlePartitions".

### Why are the changes needed?
The validation doesn't cost much and ensures schema consistency early.