### PR TITLE
fix use relative path for listing partitions

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -171,14 +171,14 @@ private[smartdatalake] object PartitionLayout {
     partitionLayoutPrepared = tokenRegex.replaceAllIn( partitionLayoutPrepared, {
       tokenMatch => if (tokenMatch.group(3) != null) s"(${tokenMatch.group(3)})" else "(.*?)"
     })
-    // create regex and match with path
-    val partitionLayoutRegex = partitionLayoutPrepared.r
+    // create regex and match with path.
+    val partitionLayoutRegex = ("^" + partitionLayoutPrepared).r // add anchor at start of string.
     partitionLayoutRegex.findFirstMatchIn(path) match {
       case Some(regexMatch) =>
         val tokenValues = (1 to regexMatch.groupCount).map( i => regexMatch.group(i))
         val tokenMap = tokens.zip(tokenValues).toMap
         PartitionValues(tokenMap)
-      case None => throw new Exception(s"prepared regexp partition layout $partitionLayoutPrepared didn't match path $path")
+      case None => throw new RuntimeException(s"""prepared regexp partition layout "$partitionLayoutRegex" didn't match path "$path"""")
     }
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
@@ -58,6 +58,8 @@ case class CustomFileDataObject(override val id: DataObjectId,
 
   override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = Seq()
 
+  override def relativizePath(filePath: String): String = filePath
+
   override def factory: FromConfigFactory[DataObject] = CustomFileDataObject
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
@@ -37,4 +37,9 @@ private[smartdatalake] trait FileDataObject extends DataObject with CanHandlePar
     super.prepare
     filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
+
+  /**
+   * Make a given path relative to this DataObjects base path
+   */
+  def relativizePath(filePath: String): String
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -22,6 +22,7 @@ import io.smartdatalake.definitions.Environment
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.hdfs.{PartitionLayout, PartitionValues}
 import io.smartdatalake.workflow.ActionPipelineContext
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 
 private[smartdatalake] trait FileRefDataObject extends FileDataObject {
@@ -108,7 +109,7 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
    * Extract partition values from a given file path
    */
   protected def extractPartitionValuesFromPath(filePath: String): PartitionValues = {
-    PartitionLayout.extractPartitionValues(partitionLayout().get, fileName, filePath.stripPrefix(path + separator))
+    PartitionLayout.extractPartitionValues(partitionLayout().get, fileName, relativizePath(filePath))
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -195,11 +195,15 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
         // list directories and extract partition values
         filesystem.globStatus( new Path(hadoopPath, pattern))
           .filter{fs => fs.isDirectory}
-          .map(_.getPath.toString)
-          .map( path => PartitionLayout.extractPartitionValues(partitionLayout, "", path + separator))
+          .map(path => PartitionLayout.extractPartitionValues(partitionLayout, "", relativizePath(path.getPath.toString) + separator))
           .toSeq
     }.getOrElse(Seq())
   }
+
+  override def relativizePath(path: String): String = {
+    hadoopPathUri.relativize(new Path(path).toUri).toString
+  }
+  private val hadoopPathUri = hadoopPath.toUri
 
   override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {
     // check if valid init of partitions -> otherwise we can not create empty partition as path is not fully defined

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -131,9 +131,13 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
             val pattern = PartitionLayout.replaceTokens(partitionLayout, PartitionValues(Map()))
             // list directories and extract partition values
             SshUtil.sftpListFiles(path + separator + pattern)(sftp)
-              .map( f => PartitionLayout.extractPartitionValues(partitionLayout, "", f.stripPrefix(path+separator) + separator))
+              .map( f => PartitionLayout.extractPartitionValues(partitionLayout, "", relativizePath(f) + separator))
         }
     }.getOrElse(Seq())
+  }
+
+  override def relativizePath(filePath: String): String = {
+    filePath.stripPrefix(path+separator)
   }
 
   override def prepare(implicit session: SparkSession): Unit = try {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -214,6 +214,8 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
    */
   override def path: String = ""
 
+  override def relativizePath(filePath: String): String = filePath
+
   override def factory: FromConfigFactory[DataObject] = WebserviceFileDataObject
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionLayoutTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionLayoutTest.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.util.hdfs
 
+import io.smartdatalake.definitions.Environment
 import org.scalatest.FunSuite
 
 class PartitionLayoutTest extends FunSuite {
@@ -43,5 +44,20 @@ class PartitionLayoutTest extends FunSuite {
     val partitionString = "abc/date2000-01-01-ZZ-test.csv"
     val partitionValues = PartitionLayout.extractPartitionValues(testLayout, "*.csv", partitionString)
     assert(partitionValues == PartitionValues(Map("date" -> "2000-01-01", "type" -> "ZZ")))
+  }
+
+  test("extracting partition values according to hadoop partition layout") {
+    val delimiter = PartitionLayout.delimiter
+    val testLayout = HdfsUtil.getHadoopPartitionLayout(Seq("a","b"), Environment.defaultPathSeparator)
+    val partitionString = "a=1/b=2/test.csv"
+    val partitionValues = PartitionLayout.extractPartitionValues(testLayout, "*.csv", partitionString)
+    assert(partitionValues == PartitionValues(Map("a" -> "1", "b" -> "2")))
+  }
+
+  test("fail extracting partition values if partition string doesn't start with partition layout") {
+    val delimiter = PartitionLayout.delimiter
+    val testLayout = HdfsUtil.getHadoopPartitionLayout(Seq("a","b"), Environment.defaultPathSeparator)
+    val partitionString = "test/a=1/b=2/test.csv"
+    intercept[RuntimeException](PartitionLayout.extractPartitionValues(testLayout, "*.csv", partitionString))
   }
 }


### PR DESCRIPTION
### Why are the changes needed?
Listing partitions is currently done on absolute path. Wrong results are produces if the partition layout pattern is already found in the base path of the DataObject. Note that this is a rare case as the pattern normally includes "=", but i struggled with it.

### What changes are included in the pull request?
Listing Partitions is done on relative path. Path of files/directories are relativized against the base path of the DataObject before extracting partitions.
