### PR TITLE
Feature/sdl snowflake improvements

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/evolution/ValueProjector.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/evolution/ValueProjector.scala
@@ -90,6 +90,7 @@ private[smartdatalake] object ValueProjector {
       case (_: FloatType, _: DoubleType) => (x => x.asInstanceOf[Float].toDouble)
       case (d: DecimalType, _: FloatType) if d.precision <= 7 => (x => x.asInstanceOf[BigDecimal].toFloat)
       case (d: DecimalType, _: DoubleType) if d.precision <= 16 => (x => x.asInstanceOf[BigDecimal].toDouble)
+      case (d: DecimalType, _: IntegerType) => (x => x.asInstanceOf[BigDecimal].toDouble)
       case _ => throw SchemaEvolutionException(s"""schema evolution from $srcType to $tgtType not supported (field ${path.mkString(",")})""")
     }
     // add null check

--- a/sdl-core/src/main/scala/io/smartdatalake/util/evolution/ValueProjector.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/evolution/ValueProjector.scala
@@ -90,7 +90,6 @@ private[smartdatalake] object ValueProjector {
       case (_: FloatType, _: DoubleType) => (x => x.asInstanceOf[Float].toDouble)
       case (d: DecimalType, _: FloatType) if d.precision <= 7 => (x => x.asInstanceOf[BigDecimal].toFloat)
       case (d: DecimalType, _: DoubleType) if d.precision <= 16 => (x => x.asInstanceOf[BigDecimal].toDouble)
-      case (d: DecimalType, _: IntegerType) => (x => x.asInstanceOf[BigDecimal].toDouble)
       case _ => throw SchemaEvolutionException(s"""schema evolution from $srcType to $tgtType not supported (field ${path.mkString(",")})""")
     }
     // add null check

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/connection/SnowflakeTableConnection.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/connection/SnowflakeTableConnection.scala
@@ -33,17 +33,17 @@ import net.snowflake.spark.snowflake.Utils
  *
  * @param id        unique id of this connection
  * @param url       snowflake connection url
- * @param authMode  optional authentication information: for now BasicAuthMode is supported.
  * @param warehouse Snowflake namespace
- * @param db        Snowflake database
- * @param schema    Snowflake database
- * @param metadata
+ * @param database  Snowflake database
+ * @param role      Snowflake role
+ * @param authMode  optional authentication information: for now BasicAuthMode is supported.
+ * @param metadata  Connection metadata
  */
 case class SnowflakeTableConnection(override val id: ConnectionId,
                                     url: String,
                                     warehouse: String,
-                                    db: String,
-                                    schema: String,
+                                    database: String,
+                                    role: String,
                                     authMode: Option[AuthMode] = None,
                                     override val metadata: Option[ConnectionMetadata] = None
                                    ) extends Connection with SmartDataLakeLogger {
@@ -63,8 +63,8 @@ case class SnowflakeTableConnection(override val id: ConnectionId,
           "sfURL" -> url,
           "sfUser" -> m.user,
           "sfPassword" -> m.password,
-          "sfDatabase" -> schema,
-          "sfSchema" -> db,
+          "sfDatabase" -> database,
+          "sfRole" -> role,
           "sfWarehouse" -> warehouse
         )
       case _ => throw new IllegalArgumentException(s"($id) No supported authMode given for Snowflake connection.")

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/connection/SnowflakeTableConnection.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/connection/SnowflakeTableConnection.scala
@@ -53,10 +53,10 @@ case class SnowflakeTableConnection(override val id: ConnectionId,
 
   def execSnowflakeStatement(sql: String, logging: Boolean = true): ResultSet = {
     if (logging) logger.info(s"($id) execSnowflakeStatement: $sql")
-    Utils.runQuery(getSnowflakeOptions, sql)
+    Utils.runQuery(getSnowflakeOptions(""), sql)
   }
 
-  def getSnowflakeOptions: Map[String, String] = {
+  def getSnowflakeOptions(schema: String): Map[String, String] = {
     if (authMode.isDefined) authMode.get match {
       case m: BasicAuthMode =>
         Map(
@@ -65,6 +65,7 @@ case class SnowflakeTableConnection(override val id: ConnectionId,
           "sfPassword" -> m.password,
           "sfDatabase" -> database,
           "sfRole" -> role,
+          "sfSchema" -> schema,
           "sfWarehouse" -> warehouse
         )
       case _ => throw new IllegalArgumentException(s"($id) No supported authMode given for Snowflake connection.")

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -68,7 +68,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
     val df = session
       .read
       .format(SNOWFLAKE_SOURCE_NAME)
-      .options(connection.getSnowflakeOptions)
+      .options(connection.getSnowflakeOptions(table.db.get))
       .options(queryOrTable)
       .load()
     validateSchemaMin(df, "read")
@@ -95,7 +95,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
 
     dfPrepared.write
       .format(SNOWFLAKE_SOURCE_NAME)
-      .options(connection.getSnowflakeOptions)
+      .options(connection.getSnowflakeOptions(table.db.get))
       .options(Map("dbtable" -> (connection.database + "." + table.fullName)))
       .mode(saveMode)
       .save()

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -59,7 +59,6 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
   private val connection = getConnection[SnowflakeTableConnection](connectionId)
 
   // prepare table
-  table = table
   if (table.db.isEmpty) {
     throw ConfigurationException(s"($id) A SnowFlake schema name must be added as the 'db' parameter of a SnowflakeTableDataObject.")
   }

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -39,14 +39,16 @@ import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
  * @param schemaMin    An optional, minimal schema that this DataObject must have to pass schema validation on reading and writing.
  * @param table        Snowflake table to be written by this output
  * @param saveMode     spark [[SaveMode]] to use when writing files, default is "overwrite"
- * @param connectionId optional id of [[SnowflakeTableConnection]]
+ * @param connectionId The SnowflakeTableConnection to use for the table
+ * @param comment      An optional comment to add to the table after writing a DataFrame to it
  * @param metadata     meta data
  */
 case class SnowflakeTableDataObject(override val id: DataObjectId,
                                     override val schemaMin: Option[StructType] = None,
                                     override var table: Table,
                                     saveMode: SaveMode = SaveMode.Overwrite,
-                                    connectionId: Option[ConnectionId] = None,
+                                    connectionId: ConnectionId,
+                                    comment: Option[String],
                                     override val metadata: Option[DataObjectMetadata] = None)
                                    (@transient implicit val instanceRegistry: InstanceRegistry)
   extends TransactionalSparkTableDataObject {
@@ -54,8 +56,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
   /**
    * Connection defines connection string, credentials and database schema/name
    */
-  private val connection = connectionId.map(c => getConnection[SnowflakeTableConnection](c))
-  assert(connection.isDefined, "($id) A SnowflakeTableDataObject needs to have an assigned SnowflakeTableConnection.")
+  private val connection = getConnection[SnowflakeTableConnection](connectionId)
 
   // prepare table
   table = table
@@ -64,11 +65,11 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
   }
 
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
-    val queryOrTable = Map(table.query.map(q => ("query", q)).getOrElse("dbtable" -> (connection.get.database + "." + table.fullName)))
+    val queryOrTable = Map(table.query.map(q => ("query", q)).getOrElse("dbtable" -> (connection.database + "." + table.fullName)))
     val df = session
       .read
       .format(SNOWFLAKE_SOURCE_NAME)
-      .options(connection.get.getSnowflakeOptions)
+      .options(connection.getSnowflakeOptions)
       .options(queryOrTable)
       .load()
     validateSchemaMin(df, "read")
@@ -95,24 +96,26 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
 
     dfPrepared.write
       .format(SNOWFLAKE_SOURCE_NAME)
-      .options(connection.get.getSnowflakeOptions)
-      .options(Map("dbtable" -> (connection.get.database + "." + table.fullName)))
+      .options(connection.getSnowflakeOptions)
+      .options(Map("dbtable" -> (connection.database + "." + table.fullName)))
       .mode(saveMode)
       .save()
+
+    if (comment.isDefined) {
+      val sql = s"comment on table ${connection.database}.${table.fullName} is '${comment.get}';"
+      connection.execSnowflakeStatement(sql)
+    }
   }
 
-  override def isDbExisting(implicit session: SparkSession): Boolean =
-    connection.map(connection => {
-      val sql = s"SHOW DATABASES LIKE '${connection.database}'"
-      connection.execSnowflakeStatement(sql)
-    }).exists(resultSet => resultSet.next())
+  override def isDbExisting(implicit session: SparkSession): Boolean = {
+    val sql = s"SHOW DATABASES LIKE '${connection.database}'"
+    connection.execSnowflakeStatement(sql).next()
+  }
 
 
   override def isTableExisting(implicit session: SparkSession): Boolean = {
-    connection.map(connection => {
-      val sql = s"SHOW TABLES LIKE '${table.name}' IN SCHEMA ${connection.database}.${table.db.get}"
-      connection.execSnowflakeStatement(sql)
-    }).exists(resultSet => resultSet.next())
+    val sql = s"SHOW TABLES LIKE '${table.name}' IN SCHEMA ${connection.database}.${table.db.get}"
+    connection.execSnowflakeStatement(sql).next()
   }
 
   override def dropTable(implicit session: SparkSession): Unit = throw new NotImplementedError()


### PR DESCRIPTION
### What changes are included in the pull request?
Some improvements to the sdl-snowflake module:
-Ability to choose the role that Snowflake uses
-Improvement to the mixup of db/schema: Snowflake database is now called database, Snowflake schema is called db (consisent with schemas in other databases that are also called db)
-Snowflake database can and must only be set on SnowflakeTableConnection
-Snowflake schema (db) can and must only be set on SnowflakeTableDataObject
-Add the ability to add Snowflake table comments to the SnowflakeTableDataObject (since the table can get recreated for every write, the comment must be set every time)