### PR TITLE
Release 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>io.smartdatalake</groupId>
 	<artifactId>sdl-parent</artifactId>
-	<version>2.0.3</version>
+	<version>2.0.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
 
 		<spark.version>3.1.1</spark.version>
 		<spark.minor.version>3.0</spark.minor.version> <!-- this is used in sdl-snowflake which has no version yet for Spark 3.1 -->
-		<spark-extensions.version>2.0.10</spark-extensions.version>
+		<spark-extensions.version>2.0.11</spark-extensions.version>
 
 		<!-- SPARK-PARENT start: properties copied from spark-parent pom version 2.4.7 for spark-parent import in dependencyManagement -->
 		<!-- attention - manually adapted are: zookeeper, scala.version, scala.binary.version -->

--- a/pom.xml
+++ b/pom.xml
@@ -219,9 +219,9 @@
 		<scala.minor.version>2.12</scala.minor.version>
 		<scala.version>${scala.minor.version}.12</scala.version>
 
-		<spark.version>3.0.1</spark.version>
-		<spark.minor.version>3.0</spark.minor.version>
-		<spark-extensions.version>2.0.8</spark-extensions.version>
+		<spark.version>3.1.1</spark.version>
+		<spark.minor.version>3.0</spark.minor.version> <!-- this is used in sdl-snowflake which has no version yet for Spark 3.1 -->
+		<spark-extensions.version>2.0.10</spark-extensions.version>
 
 		<!-- SPARK-PARENT start: properties copied from spark-parent pom version 2.4.7 for spark-parent import in dependencyManagement -->
 		<!-- attention - manually adapted are: zookeeper, scala.version, scala.binary.version -->

--- a/pom.xml
+++ b/pom.xml
@@ -234,22 +234,19 @@
 		<protobuf.version>2.5.0</protobuf.version>
 		<yarn.version>${hadoop.version}</yarn.version>
 		<zookeeper.version>3.4.14</zookeeper.version>
-		<curator.version>2.7.1</curator.version>
+		<curator.version>2.13.0</curator.version>
 		<hive.group>org.apache.hive</hive.group>
 		<hive.classifier>core</hive.classifier>
-		<!--  Version used in Maven Hive dependency  -->
+		<!-- Version used in Maven Hive dependency -->
 		<hive.version>2.3.7</hive.version>
 		<hive23.version>2.3.7</hive23.version>
 		<!-- Version used for internal directory structure -->
 		<hive.version.short>2.3</hive.version.short>
 		<derby.version>10.12.1.1</derby.version>
 		<parquet.version>1.10.1</parquet.version>
-		<orc.version>1.5.10</orc.version>
-		<orc.classifier/>
-		<hive.parquet.group>com.twitter</hive.parquet.group>
-		<hive.parquet.version>1.6.0</hive.parquet.version>
-		<jetty.version>9.4.18.v20190429</jetty.version>
-		<javaxservlet.version>3.1.0</javaxservlet.version>
+		<orc.version>1.5.12</orc.version>
+		<jetty.version>9.4.36.v20210114</jetty.version>
+		<jakartaservlet.version>4.0.3</jakartaservlet.version>
 		<chill.version>0.9.5</chill.version>
 		<ivy.version>2.4.0</ivy.version>
 		<oro.version>2.0.8</oro.version>
@@ -280,14 +277,15 @@
 		<scalafmt.skip>true</scalafmt.skip>
 		<codehaus.jackson.version>1.9.13</codehaus.jackson.version>
 		<fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
-		<snappy.version>1.1.7.5</snappy.version>
+		<snappy.version>1.1.8.2</snappy.version>
 		<netlib.java.version>1.1.2</netlib.java.version>
 		<commons-codec.version>1.10</commons-codec.version>
-		<commons-io.version>2.4</commons-io.version>
+		<commons-compress.version>1.20</commons-compress.version>
+		<commons-io.version>2.5</commons-io.version>
 		<!-- org.apache.commons/commons-lang/-->
 		<commons-lang2.version>2.6</commons-lang2.version>
 		<!-- org.apache.commons/commons-lang3/-->
-		<commons-lang3.version>3.9</commons-lang3.version>
+		<commons-lang3.version>3.10</commons-lang3.version>
 		<!-- org.apache.commons/commons-pool2/-->
 		<commons-pool2.version>2.6.2</commons-pool2.version>
 		<datanucleus-core.version>4.1.17</datanucleus-core.version>
@@ -298,25 +296,24 @@
 		<jodd.version>3.5.2</jodd.version>
 		<jsr305.version>3.0.0</jsr305.version>
 		<libthrift.version>0.12.0</libthrift.version>
-		<antlr4.version>4.7.1</antlr4.version>
+		<antlr4.version>4.8-1</antlr4.version>
 		<jpam.version>1.1</jpam.version>
-		<selenium.version>2.52.0</selenium.version>
-		<htmlunit.version>2.22</htmlunit.version>
+		<selenium.version>3.141.59</selenium.version>
+		<htmlunit.version>2.40.0</htmlunit.version>
 		<!--
-        Managed up from older version from Avro; sync with jackson-module-paranamer dependency version
-        -->
+    	Managed up from older version from Avro; sync with jackson-module-paranamer dependency version
+   		-->
 		<paranamer.version>2.8</paranamer.version>
 		<maven-antrun.version>1.8</maven-antrun.version>
-		<commons-crypto.version>1.0.0</commons-crypto.version>
+		<commons-crypto.version>1.1.0</commons-crypto.version>
 		<!--
-        If you are changing Arrow version specification, please check ./python/pyspark/sql/utils.py,
-        and ./python/setup.py too.
+        If you are changing Arrow version specification, please check
+        ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.
         -->
-		<arrow.version>0.15.1</arrow.version>
+		<arrow.version>2.0.0</arrow.version>
 		<!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
 		<leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
 		<!-- SPARK-PARENT finished -->
-
 
 		<!-- other dependency versions -->
 		<scopt.version>3.7.1</scopt.version>
@@ -2288,12 +2285,6 @@
 				<artifactId>parquet-avro</artifactId>
 				<version>${parquet.version}</version>
 				<scope>${parquet.test.deps.scope}</scope>
-			</dependency>
-			<dependency>
-				<groupId>${hive.parquet.group}</groupId>
-				<artifactId>parquet-hadoop-bundle</artifactId>
-				<version>${hive.parquet.version}</version>
-				<scope>${hive.parquet.scope}</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.janino</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
 		<ucanaccess.version>4.0.4</ucanaccess.version>
 		<!-- when changing config version, remember to update it in DatabricksSmartDataLakeBuilder main method -->
 		<typesafe.config.version>1.4.1</typesafe.config.version>
-		<kxbmap.configs.version>0.4.4</kxbmap.configs.version>
+		<kxbmap.configs.version>0.6.0</kxbmap.configs.version>
 		<monix.version>3.1.0</monix.version>
 		<scala-arm.version>2.0</scala-arm.version>
 		<splunk.version>1.6.5.0</splunk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
 		<ucanaccess.version>4.0.4</ucanaccess.version>
 		<!-- when changing config version, remember to update it in DatabricksSmartDataLakeBuilder main method -->
 		<typesafe.config.version>1.4.1</typesafe.config.version>
-		<kxbmap.configs.version>0.6.0</kxbmap.configs.version>
+		<kxbmap.configs.version>0.6.1</kxbmap.configs.version>
 		<monix.version>3.1.0</monix.version>
 		<scala-arm.version>2.0</scala-arm.version>
 		<splunk.version>1.6.5.0</splunk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
 		<kafka.version>2.4.1</kafka.version>
 		<snowflake.version>2.8.4</snowflake.version>
 		<keycloak.version>4.5.0.Final</keycloak.version>
-		<deltaTable.version>0.7.0</deltaTable.version>
+		<delta.version>0.8.0</delta.version>
 		<poi.version>4.1.2</poi.version>
 
 		<scalatest.test.version>3.0.8</scalatest.test.version>
@@ -2336,6 +2336,11 @@
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
+				<version>${antlr4.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4</artifactId>
 				<version>${antlr4.version}</version>
 			</dependency>
 			<dependency>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>2.0.3</version>
+		<version>2.0.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -84,7 +84,7 @@ extends SmartDataLakeLogger {
     if (Environment._sparkSession != null) logger.warn("Your SparkSession was already set, that should not happen. We will re-initialize it anyway now.")
     // prepare additional spark options
     // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
-    val executorPlugins = (sparkOptions.flatMap(_.get("spark.executor.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq()))
+    val executorPlugins = (sparkOptions.flatMap(_.get("spark.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq()))
     // config for MemoryLoggerExecutorPlugin can only be transferred to Executor by spark-options
     val memoryLogOptions = memoryLogTimer.map(_.getAsMap).getOrElse(Map())
     val sparkOptionsExtended = sparkOptions.getOrElse(Map()) ++ memoryLogOptions ++ (if (executorPlugins.nonEmpty) Map("spark.executor.plugins" -> executorPlugins.mkString(",")) else Map())

--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -20,7 +20,7 @@
 package io.smartdatalake.app
 
 import com.typesafe.config.Config
-import configs.Configs
+import configs.ConfigReader
 import configs.syntax._
 import io.smartdatalake.config.ConfigImplicits
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
@@ -106,7 +106,7 @@ extends SmartDataLakeLogger {
 }
 object GlobalConfig extends ConfigImplicits {
   private[smartdatalake] def from(config: Config): GlobalConfig = {
-    implicit val customStateListenerConfig: Configs[StateListenerConfig] = Configs.derive[StateListenerConfig]
+    implicit val customStateListenerConfig: ConfigReader[StateListenerConfig] = ConfigReader.derive[StateListenerConfig]
     globalConfig = Some(config.get[Option[GlobalConfig]]("global").value.getOrElse(GlobalConfig()))
     globalConfig.get
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -27,7 +27,7 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.misc.{MemoryUtils, SmartDataLakeLogger}
 import io.smartdatalake.util.secrets.{SecretProviderConfig, SecretsUtil}
-import io.smartdatalake.workflow.action.customlogic.SparkUDFCreatorConfig
+import io.smartdatalake.workflow.action.customlogic.{PythonUDFCreatorConfig, SparkUDFCreatorConfig}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.custom.ExpressionEvaluator
 
@@ -42,6 +42,8 @@ import org.apache.spark.sql.custom.ExpressionEvaluator
  * @param stateListeners Define state listeners to be registered for receiving events of the execution of SmartDataLake job
  * @param sparkUDFs      Define UDFs to be registered in spark session. The registered UDFs are available in Spark SQL transformations
  *                       and expression evaluation, e.g. configuration of ExecutionModes.
+ * @param pythonUDFs     Define UDFs in python to be registered in spark session. The registered UDFs are available in Spark SQL transformations
+ *                       but not for expression evaluation.
  * @param secretProviders Define SecretProvider's to be registered.
  * @param allowOverwriteAllPartitionsWithoutPartitionValues Configure a list of exceptions for partitioned DataObject id's,
  *                       which are allowed to overwrite the all partitions of a table if no partition values are set.
@@ -55,6 +57,7 @@ case class GlobalConfig( kryoClasses: Option[Seq[String]] = None
                        , shutdownHookLogger: Boolean = false
                        , stateListeners: Seq[StateListenerConfig] = Seq()
                        , sparkUDFs: Option[Map[String,SparkUDFCreatorConfig]] = None
+                       , pythonUDFs: Option[Map[String,PythonUDFCreatorConfig]] = None
                        , secretProviders: Option[Map[String,SecretProviderConfig]] = None
                        , allowOverwriteAllPartitionsWithoutPartitionValues: Seq[DataObjectId] = Seq()
                        )
@@ -82,16 +85,20 @@ extends SmartDataLakeLogger {
     // prepare additional spark options
     // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
     val executorPlugins = (sparkOptions.flatMap(_.get("spark.executor.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq()))
-    // config for MemoryLoggerExecutorPlugin can only be transfered to Executor by spark-options
+    // config for MemoryLoggerExecutorPlugin can only be transferred to Executor by spark-options
     val memoryLogOptions = memoryLogTimer.map(_.getAsMap).getOrElse(Map())
     val sparkOptionsExtended = sparkOptions.getOrElse(Map()) ++ memoryLogOptions ++ (if (executorPlugins.nonEmpty) Map("spark.executor.plugins" -> executorPlugins.mkString(",")) else Map())
     Environment._sparkSession = AppUtil.createSparkSession(appName, master, deployMode, kryoClasses, sparkOptionsExtended, enableHive)
-    sparkUDFs.getOrElse(Map()).foreach { case (name,creator) =>
-      val udf = creator.get
+    sparkUDFs.getOrElse(Map()).foreach { case (name,config) =>
+      val udf = config.getUDF
       // register in SDL spark session
       Environment._sparkSession.udf.register(name, udf)
       // register for use in expression evaluation
       ExpressionEvaluator.registerUdf(name, udf)
+    }
+    pythonUDFs.getOrElse(Map()).foreach { case (name,config) =>
+      // register in SDL spark session
+      config.registerUDF(name, Environment._sparkSession)
     }
     // return
     Environment._sparkSession

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -29,7 +29,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{LogUtil, MemoryUtils, SmartDataLakeLogger}
 import io.smartdatalake.workflow._
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
-import io.smartdatalake.workflow.action.{ResultRuntimeInfo, RuntimeEventState, SparkAction}
+import io.smartdatalake.workflow.action.{ResultRuntimeInfo, RuntimeEventState, RuntimeInfo, SparkAction}
 import org.apache.spark.sql.SparkSession
 import scopt.OptionParser
 
@@ -212,12 +212,10 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     logger.info(s"recovering application ${appConfig.applicationName.get} runId=${runState.runId} lastAttemptId=${runState.attemptId}")
     // skip all succeeded actions
     val actionsToSkip = runState.actionsState
-      .filter { case (id,info) => info.state==RuntimeEventState.SUCCEEDED }
-    val actionIdsToSkip = actionsToSkip
-      .map { case (id,info) => id }.toSeq
+      .filter { case (id,info) => info.hasCompleted() }
     val initialSubFeeds = actionsToSkip.flatMap(_._2.results.map(_.subFeed)).toSeq
     // start run, increase attempt counter
-    startRun(runState.appConfig, runState.runId, runState.attemptId+1, runState.runStartTime, actionIdsToSkip = actionIdsToSkip, initialSubFeeds = initialSubFeeds, stateStore = Some(stateStore))
+    startRun(runState.appConfig, runState.runId, runState.attemptId+1, runState.runStartTime, actionsToSkip = actionsToSkip, initialSubFeeds = initialSubFeeds, stateStore = Some(stateStore))
   }
 
   /**
@@ -232,7 +230,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
    * @return tuple of list of final subfeeds and statistics (action count per RuntimeEventState)
    */
   def startSimulation(appConfig: SmartDataLakeBuilderConfig, initialSubFeeds: Seq[SparkSubFeed])(implicit instanceRegistry: InstanceRegistry, session: SparkSession): (Seq[SparkSubFeed], Map[RuntimeEventState,Int]) = {
-    val (subFeeds, stats) = exec(appConfig, runId = 1, attemptId = 1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionIdsToSkip = Seq(), initialSubFeeds = initialSubFeeds, stateStore = None, stateListeners = Seq(), simulation = true)
+    val (subFeeds, stats) = exec(appConfig, runId = 1, attemptId = 1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionsToSkip = Map(), initialSubFeeds = initialSubFeeds, stateStore = None, stateListeners = Seq(), simulation = true)
     (subFeeds.map(_.asInstanceOf[SparkSubFeed]), stats)
   }
 
@@ -240,7 +238,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
    * Start run.
    * @return tuple of list of final subfeeds and statistics (action count per RuntimeEventState)
    */
-  private[smartdatalake] def startRun(appConfig: SmartDataLakeBuilderConfig, runId: Int = 1, attemptId: Int = 1, runStartTime: LocalDateTime = LocalDateTime.now, attemptStartTime: LocalDateTime = LocalDateTime.now, actionIdsToSkip: Seq[ActionId] = Seq(), initialSubFeeds: Seq[SubFeed] = Seq(), stateStore: Option[ActionDAGRunStateStore[_]] = None, simulation: Boolean = false) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
+  private[smartdatalake] def startRun(appConfig: SmartDataLakeBuilderConfig, runId: Int = 1, attemptId: Int = 1, runStartTime: LocalDateTime = LocalDateTime.now, attemptStartTime: LocalDateTime = LocalDateTime.now, actionsToSkip: Map[ActionId, RuntimeInfo] = Map(), initialSubFeeds: Seq[SubFeed] = Seq(), stateStore: Option[ActionDAGRunStateStore[_]] = None, simulation: Boolean = false) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
 
     // validate application config
     appConfig.validate()
@@ -267,10 +265,10 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     val session: SparkSession = Environment._globalConfig.createSparkSession(appConfig.appName, appConfig.master, appConfig.deployMode)
     LogUtil.setLogLevel(session.sparkContext)
 
-    exec(appConfig, runId, attemptId, runStartTime, attemptStartTime, actionIdsToSkip, initialSubFeeds, stateStore, stateListeners, simulation)(Environment._instanceRegistry, session)
+    exec(appConfig, runId, attemptId, runStartTime, attemptStartTime, actionsToSkip, initialSubFeeds, stateStore, stateListeners, simulation)(Environment._instanceRegistry, session)
   }
 
-  private[smartdatalake] def exec(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, runStartTime: LocalDateTime, attemptStartTime: LocalDateTime, actionIdsToSkip: Seq[ActionId], initialSubFeeds: Seq[SubFeed], stateStore: Option[ActionDAGRunStateStore[_]], stateListeners: Seq[StateListener], simulation: Boolean)(implicit instanceRegistry: InstanceRegistry, session: SparkSession) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
+  private[smartdatalake] def exec(appConfig: SmartDataLakeBuilderConfig, runId: Int, attemptId: Int, runStartTime: LocalDateTime, attemptStartTime: LocalDateTime, actionsToSkip: Map[ActionId, RuntimeInfo], initialSubFeeds: Seq[SubFeed], stateStore: Option[ActionDAGRunStateStore[_]], stateListeners: Seq[StateListener], simulation: Boolean)(implicit instanceRegistry: InstanceRegistry, session: SparkSession) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
 
     // select actions by feedSel
     val actionsSelected = instanceRegistry.getActions.filter(_.metadata.flatMap(_.feed).exists(_.matches(appConfig.feedSel)))
@@ -283,6 +281,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
     // filter actions to skip
     val actionIdsSelected = actionsSelected.map(_.id)
+    val actionIdsToSkip = actionsToSkip.keys.toSeq
     val missingActionsToSkip = actionIdsToSkip.filterNot( id => actionIdsSelected.contains(id))
     if (missingActionsToSkip.nonEmpty) logger.warn(s"actions to skip ${missingActionsToSkip.mkString(" ,")} not found in selected actions")
     val actionIdsSkipped = actionIdsSelected.filter( id => actionIdsToSkip.contains(id))
@@ -293,7 +292,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     // create and execute DAG
     logger.info(s"starting application ${appConfig.appName} runId=$runId attemptId=$attemptId")
     implicit val context: ActionPipelineContext = ActionPipelineContext(appConfig.feedSel, appConfig.appName, runId, attemptId, instanceRegistry, referenceTimestamp = Some(LocalDateTime.now), appConfig, runStartTime, attemptStartTime, simulation)
-    val actionDAGRun = ActionDAGRun(actionsToExec, runId, attemptId, appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism, initialSubFeeds, stateStore, stateListeners)
+    val actionDAGRun = ActionDAGRun(actionsToExec, runId, attemptId, actionsToSkip, appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism, initialSubFeeds, stateStore, stateListeners)
     val finalSubFeeds = try {
       if (simulation) {
         require(actionsToExec.forall(_.isInstanceOf[SparkAction]), s"Simulation needs all selected actions to be instances of SparkAction. This is not the case for ${actionsToExec.filterNot(_.isInstanceOf[SparkAction]).map(_.id).mkString(", ")}")

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigImplicits.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigImplicits.scala
@@ -18,13 +18,12 @@
  */
 package io.smartdatalake.config
 
-import configs.{ConfigError, Configs, Result}
+import configs.{ConfigError, ConfigKeyNaming, ConfigReader, Result}
 import io.smartdatalake.config.SdlConfigObject.{ActionId, ConnectionId, DataObjectId}
 import io.smartdatalake.definitions.{AuthMode, Condition, ExecutionMode}
 import io.smartdatalake.util.hdfs.SparkRepartitionDef
 import io.smartdatalake.util.secrets.SecretProviderConfig
 import io.smartdatalake.workflow.action.customlogic.{CustomDfCreatorConfig, CustomDfTransformerConfig, CustomDfsTransformerConfig, CustomFileTransformerConfig, SparkUDFCreatorConfig}
-import io.smartdatalake.workflow.dataobject.WebserviceFileDataObject
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 
@@ -35,27 +34,24 @@ trait ConfigImplicits {
   /**
    * default naming strategy is to allow lowerCamelCase and hypen-separated key naming, and fail on superfluous keys
    */
-  //TODO: this is needed for configs 0.5.0
-  /*
   implicit def sdlDefaultNaming[A]: ConfigKeyNaming[A] =
     ConfigKeyNaming.hyphenSeparated[A].or(ConfigKeyNaming.lowerCamelCase[A].apply _)
-      .withFailOnSuperfluousKeys()
-  */
+      .withFailOnSuperfluousKeys
 
   /**
-   * A ConfigReader reader that reads [[StructType]] values.
+   * A [[ConfigReader]] reader that reads [[StructType]] values.
    *
    * This reader parses a [[StructType]] from a DDL string.
    */
-  implicit val structTypeReader: Configs[StructType] = Configs.fromTry { (c, p) =>
+  implicit val structTypeReader: ConfigReader[StructType] = ConfigReader.fromTry { (c, p) =>
     StructType.fromDDL(c.getString(p))
   }
 
   /**
-   * A ConfigReader reader that reads [[OutputMode]].
+   * A [[ConfigReader]] reader that reads [[OutputMode]].
    */
-  implicit val outputModeReader: Configs[OutputMode] = {
-    Configs.fromConfig(_.toString.toLowerCase match {
+  implicit val outputModeReader: ConfigReader[OutputMode] = {
+    ConfigReader.fromConfig(_.toString.toLowerCase match {
       case "append" => Result.successful(OutputMode.Append())
       case "complete" => Result.successful(OutputMode.Complete())
       case "update" => Result.successful(OutputMode.Update())
@@ -70,35 +66,35 @@ trait ConfigImplicits {
   // see: https://github.com/kxbmap/configs/issues/44
   // TODO: check periodically if still needed, should not be needed with scala 2.13+
   // --------------------------------------------------------------------------------
-  implicit val customDfCreatorConfigReader: Configs[CustomDfCreatorConfig] = Configs.derive[CustomDfCreatorConfig]
-  implicit val customDfTransformerConfigReader: Configs[CustomDfTransformerConfig] = Configs.derive[CustomDfTransformerConfig]
-  implicit val customDfsTransformerConfigReader: Configs[CustomDfsTransformerConfig] = Configs.derive[CustomDfsTransformerConfig]
-  implicit val customFileTransformerConfigReader: Configs[CustomFileTransformerConfig] = Configs.derive[CustomFileTransformerConfig]
-  implicit val sparkUdfCreatorConfigReader: Configs[SparkUDFCreatorConfig] = Configs.derive[SparkUDFCreatorConfig]
-  implicit val sparkRepartitionDefReader: Configs[SparkRepartitionDef] = Configs.derive[SparkRepartitionDef]
-  implicit val secretProviderConfigReader: Configs[SecretProviderConfig] = Configs.derive[SecretProviderConfig]
-  implicit val executionModeReader: Configs[ExecutionMode] = Configs.derive[ExecutionMode]
-  implicit val conditionReader: Configs[Condition] = Configs.derive[Condition]
-  implicit val authModeReader: Configs[AuthMode] = Configs.derive[AuthMode]
+  implicit val customDfCreatorConfigReader: ConfigReader[CustomDfCreatorConfig] = ConfigReader.derive[CustomDfCreatorConfig]
+  implicit val customDfTransformerConfigReader: ConfigReader[CustomDfTransformerConfig] = ConfigReader.derive[CustomDfTransformerConfig]
+  implicit val customDfsTransformerConfigReader: ConfigReader[CustomDfsTransformerConfig] = ConfigReader.derive[CustomDfsTransformerConfig]
+  implicit val customFileTransformerConfigReader: ConfigReader[CustomFileTransformerConfig] = ConfigReader.derive[CustomFileTransformerConfig]
+  implicit val sparkUdfCreatorConfigReader: ConfigReader[SparkUDFCreatorConfig] = ConfigReader.derive[SparkUDFCreatorConfig]
+  implicit val sparkRepartitionDefReader: ConfigReader[SparkRepartitionDef] = ConfigReader.derive[SparkRepartitionDef]
+  implicit val secretProviderConfigReader: ConfigReader[SecretProviderConfig] = ConfigReader.derive[SecretProviderConfig]
+  implicit val executionModeReader: ConfigReader[ExecutionMode] = ConfigReader.derive[ExecutionMode]
+  implicit val conditionReader: ConfigReader[Condition] = ConfigReader.derive[Condition]
+  implicit val authModeReader: ConfigReader[AuthMode] = ConfigReader.derive[AuthMode]
   // --------------------------------------------------------------------------------
 
-  implicit def mapDataObjectIdStringReader(implicit mapReader: Configs[Map[String,String]]): Configs[Map[DataObjectId, String]] = {
-    Configs.fromConfig { c => mapReader.extract(c).map(_.map{ case (k,v) => (DataObjectId(k), v)})}
+  implicit def mapDataObjectIdStringReader(implicit mapReader: ConfigReader[Map[String,String]]): ConfigReader[Map[DataObjectId, String]] = {
+    ConfigReader.fromConfig { c => mapReader.extract(c).map(_.map{ case (k,v) => (DataObjectId(k), v)})}
   }
 
   /**
-   * A ConfigReader reader that reads [[ConnectionId]] values.
+   * A reader that reads [[ConnectionId]] values.
    */
-  implicit val connectionIdReader: Configs[ConnectionId] = Configs.fromTry { (c, p) => ConnectionId(c.getString(p))}
+  implicit val connectionIdReader: ConfigReader[ConnectionId] = ConfigReader.fromTry { (c, p) => ConnectionId(c.getString(p))}
 
   /**
-   * A ConfigReader reader that reads [[DataObjectId]] values.
+   * A reader that reads [[DataObjectId]] values.
    */
-  implicit val dataObjectIdReader: Configs[DataObjectId] = Configs.fromTry { (c, p) => DataObjectId(c.getString(p))}
+  implicit val dataObjectIdReader: ConfigReader[DataObjectId] = ConfigReader.fromTry { (c, p) => DataObjectId(c.getString(p))}
 
   /**
-   * A ConfigReader reader that reads [[ActionId]] values.
+   * A reader that reads [[ActionId]] values.
    */
-  implicit val actionIdReader: Configs[ActionId] = Configs.fromTry { (c, p) => ActionId(c.getString(p))}
+  implicit val actionIdReader: ConfigReader[ActionId] = ConfigReader.fromTry { (c, p) => ActionId(c.getString(p))}
 
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigImplicits.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigImplicits.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ActionId, ConnectionId, DataObje
 import io.smartdatalake.definitions.{AuthMode, Condition, ExecutionMode}
 import io.smartdatalake.util.hdfs.SparkRepartitionDef
 import io.smartdatalake.util.secrets.SecretProviderConfig
-import io.smartdatalake.workflow.action.customlogic.{CustomDfCreatorConfig, CustomDfTransformerConfig, CustomDfsTransformerConfig, CustomFileTransformerConfig, SparkUDFCreatorConfig}
+import io.smartdatalake.workflow.action.customlogic._
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 

--- a/sdl-core/src/main/scala/io/smartdatalake/config/FromConfigFactory.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/FromConfigFactory.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.config
 
 import com.typesafe.config.Config
-import configs.Configs
+import configs.{ConfigKeyNaming, ConfigReader}
 
 /**
  * A factory object that fulfils the contract for a static factory method that parses (case) classes from [[Config]]s.
@@ -42,8 +42,8 @@ private[smartdatalake] trait FromConfigFactory[+CO <: SdlConfigObject with Parsa
   /**
    * Helper method to extract case class from config
    */
-  protected def extract[T: Configs](config: Config): T = {
-    import configs.syntax._
+  protected def extract[T: ConfigReader](config: Config): T = {
+    import configs.syntax.RichConfig
     config.extract[T].value
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/ExecutionMode.scala
@@ -399,7 +399,7 @@ case class ProcessAllMode() extends ExecutionMode {
  *                            It can be used to ensure processing all partitions over multiple actions in case of errors.
  * @param options Options specified in the configuration for this execution mode
  */
-case class CustomPartitionMode(className: String, override val alternativeOutputId: Option[DataObjectId] = None, options: Map[String,String] = Map())
+case class CustomPartitionMode(className: String, override val alternativeOutputId: Option[DataObjectId] = None, options: Option[Map[String,String]] = None)
 extends ExecutionMode with ExecutionModeWithMainInputOutput {
   private[smartdatalake] override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
   private val impl = CustomCodeUtil.getClassInstanceByName[CustomPartitionModeLogic](className)
@@ -409,7 +409,7 @@ extends ExecutionMode with ExecutionModeWithMainInputOutput {
     val output = alternativeOutput.getOrElse(mainOutput)
     (mainInput, output) match {
       case (input: CanHandlePartitions, output: CanHandlePartitions) =>
-        val partitionValuesOpt = impl.apply(session, options, actionId, input, output, subFeed.partitionValues.map(_.getMapString), context)
+        val partitionValuesOpt = impl.apply(session, options.getOrElse(Map()), actionId, input, output, subFeed.partitionValues.map(_.getMapString), context)
           .map(_.map( pv => PartitionValues(pv)))
         partitionValuesOpt.map(pvs => ExecutionModeResult(inputPartitionValues = pvs, outputPartitionValues = pvs))
       case (_: CanHandlePartitions, _) =>

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -171,14 +171,14 @@ private[smartdatalake] object PartitionLayout {
     partitionLayoutPrepared = tokenRegex.replaceAllIn( partitionLayoutPrepared, {
       tokenMatch => if (tokenMatch.group(3) != null) s"(${tokenMatch.group(3)})" else "(.*?)"
     })
-    // create regex and match with path
-    val partitionLayoutRegex = partitionLayoutPrepared.r
+    // create regex and match with path.
+    val partitionLayoutRegex = ("^" + partitionLayoutPrepared).r // add anchor at start of string.
     partitionLayoutRegex.findFirstMatchIn(path) match {
       case Some(regexMatch) =>
         val tokenValues = (1 to regexMatch.groupCount).map( i => regexMatch.group(i))
         val tokenMap = tokens.zip(tokenValues).toMap
         PartitionValues(tokenMap)
-      case None => throw new Exception(s"prepared regexp partition layout $partitionLayoutPrepared didn't match path $path")
+      case None => throw new RuntimeException(s"""prepared regexp partition layout "$partitionLayoutRegex" didn't match path "$path"""")
     }
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/secrets/SecretProvider.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/secrets/SecretProvider.scala
@@ -28,12 +28,12 @@ import org.apache.spark.annotation.DeveloperApi
  * @param className fully qualified class name of class implementing SecretProvider interface. The class needs a constructor with parameter "options: Map[String,String]".
  * @param options Options are passed to SecretProvider apply method.
  */
-case class SecretProviderConfig(className: String, options: Map[String,String] = Map()) {
+case class SecretProviderConfig(className: String, options: Option[Map[String,String]] = None) {
   // instantiate SecretProvider
   private[smartdatalake] val provider: SecretProvider = try {
     val clazz = Class.forName(className)
     val constructor = clazz.getConstructor(classOf[Map[String,String]])
-    constructor.newInstance(options).asInstanceOf[SecretProvider]
+    constructor.newInstance(options.getOrElse(Map())).asInstanceOf[SecretProvider]
   } catch {
     case e: NoSuchMethodException => throw ConfigurationException(s"""SecretProvider class $className needs constructor with parameter "options: Map[String,String]": ${e.getMessage}""", Some("globalConfig.secretProviders"), e)
     case e: Exception => throw ConfigurationException(s"Cannot instantiate SecretProvider class $className: ${e.getClass.getSimpleName} ${e.getMessage}", Some("globalConfig.secretProviders"), e)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -281,7 +281,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
   /**
    * get latest runtime information for this action
    */
-  def getRuntimeInfo: Option[RuntimeInfo] = {
+  def getRuntimeInfo : Option[RuntimeInfo] = {
     if (runtimeEvents.nonEmpty) {
       val lastEvent = runtimeEvents.last
       val lastResults = runtimeEvents.reverseIterator.map(_.results).find(_.nonEmpty) // on failed actions we take the results from initialization to store what partition values have been tried to process
@@ -390,9 +390,13 @@ case class ActionMetadata(
 private[smartdatalake] case class RuntimeEvent(tstmp: LocalDateTime, phase: ExecutionPhase, state: RuntimeEventState, msg: Option[String], results: Seq[SubFeed])
 private[smartdatalake] object RuntimeEventState extends Enumeration {
   type RuntimeEventState = Value
-  val STARTED, PREPARED, INITIALIZED, SUCCEEDED, FAILED, SKIPPED, PENDING = Value
+  val STARTED, PREPARED, INITIALIZED, SUCCEEDED, FAILED, CANCELLED, SKIPPED, PENDING = Value
 }
-private[smartdatalake] case class RuntimeInfo(state: RuntimeEventState, startTstmp: Option[LocalDateTime] = None, duration: Option[Duration] = None, msg: Option[String] = None, results: Seq[ResultRuntimeInfo] = Seq()) {
+private[smartdatalake] case class RuntimeInfo(state: RuntimeEventState, startTstmp: Option[LocalDateTime] = None, duration: Option[Duration] = None, msg: Option[String] = None, attemptId: Option[Int] = None, results: Seq[ResultRuntimeInfo] = Seq()) {
+  /**
+   * Completed Actions will be ignored in recovery
+   */
+  def hasCompleted(): Boolean = state==RuntimeEventState.SUCCEEDED || state==RuntimeEventState.SKIPPED
   override def toString: String = {
     duration.map(d => s"$state $d")
       .getOrElse(state.toString)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
@@ -47,7 +47,7 @@ trait CustomFileTransformer extends Serializable {
  * @param scalaCode Optional scala code for transformation
  * @param options Options to pass to the transformation
  */
-case class CustomFileTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, options: Map[String,String] = Map()) {
+case class CustomFileTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, options: Option[Map[String,String]] = None) {
   require(className.isDefined || scalaFile.isDefined || scalaCode.isDefined, "Either className or scalaFile must be defined for CustomDfTransformer")
 
   val impl : CustomFileTransformer = className.map {
@@ -67,7 +67,7 @@ case class CustomFileTransformerConfig( className: Option[String] = None, scalaF
   }.get
 
   def transform(input: FSDataInputStream, output: FSDataOutputStream): Option[Exception] = {
-    impl.transform(options, input, output)
+    impl.transform(options.getOrElse(Map()), input, output)
   }
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonUDFCreatorConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonUDFCreatorConfig.scala
@@ -34,13 +34,13 @@ import org.apache.spark.sql.SparkSession
  * @param pythonCode Optional pythonCode to use for python UDF.
  * @param options Options are available in your python code as variable options.
  */
-case class PythonUDFCreatorConfig(pythonFile: Option[String] = None, pythonCode: Option[String] = None, options: Map[String,String] = Map()) {
+case class PythonUDFCreatorConfig(pythonFile: Option[String] = None, pythonCode: Option[String] = None, options: Option[Map[String,String]] = None) {
   require(pythonFile.isDefined || pythonCode.isDefined, "Either pythonFile or pythonCode must be defined for SparkUDFCreatorConfig")
 
   private val functionCode = pythonFile.map(HdfsUtil.readHadoopFile).orElse(pythonCode.map(_.stripMargin)).get
 
   private[smartdatalake] def registerUDF(functionName: String, session: SparkSession): Unit = {
-    val entryPoint = new PythonSparkEntryPoint(session, options)
+    val entryPoint = new PythonSparkEntryPoint(session, options.getOrElse(Map()))
     val registrationCode =
       s"""
          |session.udf.register("$functionName", $functionName)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonUDFCreatorConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/PythonUDFCreatorConfig.scala
@@ -1,0 +1,52 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2021 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.customlogic
+
+import io.smartdatalake.config.ConfigurationException
+import io.smartdatalake.util.hdfs.HdfsUtil
+import io.smartdatalake.util.misc.{PythonSparkEntryPoint, PythonUtil}
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Configuration to register a Python UDF in the spark session of SmartDataLake.
+ * Define a python function with type hints i python code and register it in global configuration.
+ * The name of the function must match the name you use to declare it in GlobalConf.
+ * The Python function can then be used in Spark SQL expressions.
+ *
+ * @param pythonFile Optional pythonFile to use for python UDF.
+ * @param pythonCode Optional pythonCode to use for python UDF.
+ * @param options Options are available in your python code as variable options.
+ */
+case class PythonUDFCreatorConfig(pythonFile: Option[String] = None, pythonCode: Option[String] = None, options: Map[String,String] = Map()) {
+  require(pythonFile.isDefined || pythonCode.isDefined, "Either pythonFile or pythonCode must be defined for SparkUDFCreatorConfig")
+
+  private val functionCode = pythonFile.map(HdfsUtil.readHadoopFile).orElse(pythonCode.map(_.stripMargin)).get
+
+  private[smartdatalake] def registerUDF(functionName: String, session: SparkSession): Unit = {
+    val entryPoint = new PythonSparkEntryPoint(session, options)
+    val registrationCode =
+      s"""
+         |session.udf.register("$functionName", $functionName)
+         |print()
+         |print("python udf $functionName registered")
+         |""".stripMargin
+    PythonUtil.execPythonSparkCode( entryPoint, functionCode + sys.props("line.separator") + registrationCode)
+  }
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
  * @param className fully qualified class name of class implementing SparkUDFCreator interface. The class needs a constructor without parameters.
  * @param options Options are passed to SparkUDFCreator apply method.
  */
-case class SparkUDFCreatorConfig(className: String, options: Map[String,String] = Map()) {
+case class SparkUDFCreatorConfig(className: String, options: Option[Map[String,String]] = None) {
   // instantiate SparkUDFCreator
   private[smartdatalake] val creator: SparkUDFCreator = try {
     val clazz = Class.forName(className)
@@ -39,7 +39,7 @@ case class SparkUDFCreatorConfig(className: String, options: Map[String,String] 
     case e: NoSuchMethodException => throw ConfigurationException(s"SparkUDFCreatorConfig class $className needs constructor without parameters: ${e.getMessage}", Some("globalConfig.sparkUDFs"), e)
     case e: Exception => throw ConfigurationException(s"Cannot instantiate SparkUDFCreatorConfig class $className: ${e.getMessage}", Some("globalConfig.sparkUDFs"), e)
   }
-  private[smartdatalake] def getUDF: UserDefinedFunction = creator.get(options)
+  private[smartdatalake] def getUDF: UserDefinedFunction = creator.get(options.getOrElse(Map()))
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
@@ -45,7 +45,7 @@ case class SparkUDFCreatorConfig(className: String, options: Map[String,String] 
 /**
  * Interface to create a UserDefinedFunction object to be registered as udf.
  */
-trait SparkUDFCreator {
+trait SparkUDFCreator extends Serializable {
 
   /**
    * Function that returns a Spark UserDefinedFunction object to be registered as udf.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/SparkUDFCreator.scala
@@ -39,7 +39,7 @@ case class SparkUDFCreatorConfig(className: String, options: Map[String,String] 
     case e: NoSuchMethodException => throw ConfigurationException(s"SparkUDFCreatorConfig class $className needs constructor without parameters: ${e.getMessage}", Some("globalConfig.sparkUDFs"), e)
     case e: Exception => throw ConfigurationException(s"Cannot instantiate SparkUDFCreatorConfig class $className: ${e.getMessage}", Some("globalConfig.sparkUDFs"), e)
   }
-  private[smartdatalake] def get: UserDefinedFunction = creator.get(options)
+  private[smartdatalake] def getUDF: UserDefinedFunction = creator.get(options)
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
@@ -19,14 +19,15 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.SchemaViolationException
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
  * A trait to be implemented by DataObjects which store partitioned data
  */
 @DeveloperApi
-trait CanHandlePartitions {
+trait CanHandlePartitions { this: DataObject =>
 
   /**
    * Definition of partition columns
@@ -78,5 +79,17 @@ trait CanHandlePartitions {
       val expectedHashCodes = partitionsValuesStringWithHashCode.toDF("elements","hashCode").where(expr(condition)).select($"hashCode").as[Int].collect.toSet
       partitionValues.filter( pv => expectedHashCodes.contains(pv.hashCode))
     }.getOrElse(partitionValues)
+  }
+
+  /**
+   * Validate the schema of a given Spark Data Frame `df` that it contains the specified partition columns
+   *
+   * @param df The data frame to validate.
+   * @param role role used in exception message. Set to read or write.
+   * @throws SchemaViolationException if the partitions columns are not included.
+   */
+  def validateSchemaHasPartitionCols(df: DataFrame, role: String): Unit = {
+    val missingCols = partitions.diff(df.columns)
+    if (missingCols.nonEmpty) throw new SchemaViolationException(s"($id) DataFrame is missing partition cols ${missingCols.mkString(", ")} on $role")
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObject.scala
@@ -19,6 +19,7 @@
 package io.smartdatalake.workflow.dataobject
 
 import com.typesafe.config.Config
+import configs.ConfigKeyNaming
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
@@ -58,6 +58,8 @@ case class CustomFileDataObject(override val id: DataObjectId,
 
   override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = Seq()
 
+  override def relativizePath(filePath: String): String = filePath
+
   override def factory: FromConfigFactory[DataObject] = CustomFileDataObject
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
@@ -58,7 +58,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  */
 case class ExcelFileDataObject(override val id: DataObjectId,
                                override val path: String,
-                               excelOptions: ExcelOptions,
+                               excelOptions: ExcelOptions  = ExcelOptions(),
                                override val partitions: Seq[String] = Seq(),
                                override val schema: Option[StructType] = None,
                                override val schemaMin: Option[StructType] = None,
@@ -178,7 +178,6 @@ case class ExcelOptions(
       Some( xSheet.getOrElse("") + xStartArea.getOrElse("") + xEndArea.getOrElse(""))
     } else None
   }
-
 
   def toMap(schema: Option[StructType]): Map[String, Option[Any]] = Map(
       "dataAddress" -> getDataAddress,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
@@ -37,4 +37,9 @@ private[smartdatalake] trait FileDataObject extends DataObject with CanHandlePar
     super.prepare
     filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
+
+  /**
+   * Make a given path relative to this DataObjects base path
+   */
+  def relativizePath(filePath: String): String
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -22,6 +22,7 @@ import io.smartdatalake.definitions.Environment
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.hdfs.{PartitionLayout, PartitionValues}
 import io.smartdatalake.workflow.ActionPipelineContext
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 
 private[smartdatalake] trait FileRefDataObject extends FileDataObject {
@@ -108,7 +109,7 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
    * Extract partition values from a given file path
    */
   protected def extractPartitionValuesFromPath(filePath: String): PartitionValues = {
-    PartitionLayout.extractPartitionValues(partitionLayout().get, fileName, filePath.stripPrefix(path + separator))
+    PartitionLayout.extractPartitionValues(partitionLayout().get, fileName, relativizePath(filePath))
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -203,7 +203,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   override def relativizePath(path: String): String = {
     val normalizedPath = new Path(path).toString
     val pathPrefix = (".*"+hadoopPath.toString).r // ignore any absolute path prefix up and including hadoop path
-    pathPrefix.replaceAllIn(normalizedPath, "").stripPrefix(Path.SEPARATOR)
+    pathPrefix.replaceFirstIn(normalizedPath, "").stripPrefix(Path.SEPARATOR)
   }
 
   override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -195,11 +195,15 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
         // list directories and extract partition values
         filesystem.globStatus( new Path(hadoopPath, pattern))
           .filter{fs => fs.isDirectory}
-          .map(_.getPath.toString)
-          .map( path => PartitionLayout.extractPartitionValues(partitionLayout, "", path + separator))
+          .map(path => PartitionLayout.extractPartitionValues(partitionLayout, "", relativizePath(path.getPath.toString) + separator))
           .toSeq
     }.getOrElse(Seq())
   }
+
+  override def relativizePath(path: String): String = {
+    hadoopPathUri.relativize(new Path(path).toUri).toString
+  }
+  private val hadoopPathUri = hadoopPath.toUri
 
   override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {
     // check if valid init of partitions -> otherwise we can not create empty partition as path is not fully defined

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -201,9 +201,9 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   }
 
   override def relativizePath(path: String): String = {
-    hadoopPathUri.relativize(new Path(path).toUri).toString
+    val normalizedPath = new Path(path).toString
+    normalizedPath.stripPrefix(hadoopPath.toString).stripPrefix(Path.SEPARATOR)
   }
-  private val hadoopPathUri = hadoopPath.toUri
 
   override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {
     // check if valid init of partitions -> otherwise we can not create empty partition as path is not fully defined

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -202,7 +202,8 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
 
   override def relativizePath(path: String): String = {
     val normalizedPath = new Path(path).toString
-    normalizedPath.stripPrefix(hadoopPath.toString).stripPrefix(Path.SEPARATOR)
+    val pathPrefix = (".*"+hadoopPath.toString).r // ignore any absolute path prefix up and including hadoop path
+    pathPrefix.replaceAllIn(normalizedPath, "").stripPrefix(Path.SEPARATOR)
   }
 
   override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -129,6 +129,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
     val df = session.table(s"${table.fullName}")
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     df
   }
 
@@ -140,6 +141,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
   override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.init(df, partitionValues)
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     // validate against hive table schema if existing
     if (isTableExisting && !isOverwriteSchemaAllowed) validateSchema(df, session.table(table.fullName).schema, "write")
   }
@@ -156,6 +158,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     require(!isRecursiveInput, "($id) HiveTableDataObject cannot write dataframe when dataobject is also used as recursive input ")
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     writeDataFrameInternal(df, createTableOnly = false, partitionValues)
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -131,9 +131,13 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
             val pattern = PartitionLayout.replaceTokens(partitionLayout, PartitionValues(Map()))
             // list directories and extract partition values
             SshUtil.sftpListFiles(path + separator + pattern)(sftp)
-              .map( f => PartitionLayout.extractPartitionValues(partitionLayout, "", f.stripPrefix(path+separator) + separator))
+              .map( f => PartitionLayout.extractPartitionValues(partitionLayout, "", relativizePath(f) + separator))
         }
     }.getOrElse(Seq())
+  }
+
+  override def relativizePath(filePath: String): String = {
+    filePath.stripPrefix(path+separator)
   }
 
   override def prepare(implicit session: SparkSession): Unit = try {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -65,6 +65,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
    */
   def beforeWrite(df: DataFrame)(implicit session: SparkSession): DataFrame = {
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     schema.foreach(schemaExpected => validateSchema(df, schemaExpected, "write"))
     df
   }
@@ -76,6 +77,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
    */
   def afterRead(df: DataFrame)(implicit session: SparkSession): DataFrame = {
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     schema.map(createReadSchema).foreach(schemaExpected => validateSchema(df, schemaExpected, "read"))
     df
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -130,7 +130,8 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
         .option("basePath", hadoopPath.toString) // this is needed for partitioned tables when subdirectories are read directly; it then keeps the partition columns from the subdirectory path in the dataframe
       // create data frame for every partition value and then build union
       val pathsToRead = partitionValues.flatMap(getConcretePaths).map(_.toString)
-      pathsToRead.map(reader.load).reduceOption(_ union _)
+      val df = if (pathsToRead.nonEmpty) Some(reader.load(pathsToRead:_*)) else None
+      df.filter(df => schemaOpt.isDefined || partitions.diff(df.columns).isEmpty) // filter DataFrames without partition columns as they are empty (this might happen if there is no schema specified and the partition is empty)
         .getOrElse {
           // if there are no paths to read then an empty DataFrame is created
           require(schema.isDefined, s"($id) DataObject schema is undefined. A schema must be defined as there are no existing files for partition values ${partitionValues.mkString(", ")}.")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -105,6 +105,11 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
 
+  override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.init(df, partitionValues)
+    validateSchemaMin(df, "write")
+  }
+
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
     val df = if(!isTableExisting && schemaMin.isDefined) {
       logger.info(s"Table ${table.fullName} does not exist but schemaMin was provided. Creating empty DataFrame.")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -108,6 +108,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
   override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.init(df, partitionValues)
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
   }
 
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
@@ -120,6 +121,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     }
 
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     df
   }
 
@@ -134,6 +136,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     writeDataFrameInternal(df, createTableOnly=false, partitionValues, isRecursiveInput)
 
     // make sure empty partitions are created as well

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -214,6 +214,8 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
    */
   override def path: String = ""
 
+  override def relativizePath(filePath: String): String = filePath
+
   override def factory: FromConfigFactory[DataObject] = WebserviceFileDataObject
 
 }

--- a/sdl-core/src/test/resources/config/config.conf
+++ b/sdl-core/src/test/resources/config/config.conf
@@ -22,7 +22,7 @@ overwrite = original
 
 dataObjects = {
   testDataObjectFromConfig = {
-    type = io.smartdatalake.config.TestDataObject
+    type = io.smartdatalake.config.objects.TestDataObject
     arg1 = Foo
     args = [Bar]
     metadata = {

--- a/sdl-core/src/test/resources/config/subdirectory/foo.json
+++ b/sdl-core/src/test/resources/config/subdirectory/foo.json
@@ -5,19 +5,19 @@
 
   "dataObjects": {
     "do1": {
-      "type": "io.smartdatalake.config.TestDataObject",
+      "type": "io.smartdatalake.config.objects.TestDataObject",
       "arg1": "Foo",
       "args": ["Bar"]
     },
     "do2": {
-      "type": "io.smartdatalake.config.TestDataObject",
+      "type": "io.smartdatalake.config.objects.TestDataObject",
       "arg1": "Bar",
       "args": ["Baz"]
     }
   },
   "actions": {
     "testActionFromConfig": {
-      "type": "io.smartdatalake.config.TestAction",
+      "type": "io.smartdatalake.config.objects.TestAction",
       "input-id": "do1",
       "output-id": "do2",
       "metadata": {

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
@@ -31,12 +31,12 @@ private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
     """
       |dataObjects = {
       | tdo1 = {
-      |   type = io.smartdatalake.config.TestDataObject
+      |   type = io.smartdatalake.config.objects.TestDataObject
       |   arg1 = foo
       |   args = [bar, "!"]
       | }
       | tdo2 = {
-      |   type = io.smartdatalake.config.TestDataObject
+      |   type = io.smartdatalake.config.objects.TestDataObject
       |   arg1 = goo
       |   args = [bar]
       | }
@@ -126,7 +126,7 @@ private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
         |   inputId = tdo3
         |   outputId = tdo4
         |   transformer = {
-        |     class-name = io.smartdatalake.config.TestFileTransformer
+        |     class-name = io.smartdatalake.config.objects.TestFileTransformer
         |   }
         |   deleteDataAfterRead = true
         | }
@@ -141,7 +141,7 @@ private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
       outputId = "tdo4",
       deleteDataAfterRead = true,
       transformer = CustomFileTransformerConfig(
-        className = Some("io.smartdatalake.config.TestFileTransformer")
+        className = Some("io.smartdatalake.config.objects.TestFileTransformer")
       )
     )
   }
@@ -156,7 +156,7 @@ private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
         |   inputId = tdo1
         |   outputId = tdo1
         |   transformer = {
-        |     class-name = io.smartdatalake.config.TestFileTransformer
+        |     class-name = io.smartdatalake.config.objects.TestFileTransformer
         |   }
         |   deleteDataAfterRead = true
         | }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
@@ -90,7 +90,7 @@ private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
   "CustomSparkAction" should "be parsable" in {
 
     val customTransformerConfig = CustomDfsTransformerConfig(
-      sqlCode = Map(DataObjectId("test") -> "select * from test")
+      sqlCode = Some(Map(DataObjectId("test") -> "select * from test"))
     )
 
     val config = ConfigFactory.parseString(

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
@@ -20,7 +20,9 @@ package io.smartdatalake.config
 
 import com.typesafe.config.{ConfigException, ConfigFactory}
 import io.smartdatalake.config.ConfigParser.localSubstitution
+import io.smartdatalake.config.{ConfigParser, InstanceRegistry, SdlConfigObject}
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
+import io.smartdatalake.config.objects.{TestAction, TestConnection, TestDataObject}
 import io.smartdatalake.definitions.{Environment, PartitionDiffMode, SDLSaveMode}
 import io.smartdatalake.workflow.action.{Action, FileTransferAction}
 import io.smartdatalake.workflow.dataobject.{CsvFileDataObject, DataObject, DataObjectMetadata, RawFileDataObject}
@@ -119,12 +121,12 @@ class ConfigParsingTest extends FlatSpec with Matchers {
       """
         |connections = {
         |   tcon = {
-        |     type = io.smartdatalake.config.TestConnection
+        |     type = io.smartdatalake.config.objects.TestConnection
         |   }
         |}
         |dataObjects = {
         |   tdo = {
-        |     type = io.smartdatalake.config.TestDataObject
+        |     type = io.smartdatalake.config.objects.TestDataObject
         |     arg1 = foo
         |     args = [bar, "!"]
         |     connectionId = tcon
@@ -148,12 +150,12 @@ class ConfigParsingTest extends FlatSpec with Matchers {
       """
         |dataObjects = {
         |   tdo1 = {
-        |     type = io.smartdatalake.config.TestDataObject
+        |     type = io.smartdatalake.config.objects.TestDataObject
         |     arg1 = foo
         |     args = [bar, "!"]
         |   }
         |   tdo2 = {
-        |     type = io.smartdatalake.config.TestDataObject
+        |     type = io.smartdatalake.config.objects.TestDataObject
         |     arg1 = goo
         |     args = [bar]
         |   }
@@ -184,13 +186,13 @@ class ConfigParsingTest extends FlatSpec with Matchers {
         |dataObjects = {
         |   tdo1 = {
         |     id = tdo1
-        |     type = io.smartdatalake.config.TestDataObject
+        |     type = io.smartdatalake.config.objects.TestDataObject
         |     arg1 = foo
         |     args = []
         |   }
         |   tdo2 = {
         |     id = tdo2
-        |     type = io.smartdatalake.config.TestDataObject
+        |     type = io.smartdatalake.config.objects.TestDataObject
         |     arg1 = bar
         |     args = []
         |   }
@@ -198,7 +200,7 @@ class ConfigParsingTest extends FlatSpec with Matchers {
         |
         |actions = {
         |   ta1 = {
-        |     type = io.smartdatalake.config.TestAction
+        |     type = io.smartdatalake.config.objects.TestAction
         |     inputId = tdo1
         |     outputId = tdo2
         |   }
@@ -230,12 +232,12 @@ class ConfigParsingTest extends FlatSpec with Matchers {
       """
         |dataObjects = {
         | tdo1 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = foo
         |   args = [bar, "!"]
         | }
         | tdo2 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = goo
         |   args = [bar]
         | }
@@ -243,12 +245,12 @@ class ConfigParsingTest extends FlatSpec with Matchers {
         |
         |actions = {
         |   ta1 = {
-        |     type = io.smartdatalake.config.TestAction
+        |     type = io.smartdatalake.config.objects.TestAction
         |     inputId = tdo1
         |     outputId = tdo2
         |   }
         |   ta2 = {
-        |     type = io.smartdatalake.config.TestAction
+        |     type = io.smartdatalake.config.objects.TestAction
         |     inputId = tdo2
         |     outputId = tdo1
         |   }
@@ -291,12 +293,12 @@ class ConfigParsingTest extends FlatSpec with Matchers {
       """
         |dataObjects = {
         | tdo1 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = foo
         |   args = [bar, "!"]
         | }
         | tdo2 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = goo
         |   args = [bar]
         | }
@@ -324,18 +326,17 @@ class ConfigParsingTest extends FlatSpec with Matchers {
 
   }
 
-  /*
   "TestAction" should "fail on superfluous key" in {
     val dataObjectsConfig = ConfigFactory.parseString(
       """
         |dataObjects = {
         | tdo1 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = foo
         |   args = [bar, "!"]
         | }
         | tdo2 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = goo
         |   args = [bar]
         | }
@@ -365,12 +366,12 @@ class ConfigParsingTest extends FlatSpec with Matchers {
       """
         |dataObjects = {
         | tdo1 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = foo
         |   args = [bar, "!"]
         | }
         | tdo2 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = goo
         |   args = [bar]
         | }
@@ -382,6 +383,7 @@ class ConfigParsingTest extends FlatSpec with Matchers {
         | id = a
         | inputId = tdo1
         | outputId = tdo2
+        | test = test
         | executionMode = {
         |  type = PartitionDiffMode
         |  partitionColNb = 2
@@ -402,12 +404,12 @@ class ConfigParsingTest extends FlatSpec with Matchers {
       """
         |dataObjects = {
         | tdo1 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = foo
         |   args = [bar, "!"]
         | }
         | tdo2 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = goo
         |   args = [bar]
         | }
@@ -431,19 +433,18 @@ class ConfigParsingTest extends FlatSpec with Matchers {
     implicit val registry: InstanceRegistry = ConfigParser.parse(dataObjectsConfig)
     intercept[ConfigException](TestAction.fromConfig(config.getConfig("a")))
   }
-  */
 
   "TestAction" should "fail on unknown type of optional sealed trait" in {
     val dataObjectsConfig = ConfigFactory.parseString(
       """
         |dataObjects = {
         | tdo1 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = foo
         |   args = [bar, "!"]
         | }
         | tdo2 = {
-        |   type = io.smartdatalake.config.TestDataObject
+        |   type = io.smartdatalake.config.objects.TestDataObject
         |   arg1 = goo
         |   args = [bar]
         | }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigsMacroDebug.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigsMacroDebug.scala
@@ -1,0 +1,51 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.config
+
+import com.typesafe.config.ConfigFactory
+import io.smartdatalake.workflow.dataobject.CustomDfDataObject
+
+/**
+ * Configs macro expansion can be debugged in Intellij by creating a run configuration as follows:
+ * - Main class: scala.tools.nsc.Main
+ * - VM options: -Dscala.usejavacp=true
+ * - program arguments: -cp io.smartdatalake.config.ConfigsMacroDebug C:\Entwicklung\smart-data-lake\sdl-core\src\test\scala\io\smartdatalake\config\ConfigsMacroDebug.scala
+ */
+object ConfigsMacroDebug extends App with ConfigImplicits {
+
+  val config = ConfigFactory.parseString(
+    """
+      | {
+      |   id = 123
+      |   creator {
+      |     class-name = io.smartdatalake.config.TestCustomDfCreator
+      |     options = {
+      |       test = foo
+      |     }
+      |   }
+      | }
+      |""".stripMargin).resolve
+
+  implicit val instanceRegistry = new InstanceRegistry
+  import configs.syntax.RichConfig
+  config.extract[CustomDfDataObject].value
+  //CustomDfDataObject.fromConfig(config)(new InstanceRegistry)
+
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/config/DataObjectImplTests.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/DataObjectImplTests.scala
@@ -18,7 +18,8 @@
  */
 package io.smartdatalake.config
 
-import com.typesafe.config.{ConfigException, ConfigFactory}
+import com.typesafe.config.{ConfigException, ConfigFactory, ConfigValueFactory}
+import configs.ConfigKeyNaming
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.definitions.{DateColumnType, KeycloakClientSecretAuthMode, SDLSaveMode}
 import io.smartdatalake.testutils.custom.TestCustomDfCreator
@@ -326,7 +327,7 @@ class DataObjectImplTests extends FlatSpec with Matchers {
          | 123 = {
          |  type = WebserviceFileDataObject
          |  url = "http://test"
-         |  authMode = {
+         |  auth-mode = {
          |    type = KeycloakClientSecretAuthMode
          |    ssoServer = server
          |    ssoRealm = realm

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestAction.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestAction.scala
@@ -16,10 +16,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package io.smartdatalake.config
+package io.smartdatalake.config.objects
 
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.{Condition, ExecutionMode}
 import io.smartdatalake.workflow.action.{Action, ActionMetadata}
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, DataObject, TransactionalSparkTableDataObject}

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestConnection.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestConnection.scala
@@ -16,10 +16,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package io.smartdatalake.config
+package io.smartdatalake.config.objects
 
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.ConnectionId
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.workflow.connection.{Connection, ConnectionMetadata}
 
 /**

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
@@ -16,10 +16,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package io.smartdatalake.config
+package io.smartdatalake.config.objects
 
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataobject._

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestFileTransformer.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestFileTransformer.scala
@@ -1,7 +1,7 @@
 /*
  * Smart Data Lake - Build your data lake the smart way.
  *
- * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ * Copyright © 2019-2021 ELCA Informatique SA (<https://www.elca.ch>)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package io.smartdatalake.config
+package io.smartdatalake.config.objects
 
 import io.smartdatalake.workflow.action.customlogic.CustomFileTransformer
 import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream}

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionLayoutTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionLayoutTest.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.util.hdfs
 
+import io.smartdatalake.definitions.Environment
 import org.scalatest.FunSuite
 
 class PartitionLayoutTest extends FunSuite {
@@ -43,5 +44,20 @@ class PartitionLayoutTest extends FunSuite {
     val partitionString = "abc/date2000-01-01-ZZ-test.csv"
     val partitionValues = PartitionLayout.extractPartitionValues(testLayout, "*.csv", partitionString)
     assert(partitionValues == PartitionValues(Map("date" -> "2000-01-01", "type" -> "ZZ")))
+  }
+
+  test("extracting partition values according to hadoop partition layout") {
+    val delimiter = PartitionLayout.delimiter
+    val testLayout = HdfsUtil.getHadoopPartitionLayout(Seq("a","b"), Environment.defaultPathSeparator)
+    val partitionString = "a=1/b=2/test.csv"
+    val partitionValues = PartitionLayout.extractPartitionValues(testLayout, "*.csv", partitionString)
+    assert(partitionValues == PartitionValues(Map("a" -> "1", "b" -> "2")))
+  }
+
+  test("fail extracting partition values if partition string doesn't start with partition layout") {
+    val delimiter = PartitionLayout.delimiter
+    val testLayout = HdfsUtil.getHadoopPartitionLayout(Seq("a","b"), Environment.defaultPathSeparator)
+    val partitionString = "test/a=1/b=2/test.csv"
+    intercept[RuntimeException](PartitionLayout.extractPartitionValues(testLayout, "*.csv", partitionString))
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/secrets/SecretsUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/secrets/SecretsUtilTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.FunSuite
 class SecretsUtilTest extends FunSuite {
 
   test("register custom config provider and get secret") {
-    val providerConfig = new SecretProviderConfig(classOf[TestSecretProvider].getName, Map("option1" -> "1"))
+    val providerConfig = new SecretProviderConfig(classOf[TestSecretProvider].getName, Some(Map("option1" -> "1")))
     SecretsUtil.registerProvider("TEST", providerConfig.provider)
     assert(SecretsUtil.getSecret("TEST#test") == "test1")
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -241,7 +241,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // exec dag
     val sdlb = new DefaultSmartDataLakeBuilder
     val appConfig = SmartDataLakeBuilderConfig(feedSel=feed)
-    sdlb.exec(appConfig, 1, 1, LocalDateTime.now(), LocalDateTime.now(), Seq(), Seq(), None, Seq(), simulation = false)
+    sdlb.exec(appConfig, 1, 1, LocalDateTime.now(), LocalDateTime.now(), Map(), Seq(), None, Seq(), simulation = false)
 
     val r1 = tgtBDO.getDataFrame()
       .select($"rating")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -986,7 +986,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkIncrementalMode(compareCol = "tstmp", stopIfNoData = false)))
     val action2 = CustomSparkAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id)
-      , CustomDfsTransformerConfig.apply(sqlCode = Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)")))
+      , CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)"))))
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2), 1, 1)
 
     // first dag run, first file processed
@@ -1042,7 +1042,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val df2 = Seq(("doe","john","waikiki beach")).toDF("lastname", "firstname", "address")
     src2DO.writeDataFrame(df2, Seq())
 
-    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)"))
+    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)")))
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkIncrementalMode(compareCol = "tstmp", stopIfNoData = true)))
     val action2 = CustomSparkAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id), transformation, executionCondition = Some(Condition("true")))
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2), 1, 1)
@@ -1097,7 +1097,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val df2 = Seq(("doe","john","waikiki beach")).toDF("lastname", "firstname", "address")
     src2DO.writeDataFrame(df2, Seq())
 
-    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)"))
+    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)")))
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkIncrementalMode(compareCol = "tstmp", stopIfNoData = true)))
     val action2 = CustomSparkAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id), transformation, executionCondition = Some(Condition("true")), executionMode = Some(ProcessAllMode()))
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2), 1, 1)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -239,7 +239,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val customTransformerConfig = CustomDfTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestOptionsDfTransformer"), options = Map("test" -> "test"), runtimeOptions = Map("appName" -> "application"))
+    val customTransformerConfig = CustomDfTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestOptionsDfTransformer"), options = Some(Map("test" -> "test")), runtimeOptions = Some(Map("appName" -> "application")))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformer = Some(customTransformerConfig), filterClause = Some("lastname='jonson'"), additionalColumns = Some(Map("run_id" -> "runId")))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
@@ -67,7 +67,7 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start load
     implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
-    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Map("test"->"true"))
+    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Some(Map("test"->"true")))
     val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, false, 1)
     val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head
@@ -110,7 +110,7 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start load
     implicit val context1 = ActionPipelineContext(feed, "test", 1, 1, instanceRegistry, None, SmartDataLakeBuilderConfig())
-    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Map("test"->"true"))
+    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Some(Map("test"->"true")))
     val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, false, 1, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", srcPartitionValues) // InitSubFeed needed to test initExecutionMode!
     val tgtSubFeed = action1.exec(Seq(srcSubFeed)).head

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomSparkActionTest.scala
@@ -73,7 +73,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     // prepare & start load
     val customTransformerConfig = CustomDfsTransformerConfig(
       className = Some("io.smartdatalake.workflow.action.TestDfsTransformerIncrement"),
-      options = Map("increment1" -> "1"), runtimeOptions = Map("increment2" -> "runId")
+      options = Some(Map("increment1" -> "1")), runtimeOptions = Some(Map("increment2" -> "runId"))
     )
 
     val action1 = CustomSparkAction("action1", List(srcDO1.id, srcDO2.id), List(tgtDO1.id, tgtDO2.id), transformer = customTransformerConfig)
@@ -269,7 +269,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO2)
 
     // prepare & start load
-    val customTransformerConfig = CustomDfsTransformerConfig(sqlCode = Map(DataObjectId("tgt1")->"select * from copy_input where rating = 5", DataObjectId("tgt2")->"select * from copy_input where rating = 3"))
+    val customTransformerConfig = CustomDfsTransformerConfig(sqlCode = Some(Map(DataObjectId("tgt1")->"select * from copy_input where rating = 5", DataObjectId("tgt2")->"select * from copy_input where rating = 3")))
     val action1 = CustomSparkAction("ca", List(srcDO.id), List(tgtDO1.id,tgtDO2.id), transformer = customTransformerConfig)
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
@@ -310,7 +310,7 @@ class CustomSparkActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO1)
 
     // prepare
-    val customTransformerConfig = CustomDfsTransformerConfig(sqlCode = Map(DataObjectId("tgt1")->"select * from src1 union all select * from src2"))
+    val customTransformerConfig = CustomDfsTransformerConfig(sqlCode = Some(Map(DataObjectId("tgt1")->"select * from src1 union all select * from src2")))
     val l1 = Seq(("jonson","rob",5)).toDF("lastname", "firstname", "rating")
     srcDO1.writeDataFrame(l1, Seq())
     val l2 = Seq(("doe","bob",3)).toDF("lastname", "firstname", "rating")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
@@ -123,7 +123,7 @@ class ExecutionModeTest extends FunSuite with BeforeAndAfter {
 
   test("PartitionDiffMode selectAdditionalInputExpression with udf") {
     val udfConfig = SparkUDFCreatorConfig(classOf[TestUdfAddLastnameEinstein].getName)
-    ExpressionEvaluator.registerUdf("testUdfAddLastNameEinstein", udfConfig.get)
+    ExpressionEvaluator.registerUdf("testUdfAddLastNameEinstein", udfConfig.getUDF)
     val executionMode = PartitionDiffMode(selectAdditionalInputExpression = Some("testUdfAddLastNameEinstein(selectedInputPartitionValues,inputPartitionValues)"))
     executionMode.prepare(ActionId("test"))
     val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObjectTest.scala
@@ -57,7 +57,6 @@ class ExcelFileDataObjectTest extends DataObjectTestSuite with BeforeAndAfterAll
     s"""
        |{
        | id = src1
-       | type = excel
        | path = "${escapedFilePath(xslxTempFilePath)}"
        | excel-options {
        |   sheet-name = "sheet number 1"
@@ -93,7 +92,6 @@ class ExcelFileDataObjectTest extends DataObjectTestSuite with BeforeAndAfterAll
       s"""
          |{
          | id = src1
-         | type = excel
          | path = "${escapedFilePath(xslTempFilePath)}"
          | excel-options {
          |   useHeader = true

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ExportMetadataDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ExportMetadataDataObjectTest.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.workflow.dataobject
 
 import com.typesafe.config.{Config, ConfigFactory}
-import io.smartdatalake.config.{TestAction, TestConnection, TestDataObject}
+import io.smartdatalake.config.objects.{TestAction, TestConnection, TestDataObject}
 import io.smartdatalake.testutils.DataObjectTestSuite
 import io.smartdatalake.workflow.action.ActionMetadata
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
@@ -306,6 +306,7 @@ class SparkFileDataObjectTest extends DataObjectTestSuite {
     assert(dataObject.filesystem.isDirectory(partitionPath))
 
     // delete files in base dir
+    dataObject.filesystem.createNewFile(new Path(dataObject.hadoopPath, "testFile"))
     assert(dataObject.filesystem.listStatus(dataObject.hadoopPath).exists(_.isFile))
     dataObject.deleteAllFiles(dataObject.hadoopPath)
     assert(!dataObject.filesystem.listStatus(dataObject.hadoopPath).exists(_.isFile))

--- a/sdl-deltalake/pom.xml
+++ b/sdl-deltalake/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>io.delta</groupId>
 			<artifactId>delta-core_${scala.minor.version}</artifactId>
-			<version>${deltaTable.version}</version>
+			<version>${delta.version}</version>
 		</dependency>
 
 		<dependency>

--- a/sdl-deltalake/pom.xml
+++ b/sdl-deltalake/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>2.0.3</version>
+		<version>2.0.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.workflow.dataobject
 
+import com.typesafe.config.Config
 import io.delta.tables.DeltaTable
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
@@ -232,9 +233,13 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   /**
    * @inheritdoc
    */
-  override def factory: FromConfigFactory[DataObject] = TickTockHiveTableDataObject
+  override def factory: FromConfigFactory[DataObject] = DeltaLakeTableDataObject
 
 }
 
-
+object DeltaLakeTableDataObject extends FromConfigFactory[DataObject] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): DeltaLakeTableDataObject = {
+    extract[DeltaLakeTableDataObject](config)
+  }
+}
 

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -97,9 +97,16 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
 
+  override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    super.init(df, partitionValues)
+    validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
+  }
+
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
     val df = session.read.format("delta").load(hadoopPath.toString)
     validateSchemaMin(df, "read")
+    validateSchemaHasPartitionCols(df, "read")
     df
   }
 
@@ -114,6 +121,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
+    validateSchemaHasPartitionCols(df, "write")
     writeDataFrame(df, createTableOnly=false, partitionValues)
   }
 

--- a/sdl-jms/pom.xml
+++ b/sdl-jms/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>2.0.3</version>
+		<version>2.0.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-kafka/pom.xml
+++ b/sdl-kafka/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>2.0.3</version>
+		<version>2.0.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
@@ -38,13 +38,13 @@ import scala.collection.JavaConverters._
  * @param id unique id of this connection
  * @param brokers comma separated list of kafka bootstrap server incl. port, e.g. "host1:9092,host2:9092:
  * @param schemaRegistry url of schema registry service, e.g. "https://host2"
- * @param datasourceOptions Options for the Kafka stream reader (see https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html)
+ * @param options Options for the Kafka stream reader (see https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html)
  * @param metadata
  */
 case class KafkaConnection(override val id: ConnectionId,
                            brokers: String,
                            schemaRegistry: Option[String] = None,
-                           datasourceOptions: Map[String,String] = Map(),
+                           options: Map[String,String] = Map(),
                            authMode: Option[AuthMode] = None,
                            override val metadata: Option[ConnectionMetadata] = None
                           ) extends Connection {
@@ -58,7 +58,7 @@ case class KafkaConnection(override val id: ConnectionId,
 
   @transient lazy val confluentHelper: Option[ConfluentClient] = schemaRegistry.map(new ConfluentClient(_))
 
-  private val KafkaConfigOptionPrefix = "kafka."
+  private[smartdatalake] val KafkaConfigOptionPrefix = "kafka."
   private val KafkaSSLSecurityProtocol = "SSL"
 
   // Early validation and partition init use kafka clients directly and need
@@ -83,7 +83,7 @@ case class KafkaConnection(override val id: ConnectionId,
 
   // Kafka Configs are prepended with "kafka." in data source option map
   private val authOptions = authProps.asScala.map(c => (s"${KafkaConfigOptionPrefix}${c._1}", c._2))
-  private[workflow] val sparkOptions = authOptions ++ datasourceOptions + (KafkaConfigOptionPrefix+ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> brokers)
+  private[workflow] val sparkOptions = authOptions ++ options + (KafkaConfigOptionPrefix+ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> brokers)
 
   def topicExists(topic: String): Boolean = {
     adminClient.listTopics.names.get.asScala.contains(topic)

--- a/sdl-kafka/src/test/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObjectTest.scala
+++ b/sdl-kafka/src/test/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObjectTest.scala
@@ -24,100 +24,132 @@ import java.time.temporal.ChronoUnit
 import io.smartdatalake.testutils.DataObjectTestSuite
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.connection.KafkaConnection
-import net.manub.embeddedkafka.EmbeddedKafka
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.spark.sql.streaming.Trigger
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
 
-class KafkaTopicDataObjectTest extends FunSuite with EmbeddedKafka with DataObjectTestSuite with SmartDataLakeLogger {
+/**
+ * Note about EmbeddedKafka compatibility:
+ * The currently used version 2.4.1 (in sync with the kafka version of sparks parent pom) is not compatible with JDK14+
+ * because of a change of InetSocketAddress::toString. Zookeeper doesn't start because of
+ * "java.nio.channels.UnresolvedAddressException: Session 0x0 for server localhost/<unresolved>:6001, unexpected error, closing socket connection and attempting reconnect"
+ * see also https://www.oracle.com/java/technologies/javase/14all-relnotes.html#JDK-8225499
+ */
+class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with BeforeAndAfter with EmbeddedKafka with DataObjectTestSuite with SmartDataLakeLogger {
 
   import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
   import session.implicits._
 
   private val kafkaConnection = KafkaConnection("kafkaCon1", "localhost:6000")
 
+  private lazy val kafka = EmbeddedKafka.start()
+  override def beforeAll() {
+    kafka // initialize lazy variable
+  }
+
+  override def afterAll(): Unit = {
+    kafka.stop(true)
+  }
+
   test("Can read and write from Kafka") {
-    withRunningKafka {
-      createCustomTopic("topic", Map(), 1, 1)
-      publishStringMessageToKafka("topic", "message")
-      assert(consumeFirstStringMessageFrom("topic")=="message", "Whoops - couldn't read message")
-    }
+    Thread.sleep(1000)
+    createCustomTopic("topic", Map(), 1, 1)
+    publishStringMessageToKafka("topic", "message")
+    assert(consumeFirstStringMessageFrom("topic")=="message", "Whoops - couldn't read message")
   }
 
   test("DataObject can write and read kafka topic") {
     val topic = "testTopic"
-    withRunningKafka {
-      createCustomTopic(topic, Map(), 1, 1)
-      instanceRegistry.register(kafkaConnection)
-      val dataObject = KafkaTopicDataObject("kafka1", topicName = topic, connectionId = "kafkaCon1")
-      val df = Seq(("john doe", "5"), ("peter smith", "3"), ("emma brown", "7")).toDF("key", "value")
-      dataObject.writeDataFrame(df, Seq())
-      val dfRead = dataObject.getDataFrame(Seq())
-      assert(dfRead.symmetricDifference(df).isEmpty)
-    }
+    createCustomTopic(topic, Map(), 1, 1)
+    instanceRegistry.register(kafkaConnection)
+    val dataObject = KafkaTopicDataObject("kafka1", topicName = topic, connectionId = "kafkaCon1")
+    val df = Seq(("john doe", "5"), ("peter smith", "3"), ("emma brown", "7")).toDF("key", "value")
+    dataObject.writeDataFrame(df, Seq())
+    val dfRead = dataObject.getDataFrame(Seq())
+    assert(dfRead.symmetricDifference(df).isEmpty)
   }
 
   test("DataObject can write and stream once kafka topic") {
     val topic1 = "testTopic1"
     val topic2 = "testTopic2"
     val tempDir = Files.createTempDirectory("streamTest")
-    withRunningKafka {
-      createCustomTopic(topic1, Map(), 1, 1)
-      createCustomTopic(topic2, Map(), 1, 1)
-      instanceRegistry.register(kafkaConnection)
-      val dataObject1 = KafkaTopicDataObject("kafka1", topicName = topic1, connectionId = "kafkaCon1")
-      val dataObject2 = KafkaTopicDataObject("kafka1", topicName = topic2, connectionId = "kafkaCon1")
+    createCustomTopic(topic1, Map(), 1, 1)
+    createCustomTopic(topic2, Map(), 1, 1)
+    instanceRegistry.register(kafkaConnection)
+    val dataObject1 = KafkaTopicDataObject("kafka1", topicName = topic1, connectionId = "kafkaCon1")
+    val dataObject2 = KafkaTopicDataObject("kafka1", topicName = topic2, connectionId = "kafkaCon1")
 
-      // prepare data
-      val df1 = Seq(("john doe", "5"), ("peter smith", "3"), ("emma brown", "7")).toDF("key", "value")
-      dataObject1.writeDataFrame(df1, Seq())
+    // prepare data
+    val df1 = Seq(("john doe", "5"), ("peter smith", "3"), ("emma brown", "7")).toDF("key", "value")
+    dataObject1.writeDataFrame(df1, Seq())
 
-      // stream
-      val dfStream1 = dataObject1.getStreamingDataFrame(Map("startingOffsets"->"earliest"), None)
-      val query = dataObject2.writeStreamingDataFrame(dfStream1, Trigger.Once, Map(), checkpointLocation = tempDir.resolve("state").toString, "test")
-      query.awaitTermination()
-      logger.info(s"streaming query finished, rows processed = ${query.lastProgress.numInputRows}")
+    // stream
+    val dfStream1 = dataObject1.getStreamingDataFrame(Map("startingOffsets"->"earliest"), None)
+    val query = dataObject2.writeStreamingDataFrame(dfStream1, Trigger.Once, Map(), checkpointLocation = tempDir.resolve("state").toString, "test")
+    query.awaitTermination()
+    logger.info(s"streaming query finished, rows processed = ${query.lastProgress.numInputRows}")
 
-      // check
-      val df2 = dataObject2.getDataFrame().cache
-      df2.show
-      assert(df2.symmetricDifference(df1).isEmpty)
-    }
+    // check
+    val df2 = dataObject2.getDataFrame().cache
+    df2.show
+    assert(df2.symmetricDifference(df1).isEmpty)
   }
 
   test("Can list and query partitions") {
-    withRunningKafka {
-      val topic1 = "testPartitionTopic1"
-      createCustomTopic(topic1, Map(), 1, 1)
-      logger.info("topic created")
+    val topic1 = "testPartitionTopic1"
+    createCustomTopic(topic1, Map(), 1, 1)
+    logger.info("topic created")
 
-      // publish several messages with some delay between to have different timestamps
-      implicit val stringSerializer = new StringSerializer
-      publishToKafka(topic1, "A", "1")
-      Thread.sleep(1000)
-      publishToKafka(topic1, "B", "2")
-      Thread.sleep(2000)
-      publishToKafka(topic1, "C", "3")
-      logger.info("3 test messages written")
+    // publish several messages with some delay between to have different timestamps
+    implicit val stringSerializer = new StringSerializer
+    publishToKafka(topic1, "A", "1")
+    Thread.sleep(1000)
+    publishToKafka(topic1, "B", "2")
+    Thread.sleep(2000)
+    publishToKafka(topic1, "C", "3")
+    logger.info("3 test messages written")
 
-      // configure DataObject with partition column defined as seconds
-      instanceRegistry.register(kafkaConnection)
-      val dataObject1 = KafkaTopicDataObject("kafka1", topicName = topic1, connectionId = "kafkaCon1"
-        , datePartitionCol = Some(DatePartitionColumnDef( colName = "sec", timeUnit = ChronoUnit.SECONDS.toString, timeFormat ="yyyyMMddHHmmss")))
+    // configure DataObject with partition column defined as seconds
+    instanceRegistry.register(kafkaConnection)
+    val dataObject1 = KafkaTopicDataObject("kafka1", topicName = topic1, connectionId = "kafkaCon1"
+      , datePartitionCol = Some(DatePartitionColumnDef( colName = "sec", timeUnit = ChronoUnit.SECONDS.toString, timeFormat ="yyyyMMddHHmmss")))
 
-      // list and check partitions
-      val partitions = dataObject1.listPartitions
-      assert(partitions.size >= 3) // as we have written messages over a timestamp of 3secs
+    // list and check partitions
+    val partitions = dataObject1.listPartitions
+    assert(partitions.size >= 3) // as we have written messages over a timestamp of 3secs
 
-      // check query first partitions data
-      val dfP1 = dataObject1.getDataFrame(Seq(partitions.minBy( p => p("sec").toString.toLong))).cache
-      assert(dfP1.columns.contains("sec"))
-      val dataP1 = dfP1.select($"key",$"value").as[(String,String)].collect.toSeq
-      assert(dataP1 == Seq(("A","1")))
-    }
+    // check query first partitions data
+    val dfP1 = dataObject1.getDataFrame(Seq(partitions.minBy( p => p("sec").toString.toLong))).cache
+    assert(dfP1.columns.contains("sec"))
+    val dataP1 = dfP1.select($"key",$"value").as[(String,String)].collect.toSeq
+    assert(dataP1 == Seq(("A","1")))
   }
 
-  after {
-    EmbeddedKafka.stop()
+  test("Exclude or include current date partition in list partitions") {
+    val topic1 = "testPartitionTopic2"
+    createCustomTopic(topic1, Map(), 1, 1)
+    logger.info("topic created")
+
+    // publish one messages
+    implicit val stringSerializer = new StringSerializer
+    publishToKafka(topic1, "A", "1")
+
+    // configure DataObject with partition column defined as day and excluding current partition
+    instanceRegistry.register(kafkaConnection)
+    val dataObject1 = KafkaTopicDataObject("kafka1", topicName = topic1, connectionId = "kafkaCon1"
+      , datePartitionCol = Some(DatePartitionColumnDef( colName = "dt", timeUnit = ChronoUnit.DAYS.toString, timeFormat ="yyyyMMdd")))
+
+    // list and check partitions
+    val partitions1 = dataObject1.listPartitions
+    assert(partitions1.isEmpty) // only current partition holds data, but it is excluded
+
+    // configure DataObject with partition column defined as day and including current partition
+    val dataObject2 = KafkaTopicDataObject("kafka2", topicName = topic1, connectionId = "kafkaCon1"
+      , datePartitionCol = Some(DatePartitionColumnDef( colName = "dt", timeUnit = ChronoUnit.DAYS.toString, timeFormat ="yyyyMMdd", includeCurrentPartition = true)))
+
+    // list and check partitions
+    val partitions2 = dataObject2.listPartitions
+    assert(partitions2.size == 1) // current partition is included
   }
 }

--- a/sdl-snowflake/pom.xml
+++ b/sdl-snowflake/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>2.0.3</version>
+		<version>2.0.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-splunk/pom.xml
+++ b/sdl-splunk/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>io.smartdatalake</groupId>
 		<artifactId>sdl-parent</artifactId>
-		<version>2.0.3</version>
+		<version>2.0.4-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/sdl-splunk/src/main/scala/io/smartdatalake/workflow/dataobject/SplunkDataObject.scala
+++ b/sdl-splunk/src/main/scala/io/smartdatalake/workflow/dataobject/SplunkDataObject.scala
@@ -25,8 +25,7 @@ import java.time.{Duration, LocalDateTime}
 
 import com.splunk._
 import com.typesafe.config.Config
-import configs.Configs
-import configs.syntax._
+import configs.ConfigReader
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
@@ -161,15 +160,13 @@ object SplunkDataObject extends FromConfigFactory[DataObject] {
     ofMinutes(value)
   }
 
-  /**
-   * A ConfigReader that reads [[SplunkParams]] values.
-   *
-   * SplunkParams have special semantics for Duration which are covered with this reader.
-   */
-  implicit val splunkParamsReader: Configs[SplunkParams] = Configs.fromConfigTry { c =>
-    SplunkParams.fromConfig(c)
+  implicit val splunkParamsReader: ConfigReader[SplunkParams] = ConfigReader.derive[SplunkParams]
+  implicit val splunkLocalDateTimeReader: ConfigReader[LocalDateTime] = ConfigReader.fromTry { (c, p) =>
+    SplunkDataObject.parseConfigDateTime(c.getString(p))
   }
-
+  implicit val splunkDurationReader: ConfigReader[Duration] = ConfigReader.fromTry { (c, p) =>
+    SplunkDataObject.parseConfigDuration(c.getInt(p))
+  }
   override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): SplunkDataObject = {
     extract[SplunkDataObject](config)
   }
@@ -227,16 +224,4 @@ case class SplunkParams(
                          parallelRequests: Int = 2
                        ) {
   val schema: StructType = StructType(columnNames.toArray.map(name => StructField(name, StringType, nullable = true)).toList)
-}
-
-object SplunkParams {
-  def fromConfig(config: Config): SplunkParams = {
-    implicit val splunkLocalDateTimeReader: Configs[LocalDateTime] = Configs.fromTry { (c, p) =>
-      SplunkDataObject.parseConfigDateTime(c.getString(p))
-    }
-    implicit val splunkDurationReader: Configs[Duration] = Configs.fromTry { (c, p) =>
-      SplunkDataObject.parseConfigDuration(c.getInt(p))
-    }
-    config.extract[SplunkParams].value
-  }
 }

--- a/sdl-splunk/src/test/scala/io/smartdatalake/workflow/dataobject/SplunkDataObjectTest.scala
+++ b/sdl-splunk/src/test/scala/io/smartdatalake/workflow/dataobject/SplunkDataObjectTest.scala
@@ -155,7 +155,6 @@ class SplunkDataObjectTest extends DataObjectTestSuite {
       s"""
          |{
          | id = src1
-         | type = splunk
          | connectionId = con1
          | params {
          |   query = "$query"


### PR DESCRIPTION
New features
- enable fail-on-superfluous-config-keys (#27)
- implement support to register python UDFs for Spark SQL transformations
- add org.apache.spark:hadoop-cloud s3a optimizations (#208)

Minor improvements
- optimize reading multiple partitions in SparkFileDataObject
- validate partition columns existing on write and read
- update to spark 3.1.1
- update delta lake version
- implement including current date partition in KafkaTopicDataObject.listPartitions
- use options to customize kafka consumer creation

Bugfixes
- fix recovery re-executing skipped actions (#349) 
- fix SparkUDFCreator not serializable
- avoid PythonAccumulatorV2 "java.net.ConnectException: Connection refused: connect"
- fix allow overwrite hive table with different schema
- fix the Schema/Database naming mess partly in Snowflake module
- performance fix for ConfluentAvroDataToCatalyst conversion
- fix listing partitions on relative path