### PR TITLE
Fix anchor in partitionLayoutRegex

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -172,7 +172,7 @@ private[smartdatalake] object PartitionLayout {
       tokenMatch => if (tokenMatch.group(3) != null) s"(${tokenMatch.group(3)})" else "(.*?)"
     })
     // create regex and match with path.
-    val partitionLayoutRegex = ("^.*" + partitionLayoutPrepared).r // add anchor at start of string.
+    val partitionLayoutRegex = ("^" + partitionLayoutPrepared).r // add anchor at start of string.
     partitionLayoutRegex.findFirstMatchIn(path) match {
       case Some(regexMatch) =>
         val tokenValues = (1 to regexMatch.groupCount).map( i => regexMatch.group(i))

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -172,7 +172,7 @@ private[smartdatalake] object PartitionLayout {
       tokenMatch => if (tokenMatch.group(3) != null) s"(${tokenMatch.group(3)})" else "(.*?)"
     })
     // create regex and match with path.
-    val partitionLayoutRegex = ("^" + partitionLayoutPrepared).r // add anchor at start of string.
+    val partitionLayoutRegex = ("^.*" + partitionLayoutPrepared).r // add anchor at start of string.
     partitionLayoutRegex.findFirstMatchIn(path) match {
       case Some(regexMatch) =>
         val tokenValues = (1 to regexMatch.groupCount).map( i => regexMatch.group(i))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -202,7 +202,8 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
 
   override def relativizePath(path: String): String = {
     val normalizedPath = new Path(path).toString
-    normalizedPath.stripPrefix(hadoopPath.toString).stripPrefix(Path.SEPARATOR)
+    val pathPrefix = (".*"+hadoopPath.toString).r // ignore any absolute path prefix up and including hadoop path
+    pathPrefix.replaceAllIn(normalizedPath, "").stripPrefix(Path.SEPARATOR)
   }
 
   override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {


### PR DESCRIPTION
<!--
Thanks for creating a pull request. A few reminders:
Please follow the contributor guidelines: https://github.com/smart-data-lake/smart-data-lake/blob/develop/CONTRIBUTING.md
If your contribution is based on an issue, please link the issue (bug / feature) so the connection is clear.
If you added new functionality, please make sure you added adequate tests for it.
Enter a concise title and description for your PR to reflect the changes.
--> 

### What changes are included in the pull request?
The regex in Partition:175 expects the path to start with the partition layout (relative path) but the absolute path is provided, so the regex is replaced to start with `^.*` instead of `^`.

### Why are the changes needed?
Using the committed code in https://github.com/smart-data-lake/smart-data-lake/pull/350 turns out to throw an exception
`prepared regexp partition layout ... didn't match path ... `