### PR TITLE
Bugfix/spark tags dependency

### DIFF
--- a/sdl-deltalake/pom.xml
+++ b/sdl-deltalake/pom.xml
@@ -69,6 +69,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-tags_${scala.minor.version}</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-sql-kafka-0-10_${scala.minor.version}</artifactId>
 			<version>${spark.version}</version>
 			<scope>runtime</scope>

--- a/sdl-deltalake/pom.xml
+++ b/sdl-deltalake/pom.xml
@@ -67,9 +67,14 @@
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-catalyst_${scala.minor.version}</artifactId>
 		</dependency>
+		<!--
+		 	prevent hitting missing dependency exception
+		 	see https://stackoverflow.com/questions/42327777/spark-sql-errors
+		 -->
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-tags_${scala.minor.version}</artifactId>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### What changes are included in the pull request?
Add spark-tags dependency for sdl-deltalake

### Why are the changes needed?
Somehow, sdl-deltalake doesn't always resolve the transitive dependency for spark-tags. When doing a fresh clone, maven would build correctly the first time. But when compiling a second time, I hit the error described here: https://stackoverflow.com/questions/42327777/spark-sql-errors. 

> error: missing or invalid dependency detected while loading class file 'package.class'. Could not access term annotation in package org.apache.spark, because it (or its dependencies) are missing. 