### PR TITLE
Replace json4s with kxbmap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1124,17 +1124,6 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>org.json4s</groupId>
-				<artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-				<version>3.6.6</version>
-				<exclusions>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.core</groupId>
-						<artifactId>*</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
 				<groupId>org.scala-lang.modules</groupId>
 				<artifactId>scala-xml_${scala.binary.version}</artifactId>
 				<version>1.2.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1124,6 +1124,17 @@
 				</exclusions>
 			</dependency>
 			<dependency>
+				<groupId>org.json4s</groupId>
+				<artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+				<version>3.6.6</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
 				<groupId>org.scala-lang.modules</groupId>
 				<artifactId>scala-xml_${scala.binary.version}</artifactId>
 				<version>1.2.0</version>

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -20,12 +20,19 @@
 package io.smartdatalake.workflow
 
 import java.time.{LocalDateTime, Duration => JavaDuration}
-
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.SdlConfigObject.ActionId
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.action.{RuntimeEventState, RuntimeInfo}
+import com.typesafe.config.{ConfigException, ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
+import configs.{ConfigKeyNaming, ConfigObject, ConfigReader, ConfigValue, ConfigWriter, Result, StringConverter}
+import configs.Result.{Failure, Success}
+import io.smartdatalake.config.ConfigurationException
+import io.smartdatalake.util.hdfs.PartitionValues
+
+import java.net.InetAddress
+import scala.collection.generic.CanBuildFrom
 
 /**
  * ActionDAGRunState contains all configuration and state of an ActionDAGRun needed to start a recovery run in case of failure.
@@ -37,43 +44,103 @@ private[smartdatalake] case class ActionDAGRunState(appConfig: SmartDataLakeBuil
   def isSucceeded: Boolean = isFinal && !isFailed
 }
 private[smartdatalake] object ActionDAGRunState {
-  // json4s is used because kxbmap configs supports converting case classes to config only from version 5.0 which isn't yet stable
-  // json4s is included with spark-core
-  // Note that key-type of Maps must be String in json4s (e.g. actionsState...)
-  import org.json4s._
-  import org.json4s.jackson.JsonMethods._
-  import org.json4s.jackson.Serialization
-  implicit val formats =  DefaultFormats.withHints(ShortTypeHints(List(classOf[SparkSubFeed],classOf[FileSubFeed]))).withTypeHintFieldName("type") +
-    RuntimeEventStateSerializer + DurationSerializer + LocalDateTimeSerializer + ActionIdKeySerializer
 
-  def toJson(actionDAGRunState: ActionDAGRunState): String = pretty(parse(Serialization.write(actionDAGRunState)))
+  import configs.syntax._
 
-  def fromJson(stateJson: String): ActionDAGRunState = {
-    val rawState = parse(stateJson).extract[ActionDAGRunState]
-    // fix key class type of "value class ActionId" for scala 2.11 (ActionDAGRunTest fails for scala 2.11 otherwise)
-    rawState.copy(actionsState = rawState.actionsState.map( e => (if (e._1.getClass==classOf[String]) ActionId(e._1.asInstanceOf[String]) else e._1, e._2)))
+  def localDateTime(): ConfigReader[LocalDateTime] =
+    ConfigReader.fromTry { (c, p) =>
+      val s = c.getString(p)
+      try LocalDateTime.parse(s) catch {
+        case e: Exception =>
+          throw new ConfigException.WrongType(c.origin(), p, "LocalDateTime", s"STRING value '$s'", e)
+      }
+    }
+  implicit lazy val localDateTimeConfigReader: ConfigReader[LocalDateTime] = localDateTime
+
+  def actionId(): ConfigReader[ActionId] =
+    ConfigReader.fromTry { (c,p) =>
+      ActionId(c.getString(p))
+    }
+  implicit lazy val actionIdConfigReader: ConfigReader[ActionId] = actionId
+
+  def runtimeEventState(): ConfigReader[RuntimeEventState] =
+    ConfigReader.fromTry { (c,p) =>
+      RuntimeEventState.withName(c.getString(p))
+    }
+  implicit lazy val runtimeEventStateConfigReader: ConfigReader[RuntimeEventState] = runtimeEventState
+
+  // TODO: Dummy implementation
+  def partitionValues(): ConfigReader[PartitionValues] =
+    ConfigReader.fromTry { (c,p) =>
+      PartitionValues(Map("1"->5))
+    }
+  implicit lazy val partitionValuesConfigReader: ConfigReader[PartitionValues] = partitionValues
+
+  // TODO: Dummy implementation
+  def runtimeInfo(): ConfigReader[RuntimeInfo] =
+    ConfigReader.fromTry { (c,p) =>
+      RuntimeInfo(RuntimeEventState.STARTED)
+    }
+  implicit lazy val runtimeInfoConfigReader: ConfigReader[RuntimeInfo] = runtimeInfo
+
+  val any: ConfigWriter[Any] = ConfigValueFactory.fromAnyRef(_)
+  def fromAny[A]: ConfigWriter[A] = any.asInstanceOf[ConfigWriter[A]]
+  implicit val stringConfigWriter: ConfigWriter[String] = fromAny[String]
+  implicit val localDateTimeConfigWriter: ConfigWriter[LocalDateTime] = stringConfigWriter.contramap(_.toString)
+  implicit val actionIdConfigWriter: ConfigWriter[ActionId] = stringConfigWriter.contramap(_.id)
+  // TODO: Implement
+  implicit val runtimeEventStateConfigWriter: ConfigWriter[RuntimeEventState] = stringConfigWriter.contramap(_.toString)
+  implicit val runtimeInfoConfigWriter: ConfigWriter[RuntimeInfo] = stringConfigWriter.contramap(_.toString)
+  implicit val partitionValuesConfigWriter: ConfigWriter[PartitionValues] = stringConfigWriter.contramap(_.toString)
+
+//  implicit val runtimeInfoConfigWriter: ConfigWriter[RuntimeInfo] = stringConfigWriter.contramap(_.state.toString)
+
+  implicit val stringStringConverter: StringConverter[String] =
+    new StringConverter[String] {
+      def fromString(string: String): Result[String] = Result.successful(string)
+      def toString(value: String): String = value
+    }
+  implicit val actionIdStringConverter: StringConverter[ActionId] = stringStringConverter.xmap(ActionId.apply, _.id)
+
+  def toJson(actionDAGRunState: ActionDAGRunState): String = {
+
+    implicit val naming = ConfigKeyNaming.lowerCamelCase[ActionDAGRunState].or(ConfigKeyNaming.hyphenSeparated[ActionDAGRunState].apply)
+    val renderOptions = ConfigRenderOptions.defaults().setJson(true).setFormatted(true)
+    val writer = ConfigWriter.derive[ActionDAGRunState](naming)
+
+    writer.write(actionDAGRunState).render(renderOptions)
   }
 
+  def fromJson(stateJson: String): ActionDAGRunState = {
+    ConfigFactory.parseString(stateJson).extract[ActionDAGRunState] match {
+      case Success(value) => value
+      case Failure(e) => throw new ConfigurationException(s"Unable to parse state from json: ${e.messages.mkString(",")}")
+      case _ => throw new Exception("Unmatched case, should never happen.")
+    }
+  }
+
+
+
   // custom serialization for RuntimeEventState which is shorter than the default
-  case object RuntimeEventStateSerializer extends CustomSerializer[RuntimeEventState](format => (
-    { case JString(state) => RuntimeEventState.withName(state) },
-    { case state: RuntimeEventState => JString(state.toString) }
-  ))
-  // custom serialization for Duration
-  case object DurationSerializer extends CustomSerializer[JavaDuration](format => (
-    { case JString(dur) => JavaDuration.parse(dur) },
-    { case dur: JavaDuration => JString(dur.toString) }
-  ))
-  // custom serialization for LocalDateTime
-  case object LocalDateTimeSerializer extends CustomSerializer[LocalDateTime](format => (
-    { case JString(tstmp) => LocalDateTime.parse(tstmp) },
-    { case tstmp: LocalDateTime => JString(tstmp.toString) }
-  ))
-  // custom serialization for ActionId as key of Maps
-  case object ActionIdKeySerializer extends CustomKeySerializer[ActionId](format => (
-    { case id => ActionId(id) },
-    { case id: ActionId => id.id }
-  ))
+//  case object RuntimeEventStateSerializer extends CustomSerializer[RuntimeEventState](format => (
+//    { case JString(state) => RuntimeEventState.withName(state) },
+//    { case state: RuntimeEventState => JString(state.toString) }
+//  ))
+//  // custom serialization for Duration
+//  case object DurationSerializer extends CustomSerializer[JavaDuration](format => (
+//    { case JString(dur) => JavaDuration.parse(dur) },
+//    { case dur: JavaDuration => JString(dur.toString) }
+//  ))
+//  // custom serialization for LocalDateTime
+//  case object LocalDateTimeSerializer extends CustomSerializer[LocalDateTime](format => (
+//    { case JString(tstmp) => LocalDateTime.parse(tstmp) },
+//    { case tstmp: LocalDateTime => JString(tstmp.toString) }
+//  ))
+//  // custom serialization for ActionId as key of Maps
+//  case object ActionIdKeySerializer extends CustomKeySerializer[ActionId](format => (
+//    { case id => ActionId(id) },
+//    { case id: ActionId => id.id }
+//  ))
 }
 
 private[smartdatalake] trait ActionDAGRunStateStore[A <: StateId] extends SmartDataLakeLogger {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -31,7 +31,7 @@ import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.action.{ResultRuntimeInfo, RuntimeEventState, RuntimeInfo}
 import org.apache.spark.sql.DataFrame
 
-import java.time.LocalDateTime
+import java.time.{Duration, LocalDateTime}
 import java.time.format.DateTimeFormatter
 import java.{util => ju}
 import scala.collection.compat.Factory
@@ -59,6 +59,7 @@ private[smartdatalake] object ActionDAGRunState {
   implicit val localDateTimeStringConverter: StringConverter[LocalDateTime] = StringConverter.fromTry(
     LocalDateTime.parse(_, localDateTimeFormatter), localDateTimeFormatter.format
   )
+  implicit val durationStringConverter: StringConverter[Duration] = StringConverter.fromTry(Duration.parse, _.toString)
 
   // json readers
   implicit val mapStringAnyReader: ConfigReader[Map[String,Any]] = {
@@ -76,6 +77,7 @@ private[smartdatalake] object ActionDAGRunState {
   // DataFrames are not stored to Json -> always read none
   implicit val dataFrameReader: ConfigReader[Option[DataFrame]] = ConfigReader.successful(None)
   implicit val seqResultRuntimeInfoReader: ConfigReader[Seq[ResultRuntimeInfo]] = getSeqReader[ResultRuntimeInfo]
+  implicit val durationReader: ConfigReader[Duration] = ConfigReader.fromStringConfigReader
 
   // json writers
   implicit val mapStringAnyConfigWriter: ConfigWriter[Map[String,Any]] = {
@@ -86,6 +88,7 @@ private[smartdatalake] object ActionDAGRunState {
   // DataFrames are not stored to Json -> always write none
   implicit val dataFrameWriter: ConfigWriter[Option[DataFrame]] = ConfigWriter.from(_ => ConfigValue.Null)
   implicit val seqResultRuntimeInfoWriter: ConfigWriter[Seq[ResultRuntimeInfo]] = getSeqWriter[ResultRuntimeInfo]
+  implicit val durationWriter: ConfigWriter[Duration] = ConfigWriter.stringConfigWriter.contramap(durationStringConverter.toString)
 
   // write state to Json
   def toJson(actionDAGRunState: ActionDAGRunState): String = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -32,7 +32,7 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException
  * A SubFeed transports references to data between Actions.
  * Data can be represented by different technologies like Files or DataFrame.
  */
-trait SubFeed extends DAGResult with SmartDataLakeLogger {
+sealed trait SubFeed extends DAGResult with SmartDataLakeLogger {
   def dataObjectId: DataObjectId
   def partitionValues: Seq[PartitionValues]
   def isDAGStart: Boolean


### PR DESCRIPTION
### What changes are included in the pull request?
Solves #355 by removing json4s dependency. 

### Why are the changes needed?
Databricks Runtime 8 updated the json4s dependency from 3.6.6 to 3.7.0-M5. The newer version is not compatible with SDL.
This was a good time to get rid of json4s, as the functionality we need is now included in kxbmap. This was actually documented in ActionDAGRunState as technical debt.