### PR TITLE
added java.lang.Long to json readers

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -68,6 +68,7 @@ private[smartdatalake] object ActionDAGRunState {
         // only String and Integer needed for now
         case v: String => v
         case v: Integer => v
+        case v: java.lang.Long => v
       }
     }
     val javaMapStringAnyConfigReader: ConfigReader[ju.Map[String, Any]] = ConfigReader.javaMapConfigReader(implicitly[StringConverter[String]], anyReader)


### PR DESCRIPTION
<!--
Thanks for creating a pull request. A few reminders:
Please follow the contributor guidelines: https://github.com/smart-data-lake/smart-data-lake/blob/develop/CONTRIBUTING.md
If your contribution is based on an issue, please link the issue (bug / feature) so the connection is clear.
If you added new functionality, please make sure you added adequate tests for it.
Enter a concise title and description for your PR to reflect the changes.
--> 

### What changes are included in the pull request?
SDL needs to be able to read long values from state files.

### Why are the changes needed?
The state files can contain numbers larger than 2^31 (Integer), i.e. for bytes_written. If that's the case, state files currently are not read correctly.