### PR TITLE
Save mode merge / Jdbc schema evolution

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -22,6 +22,7 @@ The following is a list of implemented and planned (Future) features of Smart Da
 * File: SFTP, Local, Webservice
 * Easily extendable through implementing predefined scala traits
 * Support for getting secrets from different secret providers
+* Support for SQL update & merge (Jdbc, DeltaLake) 
 
 ##### Generic Transformations
 * Spark based: Copy, Historization, Deduplication
@@ -56,6 +57,7 @@ The following is a list of implemented and planned (Future) features of Smart Da
 ##### Schema Evolution
 * Automatic evolution of data schemas (new column, removed column, changed datatype)
 * Support for changes in complex datatypes (e.g. new column in array of struct)
+* Automatic adaption of DataObjects with fixed schema (Jdbc, DeltaLake) 
 
 ##### Metrics
 * Number of rows written per DataObject

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -387,12 +387,12 @@ How it works: under the hood a PySpark DataFrame is a proxy for a Java Spark Dat
 ## Schema Evolution
 SmartDataLakeBuilder is built to support schema evolution where possible. This means that data pipelines adapt themselves automatically to additional or removed columns and changes of data types if possible.
 The following cases can be distinguished:
-* Overwrite all (CopyAction): if all data of a DataObject is overwritten, the schema can replaced: additional columns are added, removed columns are removed and data types are changed. Requirements: 
+* Overwrite all (CopyAction): if all data of a DataObject is overwritten, the schema can be replaced: additional columns are added, removed columns are removed and data types are changed. Requirements: 
   * Output DataObject needs to be able to replace schema.
 * Overwrite all keeping existing data (Historize- & DeduplicateAction): Action consolidates new data with existing data. The schema needs to be evolved: additional columns are added with null value for existing records, removed columns are kept with null values for new records and data types are changed to new data type if supported. Requirements: 
   * Output DataObject needs to be able to replace schema.
   * Output DataObject must be a TransactionalSparkTableDataObject (read existing data and overwrite new data in the same SparkJob, preventing data loss in case of errors).
-* Overwrite incremental using merge (CopyAction, DeduplicateAction): Action incrementally merges new data int existing data. The schema needs to be evolved: additional columns are added with null value for existing records, removed columns are kept with null values for new records and data types are changed to new data type if supported. Requirements:
+* Overwrite incremental using merge (CopyAction, DeduplicateAction): Action incrementally merges new data into existing data. The schema needs to be evolved: additional columns are added with null value for existing records, removed columns are kept with null values for new records and data types are changed to new data type if supported. Requirements:
   * Output DataObject needs to support CanEvolveSchema (alter schema automatically when writing to this DataObject with different schema)
   * Output DataObject needs to support CanMergeDataFrame (use SQL merge statement to update and insert records transactionally)
 

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -386,6 +386,15 @@ How it works: under the hood a PySpark DataFrame is a proxy for a Java Spark Dat
 
 ## Schema Evolution
 SmartDataLakeBuilder is built to support schema evolution where possible. This means that data pipelines adapt themselves automatically to additional or removed columns and changes of data types if possible.
+The following cases can be distinguished:
+* Overwrite all (CopyAction): if all data of a DataObject is overwritten, the schema can replaced: additional columns are added, removed columns are removed and data types are changed. Requirements: 
+  * Output DataObject needs to be able to replace schema.
+* Overwrite all keeping existing data (Historize- & DeduplicateAction): Action consolidates new data with existing data. The schema needs to be evolved: additional columns are added with null value for existing records, removed columns are kept with null values for new records and data types are changed to new data type if supported. Requirements: 
+  * Output DataObject needs to be able to replace schema.
+  * Output DataObject must be a TransactionalSparkTableDataObject (read existing data and overwrite new data in the same SparkJob, preventing data loss in case of errors).
+* Overwrite incremental using merge (CopyAction, DeduplicateAction): Action incrementally merges new data int existing data. The schema needs to be evolved: additional columns are added with null value for existing records, removed columns are kept with null values for new records and data types are changed to new data type if supported. Requirements:
+  * Output DataObject needs to support CanEvolveSchema (alter schema automatically when writing to this DataObject with different schema)
+  * Output DataObject needs to support CanMergeDataFrame (use SQL merge statement to update and insert records transactionally)
 
 To assert that a defined list of columns is always present in the schema of a specific DataObject, use its `schemaMin` attribute to define a minimal schema. The minimal schema is validated on read and write with Spark.
 
@@ -400,11 +409,13 @@ The following list describes specific behaviour of DataObjects:
   * Many Data Sources support schema inference (e.g. Json, Csv), but we would not recommend this for production data pipelines as the result might not be stable when new data arrives.
   * For Data Formats with included schema (e.g. Avro, Parquet), schema is read from a random data file. If data files have different schemas, Parquet Data Source supports to consolidate schemas by setting option `mergeSchema=true`. Avro Data Source does not support this.
   * If you define the `schema` attribute of the DataObject, SDL tries to read the data files with the defined schema. This is e.g. supported by the Json Data Source, but not the CSV Data Source.
-* JdbcTableDataObject: The table has to be created manually or by providing a create table statement in `createSql` attribute. There is no automatic schema evolution for now.
+* JdbcTableDataObject: The database table can be created automatically on first write or by providing a create table statement in `createSql` attribute. Also existing table is automatically adapted (add & change column) when option `allowSchemaEvolution=true`. 
+* DeltaLakeTableDataObject: Existing schema is automatically adapted (add & change column) when option `allowSchemaEvolution=true`.
 
 Recipes for data pipelines with schema evolution:
-* CopyAction supports schema evolution if all data is processed by overwriting the whole output DataObject. It needs an output DataObject which doesn't have a fixed schema, e.g. HiveTableDataObject.
-* HistorizeAction & DeduplicateAction supports schema evolution for incremental data. They consolidate the existing data & schema of the output DataObject with a potentially new schema of the input DataObject. Then they overwrite the whole output DataObject. They need a TransactionalSparkTableDataObject as output, which doesn't have a fixed schema, e.g. TickTockHiveTableDataObject.
+* "Overwrite all" with CopyAction: overwriting the whole output DataObject including its schema. It needs an output DataObject which doesn't have a fixed schema, e.g. HiveTableDataObject.
+* "Overwrite all keeping existing data" with HistorizeAction & DeduplicateAction: consolidate the existing data & schema of the output DataObject with a potentially new schema of the input DataObject. Then it overwrites the whole output DataObject. It needs a TransactionalSparkTableDataObject as output, e.g. TickTockHiveTableDataObject.
+* "Overwrite incremental using merge" with CopyAction & DeduplicateAction: evolve the existing schema of the output DataObject and insert and update new data using merge. It needs an output DataObject supporting CanMergeDataFrame and CanEvolveSchema, e.g. JdbcTableDataObject, DeltaLakeTableObject
 
 ## Housekeeping
 SmartDataLakeBuilder supports housekeeping for DataObjects by specifying the HousekeepingMode.

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,8 @@
 		<scopt.version>4.0.1</scopt.version>
 		<databricks.spark-xml.version>0.9.0</databricks.spark-xml.version>
 		<spark.excel.version>0.13.5</spark.excel.version>
-		<ucanaccess.version>4.0.4</ucanaccess.version>
+		<ucanaccess.version>5.0.1</ucanaccess.version>
+		<hsqldb.version>2.5.2</hsqldb.version>
 		<!-- when changing config version, remember to update it in DatabricksSmartDataLakeBuilder main method -->
 		<typesafe.config.version>1.4.1</typesafe.config.version>
 		<kxbmap.configs.version>0.6.1</kxbmap.configs.version>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -31,6 +31,16 @@
 
 	<name>sdl-core</name>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+                <groupId>com.healthmarketscience.jackcess</groupId>
+                <artifactId>jackcess</artifactId>
+				<scope>compile</scope>
+            </dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.databricks</groupId>
@@ -111,12 +121,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.healthmarketscience.jackcess</groupId>
-			<artifactId>jackcess</artifactId>
-			<version>2.1.11</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.crealytics</groupId>
 			<artifactId>spark-excel_${scala.minor.version}</artifactId>
 			<version>${spark.excel.version}</version>
@@ -131,6 +135,12 @@
 			<artifactId>poi-ooxml</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<version>${hsqldb.version}</version>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>net.sf.ucanaccess</groupId>
 			<artifactId>ucanaccess</artifactId>

--- a/sdl-core/src/main/scala/io/smartdatalake/config/SdlConfigObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/SdlConfigObject.scala
@@ -72,7 +72,7 @@ object SdlConfigObject {
   def validateId(id: String): Unit = {
     if (!id.matches(idRegexStr)) throw ConfigurationException(s"Id $id is not valid. It must match regex '$idRegexStr'.")
   }
-  val idRegexStr = "[a-zA-Z0-9_-]+"
+  private[smartdatalake] val idRegexStr = "[a-zA-Z0-9_-]+"
 
   implicit def stringToConnectionId(str: String): ConnectionId = ConnectionId(str)
   implicit def stringToDataObjectId(str: String): DataObjectId = DataObjectId(str)

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/SDLSaveMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/SDLSaveMode.scala
@@ -18,7 +18,10 @@
  */
 package io.smartdatalake.definitions
 
-import org.apache.spark.sql.SaveMode
+import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
+import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.{Column, SaveMode}
+
 import scala.language.implicitConversions
 
 /**
@@ -71,6 +74,14 @@ object SDLSaveMode extends Enumeration {
    */
   val OverwriteOptimized: Value = Value("OverwriteOptimized")
 
+  /**
+   * Merge new data with existing data by insert new records and update (or delete) existing records.
+   * DataObjects need primary key defined to check if a record is new.
+   * To delete existing records add column '_deleted' to DataFrame and set its value to 'true' for the records which should be deleted.
+   *
+   * Note that only few DataObjects are able to merge new data, e.g. DeltaLakeTableDataObject and JdbcTableDataObject
+   */
+  val Merge: Value = Value("Merge")
 
   /* add implicit methods to enumeration, e.g. asSparkSaveMode */
   class SDLSaveModeValue(mode: Value) {
@@ -89,4 +100,38 @@ object SDLSaveMode extends Enumeration {
   }
   implicit def value2SparkSaveMode(mode: Value): SDLSaveModeValue = new SDLSaveModeValue(mode)
 
+}
+
+/**
+ * Override and control detailed behaviour of saveMode, especially SaveMode.Merge for now.
+ */
+sealed trait SaveModeOptions {
+  private[smartdatalake] def saveMode: SDLSaveMode
+}
+
+/**
+ * This class can be used to override save mode without further special parameters.
+ */
+case class SaveModeGenericOptions(override val saveMode: SDLSaveMode) extends SaveModeOptions
+
+/**
+ * Options to control detailed behaviour of SaveMode.Merge.
+ * In Spark expressions use table alias 'existing' to reference columns of the existing table data, and table alias 'new' to reference columns of new data set.
+ * @param deleteCondition A condition to control if matched records are deleted. If no condition is given, *no* records are delete.
+ * @param updateCondition A condition to control if matched records are updated. If no condition is given all matched records are updated.
+ *                        Note that delete is applied before update. Records selected for deletion are automatically excluded from the updates.
+ * @param additionalMergePredicate To optimize performance for SDLSaveMode.Merge it might be interesting to limit the records read from the existing table data, e.g. merge operation might use only the last 7 days.
+ */
+case class SaveModeMergeOptions(deleteCondition: Option[String] = None, updateCondition: Option[String] = None, additionalMergePredicate: Option[String] = None) extends SaveModeOptions {
+  override private[smartdatalake] val saveMode = SDLSaveMode.Merge
+  private[smartdatalake] val deleteConditionExpr = deleteCondition.map(expr)
+  private[smartdatalake] val updateConditionExpr = updateCondition.map(expr)
+  private[smartdatalake] val additionalMergePredicateExpr = additionalMergePredicate.map(expr)
+}
+object SaveModeMergeOptions {
+  def fromSaveModeOptions(saveModeOptions: SaveModeOptions): SaveModeMergeOptions = saveModeOptions match {
+    case m: SaveModeMergeOptions => m
+    case m: SaveModeGenericOptions if (m.saveMode == SDLSaveMode.Merge) => SaveModeMergeOptions()
+    case m => throw new IllegalStateException(s"Cannot convert ${m.getClass.getSimpleName} $m to SaveModeMergeOptions")
+  }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/evolution/SchemaEvolution.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/evolution/SchemaEvolution.scala
@@ -99,7 +99,7 @@ private[smartdatalake] object SchemaEvolution extends SmartDataLakeLogger {
    * - char and boolean to string
    * - decimal with precision <= 7 to float
    * - decimal with precision <= 16 to double
-   * - numerical type to to numerical type with higher precision, e.g int to long
+   * - numerical type to numerical type with higher precision, e.g int to long
    * - delete column in complex type (array, struct, map)
    * - new column in complex type (array, struct, map)
    * - changed data type in complex type (array, struct, map) according to the rules above
@@ -133,7 +133,7 @@ private[smartdatalake] object SchemaEvolution extends SmartDataLakeLogger {
    * - New columns: newDf contains additional columns, all other columns are the same as in in oldDf
    * - Renamed columns: this is a combination of a deleted column and a new column
    * - Changed data type: see method [[convertDataType]] for allowed changes of data type. In case of unsupported changes
-   *   of data types an [[SchemaEvolutionException]] is thrown
+   *   of data types a [[SchemaEvolutionException]] is thrown
    *
    * @param oldDf [[DataFrame]] with old data
    * @param newDf [[DataFrame]] with new data with potential changes in schema
@@ -142,7 +142,7 @@ private[smartdatalake] object SchemaEvolution extends SmartDataLakeLogger {
    * @param ignoreOldDeletedNestedColumns if true, remove no longer existing columns in result DataFrame's. Keeping deleted
    *                                      columns in complex data types has performance impact as all new data in the future
    *                                      has to be converted by a complex function.
-   * @return tuple of (newDf,oldDf) evolved to new schema
+   * @return tuple of (oldExtendedDf, newExtendedDf) evolved to new schema
    */
   def process(oldDf: DataFrame, newDf: DataFrame, colsToIgnore: Seq[String] = Seq(), ignoreOldDeletedColumns: Boolean = false, ignoreOldDeletedNestedColumns: Boolean = true): (DataFrame, DataFrame) = {
     // internal structure and functions

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/CompactionUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/CompactionUtil.scala
@@ -19,6 +19,7 @@
 
 package io.smartdatalake.util.misc
 
+import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataobject._
@@ -100,7 +101,7 @@ object CompactionUtil extends SmartDataLakeLogger {
 
     // 4. Rewrite data from partitions to be compacted to temp path
     val dfRewrite = dataObject.getDataFrame(partitionValuesToCompact)
-    dataObject.writeDataFrameToPath(dfRewrite, tempPath) // if defined this uses DataObjects options for repartition definition, otherwise Spark default parameters/optimizations are applied.
+    dataObject.writeDataFrameToPath(dfRewrite, tempPath, SDLSaveMode.Overwrite) // if defined this uses DataObjects options for repartition definition, otherwise Spark default parameters/optimizations are applied.
     logger.info(s"(${dataObject.id}) partitions rewritten")
 
     // 5. Move compacted partitions

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/DataFrameUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/DataFrameUtil.scala
@@ -282,7 +282,7 @@ private[smartdatalake] object DataFrameUtil {
      * @return the set of columns contained in `otherSchema` but not in `this.schema`.
      */
     def schemaDiffTo(schemaOther: StructType, ignoreNullable: Boolean = false, deep: Boolean = false): Set[StructField] = {
-      SchemaUtil.schemaDiff(schemaOther, df.schema, ignoreNullable, deep)
+      SchemaUtil.schemaDiff(schemaOther, df.schema, ignoreNullable = ignoreNullable, deep = deep)
     }
 
     /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/SchemaUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/SchemaUtil.scala
@@ -19,7 +19,8 @@
 
 package io.smartdatalake.util.misc
 
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
 
 object SchemaUtil {
 
@@ -31,14 +32,21 @@ object SchemaUtil {
    * @param ignoreNullable if `true`, columns that only differ in their `nullable` property are considered equal.
    * @return the set of columns contained in `schemaRight` but not in `schemaLeft`.
    */
-  def schemaDiff(schemaLeft: StructType, schemaRight: StructType, ignoreNullable: Boolean = false, deep: Boolean = false): Set[StructField] = {
+  def schemaDiff(schemaLeft: StructType, schemaRight: StructType, ignoreNullable: Boolean = false, caseSensitive: Boolean = false, deep: Boolean = false): Set[StructField] = {
     if (deep) {
-      deepPartialMatchDiffFields(schemaLeft.fields, schemaRight.fields, ignoreNullability = ignoreNullable)
+      deepPartialMatchDiffFields(schemaLeft.fields, schemaRight.fields, ignoreNullable, caseSensitive)
     } else {
-      val left = if (ignoreNullable) nullableFields(schemaLeft).toSet else schemaLeft.toSet
-      val right = if (ignoreNullable) nullableFields(schemaRight).toSet else schemaRight.toSet
+      val left = prepareSchemaForDiff(schemaLeft, ignoreNullable, caseSensitive).toSet
+      val right = prepareSchemaForDiff(schemaRight, ignoreNullable, caseSensitive).toSet
       left.diff(right)
     }
+  }
+
+  def prepareSchemaForDiff(schemaIn: StructType, ignoreNullable: Boolean, caseSensitive: Boolean): Seq[StructField] = {
+    var schema = schemaIn.fields.toSeq
+    if (ignoreNullable) schema = nullableFields(schema)
+    if (!caseSensitive) schema = lowerCaseFields(schema)
+    schema
   }
 
   /**
@@ -50,16 +58,17 @@ object SchemaUtil {
    * @param ignoreNullability whether to ignore differences in nullability.
    * @return The set of fields in `right` that are not contained in `left`.
    */
-  private def deepPartialMatchDiffFields(left: Array[StructField], right: Array[StructField], ignoreNullability: Boolean = false): Set[StructField] = {
-    val rightNamesIndex = right.groupBy(_.name)
+  private def deepPartialMatchDiffFields(left: Array[StructField], right: Array[StructField], ignoreNullability: Boolean = false, caseSensitive: Boolean = false): Set[StructField] = {
+
+    val rightNamesIndex = if (caseSensitive) right.groupBy(_.name) else right.groupBy(_.name.toLowerCase)
     left.toSet.flatMap[StructField, Set[StructField]] { leftField =>
-      rightNamesIndex.get(leftField.name) match {
+      val leftName = if (caseSensitive) leftField.name else leftField.name.toLowerCase
+      rightNamesIndex.get(leftName) match {
         case Some(rightFieldsWithSameName) if rightFieldsWithSameName.foldLeft(false) {
           (hasPreviousSubset, rightField) =>
             hasPreviousSubset || ( //if no previous match found check this rightField
               (ignoreNullability || leftField.nullable == rightField.nullable) //either nullability is ignored or nullability must match
-                && deepIsTypeSubset(leftField.dataType, rightField.dataType, ignoreNullability //left field must be a subset of right field
-              )
+                && deepIsTypeSubset(leftField.dataType, rightField.dataType, ignoreNullability, caseSensitive) //left field must be a subset of right field
               )
         } => Set.empty //found a match
         case _ => Set(leftField) //left field is not contained in right
@@ -78,28 +87,32 @@ object SchemaUtil {
    * @param ignoreNullability whether to ignore differences in nullability.
    * @return `true` iff `leftType` is a subset of `rightType`. `false` otherwise.
    */
-  private def deepIsTypeSubset(leftType: DataType, rightType: DataType, ignoreNullability: Boolean = false): Boolean = {
+  private def deepIsTypeSubset(leftType: DataType, rightType: DataType, ignoreNullability: Boolean, caseSensitive: Boolean ): Boolean = {
     if (leftType.typeName != rightType.typeName) false  /*fail fast*/ else {
       (leftType, rightType) match {
-        case (StructType(fieldsL), StructType(fieldsR)) => deepPartialMatchDiffFields(fieldsL, fieldsR, ignoreNullability).isEmpty
+        case (StructType(fieldsL), StructType(fieldsR)) => deepPartialMatchDiffFields(fieldsL, fieldsR, ignoreNullability, caseSensitive).isEmpty
         case (ArrayType(elementTpeL, containsNullL), ArrayType(elementTpeR, containsNullR)) =>
           if (!ignoreNullability && (containsNullL != containsNullR)) false else {
-            deepIsTypeSubset(elementTpeL, elementTpeR, ignoreNullability)
+            deepIsTypeSubset(elementTpeL, elementTpeR, ignoreNullability, caseSensitive: Boolean)
           }
         case (MapType(keyTpeL, valTpeL, valContainsNullL), MapType(keyTpeR, valTpeR, valContainsNullR)) =>
           if (!ignoreNullability && (valContainsNullL != valContainsNullR)) false else {
-            deepIsTypeSubset(keyTpeL, keyTpeR, ignoreNullability) && deepIsTypeSubset(valTpeL, valTpeR, ignoreNullability)
+            deepIsTypeSubset(keyTpeL, keyTpeR, ignoreNullability, caseSensitive) && deepIsTypeSubset(valTpeL, valTpeR, ignoreNullability, caseSensitive)
           }
         case _ => true //names are equal
       }
     }
   }
 
-  private def nullableFields(struct: StructType): Seq[StructField] = {
-    struct.map(field => field.copy(
+  private def nullableFields(fields: Seq[StructField]): Seq[StructField] = {
+    fields.map(field => field.copy(
       dataType = nullableDataType(field.dataType),
       nullable = true
     ))
+  }
+
+  private def lowerCaseFields(fields: Seq[StructField]): Seq[StructField] = {
+    fields.map(field => field.copy(name = field.name.toLowerCase))
   }
 
   private def nullableDataType(dataType: DataType): DataType = {
@@ -118,6 +131,10 @@ object SchemaUtil {
       )
       case _ => dataType
     }
+  }
+
+  def isSparkCaseSensitive: Boolean = {
+    SQLConf.get.getConf(SQLConf.CASE_SENSITIVE)
   }
 
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.action
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.{Condition, ExecutionMode}
+import io.smartdatalake.definitions.{Condition, ExecutionMode, SaveModeOptions}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
 import io.smartdatalake.workflow.action.sparktransformer.{DfTransformer, ParsableDfTransformer}
@@ -49,6 +49,7 @@ import scala.util.{Failure, Success, Try}
  * @param executionCondition     optional spark sql expression evaluated against [[SubFeedsExpressionData]]. If true Action is executed, otherwise skipped. Details see [[Condition]].
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
  *                             If there are any rows passing the where clause, a MetricCheckFailed exception is thrown.
+ * @param saveModeOptions override and parametrize saveMode set in output DataObject configurations when writing to DataObjects.
  */
 case class CopyAction(override val id: ActionId,
                       inputId: DataObjectId,
@@ -72,6 +73,7 @@ case class CopyAction(override val id: ActionId,
                       override val executionMode: Option[ExecutionMode] = None,
                       override val executionCondition: Option[Condition] = None,
                       override val metricsFailCondition: Option[String] = None,
+                      override val saveModeOptions: Option[SaveModeOptions] = None,
                       override val metadata: Option[ActionMetadata] = None
                      )(implicit instanceRegistry: InstanceRegistry) extends SparkSubFeedAction {
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -60,7 +60,7 @@ case class CustomSparkAction (override val id: ActionId,
                               override val metadata: Option[ActionMetadata] = None,
                               recursiveInputIds: Seq[DataObjectId] = Seq(),
                               override val inputIdsToIgnoreFilter: Seq[DataObjectId] = Seq()
-)(implicit instanceRegistry: InstanceRegistry) extends SparkSubFeedsAction {
+                             )(implicit instanceRegistry: InstanceRegistry) extends SparkSubFeedsAction {
 
   // checks
   recursiveInputIds.foreach(inputId => assert(outputIds.contains(inputId), s"($id) $inputId from recursiveInputIds is not listed in outputIds of the same action."))
@@ -79,7 +79,7 @@ case class CustomSparkAction (override val id: ActionId,
 
     // Apply custom transformation to all subfeeds
     val partitionValues = mainInputSubFeed.map(_.partitionValues).getOrElse(Seq())
-    applyTransformers(transformers ++ transformer.map(_.impl).toSeq, partitionValues, inputSubFeeds, outputSubFeeds)
+    applyTransformers(transformers ++ transformer.map(_.impl), partitionValues, inputSubFeeds, outputSubFeeds)
   }
 
   override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
@@ -21,25 +21,28 @@ package io.smartdatalake.workflow.action
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.{Condition, ExecutionMode, TechnicalTableColumn}
+import io.smartdatalake.definitions._
 import io.smartdatalake.util.evolution.SchemaEvolution
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.customlogic.CustomDfTransformerConfig
 import io.smartdatalake.workflow.action.sparktransformer.{DfTransformer, DfTransformerFunctionWrapper, ParsableDfTransformer}
-import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, DataObject, TransactionalSparkTableDataObject}
+import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanMergeDataFrame, DataObject, TransactionalSparkTableDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
-import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
-import java.sql.Timestamp
 import java.time.LocalDateTime
 import scala.util.{Failure, Success, Try}
 
 /**
  * [[Action]] to deduplicate a subfeed.
  * Deduplication keeps the last record for every key, also after it has been deleted in the source.
- * It needs a transactional table as output with defined primary keys.
+ * DeduplicateAction adds an additional Column [[TechnicalTableColumn.captured]]. It contains the timestamp of the last occurrence of the record in the source.
+ * This creates lots of updates. Especially when using saveMode.Merge it is better to set [[TechnicalTableColumn.captured]] to the last change of the record in the source. Use updateCapturedColumnOnlyWhenChanged = true to enable this optimization.
+ *
+ * DeduplicateAction needs a transactional table as output with defined primary keys.
+ * If output implements [[CanMergeDataFrame]], saveMode.Merge can be enabled by setting mergeModeEnable = true. This allows for much better performance.
  *
  * @param inputId inputs DataObject
  * @param outputId output DataObject
@@ -49,11 +52,17 @@ import scala.util.{Failure, Success, Try}
  * @param columnBlacklist Remove all columns on blacklist from dataframe
  * @param columnWhitelist Keep only columns on whitelist in dataframe
  * @param additionalColumns optional tuples of [column name, spark sql expression] to be added as additional columns to the dataframe.
- *                          The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
+ *                          The spark sql expressions are evaluated against an instance of [[io.smartdatalake.util.misc.DefaultExpressionData]].
  * @param ignoreOldDeletedColumns if true, remove no longer existing columns in Schema Evolution
  * @param ignoreOldDeletedNestedColumns if true, remove no longer existing columns from nested data types in Schema Evolution.
  *                                      Keeping deleted columns in complex data types has performance impact as all new data
  *                                      in the future has to be converted by a complex function.
+ * @param updateCapturedColumnOnlyWhenChanged Set to true to enable update Column [[TechnicalTableColumn.captured]] only if Record has changed in the source, instead of updating it with every execution (default=false).
+ *                                            This results in much less records updated with saveMode.Merge.
+ * @param mergeModeEnable Set to true to use saveMode.Merge for much better performance. Output DataObject must implement [[CanMergeDataFrame]] if enabled (default = false).
+ * @param mergeModeAdditionalJoinPredicate To optimize performance it might be interesting to limit the records read from the existing table data, e.g. it might be sufficient to use only the last 7 days.
+ *                                Specify a condition to select existing data to be used in transformation as Spark SQL expression.
+ *                                Use table alias 'existing' to reference columns of the existing table data.
  * @param executionMode optional execution mode for this Action
  * @param executionCondition optional spark sql expression evaluated against [[SubFeedsExpressionData]]. If true Action is executed, otherwise skipped. Details see [[Condition]].
  * @param metricsFailCondition optional spark sql expression evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
@@ -77,6 +86,9 @@ case class DeduplicateAction(override val id: ActionId,
                              standardizeDatatypes: Boolean = false,
                              ignoreOldDeletedColumns: Boolean = false,
                              ignoreOldDeletedNestedColumns: Boolean = true,
+                             updateCapturedColumnOnlyWhenChanged: Boolean = false,
+                             mergeModeEnable: Boolean = false,
+                             mergeModeAdditionalJoinPredicate: Option[String] = None,
                              override val breakDataFrameLineage: Boolean = false,
                              override val persist: Boolean = false,
                              override val executionMode: Option[ExecutionMode] = None,
@@ -90,31 +102,60 @@ case class DeduplicateAction(override val id: ActionId,
   override val inputs: Seq[DataObject with CanCreateDataFrame] = Seq(input)
   override val outputs: Seq[TransactionalSparkTableDataObject] = Seq(output)
 
-  // Output is used as recursive input in DeduplicateAction to get existing data. This override is needed to force tick-tock write operation.
-  override val recursiveInputs: Seq[TransactionalSparkTableDataObject] = Seq(output)
+  private val mergeModeAdditionalJoinPredicateExpr: Option[Column] = try {
+    mergeModeAdditionalJoinPredicate.map(expr)
+  } catch {
+    case ex: Exception => throw new ConfigurationException(s"($id) Cannot parse mergeModeAdditionalJoinPredicate as Spark expression: ${ex.getClass.getSimpleName} ${ex.getMessage}", Some(s"{$id.id}.mergeModeAdditionalJoinPredicate"), ex)
+  }
+  if (mergeModeEnable || mergeModeAdditionalJoinPredicateExpr.isEmpty) logger.warn(s"($id) Configuration of mergeModeAdditionalJoinPredicate as no effect if mergeModeEnable = false")
 
-  // assert primary key is defined
-  require(output.table.primaryKey.isDefined, s"(${id}) Primary key must be defined for output DataObject")
+  // force SDLSaveMode.Merge if mergeModeEnable = true
+  override def saveModeOptions: Option[SaveModeOptions] = if (mergeModeEnable) {
+    assert(output.isInstanceOf[CanMergeDataFrame], s"($id) output DataObject must support SaveMode.Merge (implement CanMergeDataFrame) if mergeModeEnable = true")
+    // customize update condition
+    val updateCondition = if (updateCapturedColumnOnlyWhenChanged) Some(checkRecordChangedColumns.map(c => s"existing.$c != new.$c").mkString(" or "))
+    else None
+    Some(SaveModeMergeOptions(updateCondition = updateCondition, additionalMergePredicate = mergeModeAdditionalJoinPredicate))
+  } else None
+  // DataFrame columns are needed in order to generate update condition for SaveModeMergeOptions. Unfortunately they are not available here. A variable is needed which gets updated in transform(...).
+  private var checkRecordChangedColumns: Seq[String] = Seq()
+
+  // If mergeModeEnabled=false, output is used as recursive input in DeduplicateAction to get existing data. This override is needed to force tick-tock write operation.
+  override val recursiveInputs: Seq[TransactionalSparkTableDataObject] = if (!mergeModeEnable) Seq(output) else Seq()
+
+  // check preconditions
+  require(output.table.primaryKey.isDefined, s"($id) Primary key must be defined for output DataObject")
+  require(mergeModeEnable || !updateCapturedColumnOnlyWhenChanged, s"($id) updateCapturedColumnOnlyWhenChanged = true is not yet implemented for mergeModeEnable = false")
 
   // parse filter clause
   private val filterClauseExpr = Try(filterClause.map(expr)) match {
     case Success(result) => result
-    case Failure(e) => throw new ConfigurationException(s"(${id}) Error parsing filterClause parameter as Spark expression: ${e.getClass.getSimpleName}: ${e.getMessage}")
+    case Failure(e) => throw new ConfigurationException(s"($id) Error parsing filterClause parameter as Spark expression: ${e.getClass.getSimpleName}: ${e.getMessage}")
   }
 
   private def getTransformers(implicit session: SparkSession, context: ActionPipelineContext): Seq[DfTransformer] = {
     val timestamp = context.referenceTimestamp.getOrElse(LocalDateTime.now)
-    val pks = output.table.primaryKey.get // existance is validated earlier
-    // get existing data
-    // Note that DeduplicateAction needs to read/write all existing data for tick-tock operation, even if only specific partitions have changed
-    val existingDf = if (output.isTableExisting) Some(output.getDataFrame())
-    else None
-    val deduplicateFunction = DeduplicateAction.deduplicateDataFrame(existingDf, pks, timestamp, ignoreOldDeletedColumns, ignoreOldDeletedNestedColumns) _
-    val deduplicateTransformer = DfTransformerFunctionWrapper("deduplicate", deduplicateFunction)
+
+    val deduplicateTransformer = if (mergeModeEnable) {
+      // deduplication & schema evolution is done by merge stmt, only captured column needs to added before
+      val enhanceFunction = DeduplicateAction.enhanceDataFrame(timestamp) _
+      DfTransformerFunctionWrapper("enhanceForMergeDeduplicate", enhanceFunction)
+    } else {
+      // get existing data
+      // Note that DeduplicateAction needs to read/write all existing data for tick-tock operation, even if only specific partitions have changed
+      val existingDf = if (output.isTableExisting) Some(output.getDataFrame())
+      else None
+      val pks = output.table.primaryKey.get // existance is validated earlier
+      val deduplicateFunction = DeduplicateAction.deduplicateDataFrame(existingDf, pks, timestamp, ignoreOldDeletedColumns, ignoreOldDeletedNestedColumns) _
+      DfTransformerFunctionWrapper("deduplicate", deduplicateFunction)
+    }
+
     getTransformers(transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, transformers :+ deduplicateTransformer, filterClauseExpr)
+
   }
 
   override def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+    checkRecordChangedColumns = inputSubFeed.dataFrame.map(_.columns.toSeq).getOrElse(Seq())
     applyTransformers(getTransformers, inputSubFeed, outputSubFeed)
   }
 
@@ -135,8 +176,10 @@ object DeduplicateAction extends FromConfigFactory[Action] {
    * deduplicates a SubFeed.
    */
   def deduplicateDataFrame(existingDf: Option[DataFrame], pks: Seq[String], refTimestamp: LocalDateTime, ignoreOldDeletedColumns: Boolean, ignoreOldDeletedNestedColumns: Boolean)(df: DataFrame)(implicit session: SparkSession): DataFrame = {
+    assert(!df.columns.contains(rnkColName), s"Column $rnkColName not allowed in DataFrame for DeduplicateAction")
+
     // enhance
-    val enhancedDf = df.withColumn(TechnicalTableColumn.captured.toString, ActionHelper.ts1(refTimestamp))
+    val enhancedDf = enhanceDataFrame(refTimestamp)(df)
 
     // deduplicate
     if (existingDf.isDefined) {
@@ -150,26 +193,22 @@ object DeduplicateAction extends FromConfigFactory[Action] {
    * deduplicate -> keep latest record per key
    *
    * @param baseDf existing data
-   * @param newDf new data
+   * @param newDf  new data
    * @return deduplicated data
    */
-  def deduplicate(baseDf: DataFrame, newDf:DataFrame, keyColumns: Seq[String])(implicit session: SparkSession) : DataFrame = {
-    import session.implicits._
-    import udfs._
-
+  def deduplicate(baseDf: DataFrame, newDf: DataFrame, keyColumns: Seq[String])(implicit session: SparkSession): DataFrame = {
     baseDf.unionByName(newDf)
-      .groupBy(keyColumns.map(col):_*)
-      .agg(collect_list(struct("*")).as("rows"))
-      .withColumn("latestRowIndex", udf_getLatestRowIndex($"rows"))
-      .withColumn("latestRow", $"rows"($"latestRowIndex"))
-      .select($"latestRow.*")
+      .withColumn(rnkColName, row_number().over(Window.partitionBy(keyColumns.map(col): _*).orderBy(col(TechnicalTableColumn.captured.toString).desc)))
+      .where(col(rnkColName) === 1)
+      .drop(rnkColName)
   }
 
-  // keep udf's in separate object to avoid Spark serialization error for DeduplicateAction
-  object udfs extends Serializable {
-    private def getLatestRowIndex(rows: Seq[Row]): Int = {
-      rows.map(_.getAs[Timestamp](TechnicalTableColumn.captured.toString)).zipWithIndex.maxBy(_._1.getTime)._2
-    }
-    val udf_getLatestRowIndex: UserDefinedFunction = udf(getLatestRowIndex _)
+  /**
+   * enhance DataFrame with captured column
+   */
+  def enhanceDataFrame(refTimestamp: LocalDateTime)(df: DataFrame)(implicit session: SparkSession): DataFrame = {
+    df.withColumn(TechnicalTableColumn.captured.toString, ActionHelper.ts1(refTimestamp))
   }
+
+  private val rnkColName = "__rnk"
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/RuntimeData.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/RuntimeData.scala
@@ -240,17 +240,17 @@ private[smartdatalake] sealed trait ExecutionId extends Ordered[ExecutionId]
 /**
  * Standard execution id for actions that are executed synchronous by SDL.
  */
-private[smartdatalake] case class SDLExecutionId(runId: Int, attemptId: Int = 1) extends ExecutionId {
+case class SDLExecutionId(runId: Int, attemptId: Int = 1) extends ExecutionId {
   override def toString: String = s"$runId-$attemptId"
   override def compare(that: ExecutionId): Int = that match {
     case that: SDLExecutionId => SDLExecutionId.ordering.compare(this, that)
     case _ => throw new RuntimeException(s"SDLExecutionId cannot be compare with ${that.getClass.getSimpleName}")
   }
-  def incrementRunId: SDLExecutionId = this.copy(runId = runId + 1, attemptId = 1)
-  def incrementAttemptId: SDLExecutionId = this.copy(attemptId = this.attemptId + 1)
+  private[smartdatalake] def incrementRunId: SDLExecutionId = this.copy(runId = runId + 1, attemptId = 1)
+  private[smartdatalake] def incrementAttemptId: SDLExecutionId = this.copy(attemptId = this.attemptId + 1)
 }
-private[smartdatalake] object SDLExecutionId {
-  val ordering: Ordering[SDLExecutionId] = Ordering.by(x => (x.runId, x.attemptId))
+object SDLExecutionId {
+  private[smartdatalake] val ordering: Ordering[SDLExecutionId] = Ordering.by(x => (x.runId, x.attemptId))
   val executionId1: SDLExecutionId = SDLExecutionId(1)
 }
 
@@ -258,7 +258,7 @@ private[smartdatalake] object SDLExecutionId {
  * Execution id for spark streaming jobs.
  * They need a different execution id as they are executed asynchronous.
  */
-private[smartdatalake] case class SparkStreamingExecutionId(batchId: Long) extends ExecutionId {
+case class SparkStreamingExecutionId(batchId: Long) extends ExecutionId {
   override def toString: String = s"$batchId"
   override def compare(that: ExecutionId): Int = that match {
     case that: SparkStreamingExecutionId => SparkStreamingExecutionId.ordering.compare(this, that)
@@ -272,7 +272,7 @@ private[smartdatalake] object SparkStreamingExecutionId {
 /**
  * Summarized runtime information
  */
-private[smartdatalake] case class RuntimeInfo(
+case class RuntimeInfo(
                                                executionId: ExecutionId,
                                                state: RuntimeEventState,
                                                startTstmp: Option[LocalDateTime] = None,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DfTransformerWrapperDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DfTransformerWrapperDfsTransformer.scala
@@ -29,8 +29,6 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * A Transformer to use single DataFrame Transformers as multiple DataFrame Transformers.
  * This works by selecting the SubFeeds (DataFrames) the single DataFrame Transformer should be applied to.
  * All other SubFeeds will be passed through without transformation.
- * @param name Name of the transformation
- * @param description Description of the transformation
  * @param transformer Configuration for a DfTransformer to be applied
  * @param subFeedsToApply Names of SubFeeds the transformation should be applied to.
  */

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanEvolveSchema.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanEvolveSchema.scala
@@ -1,0 +1,29 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject
+
+/**
+ * Marker interface to let Actions know that a DataObject can evolve its schema
+ */
+private[smartdatalake] trait CanEvolveSchema {
+  /**
+   * If set to true schema evolution will automatically occur when writing to this DataObject with different schema, otherwise SDL will stop with error.
+   */
+  def allowSchemaEvolution: Boolean
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanMergeDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanMergeDataFrame.scala
@@ -1,0 +1,24 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject
+
+/**
+ * Marker interface to let Actions know that a DataObject supports SDLSaveMode.Merge.
+ */
+private[smartdatalake] trait CanMergeDataFrame

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
@@ -20,13 +20,13 @@
 package io.smartdatalake.workflow.dataobject
 
 import java.io.InputStream
-
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.customlogic.CustomFileCreatorConfig
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
@@ -56,7 +56,7 @@ case class CustomFileDataObject(override val id: DataObjectId,
 
   override def expectedPartitionsCondition: Option[String] = None
 
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = Seq()
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = Seq()
 
   override def relativizePath(filePath: String)(implicit session: SparkSession): String = filePath
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -165,7 +165,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   /**
    * List partitions on data object's root path
    */
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = {
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
     partitionLayout().map {
       partitionLayout =>
         // get search pattern for root directory

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.DateColumnType.DateColumnType
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
-import io.smartdatalake.definitions.{DateColumnType, Environment, OutputType, SDLSaveMode}
+import io.smartdatalake.definitions.{DateColumnType, Environment, OutputType, SDLSaveMode, SaveModeOptions}
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.util.misc.{AclDef, AclUtil, CompactionUtil, SmartDataLakeLogger}
@@ -152,12 +152,12 @@ case class HiveTableDataObject(override val id: DataObjectId,
     }
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     require(!isRecursiveInput, "($id) HiveTableDataObject cannot write dataframe when dataobject is also used as recursive input ")
     validateSchemaMin(df, "write")
     validateSchemaHasPartitionCols(df, "write")
-    writeDataFrameInternal(df, createTableOnly = false, partitionValues)
+    writeDataFrameInternal(df, createTableOnly = false, partitionValues, saveModeOptions)
   }
 
    /**
@@ -165,11 +165,13 @@ case class HiveTableDataObject(override val id: DataObjectId,
    * DataFrames are repartitioned in order not to write too many small files
    * or only a few HDFS files that are too large.
    */
-  private def writeDataFrameInternal(df: DataFrame, createTableOnly:Boolean, partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession): Unit = {
+  private def writeDataFrameInternal(df: DataFrame, createTableOnly:Boolean, partitionValues: Seq[PartitionValues] = Seq(), saveModeOptions: Option[SaveModeOptions] = None)
+                                    (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     val dfPrepared = if (createTableOnly) session.createDataFrame(List[Row]().asJava, df.schema) else df
 
     // apply special save modes
-    saveMode match {
+    val finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
+    finalSaveMode match {
       case SDLSaveMode.Overwrite =>
         if (partitionValues.nonEmpty) { // delete concerned partitions if existing, as Spark dynamic partitioning doesn't delete empty partitions
           deletePartitionsIfExisting(partitionValues)
@@ -186,7 +188,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
     }
 
     // write table and fix acls
-    HiveUtil.writeDfToHive( dfPrepared, hadoopPath, table, partitions, saveMode.asSparkSaveMode, numInitialHdfsPartitions=numInitialHdfsPartitions )
+    HiveUtil.writeDfToHive( dfPrepared, hadoopPath, table, partitions, finalSaveMode.asSparkSaveMode, numInitialHdfsPartitions=numInitialHdfsPartitions )
     val aclToApply = acl.orElse(connection.flatMap(_.acl))
     if (aclToApply.isDefined) AclUtil.addACLs(aclToApply.get, hadoopPath)(filesystem)
     if (analyzeTableAfterWrite && !createTableOnly) {
@@ -198,10 +200,11 @@ case class HiveTableDataObject(override val id: DataObjectId,
     createMissingPartitions(partitionValues)
   }
 
-  override def writeDataFrameToPath(df: DataFrame, path: Path)(implicit session: SparkSession): Unit = {
+  override def writeDataFrameToPath(df: DataFrame, path: Path, finalSaveMode: SDLSaveMode)(implicit session: SparkSession): Unit = {
     df.write
       .partitionBy(partitions:_*)
       .format(OutputType.Parquet.toString)
+      .mode(finalSaveMode.asSparkSaveMode)
       .save(path.toString)
   }
 
@@ -216,7 +219,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
   /**
    * list hive table partitions
    */
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = {
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
     if(isTableExisting) HiveUtil.listPartitions(table, partitions)
     else Seq()
   }
@@ -242,7 +245,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
    * Checks if partition exists and deletes it.
    * Note that partition values to check don't need to have a key/value defined for every partition column.
    */
-  def deletePartitionsIfExisting(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit  = {
+  def deletePartitionsIfExisting(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit  = {
     val partitionValueKeys = PartitionValues.getPartitionValuesKeys(partitionValues).toSeq
     val partitionValuesToDelete = partitionValues.intersect(listPartitions.map(_.filterKeys(partitionValueKeys)))
     deletePartitions(partitionValuesToDelete)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -18,16 +18,14 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import java.sql.{ResultSet, ResultSetMetaData}
-
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
+import io.smartdatalake.definitions.{SDLSaveMode, SaveModeMergeOptions, SaveModeOptions}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
-import io.smartdatalake.util.misc.{DefaultExpressionData, SparkExpressionUtil}
+import io.smartdatalake.util.misc.{DefaultExpressionData, SchemaUtil, SparkExpressionUtil}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.connection.JdbcTableConnection
 import org.apache.spark.annotation.DeveloperApi
@@ -35,11 +33,15 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
+import java.sql.{ResultSet, ResultSetMetaData}
+import scala.util.Try
+
 /**
  * [[DataObject]] of type JDBC.
  * Provides details for an action to access tables in a database through JDBC.
  * @param id unique name of this data object
- * @param createSql DDL-statement to be executed in prepare phase, using output jdbc connection
+ * @param createSql DDL-statement to be executed in prepare phase, using output jdbc connection.
+ *                  Note that it is also possible to let Spark create the table in Init-phase. See jdbcOptions to customize column data types for auto-created DDL-statement.
  * @param preReadSql SQL-statement to be executed in exec phase before reading input table, using input jdbc connection.
  *                   Use tokens with syntax %{<spark sql expression>} to substitute with values from [[DefaultExpressionData]].
  * @param postReadSql SQL-statement to be executed in exec phase after reading input table and before action is finished, using input jdbc connection
@@ -50,11 +52,13 @@ import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
  *                   Use tokens with syntax %{<spark sql expression>} to substitute with values from [[DefaultExpressionData]].
  * @param schemaMin An optional, minimal schema that this DataObject must have to pass schema validation on reading and writing.
  * @param saveMode [[SDLSaveMode]] to use when writing table, default is "Overwrite". Only "Append" and "Overwrite" supported.
+ * @param allowSchemaEvolution If set to true schema evolution will automatically occur when writing to this DataObject with different schema, otherwise SDL will stop with error.
  * @param table The jdbc table to be read
  * @param jdbcFetchSize Number of rows to be fetched together by the Jdbc driver
  * @param connectionId Id of JdbcConnection configuration
  * @param jdbcOptions Any jdbc options according to [[https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html]].
  *                    Note that some options above set and override some of this options explicitly.
+ *                    Use "createTableOptions" and "createTableColumnTypes" to control automatic creating of database tables.
  * @param virtualPartitions Virtual partition columns. Note that this doesn't need to be the same as the database partition
  *                   columns for this table. But it is important that there is an index on these columns to efficiently
  *                   list existing "partitions".
@@ -72,13 +76,14 @@ case class JdbcTableDataObject(override val id: DataObjectId,
                                override var table: Table,
                                jdbcFetchSize: Int = 1000,
                                saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
+                               override val allowSchemaEvolution: Boolean = false,
                                connectionId: ConnectionId,
                                jdbcOptions: Map[String, String] = Map(),
                                virtualPartitions: Seq[String] = Seq(),
                                override val expectedPartitionsCondition: Option[String] = None,
                                override val metadata: Option[DataObjectMetadata] = None
                               )(@transient implicit val instanceRegistry: InstanceRegistry)
-  extends TransactionalSparkTableDataObject with CanHandlePartitions {
+  extends TransactionalSparkTableDataObject with CanHandlePartitions with CanEvolveSchema with CanMergeDataFrame {
 
   /**
    * Connection defines driver, url and db in central location
@@ -86,18 +91,20 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   @DeveloperApi
   val connection: JdbcTableConnection = getConnection[JdbcTableConnection](connectionId)
 
+  private val options = jdbcOptions ++ Map(
+    "url" -> connection.url,
+    "driver" -> connection.driver,
+    "fetchSize" -> jdbcFetchSize.toString,
+  )
+
   // Define partition columns
-  // Virtual partition column name might be quoted to force case sensitivity in database queries
-  override val partitions: Seq[String] = virtualPartitions.map(prepareCaseSensitiveName).map(_.name)
+  override val partitions: Seq[String] = if (SchemaUtil.isSparkCaseSensitive) virtualPartitions else virtualPartitions.map(_.toLowerCase)
 
   // prepare final table
   table = table.overrideDb(connection.db)
   if(table.db.isEmpty) throw ConfigurationException(s"($id) db is not defined in table and connection for dataObject.")
 
-  assert(saveMode==SDLSaveMode.Append || saveMode==SDLSaveMode.Overwrite, s"($id) Only saveMode Append and Overwrite are supported.")
-
-  // jdbc column metadata
-  lazy val columns = getJdbcColumnMetadata
+  assert(saveMode==SDLSaveMode.Append || saveMode==SDLSaveMode.Overwrite || saveMode==SDLSaveMode.Merge, s"($id) Only saveMode Append, Overwrite and Merge are supported.")
 
   override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
 
@@ -114,14 +121,11 @@ case class JdbcTableDataObject(override val id: DataObjectId,
         logger.info(s"($id) createSQL is being executed")
         connection.execJdbcStatement(sql)
       }
-      assert(isTableExisting, s"($id) Table ${table.fullName} doesn't exist. Define createSQL to create table automatically.")
     }
 
     // test partition columns exist
-    if (virtualPartitions.nonEmpty) {
-      val missingPartitionColumns = virtualPartitions.map(prepareCaseSensitiveName)
-        .filterNot( partition => columns.exists(c => partition.nameEquals(c)))
-        .map(_.name)
+    if (virtualPartitions.nonEmpty && isTableExisting) {
+      val missingPartitionColumns = partitions.toSet.diff(getExistingSchema.get.fieldNames.toSet)
       assert(missingPartitionColumns.isEmpty, s"($id) Virtual partition columns ${missingPartitionColumns.mkString(",")} missing in table definition")
     }
   }
@@ -129,11 +133,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
     val queryOrTable = Map(table.query.map(q => ("query",q)).getOrElse("dbtable"->table.fullName))
     val df = session.read.format("jdbc")
-      .options(jdbcOptions)
-      .options(
-        Map("url" -> connection.url,
-          "driver" -> connection.driver,
-          "fetchSize" -> jdbcFetchSize.toString))
+      .options(options)
       .options(connection.getAuthModeSparkOptions)
       .options(queryOrTable)
       .load()
@@ -143,75 +143,160 @@ case class JdbcTableDataObject(override val id: DataObjectId,
 
   override def init(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
-    validateSchemaOnWrite(df)
-  }
-
-  // cache response to avoid jdbc query.
-  private var cachedExistingSchema: Option[StructType] = None
-  private def validateSchemaOnWrite(df: DataFrame)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
-    // validate against hive table schema if existing
+    validateSchemaHasPartitionCols(df, "write")
+    validateSchemaHasPrimaryKeyCols(df, table.primaryKey.getOrElse(Seq()), "write")
     if (isTableExisting) {
-      val existingSchema = cachedExistingSchema.getOrElse {
-        cachedExistingSchema = Some(getDataFrame().schema)
-        cachedExistingSchema.get
-      }
-      validateSchema(df, existingSchema, "write")
+      if (allowSchemaEvolution) evolveTableSchema(df.schema)
+      else validateSchemaOnWrite(df)
+    } else {
+      connection.createTableFromSchema(table.fullName, df.schema, options)
+      require(isTableExisting, s"($id) Strangely table ${table.fullName} doesn't exist even though we tried to create it")
     }
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  /**
+   * SDL Schema evolution allows to add new columns or change datatypes.
+   * Deleted columns will remain in the table and are made nullable.
+   */
+  private def evolveTableSchema(newSchemaRaw: StructType)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    val existingSchema = getExistingSchema.get
+    val newSchema = if (SchemaUtil.isSparkCaseSensitive) newSchemaRaw else StructType(SchemaUtil.prepareSchemaForDiff(newSchemaRaw, ignoreNullable = false, caseSensitive = false))
+    // prepare changes
+    val newColumns = newSchema.fieldNames.diff(existingSchema.fieldNames) // add new column
+    val missingNotNullColumns = existingSchema.fieldNames.diff(newSchema.fieldNames) // make missing columns nullable
+      .filter { col =>
+        // as Spark doesn't now if a field is nullable in the database, but we can check jdbc metadata
+        val jdbcColumn = getJdbcColumn(col)
+        !jdbcColumn.flatMap(_.isNullable).getOrElse(false)
+      }
+    val newSchemaWithoutNewColumns = StructType(newSchema.filter(f => !newColumns.contains(f.name)))
+    val changedDatatypeColumns = SchemaUtil.schemaDiff(newSchemaWithoutNewColumns, existingSchema, ignoreNullable = true) // change column datatype if supported
+    // apply changes
+    if (newColumns.nonEmpty || missingNotNullColumns.nonEmpty || changedDatatypeColumns.nonEmpty)
+      logger.info(s"($id) schema evolution needed: newColumns=${newColumns.mkString(",")} missingNotNullColumns=${missingNotNullColumns.mkString(",")} changedDatatypeColumns=${changedDatatypeColumns.map(f => s"${f.name}:${f.dataType.sql}").mkString(",")}")
+    newColumns.foreach{ col =>
+      val field = newSchema(col)
+      val sqlType = connection.catalog.getSqlType(field.dataType, isNullable = true) // new columns must be nullable because of existing data
+      val sql = connection.catalog.getAddColumnSql(table.fullName, quoteCaseSensitiveColumn(col), sqlType)
+      connection.execJdbcStatement(sql)
+    }
+    missingNotNullColumns.foreach{ col =>
+      // as Spark doesn't now if a field is nullable in the database, but we can check jdbc metadata
+      val jdbcColumn = getJdbcColumn(col)
+      if (!jdbcColumn.flatMap(_.isNullable).getOrElse(false)) {
+        val sql = connection.catalog.getAlterColumnNullableSql(table.fullName, quoteCaseSensitiveColumn(col))
+        connection.execJdbcStatement(sql)
+      }
+    }
+    changedDatatypeColumns.foreach { field =>
+      val sqlType = connection.catalog.getSqlType(field.dataType, field.nullable || existingSchema(field.name).nullable)
+      val sql = connection.catalog.getAlterColumnSql(table.fullName, quoteCaseSensitiveColumn(field.name), sqlType)
+      connection.execJdbcStatement(sql)
+    }
+    // reset cached schema
+    if (newColumns.nonEmpty || changedDatatypeColumns.nonEmpty) {
+      cachedExistingSchema = None
+      _cachedJdbcColumnMetadata = None
+    }
+  }
+
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
+                             (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     require(table.query.isEmpty, s"($id) Cannot write to jdbc DataObject defined by a query.")
     validateSchemaMin(df, "write")
-    validateSchemaOnWrite(df)
+    validateSchemaHasPartitionCols(df, "write")
+    validateSchemaHasPrimaryKeyCols(df, table.primaryKey.getOrElse(Seq()), "write")
+    if (!allowSchemaEvolution) validateSchemaOnWrite(df)
 
-    // validate columns exists
-    val dfWrite = if (isTableExisting) {
-      val dfColumns = df.columns.map(c => JdbcColumn(c, isNameCaseSensitiv = false))
-      val colsMissingInTable = dfColumns.filter(c => !columns.exists(c.nameEquals))
-      assert(colsMissingInTable.isEmpty, s"Columns ${colsMissingInTable.mkString(", ")} missing in $id")
-      val colsMissingInDataFrame = columns.filter(c => !dfColumns.exists(c.nameEquals))
-      assert(colsMissingInTable.isEmpty, s"Columns ${colsMissingInDataFrame.mkString(", ")} exist in $id but not in DataFrame")
+    val finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
 
-      // cleanup existing data if saveMode=overwrite
-      if (saveMode == SDLSaveMode.Overwrite) {
+    // order DataFrame columns according to existing schema
+    val dfWrite = df.select(df.columns.map(c => col(c)): _*)
+
+    // write
+    finalSaveMode match {
+
+      case SDLSaveMode.Overwrite =>
+        // cleanup existing data if saveMode=overwrite
         if (partitionValues.nonEmpty) deletePartitions(partitionValues)
         else deleteAllData
-      }
+        writeDataFrameInternalWithAppend(dfWrite, table.fullName)
 
-      // order DataFrame columns according to table metadata
-      df.select(columns.map(c => col(c.name)): _*)
-    } else df
+      case SDLSaveMode.Merge =>
+        // write to tmp-table and merge by primary key
+        mergeDataFrameByPrimaryKey(dfWrite, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
 
-    // write table
+      case SDLSaveMode.Append =>
+        // write target table with SaveMode.Append
+        writeDataFrameInternalWithAppend(dfWrite, table.fullName)
+    }
+  }
+
+  /**
+   * Merges DataFrame with existing table data by writing DataFrame to a temp-table and using SQL Merge-statement.
+   * Table.primaryKey is used as condition to check if a record is matched or not. If it is matched it gets updated (or deleted), otherwise it is inserted.
+   * This all is done in one transaction.
+   */
+  def mergeDataFrameByPrimaryKey(df: DataFrame, saveModeOptions: SaveModeMergeOptions)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    assert(table.primaryKey.exists(_.nonEmpty), s"($id) table.primaryKey must be defined to use mergeDataFrameByPrimaryKey")
+
+    val tmpTableName = if (connection.catalog.isQuotedIdentifier(table.name))
+      table.db+"."+connection.catalog.quoteIdentifier(connection.catalog.removeQuotes(table.name) + "_sdltmp")
+    else s"${table.fullName}_sdltmp"
+    require(!connection.catalog.isTableExisting(tmpTableName), s"(id) Temporary table $tmpTableName for merge already exists! There might be a potential conflict with another job. Please clean up manually to continue.")
+    try {
+      // create & write to temp-table
+      connection.createTableFromSchema(tmpTableName, df.schema, options)
+      writeDataFrameInternalWithAppend(df, tmpTableName)
+      // prepare SQL merge statement
+      val additionalMergePredicateStr = saveModeOptions.additionalMergePredicate.map(p => s" $p").getOrElse("")
+      val joinConditionStr = table.primaryKey.get.map(quoteCaseSensitiveColumn).map(colName => s"new.$colName = existing.$colName").reduce(_+" AND "+_)
+      val deleteClauseStr = saveModeOptions.deleteCondition.map(c => s"\nWHEN MATCHED AND $c THEN DELETE").getOrElse("")
+      val updateConditionStr = saveModeOptions.updateCondition.map(c => s" AND $c").getOrElse("")
+      val updateSpecStr = df.columns.diff(table.primaryKey.get).map(quoteCaseSensitiveColumn).map(colName => s"existing.$colName = new.$colName").reduce(_+", "+_)
+      val insertSpecStr = df.columns.map(quoteCaseSensitiveColumn).reduce(_+", "+_)
+      val insertValueSpecStr = df.columns.map(quoteCaseSensitiveColumn).map(colName => s"new.$colName").reduce(_+", "+_)
+      val mergeStmt = s"""
+        | MERGE INTO ${table.fullName} as existing
+        | USING (SELECT * from $tmpTableName) as new
+        | ON $joinConditionStr $additionalMergePredicateStr $deleteClauseStr
+        | WHEN MATCHED $updateConditionStr THEN UPDATE SET $updateSpecStr
+        | WHEN NOT MATCHED THEN INSERT ($insertSpecStr) VALUES ($insertValueSpecStr)
+        """.stripMargin
+      // execute
+      connection.execJdbcStatement(mergeStmt)
+    } finally {
+      // cleanup temp table
+      connection.dropTable(tmpTableName)
+    }
+  }
+
+  private def writeDataFrameInternalWithAppend(df: DataFrame, tableName: String): Unit = {
     // No need to define any partitions as parallelization will be defined according to the data frame's partitions
-    dfWrite.write.mode(SaveMode.Append).format("jdbc")
-      .options(jdbcOptions)
-      .options(Map(
-        "url" -> connection.url,
-        "driver" -> connection.driver,
-        "dbtable" -> s"${table.fullName}"
-      ))
+    df.write.mode(SaveMode.Append).format("jdbc")
+      .options(options)
       .options(connection.getAuthModeSparkOptions)
+      .option("dbtable", tableName)
       .save
   }
 
   override def preRead(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.preRead(partitionValues)
-    preparedAndExecSql(preReadSql, Some("preReadSql"), partitionValues)
+    prepareAndExecSql(preReadSql, Some("preReadSql"), partitionValues)
   }
   override def postRead(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.postRead(partitionValues)
-    preparedAndExecSql(postReadSql, Some("postReadSql"), partitionValues)
+    prepareAndExecSql(postReadSql, Some("postReadSql"), partitionValues)
   }
   override def preWrite(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.preWrite
-    preparedAndExecSql(preWriteSql, Some("preWriteSql"), Seq()) // no partition values here...
+    prepareAndExecSql(preWriteSql, Some("preWriteSql"), Seq()) // no partition values here...
   }
   override def postWrite(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     super.postWrite(partitionValues)
-    preparedAndExecSql(postWriteSql, Some("postWriteSql"), partitionValues)
+    prepareAndExecSql(postWriteSql, Some("postWriteSql"), partitionValues)
   }
-  private def preparedAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  private def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     sqlOpt.foreach { sql =>
       val data = DefaultExpressionData.from(context, partitionValues)
       val preparedSql = SparkExpressionUtil.substitute(id, configName, sql, data)
@@ -232,10 +317,24 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   private var cachedIsTableExisting: Option[Boolean] = None
   override def isTableExisting(implicit session: SparkSession): Boolean = {
     cachedIsTableExisting.getOrElse {
-      val existing = connection.catalog.isTableExisting(table.db.get, table.name)
+      val existing = connection.catalog.isTableExisting(table.fullName)
       if (existing) cachedIsTableExisting = Some(existing) // only cache if existing, otherwise query again later
       existing
     }
+  }
+  // cache response to avoid jdbc query.
+  private var cachedExistingSchema: Option[StructType] = None
+  private def getExistingSchema(implicit session: SparkSession, context: ActionPipelineContext): Option[StructType] = {
+    if (isTableExisting && cachedExistingSchema.isEmpty) {
+      cachedExistingSchema = Some(getDataFrame().schema)
+      // convert to lowercase when Spark is in non-casesensitive mode
+      if (!SchemaUtil.isSparkCaseSensitive) cachedExistingSchema = Some(StructType(SchemaUtil.prepareSchemaForDiff(cachedExistingSchema.get, ignoreNullable = false, caseSensitive = true)))
+    }
+    cachedExistingSchema
+  }
+
+  private def validateSchemaOnWrite(df: DataFrame)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+    getExistingSchema.foreach(schema => validateSchema(df, schema, "write"))
   }
 
   def deleteAllData(implicit session: SparkSession): Unit = {
@@ -243,7 +342,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   }
 
   override def dropTable(implicit session: SparkSession): Unit = {
-    connection.execJdbcStatement(s"drop table if exists ${table.fullName}")
+    connection.dropTable(table.fullName)
   }
 
   override def factory: FromConfigFactory[DataObject] = JdbcTableDataObject
@@ -251,17 +350,9 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   /**
    * Listing virtual partitions by a "select distinct partition-columns" query
    */
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = {
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
     if (partitions.nonEmpty) {
-      val tableClause = table.query.map( q => s"($q)").getOrElse(table.fullName)
-      val partitionListQuery = s"select distinct ${virtualPartitions.mkString(", ")} from $tableClause"
-      val partitionsWithIdx = partitions.zipWithIndex
-      def evalPartitions(rs: ResultSet): Seq[PartitionValues] = {
-        Iterator.continually(rs.next).takeWhile(identity).map {
-          _ => PartitionValues(partitionsWithIdx.map{ case (col,idx) => col -> rs.getObject(idx+1)}.toMap)
-        }.toVector
-      }
-      connection.execJdbcQuery(partitionListQuery, evalPartitions)
+      PartitionValues.fromDataFrame(getDataFrame().select(partitions.map(col):_*).distinct)
     } else Seq()
   }
 
@@ -274,48 +365,97 @@ case class JdbcTableDataObject(override val id: DataObjectId,
       assert(partitionsColss.size == 1, "All partition values must have the same set of partition columns defined!")
       val partitionCols = partitionsColss.head
       val deletePartitionQuery = if (partitionCols.size == 1) {
-        s"delete from ${table.fullName} where ${partitionCols.head} in ('${partitionValues.map(pv => pv(partitionCols.head)).mkString("','")}')"
+        s"delete from ${table.fullName} where ${quoteCaseSensitiveColumn(partitionCols.head)} in ('${partitionValues.map(pv => pv(partitionCols.head)).mkString("','")}')"
       } else {
-        val partitionValuesStr = partitionValues.map(pv => s"('${partitionCols.map(pv(_).toString).mkString("','")}')")
-        s"delete from ${table.fullName} where (${partitionCols.mkString(",")}) in (${partitionValuesStr.mkString(",")})"
+        val partitionValuesStr = partitionValues.map(pv => s"(${partitionCols.map(c => s"'${pv(c).toString}'").mkString(",")})")
+        s"delete from ${table.fullName} where (${partitionCols.map(quoteCaseSensitiveColumn).mkString(",")}) in (${partitionValuesStr.mkString(",")})"
       }
       connection.execJdbcStatement(deletePartitionQuery)
     }
   }
 
-  private def prepareCaseSensitiveName(name: String): JdbcColumn= {
-    val caseSensitiveNamePattern = "^[\"'](.*)[\"']$".r
-    name match {
-      case caseSensitiveNamePattern(nameOnly) => JdbcColumn(nameOnly, isNameCaseSensitiv = true)
-      case _ => JdbcColumn(name, isNameCaseSensitiv = false)
+  // jdbc column metadata - exact column metadata needed to check schema with case-sensitive column names
+  private var _cachedJdbcColumnMetadata: Option[Seq[JdbcColumn]] = None
+  private def jdbcColumnMetadata(implicit session: SparkSession): Option[Seq[JdbcColumn]] = {
+    if (isTableExisting && _cachedJdbcColumnMetadata.isEmpty) {
+      // try reading from jdbc database metadata
+      _cachedJdbcColumnMetadata = if (table.query.isEmpty) Try {
+        connection.execWithJdbcConnection { con =>
+          var rs: ResultSet = null
+          try {
+            rs = con.getMetaData.getColumns(null, connection.catalog.removeQuotes(table.db.get), connection.catalog.removeQuotes(table.name), null)
+            class RsIterator(rs: ResultSet) extends Iterator[ResultSet] {
+              def hasNext: Boolean = rs.next()
+              def next(): ResultSet = rs
+            }
+            logger.info(s"($id) get jdbc column metadata from database")
+            new RsIterator(rs).map(JdbcColumn.from).toSeq
+          } finally {
+            if (rs != null) rs.close()
+          }
+        }
+      }.toOption else None
+      // otherwise make empty query and use resultset metadata
+      if (_cachedJdbcColumnMetadata.isEmpty) {
+        val metadataQuery = table.query.getOrElse(s"select * from ${table.fullName}") + " where 1=0"
+        def evalColumnNames(rs: ResultSet): Seq[JdbcColumn] = {
+          (1 to rs.getMetaData.getColumnCount).map(i => JdbcColumn.from(rs.getMetaData, i))
+        }
+        logger.info(s"($id) get jdbc column metadata from query")
+        _cachedJdbcColumnMetadata = Some(connection.execJdbcQuery(metadataQuery, evalColumnNames))
+      }
     }
+    _cachedJdbcColumnMetadata
+  }
+  private def getJdbcColumn(sparkColName: String)(implicit session: SparkSession): Option[JdbcColumn] = {
+    if (SchemaUtil.isSparkCaseSensitive) jdbcColumnMetadata.get.find(_.name == sparkColName)
+    else jdbcColumnMetadata.get.find(_.nameEqualsIgnoreCaseSensitive(sparkColName))
   }
 
-  def getJdbcColumnMetadata: Seq[JdbcColumn] = {
-    val metadataQuery = table.query.getOrElse(s"select * from ${table.fullName}") + " where 1=0"
-    def evalColumnNames(rs: ResultSet): Seq[JdbcColumn] = {
-      (1 to rs.getMetaData.getColumnCount).map( i => JdbcColumn.from(rs.getMetaData, i))
+  // if we generate sql statements with column names we need to care about quoting them properly
+  private def quoteCaseSensitiveColumn(column: String)(implicit session: SparkSession): String = {
+    if (SchemaUtil.isSparkCaseSensitive) connection.catalog.quoteIdentifier(column)
+    else {
+      val jdbcColumn = getJdbcColumn(column)
+      if (jdbcColumn.isDefined) {
+        if (jdbcColumn.get.isNameCaseSensitiv) connection.catalog.quoteIdentifier(jdbcColumn.get.name)
+        else column
+      } else {
+        // quote identifier if it contains special characters
+        if (JdbcTableDataObject.hasIdentifierSpecialChars(column)) column
+        else connection.catalog.quoteIdentifier(column)
+      }
     }
-    connection.execJdbcQuery(metadataQuery, evalColumnNames)
   }
 }
 
-private[smartdatalake] case class JdbcColumn(name: String, isNameCaseSensitiv: Boolean, jdbcType: Option[Int] = None, dbTypeName: Option[String] = None, precision: Option[Int] = None, scale: Option[Int] = None) {
+private[smartdatalake] case class JdbcColumn(name: String, isNameCaseSensitiv: Boolean, jdbcType: Option[Int] = None, dbTypeName: Option[String] = None, precision: Option[Int] = None, scale: Option[Int] = None, isNullable: Option[Boolean] = None) {
   def nameEquals(other: JdbcColumn): Boolean = {
     if (this.isNameCaseSensitiv || other.isNameCaseSensitiv) this.name.equals(other.name)
     else this.name.equalsIgnoreCase(other.name)
+  }
+  def nameEqualsIgnoreCaseSensitive(name: String): Boolean = {
+    this.name.equalsIgnoreCase(name)
   }
 }
 private[smartdatalake] object JdbcColumn {
   def from(metadata: ResultSetMetaData, colIdx: Int): JdbcColumn = {
     val name = metadata.getColumnName(colIdx)
-    val isNameCaseSensitiv = name != name.toUpperCase
-    JdbcColumn(name, isNameCaseSensitiv, Option(metadata.getColumnType(colIdx)), Option(metadata.getColumnTypeName(colIdx)), Option(metadata.getPrecision(colIdx)), Option(metadata.getScale(colIdx)))
+    val isNameCaseSensitiv = name != name.toUpperCase || JdbcTableDataObject.hasIdentifierSpecialChars(name)
+    JdbcColumn(name, isNameCaseSensitiv, Option(metadata.getColumnType(colIdx)), Option(metadata.getColumnTypeName(colIdx)), Option(metadata.getPrecision(colIdx)), Option(metadata.getScale(colIdx)), None)
+  }
+  def from(rs: ResultSet): JdbcColumn = {
+    val name = rs.getString("COLUMN_NAME")
+    val isNameCaseSensitiv = name != name.toUpperCase || JdbcTableDataObject.hasIdentifierSpecialChars(name)
+    JdbcColumn(name, isNameCaseSensitiv, None, Option(rs.getString("DATA_TYPE")), Option(rs.getInt("COLUMN_SIZE")), Option(rs.getInt("DECIMAL_DIGITS")), Some(rs.getInt("NULLABLE")>0))
   }
 }
 
 object JdbcTableDataObject extends FromConfigFactory[DataObject] {
   override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): JdbcTableDataObject = {
     extract[JdbcTableDataObject](config)
+  }
+  private[smartdatalake] def hasIdentifierSpecialChars(colName: String): Boolean = {
+    colName.matches("[a-zA-Z0-9_]*")
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -165,7 +165,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
     val newColumns = newSchema.fieldNames.diff(existingSchema.fieldNames) // add new column
     val missingNotNullColumns = existingSchema.fieldNames.diff(newSchema.fieldNames) // make missing columns nullable
       .filter { col =>
-        // as Spark doesn't now if a field is nullable in the database, but we can check jdbc metadata
+        // as Spark doesn't know if a field is nullable in the database, but we can check jdbc metadata
         val jdbcColumn = getJdbcColumn(col)
         !jdbcColumn.flatMap(_.isNullable).getOrElse(false)
       }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -123,7 +123,7 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
   /**
    * List partitions on data object's root path
    */
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = {
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
     partitionLayout.map {
       partitionLayout =>
         connection.execWithSFtpClient {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -18,7 +18,8 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import io.smartdatalake.definitions.{Environment, SDLSaveMode}
+import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
+import io.smartdatalake.definitions.{Environment, SDLSaveMode, SaveModeOptions}
 import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.DataFrameUtil.{DataFrameReaderUtils, DataFrameWriterUtils}
 import io.smartdatalake.util.misc.{CompactionUtil, DataFrameUtil}
@@ -184,7 +185,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
    * @param partitionValues The partition layout to write.
    * @param session the current [[SparkSession]].
    */
-  final override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
+  final override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     require(!isRecursiveInput, "($id) SparkFileDataObject cannot write dataframe when dataobject is also used as recursive input ")
 
@@ -194,7 +195,8 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
       .getOrElse(dfPrepared)
 
     // apply special save modes
-    saveMode match {
+    val finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
+    finalSaveMode match {
       case SDLSaveMode.Overwrite =>
         if (partitionValues.nonEmpty) { // delete concerned partitions if existing, as Spark dynamic partitioning doesn't delete empty partitions
           deletePartitions(filterPartitionsExisting(partitionValues))
@@ -224,7 +226,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
     }
 
     // write
-    writeDataFrameToPath(dfPrepared, hadoopPath)
+    writeDataFrameToPath(dfPrepared, hadoopPath, finalSaveMode)
 
     // make sure empty partitions are created as well
     createMissingPartitions(partitionValues)
@@ -233,12 +235,12 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
     sparkRepartition.foreach(_.renameFiles(getFileRefs(partitionValues))(filesystem))
   }
 
-  override private[smartdatalake] def writeDataFrameToPath(df: DataFrame, path: Path)(implicit session: SparkSession): Unit = {
+  override private[smartdatalake] def writeDataFrameToPath(df: DataFrame, path: Path, finalSaveMode: SDLSaveMode)(implicit session: SparkSession): Unit = {
     val hadoopPathString = path.toString
     logger.info(s"($id) Writing DataFrame to $hadoopPathString")
 
     df.write.format(format)
-      .mode(saveMode.asSparkSaveMode)
+      .mode(finalSaveMode.asSparkSaveMode)
       .options(options)
       .optionalPartitionBy(partitions)
       .save(hadoopPathString)
@@ -248,7 +250,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
    * Filters only existing partition.
    * Note that partition values to check don't need to have a key/value defined for every partition column.
    */
-  def filterPartitionsExisting(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Seq[PartitionValues]  = {
+  def filterPartitionsExisting(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues]  = {
     val partitionValueKeys = PartitionValues.getPartitionValuesKeys(partitionValues).toSeq
     partitionValues.intersect(listPartitions.map(_.filterKeys(partitionValueKeys)))
   }
@@ -260,12 +262,12 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
     CompactionUtil.compactHadoopStandardPartitions(this, partitionValues)
   }
 
-  override def writeStreamingDataFrame(df: DataFrame, trigger: Trigger, options: Map[String,String], checkpointLocation: String, queryName: String, outputMode: OutputMode = OutputMode.Append)
+  override def writeStreamingDataFrame(df: DataFrame, trigger: Trigger, options: Map[String,String], checkpointLocation: String, queryName: String, outputMode: OutputMode = OutputMode.Append, saveModeOptions: Option[SaveModeOptions] = None)
                              (implicit session: SparkSession, context: ActionPipelineContext): StreamingQuery = {
 
     // lambda function is ambiguous with foreachBatch in scala 2.12... we need to create a real function...
     // Note: no partition values supported when writing streaming target
-    def microBatchWriter(dfMicrobatch: Dataset[Row], batchid: Long): Unit = writeDataFrame(dfMicrobatch, Seq())
+    def microBatchWriter(dfMicrobatch: Dataset[Row], batchid: Long): Unit = writeDataFrame(dfMicrobatch, Seq(), saveModeOptions = saveModeOptions)
 
     df
       .writeStream

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.{DateColumnType, Environment, SDLSaveMode}
+import io.smartdatalake.definitions.{DateColumnType, Environment, SDLSaveMode, SaveModeOptions}
 import io.smartdatalake.definitions.DateColumnType.DateColumnType
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
@@ -134,11 +134,11 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     }
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
     validateSchemaHasPartitionCols(df, "write")
-    writeDataFrameInternal(df, createTableOnly=false, partitionValues, isRecursiveInput)
+    writeDataFrameInternal(df, createTableOnly=false, partitionValues, isRecursiveInput, saveModeOptions)
 
     // make sure empty partitions are created as well
     createMissingPartitions(partitionValues)
@@ -149,7 +149,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
    * DataFrames are repartitioned in order not to write too many small files
    * or only a few HDFS files that are too large.
    */
-  def writeDataFrameInternal(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues], isRecursiveInput: Boolean)
+  def writeDataFrameInternal(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues], isRecursiveInput: Boolean, saveModeOptions: Option[SaveModeOptions])
                             (implicit session: SparkSession): Unit = {
     val dfPrepared = if (createTableOnly) {
       // create empty df with existing df's schema
@@ -170,7 +170,8 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     }
 
     // write table and fix acls
-    HiveUtil.writeDfToHiveWithTickTock(dfPrepared, hadoopPath, table, partitions, saveMode.asSparkSaveMode, forceTickTock = isRecursiveInput)
+    val finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
+    HiveUtil.writeDfToHiveWithTickTock(dfPrepared, hadoopPath, table, partitions, finalSaveMode.asSparkSaveMode, forceTickTock = isRecursiveInput)
     val aclToApply = acl.orElse(connection.flatMap(_.acl))
     if (aclToApply.isDefined) AclUtil.addACLs(aclToApply.get, hadoopPath)(filesystem)
     if (analyzeTableAfterWrite && !createTableOnly) {
@@ -190,7 +191,7 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
   /**
    * list hive table partitions
    */
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = {
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
     if(isTableExisting) HiveUtil.listPartitions(table, partitions)
     else Seq()
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -207,7 +207,7 @@ case class WebserviceFileDataObject(override val id: DataObjectId,
    * List partition values defined for this web service.
    * Note that this is a fixed list.
    */
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = createAllPartitionValues
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = createAllPartitionValues
 
   /**
    * No root path needed for Webservice. It can be included in webserviceOptions.url.

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
@@ -21,6 +21,7 @@ package io.smartdatalake.config.objects
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.definitions.SaveModeOptions
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataobject._
@@ -47,7 +48,7 @@ case class TestDataObject( id: DataObjectId,
 
   override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = null
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {}
 
   override var table: Table = Table(db=Some("testdb"), name="testtable")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyWithMergeActionTest.scala
@@ -1,0 +1,101 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.action
+
+import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.definitions.SaveModeMergeOptions
+import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+import io.smartdatalake.workflow.connection.JdbcTableConnection
+import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, JdbcTableDataObject, Table}
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
+import org.apache.spark.sql.SparkSession
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+import java.nio.file.Files
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+class CopyWithMergeActionTest extends FunSuite with BeforeAndAfter {
+
+  protected implicit val session : SparkSession = TestUtil.sessionHiveCatalog
+  import session.implicits._
+
+  private val tempDir = Files.createTempDirectory("test")
+  private val tempPath = tempDir.toAbsolutePath.toString
+
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
+
+  private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb", "org.hsqldb.jdbcDriver")
+
+  before {
+    instanceRegistry.clear()
+  }
+
+  test("copy 1st 2nd load, SaveModeMergeOptions, schema evolution") {
+
+    // setup DataObjects
+    val feed = "copy"
+    val srcTable = Table(Some("default"), "copy_input")
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"),  table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable
+    instanceRegistry.register(srcDO)
+    instanceRegistry.register(jdbcConnection)
+    val tgtTable = Table(Some("public"), "copy_output", None, Some(Seq("lastname","firstname")))
+    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255)"), allowSchemaEvolution = true)
+    tgtDO.dropTable
+    tgtDO.connection.dropTable(tgtTable.fullName+"_sdltmp")
+    instanceRegistry.register(tgtDO)
+
+    // prepare & start 1st load
+    val action1 = CopyAction("dda", srcDO.id, tgtDO.id, saveModeOptions = Some(SaveModeMergeOptions()))
+    val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
+    srcDO.writeDataFrame(l1, Seq())
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.init(Seq(srcSubFeed))
+    action1.exec(Seq(srcSubFeed))(session, contextExec)
+
+    {
+      val expected = Seq(("doe", "john", 5), ("pan", "peter", 5), ("hans", "muster", 5))
+        .toDF("lastname", "firstname", "rating")
+      val actual = tgtDO.getDataFrame()
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
+      assert(resultat)
+    }
+
+    // prepare & start 2nd load - schema evolution: column rating -> rating2!
+    val l2 = Seq(("doe","john",10),("pan","peter",5),("pan","peter2",5)).toDF("lastname", "firstname", "rating2")
+    srcDO.writeDataFrame(l2, Seq())
+    action1.init(Seq(srcSubFeed))
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, contextExec)
+
+    {
+      val expected = Seq(("doe", "john", Some(5), Some(10)), ("pan", "peter", Some(5), Some(5)), ("pan", "peter2", None, Some(5)), ("hans", "muster", Some(5), None))
+        .toDF("lastname", "firstname", "rating", "rating2")
+      val actual = tgtDO.getDataFrame()
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
+      assert(resultat)
+    }
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateWithMergeActionTest.scala
@@ -20,23 +20,21 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.TechnicalTableColumn
-import io.smartdatalake.testutils.DataFrameTestHelper._
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
-import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
+import io.smartdatalake.workflow.connection.JdbcTableConnection
+import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, JdbcTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import java.nio.file.Files
 import java.sql.Timestamp
-import java.time.{LocalDateTime, Month}
+import java.time.LocalDateTime
 
-class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
+class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
-  protected implicit val session: SparkSession = TestUtil.sessionHiveCatalog
-
+  protected implicit val session : SparkSession = TestUtil.sessionHiveCatalog
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("test")
@@ -45,11 +43,13 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   implicit val context = TestUtil.getDefaultActionPipelineContext
 
+  private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb", "org.hsqldb.jdbcDriver")
+
   before {
     instanceRegistry.clear()
   }
 
-  test("deduplicate 1st 2nd load") {
+  test("deduplicate 1st 2nd load mergeModeEnable") {
 
     // setup DataObjects
     val feed = "deduplicate"
@@ -57,25 +57,26 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"),  table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(jdbcConnection)
+    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
+    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255)"))
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
     val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
-    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id)
+    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true)
     val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())(session, context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, context1).head
-    assert(tgtSubFeed.dataObjectId == tgtDO.id)
+    action1.init(Seq(srcSubFeed))(session, context1).head
+    action1.exec(Seq(srcSubFeed))(session, context1).head
 
     {
       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))
         .toDF("lastname", "firstname", "rating", "dl_ts_captured")
-      val actual = tgtDO.getDataFrame().cache
+      val actual = tgtDO.getDataFrame()
       val resultat = expected.isEqual(actual)
       if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
       assert(resultat)
@@ -92,100 +93,62 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
       // note that we expect pan/peter/5 with updated refTimestamp even though all attributes stay the same
       val expected = Seq(("doe", "john", 10, Timestamp.valueOf(refTimestamp2)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp2)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))
         .toDF("lastname", "firstname", "rating", "dl_ts_captured")
-      val actual = tgtDO.getDataFrame().cache
+      val actual = tgtDO.getDataFrame()
       val resultat = expected.isEqual(actual)
       if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
       assert(resultat)
     }
   }
 
-  test("early validation that output primary key exists") {
-    // setup DataObjects
-    val srcTable = Table(Some("default"), "deduplicate_input")
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-    instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "deduplicate_output")
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tgtPath), table = tgtTable, numInitialHdfsPartitions = 1)
-    instanceRegistry.register(tgtDO)
-
-    // prepare & start 1st load
-    intercept[IllegalArgumentException]{DeduplicateAction("dda", srcDO.id, tgtDO.id)}
-  }
-
-  test("deduplicate with filter clause") {
+  test("deduplicate 1st 2nd load mergeModeEnable updateCapturedColumnOnlyWhenChanged") {
 
     // setup DataObjects
     val feed = "deduplicate"
     val srcTable = Table(Some("default"), "deduplicate_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"),  table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(jdbcConnection)
+    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
+    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255)"))
     tgtDO.dropTable
+    tgtDO.connection.dropTable(tgtTable.fullName+"_sdltmp") // drop temp table if not properly cleaned up...
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
-    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(LocalDateTime.now), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
-    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, filterClause = Some("lastname='jonson'"))
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true, updateCapturedColumnOnlyWhenChanged = true)
+    val l1 = Seq(("doe","john",Some(5)),("pan","peter",Some(5)),("pan","peter2",None),("hans","muster",Some(5))).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())(session, context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, context1).head
-    assert(tgtSubFeed.dataObjectId == tgtDO.id)
+    action1.init(Seq(srcSubFeed))(session, context1).head
+    action1.exec(Seq(srcSubFeed))(session, context1).head
 
-    val r1 = tgtDO.getDataFrame()
-      .select($"rating")
-      .as[Int].collect().toSeq
-    assert(r1.size == 1)
+    {
+      val expected = Seq(("doe", "john", Some(5), Timestamp.valueOf(refTimestamp1)), ("pan", "peter", Some(5), Timestamp.valueOf(refTimestamp1)), ("pan", "peter2", None, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", Some(5), Timestamp.valueOf(refTimestamp1)))
+        .toDF("lastname", "firstname", "rating", "dl_ts_captured")
+      val actual = tgtDO.getDataFrame()
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
+      assert(resultat)
+    }
+
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val l2 = Seq(("doe","john",Some(10)),("pan","peter",Some(5)),("pan","peter2",None)).toDF("lastname", "firstname", "rating")
+    srcDO.writeDataFrame(l2, Seq())(session, context1)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
+
+    {
+      // note that we expect pan/peter/5 and pan/peter2/null with old refTimestamp because all attributes stay the same
+      val expected = Seq(("doe", "john", Some(10), Timestamp.valueOf(refTimestamp2)), ("pan", "peter", Some(5), Timestamp.valueOf(refTimestamp1)), ("pan", "peter2", None, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", Some(5), Timestamp.valueOf(refTimestamp1)))
+        .toDF("lastname", "firstname", "rating", "dl_ts_captured")
+      val actual = tgtDO.getDataFrame()
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
+      assert(resultat)
+    }
   }
-
-  test("deduplicate with schema evolution") {
-    val colId = "id"
-    val colValueOld = "old_value_column_string"
-    val colValueNew = "new_value_column_decimal"
-
-    // initial deduplication while adding new column
-    val df1 = createDf(Map(
-      colId -> 1,
-      colValueOld -> "X",
-      TechnicalTableColumn.captured.toString -> ts("2020-07-01 10:00")
-    ))
-
-    val df2 = createDf(Map(
-      colId -> 1,
-      colValueOld -> "A",
-      colValueNew -> dec(100)
-    ))
-
-    val dateTime1 = LocalDateTime.of(2020, Month.AUGUST, 15, 10, 0, 0)
-    val dfResult1 = DeduplicateAction
-      .deduplicateDataFrame(Option(df1), Seq(colId), dateTime1,
-        ignoreOldDeletedColumns = false, ignoreOldDeletedNestedColumns = true)(df2)
-
-    // deduplicate again, using the new column
-    val df3 = createDf(Map(
-      colId -> 1,
-      colValueOld -> "B",
-      colValueNew -> dec(200)
-    ))
-
-    val dateTime2 = LocalDateTime.of(2020, Month.AUGUST, 16, 10, 0, 0)
-    val dfResult2 = DeduplicateAction
-      .deduplicateDataFrame(Option(dfResult1), Seq(colId), dateTime2,
-        ignoreOldDeletedColumns = false, ignoreOldDeletedNestedColumns = true)(df3)
-
-    // the expected result is the final passed value with a captured column
-    val dfExpected = createDf(Map(
-      colId -> 1,
-      colValueOld -> "B",
-      colValueNew -> dec(200),
-      TechnicalTableColumn.captured.toString -> ts("2020-08-16 10:00")
-    ))
-
-    assertDataFramesEqual(dfExpected, dfResult2)
-  }
-
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
@@ -224,7 +224,7 @@ class ExecutionModeTest extends FunSuite with BeforeAndAfter {
 
 class TestCustomPartitionMode() extends CustomPartitionModeLogic {
   override def apply(session: SparkSession, options: Map[String, String], actionId: ActionId, input: DataObject with CanHandlePartitions, output: DataObject with CanHandlePartitions, givenPartitionValues: Seq[Map[String, String]], context: ActionPipelineContext): Option[Seq[Map[String, String]]] = {
-    val partitionValuesToProcess = input.listPartitions(session).diff(output.listPartitions(session))
+    val partitionValuesToProcess = input.listPartitions(session, context).diff(output.listPartitions(session, context))
     Some(partitionValuesToProcess.map(_.getMapString))
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObjectTest.scala
@@ -103,12 +103,12 @@ class AccessTableDataObjectTest extends DataObjectTestSuite {
 
         // run
         val thrown = intercept[Exception] {
-          val df = dataObj.getDataFrameByFramework(doPersist = false)
+          val df = dataObj.getDataFrameByFramework()
           df.collect()
         }
 
         // check
-        thrown.getCause.getMessage shouldEqual "UCAExc:::4.0.4 incompatible data type in conversion: from SQL type CHARACTER to java.lang.Integer, value: ID"
+        thrown.getCause.getMessage shouldEqual "UCAExc:::5.0.1 incompatible data type in conversion: from SQL type CHARACTER to java.lang.Integer, value: ID"
     } finally {
         Logger.getLogger("org.apache.spark.executor.Executor").setLevel(executorLogLevel)
         Logger.getLogger("org.apache.spark.scheduler.TaskSetManager").setLevel(taskSetManagerLogLevel)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
@@ -18,10 +18,12 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import io.smartdatalake.testutils.DataObjectTestSuite
+import io.smartdatalake.definitions.SDLSaveMode
+import io.smartdatalake.testutils.{DataObjectTestSuite, TestUtil}
 import io.smartdatalake.workflow.SparkSubFeed
 import io.smartdatalake.workflow.action.CopyAction
 import io.smartdatalake.workflow.connection.{DefaultSQLCatalog, JdbcTableConnection}
+import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 
 class JdbcTableDataObjectTest extends DataObjectTestSuite {
 
@@ -36,12 +38,13 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     val dataObject = JdbcTableDataObject( "jdbcDO1", table = table, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
     dataObject.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
+    dataObject.init(df, Seq())
     dataObject.writeDataFrame(df, Seq())
     val dfRead = dataObject.getDataFrame(Seq())
     assert(dfRead.symmetricDifference(df).isEmpty)
   }
 
-  test("write and read case sensitive jdbc table") {
+  test("write and read case insensitive jdbc table") {
     import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
     instanceRegistry.register(jdbcConnection)
     // Use double quotes for case sensitivity in HSQLDB
@@ -49,9 +52,11 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     val dataObject = JdbcTableDataObject( "jdbcDO1", table = table, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
     dataObject.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
+    dataObject.init(df, Seq())
     dataObject.writeDataFrame(df, Seq())
     val dfRead = dataObject.getDataFrame(Seq())
     assert(dfRead.symmetricDifference(df).isEmpty)
+    dataObject.deleteAllData
   }
 
   test("check pre/post sql") {
@@ -67,6 +72,7 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     )
     srcDO.dropTable
     val df = Seq(("ext","doe","john",5)).toDF("type", "lastname", "firstname", "rating")
+    srcDO.init(df, Seq())
     srcDO.writeDataFrame(df, Seq())
     instanceRegistry.register(srcDO)
 
@@ -81,6 +87,7 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
 
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id)
     val srcSubFeed = SparkSubFeed(None, srcDO.id, Seq())
+    action1.init(Seq(srcSubFeed))
     action1.preExec(Seq(srcSubFeed))
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
     action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed))
@@ -103,11 +110,12 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     val dataObject1 = JdbcTableDataObject( "jdbcDO1", table = table1, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
     dataObject1.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
+    dataObject1.init(df, Seq())
     dataObject1.writeDataFrame(df, Seq())
 
     // read prepared data
     val table2 = Table(Some("public"), "table1", query = Some("select lastname, firstname from public.table1"))
-    val dataObject2 = JdbcTableDataObject( "jdbcDO2", table = table2, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
+    val dataObject2 = JdbcTableDataObject( "jdbcDO2", table = table2, connectionId = "jdbcCon1")
     val dfRead = dataObject2.getDataFrame(Seq())
     assert(dfRead.symmetricDifference(df.select($"lastname", $"firstname")).isEmpty)
 
@@ -135,8 +143,8 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
       val dfReadTable = dataObjectTable.getDataFrame(Seq())
 
       val df = Seq(("test_data")).toDF("test_column")
-      assert(jdbcConnection.catalog.asInstanceOf[DefaultSQLCatalog].isTableExisting(db, view.name))
-      assert(jdbcConnection.catalog.asInstanceOf[DefaultSQLCatalog].isTableExisting(db, table.name))
+      assert(jdbcConnection.catalog.asInstanceOf[DefaultSQLCatalog].isTableExisting(s"$db.${view.name}"))
+      assert(jdbcConnection.catalog.asInstanceOf[DefaultSQLCatalog].isTableExisting(s"$db.${table.name}"))
       assert(dfReadView.symmetricDifference(df).isEmpty)
       assert(dfReadTable.symmetricDifference(df).isEmpty)
 
@@ -154,6 +162,7 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     // Be careful when writing lower case column names over Jdbc with Spark. When creating the table through Spark they will be surrounded with quotes and become case-sensitiv!
     // In consequence the virtual partition has to be surrounded with quotes as well, see next test case.
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("ABC", "lastname", "firstname", "rating")
+    dataObject.init(df, Seq())
     dataObject.writeDataFrame(df, Seq())
     dataObject.prepare
     dataObject.getDataFrame(Seq()).show
@@ -163,18 +172,81 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     assert(partitionValues.map(_.elements("abc")).toSet == Set("ext","int"))
   }
 
-  test("list jdbc table virtual partitions case sensitive") {
+  test("list jdbc table virtual partitions case quoted identifier") {
     instanceRegistry.register(jdbcConnection)
     val table = Table(Some("public"), "table1")
-    val dataObject = JdbcTableDataObject( "jdbcDO1", table = table, connectionId = "jdbcCon1", virtualPartitions = Seq("\"abc\""), jdbcOptions = Map("createTableColumnTypes"->"abc varchar(255), lastname varchar(255), firstname varchar(255)"))
+    val dataObject = JdbcTableDataObject( "jdbcDO1", table = table, connectionId = "jdbcCon1", virtualPartitions = Seq("aBc"), createSql = Some("""CREATE TABLE public.table1 ("aBc" varchar(255) , lastname varchar(255) , firstname varchar(255) , rating INTEGER NOT NULL)"""))
     dataObject.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("abc", "lastname", "firstname", "rating")
-    dataObject.writeDataFrame(df, Seq())
     dataObject.prepare
+    dataObject.init(df, Seq())
+    dataObject.writeDataFrame(df, Seq())
     dataObject.getDataFrame(Seq()).show
     assert(dataObject.isTableExisting)
     val partitionValues = dataObject.listPartitions
     assert(partitionValues.size == 2)
     assert(partitionValues.map(_.elements("abc")).toSet == Set("ext","int"))
+    dataObject.getDataFrame().select($"abc").show
+  }
+
+  test("SaveMode merge") {
+    instanceRegistry.register(jdbcConnection)
+    val targetTable = Table(db = Some("public"), name = "test_merge", query = None, primaryKey = Some(Seq("type","lastname","firstname")))
+    val targetDO = JdbcTableDataObject( "jdbcDO1", table = targetTable, connectionId = "jdbcCon1", saveMode = SDLSaveMode.Merge, jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
+    targetDO.dropTable
+
+    // first load
+    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+      .toDF("type", "lastname", "firstname", "rating")
+    targetDO.prepare
+    targetDO.init(df1, Seq())
+    targetDO.writeDataFrame(df1)
+    val actual = targetDO.getDataFrame()
+    val resultat = df1.isEqual(actual)
+    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    assert(resultat)
+
+    // 2nd load: merge data by primary key
+    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+      .toDF("type", "lastname", "firstname", "rating")
+    targetDO.writeDataFrame(df2)
+    val actual2 = targetDO.getDataFrame()
+    val expected2 = Seq(("ext","doe","john",10),("ext","smith","peter",3),("int","emma","brown",7))
+      .toDF("type", "lastname", "firstname", "rating")
+    val resultat2: Boolean = expected2.isEqual(actual2)
+    if (!resultat2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    assert(resultat2)
+  }
+
+  test("SaveMode merge with schema evolution") {
+    instanceRegistry.register(jdbcConnection)
+    val targetTable = Table(db = Some("public"), name = "test_merge", query = None, primaryKey = Some(Seq("type","lastname","firstname")))
+    val targetDO = JdbcTableDataObject( "jdbcDO1", table = targetTable, connectionId = "jdbcCon1", allowSchemaEvolution = true, saveMode = SDLSaveMode.Merge, jdbcOptions = Map("createTableColumnTypes"->"type varchar(255), lastname varchar(255), firstname varchar(255)"))
+    targetDO.dropTable
+
+    // first load
+    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+      .toDF("type", "lastname", "firstname", "rating")
+    targetDO.prepare
+    targetDO.init(df1, Seq())
+    targetDO.writeDataFrame(df1)
+    val actual = targetDO.getDataFrame()
+    val resultat = df1.isEqual(actual)
+    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    assert(resultat)
+
+    // 2nd load: merge data by primary key with different schema
+    // - column 'rating' deleted -> existing records will keep column rating untouched (values are preserved and not set to null), new records will get new column rating set to null.
+    // - column 'rating2' added -> existing records will get new column rating2 set to null
+    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+      .toDF("type", "lastname", "firstname", "rating2")
+    targetDO.init(df2, Seq())
+    targetDO.writeDataFrame(df2)
+    val actual2 = targetDO.getDataFrame()
+    val expected2 = Seq(("ext","doe","john",Some(5),Some(10)),("ext","smith","peter",Some(3),None),("int","emma","brown",None,Some(7)))
+      .toDF("type", "lastname", "firstname", "rating", "rating2")
+    val resultat2: Boolean = expected2.isEqual(actual2)
+    if (!resultat2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    assert(resultat2)
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
@@ -19,11 +19,11 @@
 package io.smartdatalake.workflow.dataobject
 
 import java.nio.file.{Files, Path}
-
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions.BasicAuthMode
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.connection.SftpFileRefConnection
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
@@ -34,6 +34,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
 
   implicit val session: SparkSession = TestUtil.sessionHiveCatalog
   implicit val registry: InstanceRegistry = new InstanceRegistry
+  implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
   private var sshd: SshServer = _
   val sshPort = 8001

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/UnpartitionedTestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/UnpartitionedTestDataObject.scala
@@ -22,6 +22,7 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.definitions.SaveModeOptions
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -40,7 +41,7 @@ case class UnpartitionedTestDataObject(override val id: DataObjectId,
     Seq(("test",1),("test",2)).toDF("a","b")
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     df.show
   }

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/connection/DeltaLakeTableConnection.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/connection/DeltaLakeTableConnection.scala
@@ -1,0 +1,50 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.connection
+
+import com.typesafe.config.Config
+import io.smartdatalake.config.SdlConfigObject.ConnectionId
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.util.misc.AclDef
+
+/**
+ * Connection information for DeltaLake tables
+ *
+ * @param id unique id of this connection
+ * @param db hive db
+ * @param pathPrefix schema, authority and base path for tables directory on hadoop
+ * @param acl permissions for files created with this connection
+ * @param metadata
+ */
+case class DeltaLakeTableConnection(override val id: ConnectionId,
+                                    db: String,
+                                    pathPrefix: String,
+                                    acl: Option[AclDef] = None,
+                                    checkDeltaLakeSparkOptions: Boolean = true,
+                                    override val metadata: Option[ConnectionMetadata] = None
+                               ) extends Connection {
+
+  override def factory: FromConfigFactory[Connection] = DeltaLakeTableConnection
+}
+
+object DeltaLakeTableConnection extends FromConfigFactory[Connection] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): DeltaLakeTableConnection = {
+    extract[DeltaLakeTableConnection](config)
+  }
+}

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
@@ -20,23 +20,23 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.TechnicalTableColumn
-import io.smartdatalake.testutils.DataFrameTestHelper._
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
-import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
+import io.smartdatalake.workflow.dataobject.{DeltaLakeModulePlugin, DeltaLakeTableDataObject, HiveTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
 import java.nio.file.Files
 import java.sql.Timestamp
-import java.time.{LocalDateTime, Month}
+import java.time.LocalDateTime
 
-class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
+class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
-  protected implicit val session: SparkSession = TestUtil.sessionHiveCatalog
-
+  protected implicit val session : SparkSession = new DeltaLakeModulePlugin().additionalSparkProperties()
+    .foldLeft(TestUtil.sparkSessionBuilder(withHive = true)) {
+      case (builder, config) => builder.config(config._1, config._2)
+    }.getOrCreate()
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("test")
@@ -49,7 +49,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.clear()
   }
 
-  test("deduplicate 1st 2nd load") {
+  test("deduplicate 1st 2nd load mergeModeEnable") {
 
     // setup DataObjects
     val feed = "deduplicate"
@@ -58,14 +58,14 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = DeltaLakeTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
     val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
-    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id)
+    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true)
     val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())(session, context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
@@ -75,7 +75,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     {
       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))
         .toDF("lastname", "firstname", "rating", "dl_ts_captured")
-      val actual = tgtDO.getDataFrame().cache
+      val actual = tgtDO.getDataFrame()
       val resultat = expected.isEqual(actual)
       if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
       assert(resultat)
@@ -92,100 +92,60 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
       // note that we expect pan/peter/5 with updated refTimestamp even though all attributes stay the same
       val expected = Seq(("doe", "john", 10, Timestamp.valueOf(refTimestamp2)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp2)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))
         .toDF("lastname", "firstname", "rating", "dl_ts_captured")
-      val actual = tgtDO.getDataFrame().cache
+      val actual = tgtDO.getDataFrame()
       val resultat = expected.isEqual(actual)
       if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
       assert(resultat)
     }
   }
 
-  test("early validation that output primary key exists") {
-    // setup DataObjects
-    val srcTable = Table(Some("default"), "deduplicate_input")
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-    instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "deduplicate_output")
-    val tgtPath = tempPath+s"/${tgtTable.fullName}"
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tgtPath), table = tgtTable, numInitialHdfsPartitions = 1)
-    instanceRegistry.register(tgtDO)
-
-    // prepare & start 1st load
-    intercept[IllegalArgumentException]{DeduplicateAction("dda", srcDO.id, tgtDO.id)}
-  }
-
-  test("deduplicate with filter clause") {
+  test("deduplicate 1st 2nd load mergeModeEnable updateCapturedColumnOnlyWhenChanged") {
 
     // setup DataObjects
     val feed = "deduplicate"
     val srcTable = Table(Some("default"), "deduplicate_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"),  table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtDO = DeltaLakeTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
-    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(LocalDateTime.now), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
-    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, filterClause = Some("lastname='jonson'"))
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true, updateCapturedColumnOnlyWhenChanged = true)
+    val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())(session, context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
-    val r1 = tgtDO.getDataFrame()
-      .select($"rating")
-      .as[Int].collect().toSeq
-    assert(r1.size == 1)
+    {
+      val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))
+        .toDF("lastname", "firstname", "rating", "dl_ts_captured")
+      val actual = tgtDO.getDataFrame()
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
+      assert(resultat)
+    }
+
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
+    srcDO.writeDataFrame(l2, Seq())(session, context1)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
+
+    {
+      // note that we expect pan/peter/5 with updated refTimestamp even though all attributes stay the same
+      val expected = Seq(("doe", "john", 10, Timestamp.valueOf(refTimestamp2)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))
+        .toDF("lastname", "firstname", "rating", "dl_ts_captured")
+      val actual = tgtDO.getDataFrame()
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("deduplicate 1st 2nd load", Seq())(actual)(expected)
+      assert(resultat)
+    }
   }
-
-  test("deduplicate with schema evolution") {
-    val colId = "id"
-    val colValueOld = "old_value_column_string"
-    val colValueNew = "new_value_column_decimal"
-
-    // initial deduplication while adding new column
-    val df1 = createDf(Map(
-      colId -> 1,
-      colValueOld -> "X",
-      TechnicalTableColumn.captured.toString -> ts("2020-07-01 10:00")
-    ))
-
-    val df2 = createDf(Map(
-      colId -> 1,
-      colValueOld -> "A",
-      colValueNew -> dec(100)
-    ))
-
-    val dateTime1 = LocalDateTime.of(2020, Month.AUGUST, 15, 10, 0, 0)
-    val dfResult1 = DeduplicateAction
-      .deduplicateDataFrame(Option(df1), Seq(colId), dateTime1,
-        ignoreOldDeletedColumns = false, ignoreOldDeletedNestedColumns = true)(df2)
-
-    // deduplicate again, using the new column
-    val df3 = createDf(Map(
-      colId -> 1,
-      colValueOld -> "B",
-      colValueNew -> dec(200)
-    ))
-
-    val dateTime2 = LocalDateTime.of(2020, Month.AUGUST, 16, 10, 0, 0)
-    val dfResult2 = DeduplicateAction
-      .deduplicateDataFrame(Option(dfResult1), Seq(colId), dateTime2,
-        ignoreOldDeletedColumns = false, ignoreOldDeletedNestedColumns = true)(df3)
-
-    // the expected result is the final passed value with a captured column
-    val dfExpected = createDf(Map(
-      colId -> 1,
-      colValueOld -> "B",
-      colValueNew -> dec(200),
-      TechnicalTableColumn.captured.toString -> ts("2020-08-16 10:00")
-    ))
-
-    assertDataFramesEqual(dfExpected, dfResult2)
-  }
-
 }

--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
@@ -23,10 +23,11 @@ import java.time._
 import java.time.format.DateTimeFormatter
 import java.time.temporal.{ChronoUnit, TemporalAccessor, TemporalQuery}
 import java.util.Properties
-
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
+import io.smartdatalake.definitions.SaveModeOptions
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.DataFrameUtil
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -273,7 +274,8 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
     )
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
+                             (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     convertToWriteDataFrame(df)
       .write
       .format("kafka")
@@ -282,7 +284,8 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
       .save
   }
 
-  override def writeStreamingDataFrame(df: DataFrame, trigger: Trigger, options: Map[String, String], checkpointLocation: String, queryName: String, outputMode: OutputMode)(implicit session: SparkSession, context: ActionPipelineContext): StreamingQuery = {
+  override def writeStreamingDataFrame(df: DataFrame, trigger: Trigger, options: Map[String, String], checkpointLocation: String, queryName: String, outputMode: OutputMode, saveModeOptions: Option[SaveModeOptions] = None)
+                                      (implicit session: SparkSession, context: ActionPipelineContext): StreamingQuery = {
     convertToWriteDataFrame(df)
       .writeStream
       .format("kafka")
@@ -316,7 +319,7 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
     }
   }
 
-  override def listPartitions(implicit session: SparkSession): Seq[PartitionValues] = {
+  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
     require(datePartitionCol.isDefined, s"(${id}) datePartitionCol column must be defined for listing partition values")
     val maxEmptyConsecutive: Int = 10 // number of empty partitions to stop searching for partitions
     val pctChronoUnitWaitToComplete = 0.02 // percentage of one chrono unit to wait after partition end date until the partition is assumed to be complete. This is to handle kafka late data.

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -22,6 +22,8 @@ package io.smartdatalake.workflow.dataobject
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.definitions.{SDLSaveMode, SaveModeOptions}
+import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.DataFrameUtil
@@ -38,7 +40,7 @@ import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
  * @param id           unique name of this data object
  * @param schemaMin    An optional, minimal schema that this DataObject must have to pass schema validation on reading and writing.
  * @param table        Snowflake table to be written by this output
- * @param saveMode     spark [[SaveMode]] to use when writing files, default is "overwrite"
+ * @param saveMode     spark [[SDLSaveMode]] to use when writing files, default is "overwrite"
  * @param connectionId The SnowflakeTableConnection to use for the table
  * @param comment      An optional comment to add to the table after writing a DataFrame to it
  * @param metadata     meta data
@@ -46,7 +48,7 @@ import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 case class SnowflakeTableDataObject(override val id: DataObjectId,
                                     override val schemaMin: Option[StructType] = None,
                                     override var table: Table,
-                                    saveMode: SaveMode = SaveMode.Overwrite,
+                                    saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                                     connectionId: ConnectionId,
                                     comment: Option[String],
                                     override val metadata: Option[DataObjectMetadata] = None)
@@ -75,17 +77,17 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
     df.colNamesLowercase
   }
 
-  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false)
+  override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
                              (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
-    writeDataFrame(df, createTableOnly = false, partitionValues)
+    writeDataFrame(df, createTableOnly = false, partitionValues, saveModeOptions)
   }
 
   /**
    * Writes DataFrame to Snowflake
    * Snowflake does not support explicit partitions, so any passed partition values are ignored
    */
-  def writeDataFrame(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues])
+  def writeDataFrame(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions])
                     (implicit session: SparkSession): Unit = {
     val dfPrepared = if (createTableOnly) {
       DataFrameUtil.getEmptyDataFrame(df.schema)
@@ -93,11 +95,12 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
       df
     }
 
+    val finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
     dfPrepared.write
       .format(SNOWFLAKE_SOURCE_NAME)
       .options(connection.getSnowflakeOptions(table.db.get))
       .options(Map("dbtable" -> (connection.database + "." + table.fullName)))
-      .mode(saveMode)
+      .mode(finalSaveMode.asSparkSaveMode)
       .save()
 
     if (comment.isDefined) {
@@ -119,16 +122,10 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
 
   override def dropTable(implicit session: SparkSession): Unit = throw new NotImplementedError()
 
-  /**
-   * @inheritdoc
-   */
   override def factory: FromConfigFactory[DataObject] = SnowflakeTableDataObject
 }
 
 object SnowflakeTableDataObject extends FromConfigFactory[DataObject] {
-  /**
-   * @inheritdoc
-   */
   override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): SnowflakeTableDataObject = {
     extract[SnowflakeTableDataObject](config)
   }


### PR DESCRIPTION
### What changes are included in the pull request?
- implement SDLSaveMode.Merge for DeltaLakeTableDataObject
- implement SDLSaveMode.Merge, auto-create table and schema evolution for JdbcTableDataObject
- extend CanWriteDataFrame with forceSaveMode, so that Actions can override saveMode set in DataObject configuration
- Implement merge mode for DeduplicateAction (#235)
- implement Schema Evolution for JdbcTableDataObject (#216)

### Why are the changes needed?
see #235, #216
