### PR TITLE
evolving schema with DeltaLakeTableDataObject with SDLSaveMode.Append

### DIFF
--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -189,7 +189,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
       if (finalSaveMode == SDLSaveMode.Merge) {
         mergeDataFrameByPrimaryKey(df, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
       } else {
-        if (partitions.isEmpty) {
+        if (partitions.isEmpty && finalSaveMode != SDLSaveMode.Append) {
           dfWriter
             .option("overwriteSchema", allowSchemaEvolution) // allow overwriting schema when overwriting whole table
             .mode(finalSaveMode.asSparkSaveMode)

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -189,9 +189,10 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
       if (finalSaveMode == SDLSaveMode.Merge) {
         mergeDataFrameByPrimaryKey(df, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
       } else {
-        if (partitions.isEmpty && finalSaveMode != SDLSaveMode.Append) {
+        if (partitions.isEmpty) {
           dfWriter
             .option("overwriteSchema", allowSchemaEvolution) // allow overwriting schema when overwriting whole table
+            .option("mergeSchema", allowSchemaEvolution)
             .mode(finalSaveMode.asSparkSaveMode)
             .saveAsTable(table.fullName)
         } else {

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
@@ -121,6 +121,31 @@ class DeltaLakeTableDataObjectTest extends FunSuite with BeforeAndAfter {
     assert(resultat2)
   }
 
+  test("SaveMode append with different schema") {
+    val targetTable = Table(db = Some("default"), name = "test_append", query = None)
+    val targetTablePath = tempPath+s"/${targetTable.fullName}"
+    val targetDO = DeltaLakeTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Append, allowSchemaEvolution = true)
+    targetDO.dropTable
+
+    // first load
+    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+      .toDF("type", "lastname", "firstname", "rating")
+    targetDO.writeDataFrame(df1)
+    val actual = targetDO.getDataFrame()
+    val resultat: Boolean = df1.isEqual(actual)
+    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    assert(resultat)
+
+    // 2nd load: append all with different schema
+    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+      .toDF("type", "lastname", "firstname", "rating2")
+    targetDO.writeDataFrame(df2)
+    val actual2 = targetDO.getDataFrame().filter($"lastname" === "doe")
+    val resultat2: Boolean = actual2.count() == 2
+    if (!resultat2) TestUtil.printFailedTestResult("SaveMode append",Seq())(actual2)(df2)
+    assert(resultat2)
+  }
+
   test("SaveMode overwrite and delete partition") {
     val targetTable = Table(db = Some("default"), name = "test_overwrite", query = None)
     val targetTablePath = tempPath+s"/${targetTable.fullName}"


### PR DESCRIPTION

### What changes are included in the pull request?
apply mergeSchema option instead of overwriteSchema when writing to DeltaLakeTableDataObject with SDLSaveMode.Append


### Why are the changes needed?
allows to support schema evolution with DeltaLakeTableDataObject and SDLSaveMode.Append