### PR TITLE
Bugfix/fix clear skipped on ignore filter

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStageMetricsListener.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStageMetricsListener.scala
@@ -27,6 +27,7 @@ import io.smartdatalake.workflow.{ActionMetrics, ActionPipelineContext}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart, SparkListenerStageCompleted}
 
 import scala.collection.mutable
+import scala.util.matching.Regex
 
 /**
  * Collects spark metrics for spark stages.
@@ -39,9 +40,9 @@ private[smartdatalake] class SparkStageMetricsListener(action: Action)(implicit 
   val jobInfoLookupTable: mutable.Map[Int, JobInfo] = mutable.Map.empty
 
   // parses job group
-  private val jobGroupRegex = (s"${context.appConfig.appName} ${action.id} runId=([0-9]+) attemptId=([0-9]+)").r.unanchored
+  private val jobGroupRegex = (s"${Regex.quote(context.appConfig.appName)} ${action.id} runId=([0-9]+) attemptId=([0-9]+)").r.unanchored
   // for spark streaming jobs we cant set the jobGroup, but only the description. They also have no executionId.
-  private val jobDescriptionRegex = (s"${context.appConfig.appName} ${action.id}").r.unanchored
+  private val jobDescriptionRegex = (s"${Regex.quote(context.appConfig.appName)} ${action.id}").r.unanchored
 
   /**
    * On job start, register the job ids and stage ids.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -53,6 +53,8 @@ sealed trait SubFeed extends DAGResult with SmartDataLakeLogger {
 
   def clearDAGStart(): SubFeed
 
+  def clearSkipped(): SubFeed
+
   def toOutput(dataObjectId: DataObjectId): SubFeed
 
   def union(other: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SubFeed
@@ -114,6 +116,9 @@ case class SparkSubFeed(@transient dataFrame: Option[DataFrame],
   }
   override def clearDAGStart(): SparkSubFeed = {
     this.copy(isDAGStart = false)
+  }
+  override def clearSkipped(): SparkSubFeed = {
+    this.copy(isSkipped = false)
   }
   override def toOutput(dataObjectId: DataObjectId): SparkSubFeed = {
     this.copy(dataFrame = None, filter=None, isDAGStart = false, isSkipped = false, isDummy = false, dataObjectId = dataObjectId)
@@ -206,6 +211,9 @@ case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
   override def clearDAGStart(): FileSubFeed = {
     this.copy(isDAGStart = false)
   }
+  override def clearSkipped(): FileSubFeed = {
+    this.copy(isSkipped = false)
+  }
   override def toOutput(dataObjectId: DataObjectId): FileSubFeed = {
     this.copy(fileRefs = None, processedInputFileRefs = None, isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId)
   }
@@ -260,6 +268,7 @@ case class InitSubFeed(override val dataObjectId: DataObjectId,
     } else this.copy(partitionValues = updatedPartitionValues)
   }
   override def clearDAGStart(): InitSubFeed = throw new NotImplementedException() // calling clearDAGStart makes no sense on InitSubFeed
+  override def clearSkipped(): InitSubFeed = throw new NotImplementedException() // calling clearSkipped makes no sense on InitSubFeed
   override def toOutput(dataObjectId: DataObjectId): FileSubFeed = throw new NotImplementedException()
   override def union(other: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SubFeed = other match {
     case x => this.copy(partitionValues = unionPartitionValues(x.partitionValues))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkAction.scala
@@ -368,7 +368,7 @@ private[smartdatalake] abstract class SparkAction extends Action {
     require(!context.simulation || !schemaChanges, s"($id) write & read schema is not the same for ${input.id}. Need to create a dummy DataFrame, but this is not allowed in simulation!")
     preparedSubFeed = if (schemaChanges) preparedSubFeed.convertToDummy(readSchema.get) else preparedSubFeed
     // remove potential filter and partition values added by execution mode
-    if (ignoreFilters) preparedSubFeed = preparedSubFeed.clearFilter().clearPartitionValues()
+    if (ignoreFilters) preparedSubFeed = preparedSubFeed.clearFilter().clearPartitionValues().clearSkipped()
     // break lineage if requested or if it's a streaming DataFrame or if a filter expression is set
     if (breakDataFrameLineage || preparedSubFeed.isStreaming.contains(true) || preparedSubFeed.filter.isDefined) preparedSubFeed = preparedSubFeed.breakLineage
     // return


### PR DESCRIPTION
### What changes are included in the pull request?

1. fix parsing spark event listener info if appName contains special characters
2. fix reading data frame from skipped SubFeed if filters are ignored

### Why are the changes needed?

1. If no application name is given feedSel is used as replacement. feedSel might contain special characters which break the regexp for parsing event info.
2. If a SubFeed is skipped because there is no data to process, an empty DataFrame is created for this SubFeed as input for CustomSparkAction. There is a constellation where an input SubFeed is skipped but inputIdsToIgnoreFilter is set for this input. In that case a DataFrame with the all input DataObjects data should be created, as filters incl. isSkipped can be ignored.
