### PR TITLE
Added origin exception for better problem analysis

### DIFF
--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
@@ -93,7 +93,7 @@ case class KafkaConnection(override val id: ConnectionId,
     try {
       confluentHelper.foreach(_.test())
     } catch {
-      case e:Exception => throw ConfigurationException(s"($id) Can not connect to schema registry (${schemaRegistry.get})")
+      case e:Exception => throw ConfigurationException(s"($id) Can not connect to schema registry (${schemaRegistry.get})", None, e)
     }
   }
 


### PR DESCRIPTION
### What changes are included in the pull request?
Here a small fix to [issue 432](https://github.com/smart-data-lake/smart-data-lake/issues/432). Currently, the original exception is lost, when an attempt to connect to a schema registry fails.
The change in the pull request adds the original exception to the thrown *ConfigurationException*.
 
### Why are the changes needed?
For a user, it is clear, that the connection to the registry failed. But the message of the *ConfigurationException* does not help in analyzing and solving the real problem. These can be 

- Wrong config
- Corrupt key/trust store
- ...