### PR TITLE
avoid loosing full error response text from webservice calls

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/webservice/ScalaJWebserviceClient.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/webservice/ScalaJWebserviceClient.scala
@@ -78,8 +78,8 @@ private[smartdatalake] object ScalaJWebserviceClient extends SmartDataLakeLogger
       // Request was sent, but the response contains an error
       case errorResponse if errorResponse.isError =>
         logger.error(s"Error when calling ${request.url}: Http status code: ${errorResponse.code}, response body: ${new String(errorResponse.body).take(200)}...")
-        Failure(new WebserviceException(s"Webservice Request failed with error <${errorResponse.code}>"))
-      // Request was successfull and response can be processed further
+        Failure(new WebserviceException(s"Webservice Request failed with error <${errorResponse.code}>", Some(errorResponse.code), Some(new String(errorResponse.body))))
+      // Request was successful and response can be processed further
       case normalResponse if normalResponse.isSuccess => Success(normalResponse.body)
     }
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/webservice/WebserviceException.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/webservice/WebserviceException.scala
@@ -20,7 +20,5 @@ package io.smartdatalake.util.webservice
 
 /**
   * Exception thrown when calling a webservice
-  *
-  * @param message error message
   */
-class WebserviceException(message: String) extends RuntimeException(message) {}
+class WebserviceException(message: String, responseCode: Option[Int] = None, responseBody: Option[String] = None) extends RuntimeException(message) {}


### PR DESCRIPTION
### What changes are included in the pull request?
Keep full error response text in WebserviceException

### Why are the changes needed?
If someone would like to log the full message this is still possible without debugging.