### PR TITLE
fix json4s-ast version to be the same as the other json4s libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1214,6 +1214,16 @@
 				</exclusions>
 			</dependency>
 			<dependency>
+				<groupId>org.json4s</groupId>
+				<artifactId>json4s-ast_${scala.minor.version}</artifactId>
+				<version>${json4s.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.json4s</groupId>
+				<artifactId>json4s-core_${scala.minor.version}</artifactId>
+				<version>${json4s.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.scala-lang.modules</groupId>
 				<artifactId>scala-xml_${scala.binary.version}</artifactId>
 				<version>1.2.0</version>

--- a/sdl-azure/pom.xml
+++ b/sdl-azure/pom.xml
@@ -110,12 +110,10 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-ast_${scala.minor.version}</artifactId>
-            <version>3.6.6</version>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-core_${scala.minor.version}</artifactId>
-            <version>${json4s.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This fixes ClassNotFoundException while writing DeltaTableDataObject when having sdl-azure and sdl-deltalake module as project dependencies.