### PR TITLE
refactor integrating SparkSession into ActionPipelineContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1214,6 +1214,16 @@
 				</exclusions>
 			</dependency>
 			<dependency>
+				<groupId>org.json4s</groupId>
+				<artifactId>json4s-ast_${scala.minor.version}</artifactId>
+				<version>${json4s.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.json4s</groupId>
+				<artifactId>json4s-core_${scala.minor.version}</artifactId>
+				<version>${json4s.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.scala-lang.modules</groupId>
 				<artifactId>scala-xml_${scala.binary.version}</artifactId>
 				<version>1.2.0</version>

--- a/sdl-azure/pom.xml
+++ b/sdl-azure/pom.xml
@@ -110,12 +110,10 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-ast_${scala.minor.version}</artifactId>
-            <version>3.6.6</version>
         </dependency>
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-core_${scala.minor.version}</artifactId>
-            <version>${json4s.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -301,7 +301,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     // parse config objects
     Environment._globalConfig = GlobalConfig.from(config)
     Environment._instanceRegistry = ConfigParser.parse(config, instanceRegistry) // share instance registry for custom code
-    val stateListeners = Environment._globalConfig.stateListeners.map(_.listener) ++ Environment._additionalStateListeners
+    val stateListeners = Environment.globalConfig.stateListeners.map(_.listener) ++ Environment._additionalStateListeners
 
     exec(appConfig, executionId, runStartTime, attemptStartTime, actionsToSkip, initialSubFeeds, dataObjectsState, stateStore, stateListeners, simulation)(Environment._instanceRegistry)
   }
@@ -329,7 +329,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
     // create and execute DAG
     logger.info(s"starting application ${appConfig.appName} runId=${executionId.runId} attemptId=${executionId.attemptId}")
-    val serializableHadoopConf = new SerializableHadoopConfiguration(Environment._globalConfig.getHadoopConfiguration)
+    val serializableHadoopConf = new SerializableHadoopConfiguration(Environment.globalConfig.getHadoopConfiguration)
     val context = ActionPipelineContext(appConfig.feedSel, appConfig.appName, executionId, instanceRegistry, referenceTimestamp = Some(LocalDateTime.now), appConfig, runStartTime, attemptStartTime, simulation, actionsSelected = actionIdsSelected, actionsSkipped = actionIdsSkipped, serializableHadoopConf = serializableHadoopConf)
     val actionDAGRun = ActionDAGRun(actionsToExec, actionsToSkip, appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism, initialSubFeeds, dataObjectsState, stateStore, stateListeners)(context)
     val finalSubFeeds = try {

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -80,9 +80,12 @@ object ConfigLoader extends SmartDataLakeLogger {
    *
    * @see [[com.typesafe.config.ConfigSyntax]]
    * @param configLocations     configuration files or directories containing configuration files.
+   * @param hadoopConf          Hadoop configuration to initialize filesystem.
+   *                            Note that maybe additional hadoop/spark configurations could not yet been loaded from the configuration files.
+   *                            In that case the default configuration is used.
    * @return                    a resolved [[Config]] merged from all found configuration files.
    */
-  def loadConfigFromFilesystem(configLocations: Seq[String]): Config = try {
+  def loadConfigFromFilesystem(configLocations: Seq[String], hadoopConf: Configuration): Config = try {
     val hadoopPaths = configLocations.map( l => HdfsUtil.addHadoopDefaultSchemaAuthority(new Path(l)))
     logger.info(s"Loading configuration from filesystem locations: ${hadoopPaths.map(_.toUri).mkString(", ")}.")
     val hadoopConf: Configuration = new Configuration() // note that we could not yet load additional hadoop/spark configurations set in the configuration files

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigToolbox.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigToolbox.scala
@@ -20,6 +20,7 @@
 package io.smartdatalake.config
 
 import io.smartdatalake.app.GlobalConfig
+import org.apache.hadoop.conf.Configuration
 
 /**
  * Helper methods to use config outside of SmartDataLakeBuilder, e.g. Notebooks
@@ -34,7 +35,8 @@ object ConfigToolbox {
    */
   def loadAndParseConfig(locations: Seq[String]): (InstanceRegistry, GlobalConfig) = {
     // load config
-    val config = ConfigLoader.loadConfigFromFilesystem(locations)
+    val defaultHadoopConf: Configuration = new Configuration()
+    val config = ConfigLoader.loadConfigFromFilesystem(locations, defaultHadoopConf)
     val globalConfig = GlobalConfig.from(config)
     val registry = ConfigParser.parse(config)
     (registry, globalConfig)

--- a/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
@@ -32,7 +32,7 @@ private[smartdatalake] trait FileTransfer {
    * @param fileRefs files to be transferred
    * @return target files which will be created when file transfer is executed
    */
-  def getFileRefMapping(fileRefs: Seq[FileRef])(implicit session: SparkSession, context: ActionPipelineContext): Seq[FileRefMapping] = {
+  def getFileRefMapping(fileRefs: Seq[FileRef])(implicit context: ActionPipelineContext): Seq[FileRefMapping] = {
     tgtDO.translateFileRefs(fileRefs)
   }
 
@@ -40,7 +40,7 @@ private[smartdatalake] trait FileTransfer {
    * Executes the file transfer
    * @param fileRefPairs: mapping from input to output file references.
    */
-  def exec(fileRefPairs: Seq[FileRefMapping])(implicit session: SparkSession, context: ActionPipelineContext): Unit
+  def exec(fileRefPairs: Seq[FileRefMapping])(implicit context: ActionPipelineContext): Unit
 
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/StreamFileTransfer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/StreamFileTransfer.scala
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success, Try}
 private[smartdatalake] class StreamFileTransfer(override val srcDO: FileRefDataObject with CanCreateInputStream, override val tgtDO: FileRefDataObject with CanCreateOutputStream, overwrite: Boolean = true)
   extends FileTransfer with SmartDataLakeLogger {
 
-  override def exec(fileRefPairs: Seq[FileRefMapping])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def exec(fileRefPairs: Seq[FileRefMapping])(implicit context: ActionPipelineContext): Unit = {
     assert(fileRefPairs != null, "fileRefPairs is null - FileTransfer must be initialized first")
     fileRefPairs.foreach { m =>
       logger.info(s"Copy ${srcDO.id}:${m.src.toStringShort} -> ${tgtDO.id}:${m.tgt.toStringShort}")

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/CompactionUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/CompactionUtil.scala
@@ -24,7 +24,7 @@ import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataobject._
 import org.apache.hadoop.fs.permission.FsPermission
-import org.apache.hadoop.fs.{FileContext, Path}
+import org.apache.hadoop.fs.{FileContext, FileSystem, Path}
 import org.apache.spark.sql.SparkSession
 
 object CompactionUtil extends SmartDataLakeLogger {
@@ -48,7 +48,9 @@ object CompactionUtil extends SmartDataLakeLogger {
    * @param dataObject: DataObject with partition values to compact. The DataObject must be partitioned, able to read & write DataFrames and have a hadoop standard partition layout.
    * @param partitionValues: partition values to compact
    */
-  def compactHadoopStandardPartitions(dataObject: DataObject with CanHandlePartitions with CanCreateDataFrame with CanWriteDataFrame with HasHadoopStandardFilestore, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, actionPipelineContext: ActionPipelineContext): Seq[PartitionValues] = {
+  def compactHadoopStandardPartitions(dataObject: DataObject with CanHandlePartitions with CanCreateDataFrame with CanWriteDataFrame with HasHadoopStandardFilestore, partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
+    implicit val session: SparkSession = context.sparkSession
+    implicit val fs: FileSystem = dataObject.filesystem
     assert(dataObject.partitions.nonEmpty, "compactPartitions needs a partitionend DataObject")
     assert(partitionValues.flatMap(_.keys).forall(dataObject.partitions.contains), "keys of partitionValues must exist as DataObject partitions")
     val partitionLayout = dataObject.partitionLayout().getOrElse(s"(${dataObject.id}) partitionLayout must be defined for compactPartitions")
@@ -65,7 +67,7 @@ object CompactionUtil extends SmartDataLakeLogger {
       if (dataObject.filesystem.getFileStatus(compactingFile).getModificationTime > System.currentTimeMillis - 12*60*60*1000) throw new IllegalStateException(s"(${dataObject.id}) Compaction already running! Compacting file younger than 12h found, please make sure there is no compaction running and clenaup file $compactingFile")
       else logger.warn(s"(${dataObject.id}) $compactingFileName older than 12h found - it seems the last compaction crashed")
     }
-    HdfsUtil.touchFile(compactingFile, dataObject.filesystem)
+    HdfsUtil.touchFile(compactingFile)
 
     // 2. fix crashed compaction if needed
     if (dataObject.filesystem.exists(tempPath)) {
@@ -79,13 +81,13 @@ object CompactionUtil extends SmartDataLakeLogger {
         else {
           // some filesystems (S3?) might be renaming/moving files in the directory one-by-one. This implements an incremental process for recovery in case of existing target files...
           // TODO: what if movingFileName was already moved, but others still missing?
-          HdfsUtil.moveFiles(new Path(tempPartitionPath, "*"), targetPartitionPath, dataObject.filesystem, customFilter = !_.getPath.toString.endsWith(movingFileName))
+          HdfsUtil.moveFiles(new Path(tempPartitionPath, "*"), targetPartitionPath, customFilter = !_.getPath.toString.endsWith(movingFileName))
         }
-        HdfsUtil.touchFile(new Path(targetPartitionPath, compactedFileName), dataObject.filesystem)
+        HdfsUtil.touchFile(new Path(targetPartitionPath, compactedFileName))
         dataObject.filesystem.delete(new Path(targetPartitionPath, movingFileName), /*recursive*/ false)
         logger.info(s"(${dataObject.id}) Recovered partition $partitionDir")
       }
-      HdfsUtil.deletePath(tempPath, dataObject.filesystem, doWarn = true)
+      HdfsUtil.deletePath(tempPath, doWarn = true)
     }
 
     // 3. Filter already compacted partitions
@@ -107,28 +109,25 @@ object CompactionUtil extends SmartDataLakeLogger {
 
     // 5. Move compacted partitions
     partitionValuesToCompact.foreach { pv =>
-      val filesystem = dataObject.filesystem
       val partitionDir = pv.getPartitionString(partitionLayout)
       val tempPartitionPath = new Path(tempPath, partitionDir)
       val targetPartitionPath = new Path(dataObject.hadoopPath, partitionDir)
       val trashPartitionPath = new Path(trashPath, partitionDir)
-      HdfsUtil.touchFile(new Path(targetPartitionPath, movingFileName), filesystem)
-      filesystem.mkdirs(trashPath) // this is needed with Hadoop 2.7.4 on windows
-      filesystem.mkdirs(tempPath) // this is needed with Hadoop 2.7.4 on windows
-      filesystem.rename(targetPartitionPath, trashPartitionPath)
-      filesystem.rename(tempPartitionPath, targetPartitionPath)
-      HdfsUtil.touchFile(new Path(targetPartitionPath, compactedFileName), filesystem)
-      filesystem.delete(new Path(targetPartitionPath, movingFileName), /*recursive*/ false)
-      filesystem.delete(trashPartitionPath, /*recursive*/ true)
+      HdfsUtil.touchFile(new Path(targetPartitionPath, movingFileName))
+      fs.mkdirs(trashPath) // this is needed with Hadoop 2.7.4 on windows
+      fs.mkdirs(tempPath) // this is needed with Hadoop 2.7.4 on windows
+      fs.rename(targetPartitionPath, trashPartitionPath)
+      fs.rename(tempPartitionPath, targetPartitionPath)
+      HdfsUtil.touchFile(new Path(targetPartitionPath, compactedFileName))
+      fs.delete(new Path(targetPartitionPath, movingFileName), /*recursive*/ false)
+      fs.delete(trashPartitionPath, /*recursive*/ true)
     }
-    HdfsUtil.deletePath(tempPath, dataObject.filesystem, doWarn = true)
-    HdfsUtil.deletePath(trashPath, dataObject.filesystem, doWarn = true)
+    HdfsUtil.deletePath(tempPath, doWarn = true)
+    HdfsUtil.deletePath(trashPath, doWarn = true)
 
     // 6. remove compacting file
     dataObject.filesystem.delete(compactingFile, /*recursive*/ false)
     logger.info(s"(${dataObject.id}) finished compaction successfully")
     partitionValuesToCompact
   }
-
-
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/LogUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/LogUtil.scala
@@ -26,14 +26,10 @@ import org.apache.spark.SparkContext
 private[smartdatalake] object LogUtil {
 
   /**
-   * Sets the util log level.
-   *
-   * Uses the system property "loglevel" if it is set.
-   * If not, the default level "INFO" is being used.
-   *
+   * Overrides the Spark log level with system property "loglevel" if it is set.
    * @param sparkContext [[SparkContext]] on which the loglevel should bet set
    */
-  def setLogLevel(sparkContext: SparkContext) = {
+  def setLogLevel(sparkContext: SparkContext): Unit = {
     if (System.getProperty("logLevel") != null) {
       sparkContext.setLogLevel(System.getProperty("logLevel"))
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -99,8 +99,8 @@ case class ActionPipelineContext (
    */
   def sparkSession: SparkSession = {
     if (_sparkSession.isEmpty) {
-      assert(Environment._globalConfig != null, "Cannot create SparkSession because Environment.globalConfig is not initialized. Please create ActionPipelineContext with SparkSession passed as parameter.")
-      _sparkSession = Some(Environment._globalConfig.createSparkSession(appConfig.appName, appConfig.master, appConfig.deployMode))
+      assert(Environment.globalConfig != null, "Cannot create SparkSession because Environment.globalConfig is not initialized. Please create ActionPipelineContext with SparkSession passed as parameter.")
+      _sparkSession = Some(Environment.globalConfig.createSparkSession(appConfig.appName, appConfig.master, appConfig.deployMode))
     }
     _sparkSession.get
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/HadoopFileActionDAGRunStateStore.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/HadoopFileActionDAGRunStateStore.scala
@@ -21,16 +21,17 @@ package io.smartdatalake.workflow
 
 import io.smartdatalake.util.hdfs.HdfsUtil
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path, PathFilter}
 
 import scala.io.Codec
 
-private[smartdatalake] case class HadoopFileActionDAGRunStateStore(statePath: String, appName: String) extends ActionDAGRunStateStore[HadoopFileStateId] with SmartDataLakeLogger {
+private[smartdatalake] case class HadoopFileActionDAGRunStateStore(statePath: String, appName: String, hadoopConf: Configuration) extends ActionDAGRunStateStore[HadoopFileStateId] with SmartDataLakeLogger {
 
   private val hadoopStatePath = HdfsUtil.addHadoopDefaultSchemaAuthority(new Path(statePath))
   private val currentStatePath = new Path(hadoopStatePath, "current")
   private val succeededStatePath = new Path(hadoopStatePath, "succeeded")
-  implicit private val filesystem: FileSystem = HdfsUtil.getHadoopFs(hadoopStatePath)
+  implicit private val filesystem: FileSystem = HdfsUtil.getHadoopFsWithConf(hadoopStatePath)(hadoopConf)
   if (!filesystem.exists(hadoopStatePath)) filesystem.mkdirs(hadoopStatePath)
   filesystem.setWriteChecksum(false) // disable writing CRC files
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -131,7 +131,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    *
    * This runs during the "prepare" phase of the DAG.
    */
-  def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  def prepare(implicit context: ActionPipelineContext): Unit = {
     reset // reset statistics, this is especially needed in unit tests when the same action is started multiple times
     inputs.foreach(_.prepare)
     outputs.foreach(_.prepare)
@@ -155,7 +155,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * Checks before initalization of Action
    * In this step execution condition is evaluated and Action init is skipped if result is false.
    */
-  def preInit(subFeeds: Seq[SubFeed], dataObjectsState: Seq[DataObjectState])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  def preInit(subFeeds: Seq[SubFeed], dataObjectsState: Seq[DataObjectState])(implicit context: ActionPipelineContext): Unit = {
     // initialize dataObjectsState
     val unrelatedStateDataObjectIds = dataObjectsState.map(_.dataObjectId).diff(inputs.map(_.id))
     assert(unrelatedStateDataObjectIds.isEmpty, s"($id) Got state for unrelated DataObjects ${unrelatedStateDataObjectIds.mkString(", ")}")
@@ -174,7 +174,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * Evaluate and check the executionCondition
    * @throws TaskSkippedDontStopWarning if no data to process
    */
-  private def checkExecutionCondition(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  private def checkExecutionCondition(subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
     // evaluate execution condition in init phase or streaming iteration and store result
     if (executionConditionResult.isEmpty) {
       //noinspection MapGetOrElseBoolean
@@ -207,7 +207,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    */
   protected def applyExecutionMode(mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
                                   , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
-                                  (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+                                  (implicit context: ActionPipelineContext): Unit = {
     executionModeResult = Some(Try(
       executionMode.flatMap(_.apply(id, mainInput, mainOutput, subFeed, partitionValuesTransform))
     ).recover {
@@ -231,14 +231,14 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * @param subFeeds [[SparkSubFeed]]'s to be processed
    * @return processed [[SparkSubFeed]]'s
    */
-  def init(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed]
+  def init(subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Seq[SubFeed]
 
   /**
    * Executes operations needed before executing an action.
    * In this step any phase on Input- or Output-DataObjects needed before the main task is executed,
    * e.g. JdbcTableDataObjects preWriteSql
    */
-  def preExec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  def preExec(subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
     if (isAsynchronousProcessStarted) return
     // reset execution condition if not start Action in pipeline, because input for execution results could change between init and exec phase
     val isStartAction = subFeeds.exists(_.isInstanceOf[InitSubFeed])
@@ -261,14 +261,14 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * @param subFeeds [[SparkSubFeed]]'s to be processed
    * @return processed [[SparkSubFeed]]'s
    */
-  def exec(subFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed]
+  def exec(subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Seq[SubFeed]
 
   /**
    * Executes operations needed after executing an action.
    * In this step any task on Input- or Output-DataObjects needed after the main task is executed,
    * e.g. JdbcTableDataObjects postWriteSql or CopyActions deleteInputData.
    */
-  def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
     if (isAsynchronousProcessStarted) return
     // evaluate metrics fail condition if defined
     metricsFailCondition.foreach( c => evaluateMetricsFailCondition(c))
@@ -287,7 +287,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
   /**
    * Executes operations needed to cleanup after executing an action failed.
    */
-  def postExecFailed(implicit session: SparkSession): Unit = Unit
+  def postExecFailed(implicit context: ActionPipelineContext): Unit = Unit
 
   /**
    * Get potential state of input DataObjects when executionMode is DataObjectStateIncrementalMode.
@@ -305,7 +305,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
   /**
    * Evaluates a condition against latest metrics and throws an MetricsCheckFailed if there is a match.
    */
-  private def evaluateMetricsFailCondition(condition: String)(implicit session: SparkSession): Unit = {
+  private def evaluateMetricsFailCondition(condition: String)(implicit context: ActionPipelineContext): Unit = {
     val conditionEvaluator = new ExpressionEvaluator[Metric,Boolean](expr(condition))
     val metrics = {
       getRuntimeMetrics().flatMap{
@@ -331,8 +331,8 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    *
    * @param operation phase description (be short...)
    */
-  def setSparkJobMetadata(operation: Option[String] = None)(implicit session: SparkSession, context: ActionPipelineContext) : Unit = {
-    session.sparkContext.setJobGroup(s"${context.appConfig.appName} $id runId=${context.executionId.runId} attemptId=${context.executionId.attemptId}", operation.getOrElse("").take(255))
+  def setSparkJobMetadata(operation: Option[String] = None)(implicit context: ActionPipelineContext) : Unit = {
+    context.sparkSession.sparkContext.setJobGroup(s"${context.appConfig.appName} $id runId=${context.executionId.runId} attemptId=${context.executionId.attemptId}", operation.getOrElse("").take(255))
   }
 
   /**
@@ -416,7 +416,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * Resets the runtime state of this Action
    * This is mainly used for testing
    */
-  private[smartdatalake] def reset(implicit session: SparkSession): Unit = {
+  private[smartdatalake] def reset(implicit context: ActionPipelineContext): Unit = {
     runtimeData.clear()
     resetExecutionResult()
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -114,7 +114,7 @@ private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
     else None
   }
 
-  def getOptionalDataFrame(sparkInput: CanCreateDataFrame, partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext) : Option[DataFrame] = try {
+  def getOptionalDataFrame(sparkInput: CanCreateDataFrame, partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext) : Option[DataFrame] = try {
     Some(sparkInput.getDataFrame(partitionValues))
   } catch {
     case e: IllegalArgumentException if e.getMessage.contains("DataObject schema is undefined") => None

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -90,19 +90,19 @@ case class CopyAction(override val id: ActionId,
 
   validateConfig()
 
-  private def getTransformers(implicit session: SparkSession, context: ActionPipelineContext): Seq[DfTransformer] = {
+  private def getTransformers(implicit context: ActionPipelineContext): Seq[DfTransformer] = {
     getTransformers(transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, transformers, filterClauseExpr)
   }
 
-  override def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  override def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit context: ActionPipelineContext): SparkSubFeed = {
     applyTransformers(getTransformers, inputSubFeed, outputSubFeed)
   }
 
-  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
+  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
     applyTransformers(getTransformers, partitionValues)
   }
 
-  override def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit context: ActionPipelineContext): Unit = {
     if (deleteDataAfterRead) input match {
       // delete input partitions if applicable
       case (partitionInput: CanHandlePartitions) if partitionInput.partitions.nonEmpty && inputSubFeed.partitionValues.nonEmpty =>

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -27,7 +27,6 @@ import io.smartdatalake.workflow.action.customlogic.CustomFileTransformerConfig
 import io.smartdatalake.workflow.dataobject.HadoopFileDataObject
 import io.smartdatalake.workflow.{ActionPipelineContext, FileSubFeed}
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.SparkSession
 
 /**
  * [[Action]] to transform files between two Hadoop Data Objects.
@@ -69,7 +68,6 @@ case class CustomFileAction(override val id: ActionId,
     outputSubFeed.copy(fileRefMapping = Some(output.translateFileRefs(inputFileRefs)))
   }
 
-
   override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult = {
     val fileRefMapping = subFeed.fileRefMapping.getOrElse(throw new IllegalStateException(s"($id) file mapping is not defined"))
     output.startWritingOutputStreams(subFeed.partitionValues)
@@ -79,16 +77,18 @@ case class CustomFileAction(override val id: ActionId,
 
       // Create a Dataset of files to be processed
       val srcDO = input // avoid serialization of whole action by assigning input to local variable
-      srcDO.filesystem // init filesystem to prepare hadoop conf serialization
+      srcDO.filesystem // init filesystem to prepare serializable hadoop configuration
       val tgtDO = output // avoid serialization of whole action by assigning output to local variable
-      tgtDO.filesystem // init filesystem to prepare hadoop conf serialization
+      tgtDO.filesystem // init filesystem to prepare serializable hadoop configuration
       val transformerVal = transformer // avoid serialization of whole action by assigning transformer to local variable
       val filePathPairs = fileRefMapping.map{ m => (m.src.fullPath, m.tgt.fullPath)}
       val nbOfPartitions = math.max(filePathPairs.size / filesPerPartition, 1)
       val transformedDs = filePathPairs.toDS.repartition(nbOfPartitions)
         .map { case (srcPath, tgtPath) =>
-          val result = TryWithRessource.exec(srcDO.filesystem.open(new Path(srcPath))) { is =>
-            TryWithRessource.exec(tgtDO.filesystem.create(new Path(tgtPath), true)) { os => // overwrite = true
+          val hadoopSrcPath = new Path(srcPath)
+          val hadoopTgtPath = new Path(tgtPath)
+          val result = TryWithRessource.exec(srcDO.getFilesystem(hadoopSrcPath).open(hadoopSrcPath)) { is =>
+            TryWithRessource.exec(tgtDO.getFilesystem(hadoopTgtPath).create(hadoopTgtPath, true)) { os => // overwrite = true
               transformerVal.transform(is, os)
             }
           }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomScriptAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomScriptAction.scala
@@ -52,7 +52,7 @@ case class CustomScriptAction(override val id: ActionId,
 
   validateConfig()
 
-  override protected def execScript(inputSubFeeds: Seq[ScriptSubFeed], outputSubFeeds: Seq[ScriptSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[ScriptSubFeed] = {
+  override protected def execScript(inputSubFeeds: Seq[ScriptSubFeed], outputSubFeeds: Seq[ScriptSubFeed])(implicit context: ActionPipelineContext): Seq[ScriptSubFeed] = {
     val inputParameters = inputSubFeeds.flatMap(_.parameters).reduceLeftOption(_ ++ _).getOrElse(Map())
     val mainPartitionValues = getMainPartitionValues(inputSubFeeds)
     val outputParameters = scripts.foldLeft(inputParameters) {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomSparkAction.scala
@@ -71,12 +71,12 @@ case class CustomSparkAction (override val id: ActionId,
 
   validateConfig()
 
-  override def transform(inputSubFeeds: Seq[SparkSubFeed], outputSubFeeds: Seq[SparkSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
+  override def transform(inputSubFeeds: Seq[SparkSubFeed], outputSubFeeds: Seq[SparkSubFeed])(implicit context: ActionPipelineContext): Seq[SparkSubFeed] = {
     val partitionValues = getMainPartitionValues(inputSubFeeds)
     applyTransformers(transformers ++ transformer.map(_.impl), partitionValues, inputSubFeeds, outputSubFeeds)
   }
 
-  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
+  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
     applyTransformers(transformers ++ transformer.map(_.impl).toSeq, partitionValues)
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileOneToOneActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileOneToOneActionImpl.scala
@@ -70,16 +70,16 @@ abstract class FileOneToOneActionImpl extends ActionSubFeedsImpl[FileSubFeed] {
    * @param outputSubFeed [[SparkSubFeed]] to be enriched with transformed result
    * @return transformed output [[SparkSubFeed]]
    */
-  def transform(inputSubFeed: FileSubFeed, outputSubFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed
+  def transform(inputSubFeed: FileSubFeed, outputSubFeed: FileSubFeed)(implicit context: ActionPipelineContext): FileSubFeed
 
-  override protected def transform(inputSubFeeds: Seq[FileSubFeed], outputSubFeeds: Seq[FileSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[FileSubFeed] = {
+  override protected def transform(inputSubFeeds: Seq[FileSubFeed], outputSubFeeds: Seq[FileSubFeed])(implicit context: ActionPipelineContext): Seq[FileSubFeed] = {
     assert(inputSubFeeds.size == 1, s"($id) Only one inputSubFeed allowed")
     assert(outputSubFeeds.size == 1, s"($id) Only one outputSubFeed allowed")
     val transformedSubFeed = transform(inputSubFeeds.head, outputSubFeeds.head)
     Seq(transformedSubFeed)
   }
 
-  override def preprocessInputSubFeedCustomized(subFeed: FileSubFeed, ignoreFilter: Boolean, isRecursive: Boolean)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
+  override def preprocessInputSubFeedCustomized(subFeed: FileSubFeed, ignoreFilter: Boolean, isRecursive: Boolean)(implicit context: ActionPipelineContext): FileSubFeed = {
     validatePartitionValuesExisting(input, subFeed)
     // get input files
     if (subFeed.fileRefs.isEmpty || breakFileRefLineage) {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -59,13 +59,13 @@ case class FileTransferAction(override val id: ActionId,
   // initialize FileTransfer
   private val fileTransfer = FileTransfer(input, output, overwrite)
 
-  override def transform(inputSubFeed: FileSubFeed, outputSubFeed: FileSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): FileSubFeed = {
+  override def transform(inputSubFeed: FileSubFeed, outputSubFeed: FileSubFeed)(implicit context: ActionPipelineContext): FileSubFeed = {
     assert(inputSubFeed.fileRefs.nonEmpty, "inputSubFeed.fileRefs must be defined for FileTransferAction.doTransform")
     val inputFileRefs = inputSubFeed.fileRefs.get
     outputSubFeed.copy(fileRefMapping = Some(fileTransfer.getFileRefMapping(inputFileRefs)))
   }
 
-  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit session: SparkSession, context: ActionPipelineContext): WriteSubFeedResult = {
+  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult = {
     val fileRefMapping = subFeed.fileRefMapping.getOrElse(throw new IllegalStateException(s"($id) file mapping is not defined"))
     output.startWritingOutputStreams(subFeed.partitionValues)
     if (fileRefMapping.nonEmpty) fileTransfer.exec(fileRefMapping)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
@@ -18,11 +18,10 @@
  */
 package io.smartdatalake.workflow.action
 
-import java.time.LocalDateTime
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.definitions.{Condition, ExecutionMode, HiveConventions, SaveModeMergeOptions, SaveModeOptions, TechnicalTableColumn}
+import io.smartdatalake.definitions._
 import io.smartdatalake.util.evolution.SchemaEvolution
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.historization.{Historization, HistorizationRecordOperations}
@@ -33,6 +32,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, SparkSubFeed}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
+import java.time.LocalDateTime
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -141,7 +141,7 @@ case class HistorizeAction(
 
   validateConfig()
 
-  private def getTransformers(implicit session: SparkSession, context: ActionPipelineContext): Seq[DfTransformer] = {
+  private def getTransformers(implicit context: ActionPipelineContext): Seq[DfTransformer] = {
     val capturedTs = context.referenceTimestamp.getOrElse(LocalDateTime.now)
     val pks = output.table.primaryKey.get // existance is validated earlier
 
@@ -160,15 +160,16 @@ case class HistorizeAction(
     getTransformers(transformer, columnBlacklist, columnWhitelist, additionalColumns, standardizeDatatypes, transformers :+ historizeTransformer)
   }
 
-  override def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  override def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit context: ActionPipelineContext): SparkSubFeed = {
     applyTransformers(getTransformers, inputSubFeed, outputSubFeed)
   }
 
-  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
+  override def transformPartitionValues(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
     applyTransformers(getTransformers, partitionValues)
   }
 
-  protected def fullHistorizeDataFrame(existingDf: Option[DataFrame], pks: Seq[String], refTimestamp: LocalDateTime)(newDf: DataFrame)(implicit session: SparkSession): DataFrame = {
+  protected def fullHistorizeDataFrame(existingDf: Option[DataFrame], pks: Seq[String], refTimestamp: LocalDateTime)(newDf: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
+    implicit val session: SparkSession = context.sparkSession
 
     val newFeedDf = newDf.dropDuplicates(pks)
 
@@ -192,7 +193,8 @@ case class HistorizeAction(
     } else Historization.getFullInitialHistory(newFeedDf, refTimestamp)
   }
 
-  protected def incrementalHistorizeDataFrame(existingDf: Option[DataFrame], pks: Seq[String], refTimestamp: LocalDateTime)(newDf: DataFrame)(implicit session: SparkSession): DataFrame = {
+  protected def incrementalHistorizeDataFrame(existingDf: Option[DataFrame], pks: Seq[String], refTimestamp: LocalDateTime)(newDf: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
+    implicit val session: SparkSession = context.sparkSession
 
     val newFeedDf = newDf.dropDuplicates(pks)
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
@@ -42,16 +42,16 @@ abstract class ScriptActionImpl extends ActionSubFeedsImpl[ScriptSubFeed] {
   /**
    * To be implemented by sub-classes
    */
-  protected def execScript(inputSubFeeds: Seq[ScriptSubFeed], outputSubFeeds: Seq[ScriptSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[ScriptSubFeed]
+  protected def execScript(inputSubFeeds: Seq[ScriptSubFeed], outputSubFeeds: Seq[ScriptSubFeed])(implicit context: ActionPipelineContext): Seq[ScriptSubFeed]
 
-  override protected def transform(inputSubFeeds: Seq[ScriptSubFeed], outputSubFeeds: Seq[ScriptSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[ScriptSubFeed] = {
+  override protected def transform(inputSubFeeds: Seq[ScriptSubFeed], outputSubFeeds: Seq[ScriptSubFeed])(implicit context: ActionPipelineContext): Seq[ScriptSubFeed] = {
     // execute scripts in exec phase
     if (context.phase == ExecutionPhase.Exec) {
       execScript(inputSubFeeds, outputSubFeeds)
     } else outputSubFeeds
   }
 
-  override def writeSubFeed(subFeed: ScriptSubFeed, isRecursive: Boolean)(implicit session: SparkSession, context: ActionPipelineContext): WriteSubFeedResult = {
+  override def writeSubFeed(subFeed: ScriptSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult = {
     val output = outputs.find(_.id == subFeed.dataObjectId).getOrElse(throw new IllegalStateException(s"($id) output for subFeed ${subFeed.dataObjectId} not found"))
     output.scriptNotification(subFeed.parameters.getOrElse(Map()))
     WriteSubFeedResult(noData = None) // unknown if there is data

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkOneToOneActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkOneToOneActionImpl.scala
@@ -47,9 +47,9 @@ abstract class SparkOneToOneActionImpl extends SparkActionImpl {
    * @param outputSubFeed [[SparkSubFeed]] to be enriched with transformed result
    * @return transformed output [[SparkSubFeed]]
    */
-  def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed
+  def transform(inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit context: ActionPipelineContext): SparkSubFeed
 
-  override final def transform(inputSubFeeds: Seq[SparkSubFeed], outputSubFeeds: Seq[SparkSubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SparkSubFeed] = {
+  override final def transform(inputSubFeeds: Seq[SparkSubFeed], outputSubFeeds: Seq[SparkSubFeed])(implicit context: ActionPipelineContext): Seq[SparkSubFeed] = {
     assert(inputSubFeeds.size == 1, s"($id) Only one inputSubFeed allowed")
     assert(outputSubFeeds.size == 1, s"($id) Only one outputSubFeed allowed")
     val transformedSubFeed = transform(inputSubFeeds.head, outputSubFeeds.head)
@@ -66,7 +66,7 @@ abstract class SparkOneToOneActionImpl extends SparkActionImpl {
                       standardizeDatatypes: Boolean,
                       additionalTransformers: Seq[DfTransformer],
                       filterClauseExpr: Option[Column] = None)
-                     (implicit session: SparkSession, context: ActionPipelineContext): Seq[DfTransformer] = {
+                     (implicit context: ActionPipelineContext): Seq[DfTransformer] = {
     Seq(
       transformation.map(t => t.impl),
       columnBlacklist.map(l => BlacklistTransformer(columnBlacklist = l)),
@@ -77,7 +77,7 @@ abstract class SparkOneToOneActionImpl extends SparkActionImpl {
     ).flatten ++ additionalTransformers
   }
 
-  override final def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override final def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
     assert(inputSubFeeds.size == 1, s"($id) Only one inputSubFeed allowed")
     assert(outputSubFeeds.size == 1, s"($id) Only one outputSubFeed allowed")
     if (isAsynchronousProcessStarted) return
@@ -89,12 +89,12 @@ abstract class SparkOneToOneActionImpl extends SparkActionImpl {
    * Executes operations needed after executing an action for the SubFeed.
    * Can be implemented by sub classes.
    */
-  def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
+  def postExecSubFeed(inputSubFeed: SubFeed, outputSubFeed: SubFeed)(implicit context: ActionPipelineContext): Unit = Unit
 
   /**
    * apply transformer to SubFeed
    */
-  protected def applyTransformers(transformers: Seq[DfTransformer], inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit session: SparkSession, context: ActionPipelineContext): SparkSubFeed = {
+  protected def applyTransformers(transformers: Seq[DfTransformer], inputSubFeed: SparkSubFeed, outputSubFeed: SparkSubFeed)(implicit context: ActionPipelineContext): SparkSubFeed = {
     val transformedSubFeed = transformers.foldLeft(inputSubFeed){
       case (subFeed, transformer) => transformer.applyTransformation(id, subFeed)
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/customlogic/CustomFileTransformer.scala
@@ -20,6 +20,7 @@ package io.smartdatalake.workflow.action.customlogic
 
 import io.smartdatalake.util.hdfs.HdfsUtil
 import io.smartdatalake.util.misc.{CustomCodeUtil, SmartDataLakeLogger}
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream}
 import org.slf4j.Logger
 
@@ -55,6 +56,7 @@ case class CustomFileTransformerConfig( className: Option[String] = None, scalaF
   }.orElse{
     scalaFile.map {
       file =>
+        implicit val defaultHadoopConf: Configuration = new Configuration()
         val fnTransform = CustomCodeUtil.compileCode[(Map[String,String], FSDataInputStream, FSDataOutputStream, Logger) => Option[Exception]](HdfsUtil.readHadoopFile(file))
         new CustomFileTransformerWrapper( fnTransform )
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/CmdScript.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/CmdScript.scala
@@ -43,7 +43,7 @@ case class CmdScript(override val name: String = "cmd", override val description
   if (EnvironmentUtil.isWindowsOS) assert(winCmd.isDefined, s"($name) winCmd must be defined when running on Windows")
   if (!EnvironmentUtil.isWindowsOS) assert(linuxCmd.isDefined, s"($name) linuxCmd must be defined when running on Linux")
 
-  override def execStdOut(actionId: ActionId, partitionValues: Seq[PartitionValues], parameters: Map[String,String])(implicit session: SparkSession, context: ActionPipelineContext): String = {
+  override def execStdOut(actionId: ActionId, partitionValues: Seq[PartitionValues], parameters: Map[String,String])(implicit context: ActionPipelineContext): String = {
     import sys.process._
     val cmd = getCmd
     logger.info(s"($actionId) executing command: ${cmd.mkString(" ")}")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/ScriptDef.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/ScriptDef.scala
@@ -40,7 +40,7 @@ trait ScriptDef {
    * @param parameters key-value parameters
    * @return standard output of script
    */
-  def execStdOut(actionId: ActionId, partitionValues: Seq[PartitionValues], parameters: Map[String,String])(implicit session: SparkSession, context: ActionPipelineContext): String
+  def execStdOut(actionId: ActionId, partitionValues: Seq[PartitionValues], parameters: Map[String,String])(implicit context: ActionPipelineContext): String
 }
 
 trait ParsableScriptDef extends ScriptDef with ParsableFromConfig[ParsableScriptDef]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/AdditionalColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/AdditionalColumnsTransformer.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  *                          The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  */
 case class AdditionalColumnsTransformer(override val name: String = "additionalColumns", override val description: Option[String] = None, additionalColumns: Map[String,String]) extends ParsableDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
     val data = DefaultExpressionData.from(context, partitionValues)
     additionalColumns.foldLeft(df){
       case (df, (colName, expr)) =>

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/BlacklistTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/BlacklistTransformer.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * @param columnBlacklist List of columns to exclude from DataFrame
  */
 case class BlacklistTransformer(override val name: String = "blacklist", override val description: Option[String] = None, columnBlacklist: Seq[String]) extends ParsableDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
     ActionHelper.filterBlacklist(columnBlacklist)(df)
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = BlacklistTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DataValidationTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DataValidationTransformer.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 case class DataValidationTransformer(override val name: String = "dataValidation", override val description: Option[String] = None, rules: Seq[ValidationRule], errorsColumn: String = "errors") extends ParsableDfTransformer {
   // check that rules are parsable
   rules.foreach(_.getValidationColumn)
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
     df.withColumn(errorsColumn, flatten(array(rules.map(rule => array(rule.getValidationColumn)): _*))) // nested array and flatten is used to eliminate null entries
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = DataValidationTransformer
@@ -50,7 +50,7 @@ object DataValidationTransformer extends FromConfigFactory[ParsableDfTransformer
 }
 
 sealed trait ValidationRule {
-  def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
+  def prepare(implicit context: ActionPipelineContext): Unit = Unit
   def getValidationColumn: Column
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DfTransformerWrapperDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DfTransformerWrapperDfsTransformer.scala
@@ -35,12 +35,12 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 case class DfTransformerWrapperDfsTransformer(transformer: ParsableDfTransformer, subFeedsToApply: Seq[String]) extends ParsableDfsTransformer {
   override def name: String = transformer.name
   override def description: Option[String] = transformer.description
-  override def transform(actionId: SdlConfigObject.ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String, DataFrame])(implicit session: SparkSession, context: ActionPipelineContext): Map[String, DataFrame] = {
+  override def transform(actionId: SdlConfigObject.ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String, DataFrame])(implicit context: ActionPipelineContext): Map[String, DataFrame] = {
     val missingSubFeeds = subFeedsToApply.toSet.diff(dfs.keySet)
     assert(missingSubFeeds.isEmpty, s"($actionId) [transformation.$name] subFeedsToApply to apply not found in input dfs: ${missingSubFeeds.mkString(", ")}")
     dfs.map { case (subFeedName,df) => if (subFeedsToApply.contains(subFeedName)) (subFeedName, transformer.transform(actionId, partitionValues, df, DataObjectId(subFeedName))) else (subFeedName, df)}.toMap
   }
-  override def transformPartitionValues(actionId: SdlConfigObject.ActionId, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Option[Map[PartitionValues, PartitionValues]] = {
+  override def transformPartitionValues(actionId: SdlConfigObject.ActionId, partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Option[Map[PartitionValues, PartitionValues]] = {
     transformer.transformPartitionValues(actionId, partitionValues)
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/DfsTransformer.scala
@@ -37,7 +37,7 @@ trait DfsTransformer extends PartitionValueTransformer {
   /**
    * Optional function to implement validations in prepare phase.
    */
-  def prepare(actionId: ActionId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
+  def prepare(actionId: ActionId)(implicit context: ActionPipelineContext): Unit = Unit
   /**
    * Function to be implemented to define the transformation between many inputs and many outputs (n:m)
    * @param actionId id of the action which executes this transformation. This is mainly used to prefix error messages.
@@ -45,9 +45,9 @@ trait DfsTransformer extends PartitionValueTransformer {
    * @param dfs Map of (dataObjectId, DataFrame) tuples available as input
    * @return Map of transformed (dataObjectId, DataFrame) tuples
    */
-  def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame])(implicit session: SparkSession, context: ActionPipelineContext): Map[String,DataFrame]
+  def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame])(implicit context: ActionPipelineContext): Map[String,DataFrame]
 
-  private[smartdatalake] def applyTransformation(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame])(implicit session: SparkSession, context: ActionPipelineContext): (Map[String,DataFrame], Seq[PartitionValues]) = {
+  private[smartdatalake] def applyTransformation(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame])(implicit context: ActionPipelineContext): (Map[String,DataFrame], Seq[PartitionValues]) = {
     val transformedDfs = transform(actionId, partitionValues, dfs)
     val transformedPartitionValues = transformPartitionValues(actionId, partitionValues).map(_.values.toSeq.distinct)
       .getOrElse(partitionValues)
@@ -70,7 +70,7 @@ trait OptionsDfsTransformer extends ParsableDfsTransformer {
    * see also [[DfsTransformer.transform()]]
    * @param options Options specified in the configuration for this transformation, including evaluated runtimeOptions
    */
-  def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame], options: Map[String,String])(implicit session: SparkSession): Map[String,DataFrame]
+  def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame], options: Map[String,String])(implicit context: ActionPipelineContext): Map[String,DataFrame]
 
   /**
    * Optional function to define the transformation of input to output partition values.
@@ -79,15 +79,15 @@ trait OptionsDfsTransformer extends ParsableDfsTransformer {
    * see also [[DfsTransformer.transformPartitionValues()]]
    * @param options Options specified in the configuration for this transformation, including evaluated runtimeOptions
    */
-  def transformPartitionValuesWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], options: Map[String,String])(implicit session: SparkSession): Option[Map[PartitionValues,PartitionValues]] = None
+  def transformPartitionValuesWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], options: Map[String,String])(implicit context: ActionPipelineContext): Option[Map[PartitionValues,PartitionValues]] = None
 
-  override def transformPartitionValues(actionId: ActionId, partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Option[Map[PartitionValues,PartitionValues]] = {
+  override def transformPartitionValues(actionId: ActionId, partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Option[Map[PartitionValues,PartitionValues]] = {
     // replace runtime options
     val runtimeOptionsReplaced = prepareRuntimeOptions(actionId, partitionValues)
     // transform
     transformPartitionValuesWithOptions(actionId, partitionValues, options ++ runtimeOptionsReplaced)
   }
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame])(implicit session: SparkSession, context: ActionPipelineContext): Map[String,DataFrame] = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame])(implicit context: ActionPipelineContext): Map[String,DataFrame] = {
     // replace runtime options
     val runtimeOptionsReplaced = prepareRuntimeOptions(actionId, partitionValues)
     // transform

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/FilterTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/FilterTransformer.scala
@@ -41,7 +41,7 @@ case class FilterTransformer(override val name: String = "filter", override val 
     case Success(result) => result
     case Failure(e) => throw new ConfigurationException(s"Error parsing filterClause parameter as Spark expression: ${e.getClass.getSimpleName}: ${e.getMessage}")
   }
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
     df.where(filterClauseExpr)
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = FilterTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/RepartitionTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/RepartitionTransformer.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * @param keyCols  Optional key columns to distribute records over Spark tasks inside a partition value.
  */
 case class RepartitionTransformer(override val name: String = "repartition", override val description: Option[String] = None, numberOfTasksPerPartition: Int, keyCols: Seq[String] = Seq()) extends ParsableDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
     SparkRepartitionDef.repartitionDataFrame(df, partitionValues, dataObjectId, keyCols, numberOfTasksPerPartition)
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = RepartitionTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/ScalaClassDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/ScalaClassDfTransformer.scala
@@ -42,10 +42,10 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  */
 case class ScalaClassDfTransformer(override val name: String = "scalaTransform", override val description: Option[String] = None, className: String, options: Map[String, String] = Map(), runtimeOptions: Map[String, String] = Map()) extends OptionsDfTransformer {
   private val customTransformer = CustomCodeUtil.getClassInstanceByName[CustomDfTransformer](className)
-  override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId, options: Map[String, String])(implicit session: SparkSession): DataFrame = {
-    customTransformer.transform(session, options, df, dataObjectId.id)
+  override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId, options: Map[String, String])(implicit context: ActionPipelineContext): DataFrame = {
+    customTransformer.transform(context.sparkSession, options, df, dataObjectId.id)
   }
-  override def transformPartitionValuesWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], options: Map[String, String])(implicit session: SparkSession): Option[Map[PartitionValues,PartitionValues]] = {
+  override def transformPartitionValuesWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], options: Map[String, String])(implicit context: ActionPipelineContext): Option[Map[PartitionValues,PartitionValues]] = {
    customTransformer.transformPartitionValues(options, partitionValues)
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = ScalaClassDfTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/ScalaClassDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/ScalaClassDfsTransformer.scala
@@ -24,6 +24,7 @@ import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{CustomCodeUtil, DefaultExpressionData}
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.customlogic.{CustomDfTransformer, CustomDfsTransformer}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -41,10 +42,10 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  */
 case class ScalaClassDfsTransformer(override val name: String = "scalaTransform", override val description: Option[String] = None, className: String, options: Map[String, String] = Map(), runtimeOptions: Map[String, String] = Map()) extends OptionsDfsTransformer {
   private val customTransformer = CustomCodeUtil.getClassInstanceByName[CustomDfsTransformer](className)
-  override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame], options: Map[String, String])(implicit session: SparkSession): Map[String,DataFrame] = {
-    customTransformer.transform(session, options, dfs)
+  override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,DataFrame], options: Map[String, String])(implicit context: ActionPipelineContext): Map[String,DataFrame] = {
+    customTransformer.transform(context.sparkSession, options, dfs)
   }
-  override def transformPartitionValuesWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], options: Map[String, String])(implicit session: SparkSession): Option[Map[PartitionValues,PartitionValues]] = {
+  override def transformPartitionValuesWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], options: Map[String, String])(implicit context: ActionPipelineContext): Option[Map[PartitionValues,PartitionValues]] = {
    customTransformer.transformPartitionValues(options, partitionValues)
   }
   override def factory: FromConfigFactory[ParsableDfsTransformer] = ScalaClassDfsTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/ScalaNotebookDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/ScalaNotebookDfTransformer.scala
@@ -53,7 +53,7 @@ import scala.util.{Failure, Success}
 case class ScalaNotebookDfTransformer(override val name: String = "scalaTransform", override val description: Option[String] = None, url: String, functionName: String, authMode: Option[AuthMode] = None, options: Map[String, String] = Map(), runtimeOptions: Map[String, String] = Map()) extends OptionsDfTransformer {
   import ScalaNotebookDfTransformer._
   private var _fnTransform: Option[fnTransformType] = None
-  override def prepare(actionId: ActionId)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def prepare(actionId: ActionId)(implicit context: ActionPipelineContext): Unit = {
     try {
       val notebookCode = prepareFunction(parseNotebook(downloadNotebook(url, authMode)), functionName)
       _fnTransform = Some(compileCode(notebookCode))
@@ -61,9 +61,9 @@ case class ScalaNotebookDfTransformer(override val name: String = "scalaTransfor
       case ex: Exception => throw new ConfigurationException(s"($actionId) " + ex.getMessage, None, ex)
     }
   }
-  override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId, options: Map[String, String])(implicit session: SparkSession): DataFrame = {
+  override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId, options: Map[String, String])(implicit context: ActionPipelineContext): DataFrame = {
     assert(_fnTransform.isDefined, s"($actionId) prepare() must be called before transformWithOptions()")
-    _fnTransform.map(_(session, options, df, dataObjectId.id)).get
+    _fnTransform.map(_(context.sparkSession, options, df, dataObjectId.id)).get
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = ScalaNotebookDfTransformer
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/StandardizeDatatypesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/StandardizeDatatypesTransformer.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * @param description  Optional description of the transformer
  */
 case class StandardizeDatatypesTransformer(override val name: String = "standardizeDatatypes", override val description: Option[String] = None) extends ParsableDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
     df.castAllDecimal2IntegralFloat
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = StandardizeDatatypesTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/WhitelistTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/sparktransformer/WhitelistTransformer.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  */
 
 case class WhitelistTransformer(override val name: String = "whitelist", override val description: Option[String] = None, columnWhitelist: Seq[String]) extends ParsableDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
     ActionHelper.filterWhitelist(columnWhitelist)(df)
   }
   override def factory: FromConfigFactory[ParsableDfTransformer] = WhitelistTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
@@ -61,7 +61,8 @@ case class ActionsExporterDataObject(id: DataObjectId,
    * @param session SparkSession to use
    * @return DataFrame including all Actions in the instanceRegistry, used for exporting the metadata
    */
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+    val session: SparkSession = context.sparkSession
     import session.implicits._
 
     val listElementsSeparator = ","
@@ -69,7 +70,7 @@ case class ActionsExporterDataObject(id: DataObjectId,
     // Get all actions from registry
     val actions: Seq[Action with Product] = config match {
       case Some(configLocation) =>
-        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq)
+        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq, context.hadoopConf)
         ConfigParser.parse(config).getActions.map(_.asInstanceOf[Action with Product])
       case None => instanceRegistry.getActions.map(_.asInstanceOf[Action with Product])
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateDataFrame.scala
@@ -25,14 +25,14 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 
 private[smartdatalake] trait CanCreateDataFrame {
 
-  def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext) : DataFrame
+  def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext) : DataFrame
 
   /**
    * Creates the read schema based on a given write schema.
    * Normally this is the same, but some DataObjects can remove & add columns on read (e.g. KafkaTopicDataObject, SparkFileDataObject)
    * In this cases we have to break the DataFrame lineage und create a dummy DataFrame in init phase.
    */
-  def createReadSchema(writeSchema: StructType)(implicit session: SparkSession): StructType = writeSchema
+  def createReadSchema(writeSchema: StructType)(implicit context: ActionPipelineContext): StructType = writeSchema
 
   protected def addFieldIfNotExisting(writeSchema: StructType, colName: String, dataType: DataType): StructType = {
     if (!writeSchema.fieldNames.contains(colName)) writeSchema.add(colName, dataType)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateIncrementalOutput.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateIncrementalOutput.scala
@@ -32,7 +32,7 @@ private[smartdatalake] trait CanCreateIncrementalOutput {
    * Note that this method is called on initializiation of the SmartDataLakeBuilder job (init Phase) and for streaming execution after every execution of an Action involving this DataObject (postExec).
    * @param state Internal state of last increment. If None then the first increment (may be a full increment) is delivered.
    */
-  def setState(state: Option[String])(implicit session: SparkSession, context: ActionPipelineContext) : Unit
+  def setState(state: Option[String])(implicit context: ActionPipelineContext) : Unit
 
   /**
    * Return the state of the last increment or empty if no increment was processed.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateInputStream.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateInputStream.scala
@@ -18,12 +18,12 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import java.io.InputStream
+import io.smartdatalake.workflow.ActionPipelineContext
 
-import org.apache.spark.sql.SparkSession
+import java.io.InputStream
 
 private[smartdatalake] trait CanCreateInputStream {
 
-  def createInputStream(path: String)(implicit session: SparkSession): InputStream
+  def createInputStream(path: String)(implicit context: ActionPipelineContext): InputStream
 
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateOutputStream.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateOutputStream.scala
@@ -30,17 +30,17 @@ private[smartdatalake] trait CanCreateOutputStream {
    * This is called before any output stream is created to initialize writing.
    * It is used to apply SaveMode, e.g. deleting existing partitions.
    */
-  def startWritingOutputStreams(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): Unit
+  def startWritingOutputStreams(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): Unit
 
   /**
    * Create an OutputStream for a given path, that the Action can use to write data into.
    */
-  def createOutputStream(path: String, overwrite: Boolean)(implicit session: SparkSession, context: ActionPipelineContext): OutputStream
+  def createOutputStream(path: String, overwrite: Boolean)(implicit context: ActionPipelineContext): OutputStream
 
   /**
    * This is called after all output streams have been written.
    * It is used for e.g. making sure empty partitions are created as well.
    */
-  def endWritingOutputStreams(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): Unit
+  def endWritingOutputStreams(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): Unit
 
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateStreamingDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanCreateStreamingDataFrame.scala
@@ -19,11 +19,12 @@
 
 package io.smartdatalake.workflow.dataobject
 
+import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 private[smartdatalake] trait CanCreateStreamingDataFrame {
 
-  def getStreamingDataFrame(options: Map[String,String], schema: Option[StructType])(implicit session: SparkSession) : DataFrame
+  def getStreamingDataFrame(options: Map[String,String], schema: Option[StructType])(implicit context: ActionPipelineContext) : DataFrame
 
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
@@ -100,7 +100,7 @@ trait CanHandlePartitions { this: DataObject =>
       partitionValues.filter( pv => expectedHashCodes.contains(pv.hashCode))
     }.getOrElse(partitionValues)
   }
-  private case class PartitionValueFilterExpressionData(elements: Map[String, String], _hashCode: Int)
+  private[smartdatalake] case class PartitionValueFilterExpressionData(elements: Map[String, String], _hashCode: Int)
 
   /**
    * Validate the schema of a given Spark Data Frame `df` that it contains the specified partition columns

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
@@ -35,7 +35,7 @@ private[smartdatalake] trait CanWriteDataFrame {
    * Called during init phase for checks and initialization.
    * If possible dont change the system until execution phase.
    */
-  def init(df: DataFrame, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions] = None)(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
+  def init(df: DataFrame, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions] = None)(implicit context: ActionPipelineContext): Unit = Unit
 
   /**
    * Write DataFrame to DataObject
@@ -43,14 +43,14 @@ private[smartdatalake] trait CanWriteDataFrame {
    * @param partitionValues partition values included in DataFrames data
    * @param isRecursiveInput if DataFrame needs this DataObject as input - special treatment might be needed in this case.
    */
-  def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)(implicit session: SparkSession, context: ActionPipelineContext): Unit
+  def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)(implicit context: ActionPipelineContext): Unit
 
   /**
    * Write DataFrame to specific Path with properties of this DataObject.
    * This is needed for compacting partitions by housekeeping.
    * Note: this is optional to implement.
    */
-  private[smartdatalake] def writeDataFrameToPath(df: DataFrame, path: Path, finalSaveMode: SDLSaveMode)(implicit session: SparkSession): Unit = throw new RuntimeException("writeDataFrameToPath not implemented")
+  private[smartdatalake] def writeDataFrameToPath(df: DataFrame, path: Path, finalSaveMode: SDLSaveMode)(implicit context: ActionPipelineContext): Unit = throw new RuntimeException("writeDataFrameToPath not implemented")
 
   /**
    * Write Spark structured streaming DataFrame
@@ -62,7 +62,7 @@ private[smartdatalake] trait CanWriteDataFrame {
    * @param checkpointLocation location for checkpoints of streaming query
    */
   def writeStreamingDataFrame(df: DataFrame, trigger: Trigger, options: Map[String,String], checkpointLocation: String, queryName: String, outputMode: OutputMode = OutputMode.Append, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit session: SparkSession, context: ActionPipelineContext): StreamingQuery = {
+                             (implicit context: ActionPipelineContext): StreamingQuery = {
 
     // lambda function is ambiguous with foreachBatch in scala 2.12... we need to create a real function...
     // Note: no partition values supported when writing streaming target

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
@@ -27,6 +27,7 @@ import io.smartdatalake.definitions.{DateColumnType, SDLSaveMode}
 import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.sql.types.{DateType, StringType, StructType}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -110,7 +111,7 @@ case class CsvFileDataObject( override val id: DataObjectId,
   /**
    * Formats date type column values according to the specified `dateColumnType` before writing to CSV file.
    */
-  override def beforeWrite(df: DataFrame)(implicit session: SparkSession): DataFrame = {
+  override def beforeWrite(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
     val dfSuper = super.beforeWrite(df)
     // standardize date column types
     dateColumnType match {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObject.scala
@@ -40,7 +40,8 @@ case class CustomDfDataObject(override val id: DataObjectId,
                              )(@transient implicit val instanceRegistry: InstanceRegistry)
   extends DataObject with CanCreateDataFrame with SchemaValidation {
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+    implicit val session = context.sparkSession
 
     // During the init phase, we want to enable getting the schema without creating the entire DataFrame
     // Because during the exec phase, the DataFrame will be created again anyway, leading to multiple calls to creator.exec

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObject.scala
@@ -36,13 +36,13 @@ case class CustomFileDataObject(override val id: DataObjectId,
                                )(@transient implicit val instanceRegistry: InstanceRegistry)
   extends DataObject with FileRefDataObject with CanCreateInputStream {
 
-  override def createInputStream(path: String)(implicit session: SparkSession): InputStream = {
+  override def createInputStream(path: String)(implicit context: ActionPipelineContext): InputStream = {
     creator.exec
   }
 
   override def partitionLayout(): Option[String] = None
 
-  override def getFileRefs(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Seq[FileRef] = {
+  override def getFileRefs(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Seq[FileRef] = {
     Seq(FileRef("custom", "custom", PartitionValues(Map())))
   }
 
@@ -56,9 +56,9 @@ case class CustomFileDataObject(override val id: DataObjectId,
 
   override def expectedPartitionsCondition: Option[String] = None
 
-  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = Seq()
+  override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = Seq()
 
-  override def relativizePath(filePath: String)(implicit session: SparkSession): String = filePath
+  override def relativizePath(filePath: String)(implicit context: ActionPipelineContext): String = filePath
 
   override def factory: FromConfigFactory[DataObject] = CustomFileDataObject
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
@@ -57,30 +57,30 @@ trait DataObject extends SdlConfigObject with ParsableFromConfig[DataObject] wit
    *
    * This runs during the "prepare" operation of the DAG.
    */
-  private[smartdatalake] def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  private[smartdatalake] def prepare(implicit context: ActionPipelineContext): Unit = {
     housekeepingMode.foreach(_.prepare(this))
   }
 
   /**
    * Runs operations before reading from [[DataObject]]
    */
-  private[smartdatalake] def preRead(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
+  private[smartdatalake] def preRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = Unit
 
   /**
    * Runs operations after reading from [[DataObject]]
    */
-  private[smartdatalake] def postRead(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
+  private[smartdatalake] def postRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = Unit
 
   /**
    * Runs operations before writing to [[DataObject]]
    * Note: As the transformed SubFeed doesnt yet exist in Action.preWrite, no partition values can be passed as parameters as in preRead
    */
-  private[smartdatalake] def preWrite(implicit session: SparkSession, context: ActionPipelineContext): Unit = Unit
+  private[smartdatalake] def preWrite(implicit context: ActionPipelineContext): Unit = Unit
 
   /**
    * Runs operations after writing to [[DataObject]]
    */
-  private[smartdatalake] def postWrite(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  private[smartdatalake] def postWrite(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     housekeepingMode.foreach(_.postWrite(this))
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObjectsExporterDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObjectsExporterDataObject.scala
@@ -60,7 +60,8 @@ case class DataObjectsExporterDataObject(id: DataObjectId,
    * @param session SparkSession to use
    * @return DataFrame including all Dataobjects in the instanceRegistry, used for exporting the metadata
    */
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+    val session: SparkSession = context.sparkSession
     import session.implicits._
 
     val listElementsSeparator = ","
@@ -68,7 +69,7 @@ case class DataObjectsExporterDataObject(id: DataObjectId,
     // Get all DataObjects from registry
     val dataObjects: Seq[DataObject with Product] = config match {
       case Some(configLocation) =>
-        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq)
+        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq, context.hadoopConf)
         ConfigParser.parse(config).getDataObjects.map(_.asInstanceOf[DataObject with Product])
       case None => instanceRegistry.getDataObjects.map(_.asInstanceOf[DataObject with Product])
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
@@ -25,6 +25,7 @@ import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.{AclDef, DataFrameUtil}
+import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -90,7 +91,7 @@ case class ExcelFileDataObject(override val id: DataObjectId,
   /**
    * @inheritdoc
    */
-  override def afterRead(df: DataFrame)(implicit session: SparkSession): DataFrame = {
+  override def afterRead(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
     val dfSuper = super.afterRead(df)
 
     // cleanup header names
@@ -101,7 +102,7 @@ case class ExcelFileDataObject(override val id: DataObjectId,
   /**
    * Checks preconditions before writing.
    */
-  override def beforeWrite(df: DataFrame)(implicit session: SparkSession): DataFrame = {
+  override def beforeWrite(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
     val dfSuper = super.beforeWrite(df)
 
     // check for unsupported write options

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
@@ -34,7 +34,7 @@ private[smartdatalake] trait FileDataObject extends DataObject with CanHandlePar
     */
   protected val separator = Path.SEPARATOR_CHAR // default is to use hadoop separator. DataObjects can override this if not suitable.
 
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def prepare(implicit context: ActionPipelineContext): Unit = {
     super.prepare
     filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
   }
@@ -42,5 +42,5 @@ private[smartdatalake] trait FileDataObject extends DataObject with CanHandlePar
   /**
    * Make a given path relative to this DataObjects base path
    */
-  def relativizePath(filePath: String)(implicit session: SparkSession): String
+  def relativizePath(filePath: String)(implicit context: ActionPipelineContext): String
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -55,7 +55,7 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
    * This is for instance needed if pathPrefix is defined in a connection.
    * @return
    */
-  def getPath(implicit session: SparkSession): String = path
+  def getPath(implicit context: ActionPipelineContext): String = path
 
   /**
    * List files for given partition values
@@ -63,12 +63,12 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
    * @param partitionValues List of partition values to be filtered. If empty all files in root path of DataObject will be listed.
    * @return List of [[FileRef]]s
    */
-  def getFileRefs(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Seq[FileRef]
+  def getFileRefs(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Seq[FileRef]
 
   /**
    * Given some [[FileRef]] for another [[DataObject]], translate the paths to the root path of this [[DataObject]]
    */
-  def translateFileRefs(fileRefs: Seq[FileRef])(implicit session: SparkSession, context: ActionPipelineContext): Seq[FileRefMapping] = {
+  def translateFileRefs(fileRefs: Seq[FileRef])(implicit context: ActionPipelineContext): Seq[FileRefMapping] = {
     assert(!partitionLayout().exists(_.contains("*")), s"Cannot translate FileRef if partition layout contains * (${partitionLayout()})")
     fileRefs.map {
       f =>
@@ -86,7 +86,7 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
   /**
    * get partition values formatted by partition layout
    */
-  def getPartitionString(partitionValues: PartitionValues)(implicit session: SparkSession): Option[String] = {
+  def getPartitionString(partitionValues: PartitionValues)(implicit context: ActionPipelineContext): Option[String] = {
     if (partitionLayout().isDefined) Some(partitionValues.getPartitionString(partitionLayout().get))
     else if (partitions.isEmpty) None
     else throw new RuntimeException("Partition layout needed when working with PartitionValues")
@@ -95,7 +95,7 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
   /**
    * prepare paths to be searched
    */
-  protected def getSearchPaths(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Seq[(PartitionValues, String)] = {
+  protected def getSearchPaths(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Seq[(PartitionValues, String)] = {
     val partitionValuesWithDefault = if (partitionValues.isEmpty) Seq(PartitionValues(Map())) else partitionValues
     val partitionValuesPaths = partitionValuesWithDefault.map(v => (v, getPartitionString(v)))
     partitionValuesPaths.map {
@@ -108,19 +108,19 @@ private[smartdatalake] trait FileRefDataObject extends FileDataObject {
   /**
    * Extract partition values from a given file path
    */
-  protected def extractPartitionValuesFromPath(filePath: String)(implicit session: SparkSession): PartitionValues = {
+  protected def extractPartitionValuesFromPath(filePath: String)(implicit context: ActionPipelineContext): PartitionValues = {
     PartitionLayout.extractPartitionValues(partitionLayout().get, fileName, relativizePath(filePath))
   }
 
   /**
    * Delete given files. This is used to cleanup files after they are processed.
    */
-  def deleteFileRefs(fileRefs: Seq[FileRef])(implicit session: SparkSession): Unit = throw new RuntimeException(s"($id) deleteFileRefs not implemented")
+  def deleteFileRefs(fileRefs: Seq[FileRef])(implicit context: ActionPipelineContext): Unit = throw new RuntimeException(s"($id) deleteFileRefs not implemented")
 
   /**
    * Delete all data. This is used to implement SaveMode.Overwrite.
    */
-  def deleteAll(implicit session: SparkSession): Unit = throw new RuntimeException(s"($id) deleteAll not implemented")
+  def deleteAll(implicit context: ActionPipelineContext): Unit = throw new RuntimeException(s"($id) deleteAll not implemented")
 
   /**
    * Overwrite or Append new data.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -77,21 +77,22 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
 
   // these variables are not serializable
   @transient private var hadoopPathHolder: Path = _
-  def hadoopPath(implicit session: SparkSession): Path = {
+  def hadoopPath(implicit context: ActionPipelineContext): Path = {
     if (hadoopPathHolder == null) { // avoid null-pointer on executors...
       hadoopPathHolder = HdfsUtil.prefixHadoopPath(path, connection.map(_.pathPrefix))
     }
     hadoopPathHolder
   }
 
-  override def getPath(implicit session: SparkSession): String = hadoopPath.toUri.toString
+  override def getPath(implicit context: ActionPipelineContext): String = hadoopPath.toUri.toString
 
   /**
    * Check if the input files exist.
    *
    * @throws IllegalArgumentException if `failIfFilesMissing` = true and no files found at `path`.
    */
-  protected def checkFilesExisting(implicit session: SparkSession): Boolean = {
+  protected def checkFilesExisting(implicit context: ActionPipelineContext): Boolean = {
+
     val files = if (filesystem.exists(hadoopPath)) {
       arrayToSeq(filesystem.listStatus(hadoopPath))
     } else {
@@ -106,7 +107,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     files.nonEmpty
   }
 
-  override def deleteFileRefs(fileRefs: Seq[FileRef])(implicit session: SparkSession): Unit = {
+  override def deleteFileRefs(fileRefs: Seq[FileRef])(implicit context: ActionPipelineContext): Unit = {
     // delete given files on hdfs
     fileRefs.foreach { file =>
       filesystem.delete(new Path(file.fullPath), false) // recursive=false
@@ -118,7 +119,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
    *
    * if there is no value for a partition column before the last partition column given, the partition path will be exploded
    */
-  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     assert(partitions.nonEmpty, s"deletePartitions called but no partition columns are defined for $id")
 
     // delete given partitions on hdfs
@@ -131,7 +132,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
    *
    * if there is no value for a partition column before the last partition column given, the partition path will be exploded
    */
-  def deletePartitionsFiles(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+  def deletePartitionsFiles(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     assert(partitions.nonEmpty, s"deletePartitions called but no partition columns are defined for $id")
 
     // delete files for given partitions on hdfs
@@ -144,7 +145,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
    * Use case: Reading all files from a given path with spark cannot contain wildcards.
    * If there are partitions without given partition value before the last partition value given, they must be searched with globs.
    */
-  def getConcretePaths(pv: PartitionValues)(implicit session: SparkSession): Seq[Path] = {
+  def getConcretePaths(pv: PartitionValues)(implicit context: ActionPipelineContext): Seq[Path] = {
     assert(partitions.nonEmpty)
     // check if valid init of partitions -> then we can read all at once, otherwise we need to search with globs as load doesnt support wildcards
     if (partitions.inits.map(_.toSet).contains(pv.keys)) {
@@ -165,7 +166,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   /**
    * List partitions on data object's root path
    */
-  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
+  override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
     partitionLayout().map {
       partitionLayout =>
         // get search pattern for root directory
@@ -178,13 +179,13 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     }.getOrElse(Seq())
   }
 
-  override def relativizePath(path: String)(implicit session: SparkSession): String = {
+  override def relativizePath(path: String)(implicit context: ActionPipelineContext): String = {
     val normalizedPath = new Path(path).toString
     val pathPrefix = (".*"+hadoopPath.toString).r // ignore any absolute path prefix up and including hadoop path
     pathPrefix.replaceFirstIn(normalizedPath, "").stripPrefix(Path.SEPARATOR)
   }
 
-  override def createEmptyPartition(partitionValues: PartitionValues)(implicit session: SparkSession): Unit = {
+  override def createEmptyPartition(partitionValues: PartitionValues)(implicit context: ActionPipelineContext): Unit = {
     // check if valid init of partitions -> otherwise we can not create empty partition as path is not fully defined
     if (partitions.inits.map(_.toSet).contains(partitionValues.keys)) {
       val partitionLayout = HdfsUtil.getHadoopPartitionLayout(partitions.filter(partitionValues.isDefinedAt))
@@ -195,14 +196,14 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     }
   }
 
-  override def movePartitions(partitionValuesMapping: Seq[(PartitionValues, PartitionValues)])(implicit session: SparkSession): Unit = {
+  override def movePartitions(partitionValuesMapping: Seq[(PartitionValues, PartitionValues)])(implicit context: ActionPipelineContext): Unit = {
     partitionValuesMapping.foreach {
-      case (pvExisting, pvNew) => HdfsUtil.movePartition(hadoopPath, pvExisting, pvNew, fileName, filesystem)
+      case (pvExisting, pvNew) => HdfsUtil.movePartition(hadoopPath, pvExisting, pvNew, fileName)(filesystem)
     }
     logger.info(s"($id) Archived partitions ${partitionValuesMapping.map(m => s"${m._1}->${m._2}").mkString(", ")}")
   }
 
-  override def getFileRefs(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Seq[FileRef] = {
+  override def getFileRefs(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Seq[FileRef] = {
     val paths: Seq[(PartitionValues, String)] = getSearchPaths(partitionValues)
     // search paths and prepare FileRef's
     paths.flatMap { case (v, p) =>
@@ -217,12 +218,12 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     }
   }
 
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def prepare(implicit context: ActionPipelineContext): Unit = {
     super.prepare
     hadoopPath // initialize hadoopPath
   }
 
-  override def preWrite(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def preWrite(implicit context: ActionPipelineContext): Unit = {
     super.preWrite
     // validate if acl's must be / are configured before writing
     if (Environment.hadoopAuthoritiesWithAclsRequired.exists(a => filesystem.getUri.toString.contains(a))) {
@@ -230,19 +231,19 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     }
   }
 
-  override def postWrite(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def postWrite(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     super.postWrite(partitionValues)
     applyAcls
   }
 
-  override def createInputStream(path: String)(implicit session: SparkSession): InputStream = {
+  override def createInputStream(path: String)(implicit context: ActionPipelineContext): InputStream = {
     Try(filesystem.open(new Path(path))) match {
       case Success(r) => r
       case Failure(e) => throw new RuntimeException(s"Can't create InputStream for $id and $path: ${e.getClass.getSimpleName} - ${e.getMessage}", e)
     }
   }
 
-  override def startWritingOutputStreams(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def startWritingOutputStreams(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): Unit = {
     if (saveMode == SDLSaveMode.Overwrite) {
       if (partitions.nonEmpty)
         if (partitionValues.nonEmpty) deletePartitions(partitionValues)
@@ -251,19 +252,19 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     }
   }
 
-  override def createOutputStream(path: String, overwrite: Boolean)(implicit session: SparkSession, context: ActionPipelineContext): OutputStream = {
+  override def createOutputStream(path: String, overwrite: Boolean)(implicit context: ActionPipelineContext): OutputStream = {
     Try(filesystem.create(new Path(path), overwrite)) match {
       case Success(r) => r
       case Failure(e) => throw new RuntimeException(s"Can't create OutputStream for $id and $path: : ${e.getClass.getSimpleName} - ${e.getMessage}", e)
     }
   }
 
-  override def endWritingOutputStreams(partitionValues: Seq[PartitionValues])(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def endWritingOutputStreams(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     // make sure empty partitions are created as well
     if (partitionValues.nonEmpty) createMissingPartitions(partitionValues)
   }
 
-  override def deleteAll(implicit session: SparkSession): Unit = {
+  override def deleteAll(implicit context: ActionPipelineContext): Unit = {
     logger.info(s"($id) deleteAll $hadoopPath")
     filesystem.delete(hadoopPath, true) // recursive=true
   }
@@ -271,7 +272,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   /**
    * delete all files inside given path recursively
    */
-  def deleteAllFiles(path: Path)(implicit session: SparkSession): Unit = {
+  def deleteAllFiles(path: Path)(implicit context: ActionPipelineContext): Unit = {
     val dirEntries = filesystem.globStatus(new Path(path, "*")).map(_.getPath)
     dirEntries.foreach { p =>
       if (filesystem.isDirectory(p)) deleteAllFiles(p)
@@ -279,7 +280,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     }
   }
 
-  protected[workflow] def applyAcls(implicit session: SparkSession): Unit = {
+  protected[workflow] def applyAcls(implicit context: ActionPipelineContext): Unit = {
     val aclToApply = acl().orElse(connection.flatMap(_.acl))
     if (aclToApply.isDefined) AclUtil.addACLs(aclToApply.get, hadoopPath)(filesystem)
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HasHadoopStandardFilestore.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HasHadoopStandardFilestore.scala
@@ -48,7 +48,14 @@ trait HasHadoopStandardFilestore extends CanHandlePartitions { this: DataObject 
    */
   private[smartdatalake] def getFilesystem(path: Path): FileSystem = {
     assert(serializableHadoopConfHolder != null, "serializableHadoopConfHolder must be initialized before using getFilesystem")
-    HdfsUtil.getHadoopFsWithConf(path)(serializableHadoopConfHolder.get) // this must use serializable HadoopConfiguration to be distributed.
+    getFilesystem(path, serializableHadoopConfHolder)
+  }
+
+  /**
+   * Creates a hadoop [[FileSystem]] for [[Path]] with a given serializable hadoop configuration.
+   */
+  private[smartdatalake] def getFilesystem(path: Path, hadoopConf: SerializableHadoopConfiguration): FileSystem = {
+    HdfsUtil.getHadoopFsWithConf(path)(hadoopConf.get) // this must use serializable HadoopConfiguration to be distributed.
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -80,12 +81,12 @@ case class JsonFileDataObject( override val id: DataObjectId,
   private val formatOptionsDefault = Map("multiLine" -> "true")
   override val options: Map[String, String] = formatOptionsDefault ++ jsonOptions.getOrElse(Map())
 
-  override def afterRead(df: DataFrame)(implicit session: SparkSession): DataFrame  = {
+  override def afterRead(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame  = {
     val dfSuper = super.afterRead(df)
     if (stringify) dfSuper.castAll2String else dfSuper
   }
 
-  override def beforeWrite(df: DataFrame)(implicit session: SparkSession): DataFrame  = {
+  override def beforeWrite(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame  = {
     val dfSuper = super.beforeWrite(df)
     if (stringify) dfSuper.castAll2String else dfSuper
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
@@ -60,13 +60,13 @@ case class PKViolatorsDataObject(id: DataObjectId,
                                 (@transient implicit val instanceRegistry: InstanceRegistry)
   extends DataObject with CanCreateDataFrame with ParsableFromConfig[PKViolatorsDataObject] {
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
 
     import PKViolatorsDataObject.{colListType, columnNameName, columnValueName}
     // Get all DataObjects from registry
     val dataObjects: Seq[DataObject with Product] = config match {
       case Some(configLocation) =>
-        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq)
+        val config = ConfigLoader.loadConfigFromFilesystem(configLocation.split(',').toSeq, context.hadoopConf)
         ConfigParser.parse(config).getDataObjects.map(_.asInstanceOf[DataObject with Product])
       case None => instanceRegistry.getDataObjects.map(_.asInstanceOf[DataObject with Product])
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
+import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
@@ -92,7 +93,7 @@ case class ParquetFileDataObject( override val id: DataObjectId,
   // when writing parquet files, schema column names are forced to lower,
   // because they can also be accessed by Hive which is case insensitive.
   // See: https://medium.com/@an_chee/why-using-mixed-case-field-names-in-hive-spark-sql-is-a-bad-idea-95da8b6ec1e0
-  override def beforeWrite(df: DataFrame)(implicit session: SparkSession): DataFrame =
+  override def beforeWrite(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame =
     super.beforeWrite(df).colNamesLowercase
 
   override def factory: FromConfigFactory[DataObject] = ParquetFileDataObject

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
@@ -30,27 +30,27 @@ private[smartdatalake] trait TableDataObject extends DataObject with CanCreateDa
 
   var tableSchema: StructType = null
 
-  def isDbExisting(implicit session: SparkSession): Boolean
+  def isDbExisting(implicit context: ActionPipelineContext): Boolean
 
-  def isTableExisting(implicit session: SparkSession): Boolean
+  def isTableExisting(implicit context: ActionPipelineContext): Boolean
 
-  def dropTable(implicit session: SparkSession): Unit
+  def dropTable(implicit context: ActionPipelineContext): Unit
 
-  def getPKduplicates(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = if (table.primaryKey.isEmpty) {
+  def getPKduplicates(implicit context: ActionPipelineContext): DataFrame = if (table.primaryKey.isEmpty) {
     getDataFrame().where(lit(false))
   } else {
     getDataFrame().getNonuniqueRows(table.primaryKey.get.toArray)
   }
 
-  def getPKnulls(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  def getPKnulls(implicit context: ActionPipelineContext): DataFrame = {
     getDataFrame().getNulls(table.primaryKey.get.toArray)
   }
 
-  def getPKviolators(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  def getPKviolators(implicit context: ActionPipelineContext): DataFrame = {
     getPKduplicates.union(getPKnulls)
   }
 
-  def isPKcandidateKey(implicit session: SparkSession, context: ActionPipelineContext): Boolean =  {
+  def isPKcandidateKey(implicit context: ActionPipelineContext): Boolean =  {
     table.primaryKey.isEmpty || getDataFrame().isCandidateKey(table.primaryKey.get.toArray)
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
@@ -96,7 +96,8 @@ case class XmlFileDataObject(override val id: DataObjectId,
    *   .load("partitionedDataObjectPath")
    *   .show
    */
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+    implicit val session: SparkSession = context.sparkSession
     import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
 
     val wrongPartitionValues = PartitionValues.checkWrongPartitionValues(partitionValues, partitions)
@@ -148,7 +149,7 @@ case class XmlFileDataObject(override val id: DataObjectId,
     afterRead(df)
   }
 
-  override def afterRead(df: DataFrame)(implicit session: SparkSession): DataFrame  = {
+  override def afterRead(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame  = {
     val dfSuper = super.afterRead(df)
     if (flatten) {
       val parser = new DefaultFlatteningParser()
@@ -156,7 +157,7 @@ case class XmlFileDataObject(override val id: DataObjectId,
     } else dfSuper
   }
 
-  override def writeDataFrameToPath(df: DataFrame, path: Path, finalSaveMode: SDLSaveMode)(implicit session: SparkSession): Unit = {
+  override def writeDataFrameToPath(df: DataFrame, path: Path, finalSaveMode: SDLSaveMode)(implicit context: ActionPipelineContext): Unit = {
     assert(partitions.isEmpty, "writing XML-Files with partitions is not supported by spark-xml")
     super.writeDataFrameToPath(df, path, finalSaveMode)
   }

--- a/sdl-core/src/main/scala/org/apache/spark/custom/PrivateAccessor.scala
+++ b/sdl-core/src/main/scala/org/apache/spark/custom/PrivateAccessor.scala
@@ -1,7 +1,7 @@
 /*
  * Smart Data Lake - Build your data lake the smart way.
  *
- * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ * Copyright © 2019-2021 ELCA Informatique SA (<https://www.elca.ch>)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,14 +16,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package io.smartdatalake.workflow.dataobject
 
-import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.workflow.ActionPipelineContext
-import org.apache.spark.sql.SparkSession
+package org.apache.spark.custom
 
-private[smartdatalake] trait CanReceiveScriptNotification {
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkConf
+import org.apache.spark.deploy.SparkHadoopUtil
 
-  def scriptNotification(parameters: Map[String,String], partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): Unit
-
+object PrivateAccessor {
+  def getHadoopConfiguration(properties: Map[String,String]): Configuration = {
+    val sparkConf = new SparkConf().setAll(properties)
+    SparkHadoopUtil.get.newConfiguration(sparkConf)
+  }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
@@ -30,7 +30,7 @@ import io.smartdatalake.workflow.action.sparktransformer.{SQLDfTransformer, Scal
 import io.smartdatalake.workflow.action._
 import io.smartdatalake.workflow.dataobject.{CsvFileDataObject, HiveTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionDAGRunState, ActionPipelineContext, HadoopFileActionDAGRunStateStore}
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.streaming.{StreamingQueryException, StreamingQueryListener}
 import org.apache.spark.sql.types.StructType
@@ -48,7 +48,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
   val statePath = "target/streamingStateTest/"
   val checkpointPath = "target/streamingCheckpointTest/"
-  val filesystem = HdfsUtil.getHadoopFs(new Path(statePath))
+  implicit val filesystem: FileSystem = HdfsUtil.getHadoopFsWithDefaultConf(new Path(statePath))
 
   after {
     // ensure cleanup
@@ -63,7 +63,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-normal"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
+    HdfsUtil.deleteFiles(new Path(statePath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
     implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
@@ -128,7 +128,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
     // check state after streaming is terminated
     {
-      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName)
+      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName, session.sparkContext.hadoopConfiguration)
       val stateId = stateStore.getLatestStateId().get
       val runState = stateStore.recoverRunState(stateId)
       assert(runState.runId >= 3)
@@ -146,9 +146,9 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-streaming"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(tempPath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(checkpointPath), filesystem, false)
+    HdfsUtil.deleteFiles(new Path(tempPath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(checkpointPath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
     implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
@@ -225,7 +225,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
     // check state after streaming is terminated
     {
-      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName)
+      val stateStore = HadoopFileActionDAGRunStateStore(statePath, appName, session.sparkContext.hadoopConfiguration)
       val stateId = stateStore.getLatestStateId().get
       val runState = stateStore.recoverRunState(stateId)
       // only one SDL run executed (streaming action is asynchronous)
@@ -244,9 +244,9 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-streaming2"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(tempPath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(checkpointPath), filesystem, false)
+    HdfsUtil.deleteFiles(new Path(tempPath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(checkpointPath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
     implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
@@ -323,9 +323,9 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-streaming3"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(tempPath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(checkpointPath), filesystem, false)
+    HdfsUtil.deleteFiles(new Path(tempPath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(checkpointPath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
     implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
@@ -414,9 +414,9 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-streaming4"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(tempPath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(checkpointPath), filesystem, false)
+    HdfsUtil.deleteFiles(new Path(tempPath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(checkpointPath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
     implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
@@ -484,9 +484,9 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-streaming5"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(tempPath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(checkpointPath), filesystem, false)
+    HdfsUtil.deleteFiles(new Path(tempPath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(checkpointPath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
     implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
@@ -569,9 +569,9 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-streaming6"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(tempPath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(statePath), filesystem, false)
-    HdfsUtil.deleteFiles(new Path(checkpointPath), filesystem, false)
+    HdfsUtil.deleteFiles(new Path(tempPath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(checkpointPath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
     implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -441,7 +441,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       assert(resultActionsState == expectedActionsState)
       assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt"->"20190101"))))
       if (!EnvironmentUtil.isWindowsOS) assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty) // doesnt work on windows
-      val stateListener = Environment._globalConfig.stateListeners.head.listener.asInstanceOf[TestStateListener]
+      val stateListener = Environment.globalConfig.stateListeners.head.listener.asInstanceOf[TestStateListener]
       assert(stateListener.firstState.isDefined && !stateListener.firstState.get.isFinal)
       assert(stateListener.finalState.isDefined && stateListener.finalState.get.isFinal)
     }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -19,77 +19,80 @@
 package io.smartdatalake.config
 
 import com.typesafe.config.ConfigException
+import org.apache.hadoop.conf.Configuration
 import org.scalatest.{FlatSpec, Matchers}
 
 
 class ConfigLoaderTest extends FlatSpec with Matchers {
 
+  val defaultHadoopConf: Configuration = new Configuration()
+
   "ConfigLoader" must "parse a single configuration file" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString), defaultHadoopConf)
     config.getString("config") shouldBe "config"
   }
 
   it must "parse all configuration files in a directory and its sub-directories without trailing slash" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString), defaultHadoopConf)
     config.getString("config") shouldBe "config"
     config.getString("config2") shouldBe "config2"
     config.getString("foo") shouldBe "foo"
   }
 
   it must "parse all configuration files in a directory and its sub-directories with trailing slash" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString), defaultHadoopConf)
     config.getString("config") shouldBe "config"
     config.getString("config2") shouldBe "config2"
     config.getString("foo") shouldBe "foo"
   }
 
   it must "overwrite values in configurations in BFS order and by extension precedence" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString), defaultHadoopConf)
     config.getString("overwrite") shouldBe "overwritten by config2"
     config.getString("donotoverwrite") shouldBe "original"
     config.getString("overwrite2") shouldBe "overwritten by bar"
   }
 
   it must "parse a special classpath entry" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq("cp:/config/config.conf"))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq("cp:/config/config.conf"), defaultHadoopConf)
     config.getString("config") shouldBe "config"
   }
 
   it must "fail parsing a non-existing location" in {
-    an [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("foo/bar"))
+    an [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("foo/bar"), defaultHadoopConf)
   }
 
   it must "fail parsing a non-existing classpath entry" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar.conf"))
+    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar.conf"), defaultHadoopConf)
   }
 
   it must "fail parsing a classpath entry with wrong extension" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar"))
+    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar"), defaultHadoopConf)
   }
 
   it must "not parse a file that is not a config file" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString), defaultHadoopConf)
     a [ConfigException] should be thrownBy config.getString("noconfig")
   }
 
   it must "ignore hidden files" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toString), defaultHadoopConf)
     config.hasPath("hidden") shouldBe false
   }
 
   it must "only parse config files in directories" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString), defaultHadoopConf)
     config.getString("foo") shouldBe "foo"
     config.getString("config2") shouldBe "config2"
     a [ConfigException] should be thrownBy config.getString("noconfig")
   }
 
   it should "fail on duplicate configuration object IDs" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/configWithDuplicates").toString))
+    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/configWithDuplicates").toString), defaultHadoopConf)
   }
 
   it must "should load configurations with templates" in {
-    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/configWithTemplates").toString))
+    val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/configWithTemplates").toString), defaultHadoopConf)
     config.getString("dataObjects.testDataObjectFromConfig.type") shouldBe "io.smartdatalake.config.TestDataObject"
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestAction.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestAction.scala
@@ -46,8 +46,8 @@ case class TestAction(override val id: ActionId,
                      )(implicit instanceRegistry: InstanceRegistry)
   extends Action {
 
-  override def init(subFeed: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = { /*NOP*/ Seq() }
-  override def exec(subFeed: Seq[SubFeed])(implicit session: SparkSession, context: ActionPipelineContext): Seq[SubFeed] = { /*NOP*/ Seq() }
+  override def init(subFeed: Seq[SubFeed])(implicit context: ActionPipelineContext): Seq[SubFeed] = { /*NOP*/ Seq() }
+  override def exec(subFeed: Seq[SubFeed])(implicit context: ActionPipelineContext): Seq[SubFeed] = { /*NOP*/ Seq() }
 
   private[config] val input = instanceRegistry.get[DataObject with CanCreateDataFrame](inputId)
   private[config] val output = instanceRegistry.get[TransactionalSparkTableDataObject](outputId)

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
@@ -46,20 +46,20 @@ case class TestDataObject( id: DataObjectId,
 
   private val connection = connectionId.map( c => getConnection[TestConnection](c))
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = null
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = null
 
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit session: SparkSession, context: ActionPipelineContext): Unit = {}
+                             (implicit context: ActionPipelineContext): Unit = {}
 
   override var table: Table = Table(db=Some("testdb"), name="testtable")
 
-  override def isDbExisting(implicit session: SparkSession): Boolean = true
+  override def isDbExisting(implicit context: ActionPipelineContext): Boolean = true
 
-  override def isTableExisting(implicit session: SparkSession): Boolean = true
+  override def isTableExisting(implicit context: ActionPipelineContext): Boolean = true
 
-  override def dropTable(implicit session: SparkSession): Unit = throw new NotImplementedError()
+  override def dropTable(implicit context: ActionPipelineContext): Unit = throw new NotImplementedError()
 
-  override def scriptNotification(parameters: Map[String, String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = Unit
+  override def scriptNotification(parameters: Map[String, String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = Unit
 
   override def factory: FromConfigFactory[DataObject] = TestDataObject
 

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/DataObjectTestSuite.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/DataObjectTestSuite.scala
@@ -31,7 +31,6 @@ trait DataObjectTestSuite extends FunSuite with Matchers with BeforeAndAfter {
 
   protected implicit lazy val session: SparkSession = TestUtil.sessionHiveCatalog
 
-
   protected val escapedFilePath: String => String = (path: String) => path.replaceAll("\\\\", "\\\\\\\\")
   protected val convertFilePath: String => String = (path: String) => path.replaceAll("\\\\", "/")
 

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/custom/TestCustomDfCreator.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/custom/TestCustomDfCreator.scala
@@ -31,10 +31,7 @@ class TestCustomDfCreator extends CustomDfCreator {
    */
   override def exec(session: SparkSession, config: Map[String, String]): DataFrame = {
       import session.implicits._
-      val rows: Seq[(Some[Int], String)] = Seq((Some(0),"Foo!"),(Some(1),"Bar!"))
-      val myDf: DataFrame = rows.toDF("num","text")
-      myDf.show(false)
-      myDf
+      Seq((Some(0),"Foo!"),(Some(1),"Bar!")).toDF("num","text")
   }
 
   override def equals(obj: Any): Boolean = getClass.equals(obj.getClass)

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/HdfsUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/HdfsUtilTest.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.util.hdfs
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Options.Rename
-import org.apache.hadoop.fs.{FileContext, Path}
+import org.apache.hadoop.fs.{FileContext, FileSystem, Path}
 import org.scalatest.FunSuite
 
 import java.nio.file.Files
@@ -30,11 +30,11 @@ class HdfsUtilTest extends FunSuite {
 
   test("touch file") {
     val file = new Path("target/touch.me")
-    val filesystem = file.getFileSystem(new Configuration())
-    HdfsUtil.touchFile(file, filesystem)
+    implicit val filesystem: FileSystem = file.getFileSystem(new Configuration())
+    HdfsUtil.touchFile(file)
     val stat1 = filesystem.getFileStatus(file)
     Thread.sleep(1000)
-    HdfsUtil.touchFile(file, filesystem)
+    HdfsUtil.touchFile(file)
     val stat2 = filesystem.getFileStatus(file)
     assert(stat1.getModificationTime != stat2.getModificationTime)
   }
@@ -45,10 +45,10 @@ class HdfsUtilTest extends FunSuite {
     val path = new Path(tempDir.toString)
     val tempPath = new Path(tempDir.toString, "temp/")
     val tempPathSubdir = new Path(tempPath, "test")
-    val filesystem = path.getFileSystem(new Configuration())
+    implicit val filesystem: FileSystem = path.getFileSystem(new Configuration())
     filesystem.mkdirs(path)
-    HdfsUtil.touchFile(new Path(path,"test1"), filesystem)
-    HdfsUtil.touchFile(new Path(tempPathSubdir,"test2"), filesystem)
+    HdfsUtil.touchFile(new Path(path,"test1"))
+    HdfsUtil.touchFile(new Path(tempPathSubdir,"test2"))
     filesystem.rename(tempPathSubdir, path)
     assert(filesystem.listStatus(tempPath).isEmpty)
     assert(filesystem.listStatus(path).map(_.getPath.getName).toSeq.sorted == Seq("temp", "test", "test1"))

--- a/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import io.smartdatalake.config.{ConfigurationException, InstanceRegistry}
 import io.smartdatalake.definitions.{AuthHeaderMode, BasicAuthMode, CustomHttpAuthMode, CustomHttpAuthModeLogic}
 import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataobject.WebserviceFileDataObject
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 import scalaj.http.{Http, HttpRequest, HttpResponse}
@@ -35,6 +36,7 @@ class WebserviceClientTest extends FunSuite with BeforeAndAfterEach  {
 
   // provide an empty instance registry
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  implicit val context : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
   override protected def beforeEach(): Unit = {
     wireMockServer = TestUtil.setupWebservice(host, port, httpsPort)
@@ -97,7 +99,7 @@ class WebserviceClientTest extends FunSuite with BeforeAndAfterEach  {
 
   test("CustomAuthMode") {
     val webserviceDO = WebserviceFileDataObject("do1", url = s"http://$host:$port/good/post/no_auth", authMode = Some(CustomHttpAuthMode(className = classOf[MyCustomHttpAuthMode].getName, options = Map("test"-> "ok"))))
-    webserviceDO.prepare(null, null)
+    webserviceDO.prepare
     val webserviceClient = ScalaJWebserviceClient(webserviceDO)
     assert(webserviceClient.request.headers.toMap.apply("test") == "ok")
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -32,6 +32,7 @@ import io.smartdatalake.workflow.action.customlogic.{CustomDfTransformerConfig, 
 import io.smartdatalake.workflow.action.sparktransformer.{SQLDfTransformer, ScalaClassDfsTransformer}
 import io.smartdatalake.workflow.action.{CopyAction, _}
 import io.smartdatalake.workflow.dataobject._
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
@@ -44,6 +45,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
   private val tempDir = Files.createTempDirectory("test")
   private val tempPath = tempDir.toAbsolutePath.toString
+  private val defaultHadoopConf: Configuration = new Configuration()
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   implicit var contextInit: ActionPipelineContext = _
@@ -78,14 +80,14 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val action1 = DeduplicateAction("a", srcDO.id, tgt1DO.id, metricsFailCondition = Some(s"dataObjectId = '${tgt1DO.id.id}' and key = 'records_written' and value = 0"))
     val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id)
     val actions: Seq[SparkOneToOneActionImpl] = Seq(action1, action2)
-    val stateStore = HadoopFileActionDAGRunStateStore(statePath, contextInit.application)
+    val stateStore = HadoopFileActionDAGRunStateStore(statePath, contextInit.application, defaultHadoopConf)
     val dag: ActionDAGRun = ActionDAGRun(actions, stateStore = Some(stateStore))
 
     // exec dag
     dag.prepare
     dag.init
     assert(contextInit.dataFrameReuseStatistics((tgt1DO.id,Seq())).size == 1)
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
     assert(contextExec.dataFrameReuseStatistics.forall(_._2.isEmpty))
 
     // check result
@@ -142,7 +144,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.prepare
     dag.init
     assert(!contextInit.dataFrameReuseStatistics.contains((tgt1DO.id, Seq()))) // no reuse because of breakDataframeLineage
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
     assert(!contextExec.dataFrameReuseStatistics.contains((tgt1DO.id, Seq())))
 
     // check result
@@ -186,7 +188,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.prepare
     dag.init
     assert(!contextInit.dataFrameReuseStatistics.contains((tgt1DO.id, Seq()))) // no reuse because of different schema
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
     assert(!contextInit.dataFrameReuseStatistics.contains((tgt1DO.id, Seq())))
 
     // check result
@@ -299,7 +301,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // exec dag
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // as filters are ignored, we expect both records from src3, but only one record from src2
     val r1 = tgtDO.getDataFrame(Seq())
@@ -357,7 +359,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     assert(contextInit.dataFrameReuseStatistics((tgtADO.id, Seq())).size == 2)
     assert(contextInit.dataFrameReuseStatistics((tgtBDO.id, Seq())).size == 1)
     assert(contextInit.dataFrameReuseStatistics((tgtCDO.id, Seq())).size == 1)
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
     assert(contextExec.dataFrameReuseStatistics.forall(_._2.isEmpty))
 
     val r1 = session.table(s"${tgtBTable.fullName}")
@@ -415,7 +417,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // exec dag
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     val r1 = tgtCDO.getDataFrame()
       .select($"rating")
@@ -460,7 +462,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // exec dag
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     val r1 = session.table(s"${tgt2Table.fullName}")
       .select($"rating")
@@ -511,7 +513,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // run dag
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // read src/tgt and count
     val dfSrc = srcDO.getDataFrame()
@@ -560,7 +562,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // run dag
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // read src/tgt and count
     val dfSrc = srcDO.getDataFrame()
@@ -613,7 +615,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run: partition lastname=einstein
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt2DO.getDataFrame()
@@ -625,7 +627,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // second dag run: partition lastname=doe
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r2 = tgt2DO.getDataFrame()
@@ -670,7 +672,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // doesnt fail for not existing unexpected partition xyz
     val dag2 = ActionDAGRun(actions, partitionValues = Seq(PartitionValues(Map("lastname" -> "xyz"))))
     dag2.prepare
-    dag2.exec(session,contextExec)
+    dag2.exec(contextExec)
   }
 
   test("action dag with 2 actions in sequence and executionMode=PartitionDiffMode alternativeOutputId") {
@@ -704,7 +706,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     assert(tgt1DO.getDataFrame().count == 0) // this should be empty because of tgt2DO.deleteDataAfterRead = true
@@ -744,7 +746,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run, first file processed
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt2DO.getDataFrame()
@@ -771,7 +773,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r3 = tgt2DO.getDataFrame()
@@ -807,7 +809,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run, first file processed
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt2DO.getDataFrame()
@@ -819,7 +821,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r2 = tgt2DO.getDataFrame()
@@ -833,7 +835,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r3 = tgt2DO.getDataFrame()
@@ -873,7 +875,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run, first file processed
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt1DO.getDataFrame().select($"lastname",$"firstname",$"rating".cast("int")).as[(String,String,Int)].collect().toSet
@@ -883,7 +885,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r2 = tgt1DO.getDataFrame().select($"lastname",$"firstname",$"rating".cast("int")).as[(String,String,Int)].collect().toSet
@@ -895,7 +897,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r3 = tgt1DO.getDataFrame().select($"lastname",$"firstname",$"rating".cast("int")).as[(String,String,Int)].collect().toSet
@@ -929,7 +931,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run, first file processed
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt2DO.getDataFrame()
@@ -955,7 +957,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r3 = tgt2DO.getDataFrame()
@@ -999,7 +1001,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run, first file processed
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt2DO.getDataFrame()
@@ -1014,7 +1016,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r2 = tgt2DO.getDataFrame()
@@ -1057,7 +1059,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run, first file processed
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt2DO.getDataFrame()
@@ -1072,7 +1074,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     assert(tgt2DO.getDataFrame().isEmpty)
@@ -1112,7 +1114,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run, first file processed
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r1 = tgt2DO.getDataFrame()
@@ -1127,7 +1129,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.reset
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // check
     val r2 = tgt2DO.getDataFrame()
@@ -1228,7 +1230,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
   }
 
   test("action dag with 2 actions in sequence and executionMode=PartitionDiffMode, second action can not handle partitions") {
@@ -1258,7 +1260,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // first dag run
     dag.prepare
     dag.init
-    dag.exec(session,contextExec)
+    dag.exec(contextExec)
 
     // second dag run - skip action execution because there are no new partitions to process
     dag.prepare

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -67,7 +67,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")),PartitionValues(Map("lastname" -> "jonson"))))
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     val r1 = session.table(s"${tgtTable.fullName}")
@@ -107,7 +107,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    action1.exec(Seq(srcSubFeed))(session,contextExec)
+    action1.exec(Seq(srcSubFeed))(contextExec)
 
     val r1 = session.table(s"${tgtTable.fullName}")
       .select($"rating")
@@ -135,7 +135,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     session.table(s"${tgtTable.fullName}").show
@@ -167,7 +167,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     val r1 = session.table(s"${tgtTable.fullName}")
@@ -201,7 +201,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     action.preInit(Seq(srcSubFeed), Seq())
     val initOutputSubFeeds = action.init(Seq(srcSubFeed))
     action.preExec(Seq(srcSubFeed))
-    val tgtSubFeed1 = action.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed1 = action.exec(Seq(srcSubFeed))(contextExec).head
     action.postExec(Seq(srcSubFeed), Seq(tgtSubFeed1))
 
     // check first load
@@ -218,7 +218,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     srcDO.writeDataFrame(l2, l2PartitionValues) // prepare testdata
     assert(srcDO.getDataFrame().count == 2) // note: this needs spark.sql.sources.partitionOverwriteMode=dynamic, otherwise the whole table is overwritten
     action.init(Seq(srcSubFeed))
-    val tgtSubFeed2 = action.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed2 = action.exec(Seq(srcSubFeed))(contextExec).head
 
     // check 2nd load
     assert(tgtSubFeed2.dataObjectId == tgtDO.id)
@@ -251,7 +251,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     action.preInit(Seq(srcSubFeed), Seq())
     val initOutputSubFeeds = action.init(Seq(srcSubFeed))
     action.preExec(Seq(srcSubFeed))
-    val tgtSubFeed1 = action.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed1 = action.exec(Seq(srcSubFeed))(contextExec).head
     action.postExec(Seq(srcSubFeed), Seq(tgtSubFeed1))
 
     // check first load
@@ -268,7 +268,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     srcDO.writeDataFrame(l2, l2PartitionValues) // prepare testdata
     assert(srcDO.getDataFrame().count == 2) // note: this needs spark.sql.sources.partitionOverwriteMode=dynamic, otherwise the whole table is overwritten
     action.init(Seq(srcSubFeed))
-    val tgtSubFeed2 = action.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed2 = action.exec(Seq(srcSubFeed))(contextExec).head
 
     // check 2nd load
     assert(tgtSubFeed2.dataObjectId == tgtDO.id)
@@ -301,7 +301,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     val r1 = tgtDO.getDataFrame()
@@ -340,10 +340,10 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     assert(tgtSubFeed.dataFrame.get.columns.contains("mt"))
 
     // run
-    action1.preExec(Seq(srcSubFeed))(session,contextExec)
-    val resultSubFeeds = action1.exec(Seq(srcSubFeed))(session,contextExec)
+    action1.preExec(Seq(srcSubFeed))(contextExec)
+    val resultSubFeeds = action1.exec(Seq(srcSubFeed))(contextExec)
     assert(tgtDO.getDataFrame().count == 2)
-    action1.postExec(Seq(srcSubFeed),resultSubFeeds)(session,contextExec)
+    action1.postExec(Seq(srcSubFeed),resultSubFeeds)(contextExec)
 
     // simulate next run with no data
     action1.reset
@@ -370,7 +370,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")),PartitionValues(Map("lastname" -> "jonson"))))
-    action1.exec(Seq(srcSubFeed))(session,contextExec).head
+    action1.exec(Seq(srcSubFeed))(contextExec).head
 
     val r1 = tgtDO.getDataFrame()
       .select($"rating")
@@ -378,7 +378,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     assert(r1.toSet == Set(5,3))
 
     // start 2nd load - data should be overwritten
-    action1.exec(Seq(srcSubFeed))(session,contextExec).head
+    action1.exec(Seq(srcSubFeed))(contextExec).head
 
     val r2 = tgtDO.getDataFrame()
       .select($"rating")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyWithMergeActionTest.scala
@@ -69,7 +69,7 @@ class CopyWithMergeActionTest extends FunSuite with BeforeAndAfter {
     srcDO.writeDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.init(Seq(srcSubFeed))
-    action1.exec(Seq(srcSubFeed))(session, contextExec)
+    action1.exec(Seq(srcSubFeed))(contextExec)
 
     {
       val expected = Seq(("doe", "john", 5), ("pan", "peter", 5), ("hans", "muster", 5))
@@ -84,7 +84,7 @@ class CopyWithMergeActionTest extends FunSuite with BeforeAndAfter {
     val l2 = Seq(("doe","john",10),("pan","peter",5),("pan","peter2",5)).toDF("lastname", "firstname", "rating2")
     srcDO.writeDataFrame(l2, Seq())
     action1.init(Seq(srcSubFeed))
-    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, contextExec)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(contextExec)
 
     {
       val expected = Seq(("doe", "john", Some(5), Some(10)), ("pan", "peter", Some(5), Some(5)), ("pan", "peter2", None, Some(5)), ("hans", "muster", Some(5), None))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomScriptActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomScriptActionTest.scala
@@ -79,7 +79,7 @@ class CustomScriptActionTest extends FunSuite with BeforeAndAfter {
 case class TestScriptNotificationDataObject(override val id: DataObjectId, notifyFunc: String => Unit) extends DataObject with CanReceiveScriptNotification {
   override def metadata: Option[DataObjectMetadata] = None
 
-  override def scriptNotification(parameters: Map[String, String], partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
+  override def scriptNotification(parameters: Map[String, String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     notifyFunc(parameters("test"))
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateWithMergeActionTest.scala
@@ -65,13 +65,13 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true)
     val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l1, Seq())(session, context1)
+    srcDO.writeDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    action1.init(Seq(srcSubFeed))(session, context1.copy(phase = ExecutionPhase.Init)).head
-    action1.exec(Seq(srcSubFeed))(session, context1).head
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init)).head
+    action1.exec(Seq(srcSubFeed))(context1).head
 
     {
       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))
@@ -84,10 +84,10 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l2, Seq())(session, context1)
-    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
+    srcDO.writeDataFrame(l2, Seq())(context1)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)
 
     {
       // note that we expect pan/peter/5 with updated refTimestamp even though all attributes stay the same
@@ -117,13 +117,13 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true, updateCapturedColumnOnlyWhenChanged = true)
     val l1 = Seq(("doe","john",Some(5)),("pan","peter",Some(5)),("pan","peter2",None),("hans","muster",Some(5))).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l1, Seq())(session, context1)
+    srcDO.writeDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    action1.init(Seq(srcSubFeed))(session, context1.copy(phase = ExecutionPhase.Init)).head
-    action1.exec(Seq(srcSubFeed))(session, context1).head
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init)).head
+    action1.exec(Seq(srcSubFeed))(context1).head
 
     {
       val expected = Seq(("doe", "john", Some(5), Timestamp.valueOf(refTimestamp1)), ("pan", "peter", Some(5), Timestamp.valueOf(refTimestamp1)), ("pan", "peter2", None, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", Some(5), Timestamp.valueOf(refTimestamp1)))
@@ -136,10 +136,10 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val l2 = Seq(("doe","john",Some(10)),("pan","peter",Some(5)),("pan","peter2",None)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l2, Seq())(session, context1)
-    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
+    srcDO.writeDataFrame(l2, Seq())(context1)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)
 
     {
       // note that we expect pan/peter/5 and pan/peter2/null with old refTimestamp because all attributes stay the same

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
@@ -209,8 +209,8 @@ class ExecutionModeTest extends FunSuite with BeforeAndAfter {
 }
 
 class TestCustomPartitionMode() extends CustomPartitionModeLogic {
-  override def apply(session: SparkSession, options: Map[String, String], actionId: ActionId, input: DataObject with CanHandlePartitions, output: DataObject with CanHandlePartitions, givenPartitionValues: Seq[Map[String, String]], context: ActionPipelineContext): Option[Seq[Map[String, String]]] = {
-    val partitionValuesToProcess = input.listPartitions(session, context).diff(output.listPartitions(session, context))
+  override def apply(options: Map[String, String], actionId: ActionId, input: DataObject with CanHandlePartitions, output: DataObject with CanHandlePartitions, givenPartitionValues: Seq[Map[String, String]], context: ActionPipelineContext): Option[Seq[Map[String, String]]] = {
+    val partitionValuesToProcess = input.listPartitions(context).diff(output.listPartitions(context))
     Some(partitionValuesToProcess.map(_.getMapString))
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
@@ -50,31 +50,33 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
 
   test("historize 1st 2nd load") {
 
+    val context = TestUtil.getDefaultActionPipelineContext
+
     // setup DataObjects
     val feed = "historize"
     val srcTable = Table(Some("default"), "historize_input")
     val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
-    srcDO.dropTable
+    srcDO.dropTable(context)
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("default"), "historize_output", None, Some(Seq("lastname","firstname")))
     val tgtDO = TickTockHiveTableDataObject("tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
-    tgtDO.dropTable
+    tgtDO.dropTable(context)
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id)
     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l1, Seq())(session, context1)
+    srcDO.writeDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,context1).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     {
       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(definitions.HiveConventions.getHistorizationSurrogateTimestamp)))
         .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-      val actual = tgtDO.getDataFrame()(session, context1)
+      val actual = tgtDO.getDataFrame()(context1)
         .drop(Historization.historizeHashColName)
       val resultat = expected.isEqual(actual)
       if (!resultat) TestUtil.printFailedTestResult("historize 1st load", Seq())(actual)(expected)
@@ -83,19 +85,19 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id)
     val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l2, Seq())(session, context1)
+    srcDO.writeDataFrame(l2, Seq())(context1)
     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-    action2.exec(Seq(srcSubFeed2))(session, context2)
+    action2.exec(Seq(srcSubFeed2))(context2)
 
     {
       val expected = Seq(
         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
         ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(definitions.HiveConventions.getHistorizationSurrogateTimestamp))
       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-      val actual = tgtDO.getDataFrame()(session, context1)
+      val actual = tgtDO.getDataFrame()(context1)
         .drop(Historization.historizeHashColName)
       val resultat = expected.isEqual(actual)
       if (!resultat) TestUtil.printFailedTestResult("historize 2nd load", Seq())(actual)(expected)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeWithMergeActionTest.scala
@@ -52,32 +52,34 @@ import java.time.LocalDateTime
 
    test("historize 1st 2nd load mergeModeEnable") {
 
+     val context = TestUtil.getDefaultActionPipelineContext
+
      // setup DataObjects
      val feed = "historize"
      val srcTable = Table(Some("default"), "historize_input")
      val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
-     srcDO.dropTable
+     srcDO.dropTable(context)
      instanceRegistry.register(srcDO)
      instanceRegistry.register(jdbcConnection)
      val tgtTable = Table(Some("public"), "historize_output", None, Some(Seq("lastname","firstname")))
      val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1")//, jdbcOptions = Map("createTableColumnTypes"->"lastname varchar, firstname varchar"))
-     tgtDO.dropTable
+     tgtDO.dropTable(context)
      instanceRegistry.register(tgtDO)
 
      // prepare & start 1st load
      val refTimestamp1 = LocalDateTime.now()
-     val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
      val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
      val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-     srcDO.writeDataFrame(l1, Seq())(session, context1)
+     srcDO.writeDataFrame(l1, Seq())(context1)
      val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.init(Seq(srcSubFeed))(session, context1.copy(phase = ExecutionPhase.Init)).head
-     action1.exec(Seq(srcSubFeed))(session,context1).head
+     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init)).head
+     action1.exec(Seq(srcSubFeed))(context1).head
 
      {
        val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(definitions.HiveConventions.getHistorizationSurrogateTimestamp)))
          .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getDataFrame()(session, context1)
+       val actual = tgtDO.getDataFrame()(context1)
          .drop(Historization.historizeHashColName)
        val resultat = expected.isEqual(actual)
        if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
@@ -86,19 +88,19 @@ import java.time.LocalDateTime
 
      // prepare & start 2nd load
      val refTimestamp2 = LocalDateTime.now()
-     val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
      val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
      val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
-     srcDO.writeDataFrame(l2, Seq())(session, context1)
+     srcDO.writeDataFrame(l2, Seq())(context1)
      val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.exec(Seq(srcSubFeed2))(session, context2)
+     action2.exec(Seq(srcSubFeed2))(context2)
 
      {
        val expected = Seq(
          ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
          ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(definitions.HiveConventions.getHistorizationSurrogateTimestamp))
        ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getDataFrame()(session, context1)
+       val actual = tgtDO.getDataFrame()(context1)
          .drop(Historization.historizeHashColName)
        val resultat = expected.isEqual(actual)
        if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObjectTest.scala
@@ -32,6 +32,8 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
   private val customDfCreatorClassName = classOf[TestCustomDfCreator].getName
   private val customDfCreatorWithSchemaClassName = classOf[TestCustomDfCreatorWithSchema].getName
 
+  private val context = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
+
   test("During init where a schema method is provided, the schema of the schema method should be returned") {
     // prepare
     val config = CustomDfCreatorConfig(Option(customDfCreatorWithSchemaClassName))
@@ -39,7 +41,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
     val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(session, context)
+    val df = customDfDataObject.getDataFrame(Seq())(context)
 
     // check
     assert(df.schema.equals(customDfDataObject.creator.schema.get))
@@ -49,11 +51,9 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
     // prepare
     val config = CustomDfCreatorConfig(Option(customDfCreatorWithSchemaClassName))
     val customDfDataObject = CustomDfDataObject("testId", config)
-    val context: ActionPipelineContext =
-      ActionPipelineContext("testFeed", "testApp", SDLExecutionId.executionId1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(session, context)
+    val df = customDfDataObject.getDataFrame(Seq())(context)
 
     // check
     assert(df.schema.equals(customDfDataObject.creator.exec.schema))
@@ -66,7 +66,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
     val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(session, context)
+    val df = customDfDataObject.getDataFrame(Seq())(context)
 
     // check
     assert(df.count() == 0)
@@ -76,11 +76,9 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
     // prepare
     val config = CustomDfCreatorConfig(Option(customDfCreatorWithSchemaClassName))
     val customDfDataObject = CustomDfDataObject("testId", config)
-    val context: ActionPipelineContext =
-      ActionPipelineContext("testFeed", "testApp", SDLExecutionId.executionId1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(session, context)
+    val df = customDfDataObject.getDataFrame(Seq())(context)
 
     // check
     assert(df.count() == 2)
@@ -93,7 +91,7 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
     val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(session, context)
+    val df = customDfDataObject.getDataFrame(Seq())(context)
 
     // check
     assert(df.count() == 2)
@@ -103,11 +101,9 @@ class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
     // prepare
     val config = CustomDfCreatorConfig(Option(customDfCreatorClassName))
     val customDfDataObject = CustomDfDataObject("testId", config)
-    val context: ActionPipelineContext =
-      ActionPipelineContext("testFeed", "testApp", SDLExecutionId.executionId1, instanceRegistry, None, SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
 
     // run
-    val df = customDfDataObject.getDataFrame(Seq())(session, context)
+    val df = customDfDataObject.getDataFrame(Seq())(context)
 
     // check
     assert(df.count() == 2)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
@@ -266,7 +266,7 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
     // restrict default authority
     // remove 2 characters from the end to test that a substring is enough for restriction
-    Environment.hadoopAuthoritiesWithAclsRequired = Seq(HdfsUtil.getHadoopDefaultSchemeAuthority().toString.reverse.drop(2).reverse)
+    Environment.hadoopAuthoritiesWithAclsRequired = Seq(HdfsUtil.getHadoopDefaultSchemeAuthority.toString.reverse.drop(2).reverse)
 
     try {
       // create data object

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObjectTest.scala
@@ -89,7 +89,7 @@ class JdbcTableDataObjectTest extends DataObjectTestSuite {
     val srcSubFeed = SparkSubFeed(None, srcDO.id, Seq())
     action1.init(Seq(srcSubFeed))
     action1.preExec(Seq(srcSubFeed))
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session,contextExec).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
     action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed))
 
     val dfSrcExpected = Seq(("ext", "doe", "john", 5)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectSchemaBehavior.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectSchemaBehavior.scala
@@ -32,7 +32,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
   def readNonExistingSources(createDataObject: (String, Option[StructType]) => DataObject with CanCreateDataFrame with UserDefinedSchema,
                                      fileExtension: String = null)
-                                         (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+                                         (implicit context: ActionPipelineContext): Unit = {
 
     test("It is not possible to read from an non-existing file without user-defined-schema.") {
       val path = tempFilePath(fileExtension)
@@ -43,7 +43,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
   def readEmptySources(createDataObject: (String, Option[StructType]) => DataObject with CanCreateDataFrame with UserDefinedSchema,
                        fileExtension: String = null)
-                      (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+                      (implicit context: ActionPipelineContext): Unit = {
 
     test("Reading from an empty file with user-defined schema results in an empty data frame.") {
       val schema = Seq(
@@ -52,6 +52,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
       )
 
       val path = tempFilePath(fileExtension)
+      val session = context.sparkSession
       import session.implicits._
       createFile(path, Seq.empty[String].toDF())
       try {
@@ -71,7 +72,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
   def readEmptySourcesWithEmbeddedSchema(createDataObject: (String, Option[StructType]) => DataObject with CanCreateDataFrame with UserDefinedSchema,
                        fileExtension: String = null)
-                      (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+                      (implicit context: ActionPipelineContext): Unit = {
 
     test("Reading an empty file creates an empty data frame with the user-defined schema.") {
       val embeddedSchema = Seq(
@@ -83,6 +84,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
       )
 
       val path = tempFilePath(fileExtension)
+      implicit val session: SparkSession = context.sparkSession
       createFile(path, DataFrameUtil.getEmptyDataFrame(StructType(embeddedSchema)))
       try {
         val dataObj = createDataObject(path, Some(StructType(userSchema)))
@@ -104,6 +106,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
       )
 
       val path = tempFilePath(fileExtension)
+      implicit val session: SparkSession = context.sparkSession
       createFile(path, DataFrameUtil.getEmptyDataFrame(StructType(embeddedSchema)))
       try {
         val dataObj = createDataObject(path, None)
@@ -122,7 +125,10 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
   def validateSchemaMinOnWrite(createDataObject: (String, Option[StructType], Option[StructType]) => DataObject with CanWriteDataFrame,
                                fileExtension: String = null)
-                              (implicit session: SparkSession, context: ActionPipelineContext) : Unit = {
+                              (implicit context: ActionPipelineContext) : Unit = {
+
+    implicit val session: SparkSession = context.sparkSession
+    import session.implicits._
 
     val schemaMin = Seq(
       StructField("id", StringType, nullable = true),
@@ -130,7 +136,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     )
 
     test("Write - SchemaMin full match is valid.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -151,7 +156,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Write - SchemaMin subset is valid.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -172,7 +176,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Write - SchemaMin violation: invalid column name.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -194,7 +197,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Write - SchemaMin violation: invalid data type.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -216,7 +218,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Write - SchemaMin violation: missing columns.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -262,7 +263,10 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
   def validateSchemaMinOnRead(createDataObject: (String, Option[StructType], Option[StructType]) => DataObject with CanCreateDataFrame,
                                fileExtension: String = null)
-                              (implicit session: SparkSession, context: ActionPipelineContext) : Unit = {
+                              (implicit context: ActionPipelineContext) : Unit = {
+
+    implicit val session: SparkSession = context.sparkSession
+    import session.implicits._
 
     val schemaMin = Seq(
       StructField("id", StringType, nullable = true),
@@ -270,7 +274,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     )
 
     test("Read - SchemaMin full match is valid.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -292,7 +295,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Read - SchemaMin subset is valid.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -314,7 +316,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Read - SchemaMin violation: invalid column name.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -337,7 +338,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Read - SchemaMin violation: invalid data type.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(
@@ -360,7 +360,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
     }
 
     test("Read - SchemaMin violation: missing columns.") {
-      import session.implicits._
       val path = tempFilePath(fileExtension)
       try {
         val df = Seq(

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObjectTest.scala
@@ -70,7 +70,7 @@ class TickTockHiveTableDataObjectTest extends FunSuite with BeforeAndAfter {
     val l1 = Seq((1, "john", 5)).toDF("id", "name", "rating")
     srcDO.writeDataFrame(l1, Seq())
 
-    action.exec(Seq(SparkSubFeed(None, "input", Seq()), SparkSubFeed(None, "output", Seq())))(session, contextExec)
+    action.exec(Seq(SparkSubFeed(None, "input", Seq()), SparkSubFeed(None, "output", Seq())))(contextExec)
 
     val r = session.table(s"${tgtTable.fullName}")
       .select($"rating")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/UnpartitionedTestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/UnpartitionedTestDataObject.scala
@@ -36,13 +36,14 @@ case class UnpartitionedTestDataObject(override val id: DataObjectId,
                                       (@transient implicit val instanceRegistry: InstanceRegistry)
   extends DataObject with CanCreateDataFrame with CanWriteDataFrame {
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+    val session = context.sparkSession
     import session.implicits._
     Seq(("test",1),("test",2)).toDF("a","b")
   }
 
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+                             (implicit context: ActionPipelineContext): Unit = {
     df.show
   }
 

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -122,7 +122,6 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
 
   private def getAbsolutePath(implicit context: ActionPipelineContext) = {
     val prefixedPath = HdfsUtil.prefixHadoopPath(path.get, connection.map(_.pathPrefix))
-    val filesystem = getFilesystem(prefixedPath)
     HdfsUtil.makeAbsolutePath(prefixedPath)(filesystem)
   }
 

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -96,7 +96,8 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
 
   val filetype: String = ".parquet"
 
-  def hadoopPath(implicit session: SparkSession): Path = {
+  def hadoopPath(implicit context: ActionPipelineContext): Path = {
+    implicit val session: SparkSession = context.sparkSession
     val thisIsTableExisting = isTableExisting
     require(thisIsTableExisting || path.isDefined, s"($id) DeltaTable ${table.fullName} does not exist, so path must be set.")
 
@@ -119,7 +120,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     hadoopPathHolder
   }
 
-  private def getAbsolutePath(implicit session: SparkSession) = {
+  private def getAbsolutePath(implicit context: ActionPipelineContext) = {
     val prefixedPath = HdfsUtil.prefixHadoopPath(path.get, connection.map(_.pathPrefix))
     val filesystem = getFilesystem(prefixedPath)
     HdfsUtil.makeAbsolutePath(prefixedPath)(filesystem)
@@ -132,7 +133,8 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
 
   assert(Seq(SDLSaveMode.Overwrite, SDLSaveMode.Append, SDLSaveMode.Merge).contains(saveMode), s"($id) Only saveMode Overwrite and Append supported for now.")
 
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def prepare(implicit context: ActionPipelineContext): Unit = {
+    implicit val session: SparkSession = context.sparkSession
     super.prepare
     if (connection.exists(_.checkDeltaLakeSparkOptions)) {
       require(session.conf.getOption("spark.sql.extensions").toSeq.flatMap(_.split(',')).contains("io.delta.sql.DeltaSparkSessionExtension"),
@@ -170,31 +172,31 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   /**
    * converts an existing path with parquet files to delta format
    */
-  private[smartdatalake] def convertPathToDeltaFormat(implicit session: SparkSession): Unit = {
+  private[smartdatalake] def convertPathToDeltaFormat(implicit context: ActionPipelineContext): Unit = {
     val deltaPath = s"parquet.`$hadoopPath`"
     if (partitions.isEmpty) {
-      DeltaTable.convertToDelta(session, deltaPath)
+      DeltaTable.convertToDelta(context.sparkSession, deltaPath)
     } else {
       val partitionSchema = StructType(partitions.map(p => StructField(p, StringType)))
-      DeltaTable.convertToDelta(session, deltaPath, partitionSchema)
+      DeltaTable.convertToDelta(context.sparkSession, deltaPath, partitionSchema)
     }
   }
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
-    val df = session.table(table.fullName)
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+    val df = context.sparkSession.table(table.fullName)
     validateSchemaMin(df, "read")
     validateSchemaHasPartitionCols(df, "read")
     df
   }
 
-  override def init(df: DataFrame, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions] = None)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def init(df: DataFrame, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions] = None)(implicit context: ActionPipelineContext): Unit = {
     super.init(df, partitionValues)
     validateSchemaMin(df, "write")
     validateSchemaHasPartitionCols(df, "write")
     validateSchemaHasPrimaryKeyCols(df, table.primaryKey.getOrElse(Seq()), "write")
   }
 
-  override def preWrite(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  override def preWrite(implicit context: ActionPipelineContext): Unit = {
     super.preWrite
     // validate if acl's must be / are configured before writing
     if (Environment.hadoopAuthoritiesWithAclsRequired.exists(a => filesystem.getUri.toString.contains(a))) {
@@ -203,7 +205,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   }
 
   override def writeDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+                             (implicit context: ActionPipelineContext): Unit = {
     validateSchemaMin(df, "write")
     validateSchemaHasPartitionCols(df, "write")
     validateSchemaHasPrimaryKeyCols(df, table.primaryKey.getOrElse(Seq()), "write")
@@ -216,14 +218,15 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
    * or only a few HDFS files that are too large.
    */
   def writeDataFrame(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions])
-                    (implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+                    (implicit context: ActionPipelineContext): Unit = {
+    implicit val session: SparkSession = context.sparkSession
     val dfPrepared = if (createTableOnly) {
       // create empty df with existing df's schema
       DataFrameUtil.getEmptyDataFrame(df.schema)
     } else df
 
     val finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
-    val saveModeTargetDf = saveModeOptions.map(_.convertToTargetSchema(df)).getOrElse(df) // remove auxiliary columns to validate schema and create table if it doesnt exist
+    val saveModeTargetDf = saveModeOptions.map(_.convertToTargetSchema(dfPrepared)).getOrElse(dfPrepared)
     val dfWriter = saveModeTargetDf.write
       .format("delta")
       .options(options.getOrElse(Map()))
@@ -232,7 +235,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     if (isTableExisting) {
       if (!allowSchemaEvolution) validateSchema(saveModeTargetDf, session.table(table.fullName).schema, "write")
       if (finalSaveMode == SDLSaveMode.Merge) {
-        mergeDataFrameByPrimaryKey(df, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
+        mergeDataFrameByPrimaryKey(saveModeTargetDf, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
       } else {
         if (partitions.isEmpty) {
           dfWriter
@@ -277,7 +280,8 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
    *
    * This all is done in one transaction.
    */
-  def mergeDataFrameByPrimaryKey(df: DataFrame, saveModeOptions: SaveModeMergeOptions)(implicit session: SparkSession, context: ActionPipelineContext): Unit = {
+  def mergeDataFrameByPrimaryKey(df: DataFrame, saveModeOptions: SaveModeMergeOptions)(implicit context: ActionPipelineContext): Unit = {
+    implicit val session: SparkSession = context.sparkSession
     assert(table.primaryKey.exists(_.nonEmpty), s"($id) table.primaryKey must be defined to use mergeDataFrameByPrimaryKey")
 
     // set schema evolution support
@@ -309,21 +313,21 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     }
   }
 
-  def vacuum(implicit session: SparkSession): Unit = {
+  def vacuum(implicit context: ActionPipelineContext): Unit = {
     retentionPeriod.foreach { period =>
       val (_, d) = PerformanceUtils.measureDuration {
-        DeltaTable.forPath(session, hadoopPath.toString).vacuum(period)
+        DeltaTable.forPath(context.sparkSession, hadoopPath.toString).vacuum(period)
       }
       logger.info(s"($id) vacuum took $d")
     }
   }
 
-  override def isDbExisting(implicit session: SparkSession): Boolean = {
-    session.catalog.databaseExists(table.db.get)
+  override def isDbExisting(implicit context: ActionPipelineContext): Boolean = {
+    context.sparkSession.catalog.databaseExists(table.db.get)
   }
 
-  override def isTableExisting(implicit session: SparkSession): Boolean = {
-    session.catalog.tableExists(table.fullName)
+  override def isTableExisting(implicit context: ActionPipelineContext): Boolean = {
+    context.sparkSession.catalog.tableExists(table.fullName)
   }
 
   /**
@@ -339,7 +343,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
    *
    * @throws IllegalArgumentException if `failIfFilesMissing` = true and no files found at `path`.
    */
-  protected def checkFilesExisting(implicit session:SparkSession): Boolean = {
+  protected def checkFilesExisting(implicit context: ActionPipelineContext): Boolean = {
     val hasFiles = filesystem.exists(hadoopPath.getParent) &&
       RemoteIteratorWrapper(filesystem.listFiles(hadoopPath, true)).exists(_.getPath.getName.endsWith(filetype))
     if (!hasFiles) {
@@ -355,9 +359,9 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
    * List partitions.
    * Note that we need a Spark SQL statement as there might be partition directories with no current data inside
    */
-  override def listPartitions(implicit session: SparkSession, context: ActionPipelineContext): Seq[PartitionValues] = {
+  override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
     val (pvs,d) = PerformanceUtils.measureDuration(
-      if(isTableExisting) PartitionValues.fromDataFrame(session.table(table.fullName).select(partitions.map(col):_*).distinct)
+      if(isTableExisting) PartitionValues.fromDataFrame(context.sparkSession.table(table.fullName).select(partitions.map(col):_*).distinct)
       else Seq()
     )
     logger.debug(s"($id) listPartitions took $d")
@@ -367,12 +371,15 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   /**
    * Note that we will not delete the whole partition but just the data of the partition because delta lake keeps history
    */
-  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit session: SparkSession): Unit = {
-    val deltaTable = DeltaTable.forName(session, table.fullName)
+  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    val deltaTable = DeltaTable.forName(context.sparkSession, table.fullName)
     partitionValues.map(_.getSparkExpr).foreach(expr => deltaTable.delete(expr))
   }
 
-  override def dropTable(implicit session: SparkSession): Unit = HiveUtil.dropTable(table, hadoopPath, doPurge = false)
+  override def dropTable(implicit context: ActionPipelineContext): Unit = {
+    implicit val session: SparkSession = context.sparkSession
+    HiveUtil.dropTable(table, hadoopPath, doPurge = false)
+  }
 
   override def factory: FromConfigFactory[DataObject] = DeltaLakeTableDataObject
 

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -234,7 +234,8 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     if (isTableExisting) {
       if (!allowSchemaEvolution) validateSchema(saveModeTargetDf, session.table(table.fullName).schema, "write")
       if (finalSaveMode == SDLSaveMode.Merge) {
-        mergeDataFrameByPrimaryKey(saveModeTargetDf, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
+        // merge operations still need all columns for potential insert/updateConditions. Therefore dfPrepared instead of saveModeTargetDf is passed on.
+        mergeDataFrameByPrimaryKey(dfPrepared, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
       } else {
         if (partitions.isEmpty) {
           dfWriter
@@ -293,14 +294,14 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
       var mergeStmt = deltaTable.merge(df.as("new"), joinCondition and saveModeOptions.additionalMergePredicateExpr.getOrElse(lit(true)))
       // add delete clause if configured
       saveModeOptions.deleteConditionExpr.foreach(c => mergeStmt = mergeStmt.whenMatched(c).delete())
-      // add update clause - updateExpr does not support referring new columns in existing table on schema evolution, thats why we use it only when needed, and updateAll otherwise
+      // add update clause - updateExpr does not support referring new columns in existing table on schema evolution, that's why we use it only when needed, and updateAll otherwise
       mergeStmt = if (saveModeOptions.updateColumnsOpt.isDefined) {
         val updateCols = saveModeOptions.updateColumnsOpt.getOrElse(df.columns.toSeq.diff(table.primaryKey.get))
         mergeStmt.whenMatched(saveModeOptions.updateConditionExpr.getOrElse(lit(true))).updateExpr(updateCols.map(c => c -> s"new.$c").toMap)
       } else {
         mergeStmt.whenMatched(saveModeOptions.updateConditionExpr.getOrElse(lit(true))).updateAll()
       }
-      // add insert clause - insertExpr does not support referring new columns in existing table on schema evolution, thats why we use it only when needed, and insertAll otherwise
+      // add insert clause - insertExpr does not support referring new columns in existing table on schema evolution, that's why we use it only when needed, and insertAll otherwise
       mergeStmt = if (saveModeOptions.insertColumnsToIgnore.nonEmpty) {
         val insertCols = df.columns.diff(saveModeOptions.insertColumnsToIgnore)
         mergeStmt.whenNotMatched(saveModeOptions.insertConditionExpr.getOrElse(lit(true))).insertExpr(insertCols.map(c => c -> s"new.$c").toMap)

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
@@ -64,12 +64,12 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true)
     val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l1, Seq())(session, context1)
+    srcDO.writeDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, context1).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     {
@@ -83,10 +83,10 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l2, Seq())(session, context1)
-    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
+    srcDO.writeDataFrame(l2, Seq())(context1)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)
 
     {
       // note that we expect pan/peter/5 with updated refTimestamp even though all attributes stay the same
@@ -114,12 +114,12 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true, updateCapturedColumnOnlyWhenChanged = true)
     val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l1, Seq())(session, context1)
+    srcDO.writeDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(session, context1).head
+    val tgtSubFeed = action1.exec(Seq(srcSubFeed))(context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     {
@@ -133,10 +133,10 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeDataFrame(l2, Seq())(session, context1)
-    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(session, context2)
+    srcDO.writeDataFrame(l2, Seq())(context1)
+    action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)
 
     {
       // note that we expect pan/peter/5 with updated refTimestamp even though all attributes stay the same

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
@@ -18,7 +18,6 @@
  */
 package io.smartdatalake.workflow.action
 
-import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
@@ -33,6 +32,7 @@ import java.time.LocalDateTime
 
 class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
+  // set additional spark options for delta lake
   protected implicit val session : SparkSession = new DeltaLakeModulePlugin().additionalSparkProperties()
     .foldLeft(TestUtil.sparkSessionBuilder(withHive = true)) {
       case (builder, config) => builder.config(config._1, config._2)
@@ -43,7 +43,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
   private val tempPath = tempDir.toAbsolutePath.toString
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
-  implicit val context = TestUtil.getDefaultActionPipelineContext
+  implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
   before {
     instanceRegistry.clear()
@@ -64,7 +64,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val context1 = context.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true)
     val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())(context1)
@@ -83,7 +83,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val context2 = context.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l2, Seq())(context1)
     action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)
@@ -114,7 +114,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
-    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val context1 = context.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true, updateCapturedColumnOnlyWhenChanged = true)
     val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l1, Seq())(context1)
@@ -133,7 +133,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
-    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val context2 = context.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
     srcDO.writeDataFrame(l2, Seq())(context1)
     action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeHistorizeWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeHistorizeWithMergeActionTest.scala
@@ -53,31 +53,33 @@ import java.time.LocalDateTime
 
    test("historize 1st 2nd load mergeModeEnable") {
 
+     val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+
      // setup DataObjects
      val feed = "historize"
      val srcTable = Table(Some("default"), "historize_input")
      val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
-     srcDO.dropTable
+     srcDO.dropTable(context)
      instanceRegistry.register(srcDO)
      val tgtTable = Table(Some("default"), "historize_output", None, Some(Seq("lastname","firstname")))
      val tgtDO = DeltaLakeTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
-     tgtDO.dropTable
+     tgtDO.dropTable(context)
      instanceRegistry.register(tgtDO)
 
      // prepare & start 1st load
      val refTimestamp1 = LocalDateTime.now()
-     val context1 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp1), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
      val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
      val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-     srcDO.writeDataFrame(l1, Seq())(session, context1)
+     srcDO.writeDataFrame(l1, Seq())(context1)
      val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.init(Seq(srcSubFeed))(session, context1).head
-     action1.exec(Seq(srcSubFeed))(session,context1).head
+     action1.init(Seq(srcSubFeed))(context1).head
+     action1.exec(Seq(srcSubFeed))(context1).head
 
      {
        val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(definitions.HiveConventions.getHistorizationSurrogateTimestamp)))
          .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getDataFrame()(session, context1)
+       val actual = tgtDO.getDataFrame()(context1)
          .drop(Historization.historizeHashColName)
        val resultat = expected.isEqual(actual)
        if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
@@ -86,19 +88,19 @@ import java.time.LocalDateTime
 
      // prepare & start 2nd load
      val refTimestamp2 = LocalDateTime.now()
-     val context2 = ActionPipelineContext(feed, "test", SDLExecutionId.executionId1, instanceRegistry, Some(refTimestamp2), SmartDataLakeBuilderConfig(), phase = ExecutionPhase.Exec)
+     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
      val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
      val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
-     srcDO.writeDataFrame(l2, Seq())(session, context1)
+     srcDO.writeDataFrame(l2, Seq())(context1)
      val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.exec(Seq(srcSubFeed2))(session, context2)
+     action2.exec(Seq(srcSubFeed2))(context2)
 
      {
        val expected = Seq(
          ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
          ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(definitions.HiveConventions.getHistorizationSurrogateTimestamp))
        ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getDataFrame()(session, context1)
+       val actual = tgtDO.getDataFrame()(context1)
          .drop(Historization.historizeHashColName)
        val resultat = expected.isEqual(actual)
        if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeHistorizeWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeHistorizeWithMergeActionTest.scala
@@ -18,14 +18,12 @@
  */
  package io.smartdatalake.workflow.action
 
-import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.historization.Historization
 import io.smartdatalake.util.misc.DataFrameUtil.DfSDL
-import io.smartdatalake.workflow.connection.JdbcTableConnection
-import io.smartdatalake.workflow.dataobject.{DeltaLakeModulePlugin, DeltaLakeTableDataObject, HiveTableDataObject, JdbcTableDataObject, Table}
+import io.smartdatalake.workflow.dataobject.{DeltaLakeModulePlugin, DeltaLakeTableDataObject, HiveTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfter, FunSuite}
@@ -36,6 +34,7 @@ import java.time.LocalDateTime
 
  class DeltaLakeHistorizeWithMergeActionTest extends FunSuite with BeforeAndAfter {
 
+   // set additional spark options for delta lake
    protected implicit val session: SparkSession =  new DeltaLakeModulePlugin().additionalSparkProperties()
      .foldLeft(TestUtil.sparkSessionBuilder(withHive = true)) {
        case (builder, config) => builder.config(config._1, config._2)

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
@@ -18,9 +18,8 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import io.smartdatalake.app.GlobalConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.{Environment, SDLSaveMode, SaveModeMergeOptions}
+import io.smartdatalake.definitions.{SDLSaveMode, SaveModeMergeOptions}
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.testutils.custom.TestCustomDfCreator
 import io.smartdatalake.util.hdfs.PartitionValues
@@ -35,24 +34,23 @@ import java.nio.file.Files
 
 class DeltaLakeTableDataObjectTest extends FunSuite with BeforeAndAfter {
 
-  // we need a session with additional properties...
+  // set additional spark options for delta lake
   protected implicit val session : SparkSession = new DeltaLakeModulePlugin().additionalSparkProperties()
     .foldLeft(TestUtil.sparkSessionBuilder(withHive = true)) {
       case (builder, config) => builder.config(config._1, config._2)
     }.getOrCreate()
   import session.implicits._
 
-  // initialize empty Global Config in Environment
-  if (Environment._globalConfig == null) Environment._globalConfig = GlobalConfig()
-
   val tempDir = Files.createTempDirectory("tempHadoopDO")
   val tempPath: String = tempDir.toAbsolutePath.toString
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
-  implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
-  val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
+  implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  val contextExec: ActionPipelineContext = context.copy(phase = ExecutionPhase.Exec)
 
-  before { instanceRegistry.clear() }
+  before {
+    instanceRegistry.clear()
+  }
 
   test("CustomDf2DeltaTable") {
 

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
@@ -18,8 +18,9 @@
  */
 package io.smartdatalake.workflow.dataobject
 
+import io.smartdatalake.app.GlobalConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.{SDLSaveMode, SaveModeMergeOptions}
+import io.smartdatalake.definitions.{Environment, SDLSaveMode, SaveModeMergeOptions}
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.testutils.custom.TestCustomDfCreator
 import io.smartdatalake.util.hdfs.PartitionValues
@@ -40,6 +41,9 @@ class DeltaLakeTableDataObjectTest extends FunSuite with BeforeAndAfter {
       case (builder, config) => builder.config(config._1, config._2)
     }.getOrCreate()
   import session.implicits._
+
+  // initialize empty Global Config in Environment
+  if (Environment._globalConfig == null) Environment._globalConfig = GlobalConfig()
 
   val tempDir = Files.createTempDirectory("tempHadoopDO")
   val tempPath: String = tempDir.toAbsolutePath.toString

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
@@ -64,7 +64,7 @@ class DeltaLakeTableDataObjectTest extends FunSuite with BeforeAndAfter {
     // prepare & start load
     val testAction = CopyAction(id = s"${feed}Action", inputId = sourceDO.id, outputId = targetDO.id)
     val srcSubFeed = SparkSubFeed(None, "source", partitionValues = Seq())
-    testAction.exec(Seq(srcSubFeed))(session, contextExec)
+    testAction.exec(Seq(srcSubFeed))(contextExec)
 
     val expected = sourceDO.getDataFrame()
     val actual = targetDO.getDataFrame()
@@ -87,7 +87,7 @@ class DeltaLakeTableDataObjectTest extends FunSuite with BeforeAndAfter {
     // prepare & start load
     val testAction = CopyAction(id = s"${feed}Action", inputId = sourceDO.id, outputId = targetDO.id)
     val srcSubFeed = SparkSubFeed(None, "source", partitionValues = Seq())
-    testAction.exec(Seq(srcSubFeed))(session, contextExec)
+    testAction.exec(Seq(srcSubFeed))(contextExec)
 
     val expected = sourceDO.getDataFrame()
     val actual = targetDO.getDataFrame()

--- a/sdl-jms/src/main/scala/io/smartdatalake/workflow/dataobject/JmsDataObject.scala
+++ b/sdl-jms/src/main/scala/io/smartdatalake/workflow/dataobject/JmsDataObject.scala
@@ -65,7 +65,8 @@ case class JmsDataObject(override val id: DataObjectId,
 
   if(schemaMin.isDefined) logger.warn("SchemaMin ignored, for JmsDataObject is always fixed to payload:string")
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+    implicit val session: SparkSession = context.sparkSession
     val consumerFactory = new JmsQueueConsumerFactory(jndiContextFactory, jndiProviderUrl, basicAuthMode.user, basicAuthMode.password, connectionFactory, queue)
     val receiver = new SynchronousJmsReceiver[String](consumerFactory,
       TextMessageHandler.convert2Text, batchSize, Duration(maxWaitSec, TimeUnit.SECONDS),

--- a/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
+++ b/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
@@ -65,6 +65,7 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
   test("action dag with 2 actions in sequence where 2nd action reads different schema than produced by last action") {
     // Note: Some DataObjects remove & add columns on read (e.g. KafkaTopicDataObject, SparkFileDataObject)
     // In this cases we have to break the lineage und create a dummy DataFrame in init phase.
+    implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
     val feed = "actionpipeline"
@@ -82,9 +83,6 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val refTimestamp1 = LocalDateTime.now()
-    val appName = "test"
-    implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
     val l1 = Seq(("doe-john", 5)).toDF("key", "value")
     srcDO.writeDataFrame(l1, Seq())
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id)

--- a/sdl-splunk/src/main/scala/io/smartdatalake/workflow/dataobject/SplunkDataObject.scala
+++ b/sdl-splunk/src/main/scala/io/smartdatalake/workflow/dataobject/SplunkDataObject.scala
@@ -59,21 +59,22 @@ case class SplunkDataObject(override val id: DataObjectId,
   private implicit val rowSeqEncoder: Encoder[Seq[Row]] = Encoders.kryo[Seq[Row]]
   private implicit val queryTimeIntervalEncoder: Encoder[QueryTimeInterval] = Encoders.kryo[QueryTimeInterval]
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit spark: SparkSession, context: ActionPipelineContext): DataFrame = {
+  override def getDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
     readFromSplunk(params)
   }
 
-  override def prepare(implicit session: SparkSession, context: ActionPipelineContext): Unit = try {
+  override def prepare(implicit context: ActionPipelineContext): Unit = try {
     connection.test()
   } catch {
     case ex: Throwable => throw ConnectionTestException(s"($id) Can not connect. Error: ${ex.getMessage}", ex)
   }
 
-  private def readFromSplunk(params: SplunkParams)(implicit spark: SparkSession): DataFrame = {
+  private def readFromSplunk(params: SplunkParams)(implicit context: ActionPipelineContext): DataFrame = {
+    implicit val session: SparkSession = context.sparkSession
     val queryTimeIntervals = splitQueryTimes(params.queryFrom, params.queryTo, params.queryTimeInterval).repartition(params.parallelRequests)
     val searchResultRdd = queryTimeIntervals.map(interval => readRowsFromSplunk(interval, params)).as[Seq[Row]].rdd
     val searchResultRddFlattened = searchResultRdd.flatMap(identity)
-    val searchResultDf = spark.createDataFrame(searchResultRddFlattened, params.schema)
+    val searchResultDf = session.createDataFrame(searchResultRddFlattened, params.schema)
     searchResultDf
   }
 


### PR DESCRIPTION
preparation for #376 - include SparkSession into ActionPipelineContext, so that it is only created when needed.