### PR TITLE
Solve #466 by replacing API links to schema browser

### DIFF
--- a/docs/getting-started/part-1/select-columns.md
+++ b/docs/getting-started/part-1/select-columns.md
@@ -19,7 +19,7 @@ Let's use CsvFileDataObject again because that makes it easy for us to check the
 In more advanced (speak: real-life) scenarios, we would use one of numerous other possibilities, 
 such as HiveTableDataObject, SplunkDataObject...
 See [this list](https://github.com/smart-data-lake/smart-data-lake/blob/develop-spark3/docs/Reference.md#data-objects) for an overview.
-You can also consult the [API docs](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/dataobject/index.html) to see how to use all those Data Objects.
+You can also consult the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=2) to get a list of all Data Objects and related properties.
 
 In a first step, we want to make the airport data more understandable by removing any columns we don't need. 
 Since we don't introduce any business logic into the transformation, 
@@ -71,7 +71,7 @@ In this case, it automatically replaced "-" with "_"
 
 :::
 
-There are numerous other options available for the CopyAction, which you can view in the [API Docs](http://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/action/CopyAction.html).
+There are numerous other options available for the CopyAction, which you can view in the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=3-0).
 
 
 
@@ -94,7 +94,7 @@ If you encounter an error that looks like this:
     Caused by: java.lang.IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema is undefined. A schema must be defined if there are no existing files.
 
 Execute the **`download`**-feed again. After that feed was successfully executed, the execution of the feed `.*` or `compute` will work.
-More one this problem in the List of [Common Problems](../troubleshooting/common-problems.md).
+More on this problem in the list of [Common Problems](../troubleshooting/common-problems.md).
 
 
 :::
@@ -182,7 +182,7 @@ If you know Apache Spark, this column will look very familiar to you.
 After that, the query fails, because it only finds that column with error messages instead of the actual data.
 
 One way to get a better error message is to tell Spark that it should promptly fail when reading a corrupt file.
-You can do that with the option [jsonOptions](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/dataobject/JsonFileDataObject.html),
+You can do that with the option [jsonOptions](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=2-13-3),
 which allows you to directly pass on settings to Spark.
 
 In our case, we would end up with a faulty dataObject that looks like this:

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -9,8 +9,8 @@ This page is under review and currently not visible in the menu.
 
 Term|Description
 ---|---
-Action|Defines how data is moved / transformed from one data object to another. Please refer to the [API](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/action/index.html) to get an overview. It is possible and often necessary to define custom transformations which can be done by a SQL statement or Scala Code.
+Action|Defines how data is moved / transformed from one data object to another. Please refer to the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=3) to get an overview. It is possible and often necessary to define custom transformations which can be done by a SQL statement or Scala Code.
 DAG|Directed Acyclic Graph: Internally, Smart Data Lake Builder builds a DAG with data objects as vertices and actions as edges to resolve the dependencies between the actions. With this, execution can be optimized as it knows which feeds can run in parallel and what the pre-conditions for each feed are.
-    DataObject|Represents a physical data object like a single file (i.e. CSV, Excel, JSON), a directory containing multiple files, a database table (in Hive, JDBC etc) or any other data source or target. A list can be found in the [API docs](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/dataobject/DataObject.html).
+    DataObject|Represents a physical data object like a single file (i.e. CSV, Excel, JSON), a directory containing multiple files, a database table (in Hive, JDBC etc) or any other data source or target. A list can be found in the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=2).
 Feed|Multiple actions can be combined in a feed by metadata. This greatly helps to group common actions together and makes selection of the actions to execute easier.
 Global Options|The settings in the global section of the configuration file are available globally, meaning they will be used for all execution. This is mainly used for spark options.

--- a/docs/reference/hoconElements.md
+++ b/docs/reference/hoconElements.md
@@ -12,12 +12,12 @@ Some Data Objects need a connection, e.g. JdbcTableDataObject, as they need to k
 Instead of defining the connection information for every data object, you can conveniently define it in one place and just use the reference in the data objects.
 The possible parameters depend on the connection type. Please note the section on [usernames and password](#user-and-password-variables).
 
-For a list of all available connections, please consult the [API docs](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/connection/index.html) directly.
+For a list of all available connections, please consult the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=1) directly.
 
 In the package overview, you can also see the parameters available to each type of connection and which parameters are optional.
 
 ## Data Objects
-For a list of all available data objects, please consult the [API docs](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/dataobject/index.html) directly.
+For a list of all available data objects, please consult the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=2) directly.
 In the package overview, you can also see the parameters available to each type of data object and which parameters are optional.
 
 Data objects are structured in a hierarchy as many attributes are shared between them, i.e. do Hive tables and transactional tables share common attributes modeled in TableDataObject.
@@ -26,6 +26,6 @@ Here is an overview of all data objects:
 ![data object hierarchy](../images/dataobject_hierarchy.png)
 
 ## Actions
-For a list of all available actions, please consult the [API docs](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/workflow/action/index.html) directly.
+For a list of all available actions, please consult the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=3) directly.
 
 In the package overview, you can also see the parameters available to each type of action and which parameters are optional.

--- a/docs/reference/hoconOverview.md
+++ b/docs/reference/hoconOverview.md
@@ -16,7 +16,7 @@ More details and options are described below.
 
 ### Global Options
 In the global section of the configuration you can set global configurations such as spark options used by all executions.
-You can find a list of all configurations under [API docs](https://smartdatalake.ch/docs/site/scaladocs/io/smartdatalake/app/GlobalConfig.html).  
+You can find a list of all configurations in the [Configuration Schema Browser](https://smartdatalake.ch/json-schema-viewer/index.html#viewer-page?v=0).  
 A good list with examples can be found in the [application.conf](https://github.com/smart-data-lake/sdl-examples/blob/develop/src/main/resources/application.conf) of sdl-examples.
 
 ### Secrets User and Password Variables


### PR DESCRIPTION
### What changes are included in the pull request?
Replaces obsolete links to the API with links to the schema browser.

Note, that the schema browser supports "relative" links only. As soon as additional nodes are inserted, the links will point to different elements in the tree:
i.e `../index.html#viewer-page?v=3-0` for the 4th entry, then 1st entry.
It will have to do for now.

### Why are the changes needed?
Closes #466 