### PR TITLE
tutorial part2: sdl-spark Hostname specification

### DIFF
--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -145,11 +145,14 @@ This instructs Spark to use the external metastore you started with docker-compo
 Your Smart Data Lake container doesn't have access to the other containers just yet. 
 So when you run your data pipeline again, you need to add a parameter `--network getting-started_default` to join the virtual network where the metastore is located:
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
+    docker run --hostmane localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
 
 When using podman you need to join the pod where the metastore is located with `--pod getting-started`:
 
-    podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel '.*'
+    podman run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel '.*'
+
+:::info Hostname specification
+Without specifying the hostname the containter name (by default the docker/podman container ID) can not be resolved to localhost. If you need to name your container differently, the following arguments can be used alternitively: `--hostname myhost --add-host myhost:127.0.0.1 -rm ...`
 
 After you run your data pipeline again, you should now be able to see our DataObjects data in Polynote.
 No need to restart Polynote, just open it again and run all cells.

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -153,6 +153,7 @@ When using podman you need to join the pod where the metastore is located with `
 
 :::info Hostname specification
 Without specifying the hostname the containter name (by default the docker/podman container ID) can not be resolved to localhost. If you need to name your container differently, the following arguments can be used alternitively: `--hostname myhost --add-host myhost:127.0.0.1 -rm ...`
+:::
 
 After you run your data pipeline again, you should now be able to see our DataObjects data in Polynote.
 No need to restart Polynote, just open it again and run all cells.

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -152,7 +152,7 @@ When using podman you need to join the pod where the metastore is located with `
     podman run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel '.*'
 
 :::info Hostname specification
-Without specifying the hostname the containter name (by default the docker/podman container ID) can not be resolved to localhost. If you need to name your container differently, the following arguments can be used alternitively: `--hostname myhost --add-host myhost:127.0.0.1 -rm ...`
+Without specifying the hostname, the containter name (by default the docker/podman container ID) can not be resolved to localhost. If you need to name your container differently, the following arguments can be used alternatively: `--hostname myhost --add-host myhost:127.0.0.1 -rm ...`
 :::
 
 After you run your data pipeline again, you should now be able to see our DataObjects data in Polynote.

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -145,7 +145,7 @@ This instructs Spark to use the external metastore you started with docker-compo
 Your Smart Data Lake container doesn't have access to the other containers just yet. 
 So when you run your data pipeline again, you need to add a parameter `--network getting-started_default` to join the virtual network where the metastore is located:
 
-    docker run --hostmane localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
+    docker run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
 
 When using podman you need to join the pod where the metastore is located with `--pod getting-started`:
 


### PR DESCRIPTION
The sdl-spark call in part2 Delta Lake is update. And a hint is added.
Due to spark 2.3.1 behaviour the hostname need to be specified in the `/etc/hosts` as localhost, otherwise we get a `java.lang.ExceptionInInitializerError` from `java.net.UnknownHostException: dbfa2f2a4128: Temporary failure in name resolution`.