### PR TITLE
podman-compose version

### DIFF
--- a/docs/getting-started/troubleshooting/docker-on-windows.md
+++ b/docs/getting-started/troubleshooting/docker-on-windows.md
@@ -34,6 +34,7 @@ Install podman-compose for podman in WSL2:
 
 :::Info podman version
 Starting with podman-compose major version 1, no pods are created automatically. This results in networking issues between the containers. Therefore, we recommend to use a the latest version of 0.x.x which is here `0.1.11`. The behaviour may change in future versions.
+:::
 
 After starting `podman-compose up` in the getting-started folder you should now be able to open Polynote on port localhost:8192, as WSL2 automatically publishes all ports on Windows.
 If the port is not accessible, you can use `wsl hostname -I` on Windows command line to get the IP adress of WSL, and then access Polynote over {ip-address}:8192.

--- a/docs/getting-started/troubleshooting/docker-on-windows.md
+++ b/docs/getting-started/troubleshooting/docker-on-windows.md
@@ -30,7 +30,10 @@ For Windows, you can use the alternative podman compose.
 Install podman-compose for podman in WSL2:
 
     sudo apt install python3-pip
-    sudo pip3 install podman-compose
+    sudo pip3 install podman-compose==0.1.11
+
+:::Info podman version
+Starting with podman-compose major version 1, no pods are created automatically. This results in networking issues between the containers. Therefore, we recommend to use a the latest version of 0.x.x which is here `0.1.11`. The behaviour may change in future versions.
 
 After starting `podman-compose up` in the getting-started folder you should now be able to open Polynote on port localhost:8192, as WSL2 automatically publishes all ports on Windows.
 If the port is not accessible, you can use `wsl hostname -I` on Windows command line to get the IP adress of WSL, and then access Polynote over {ip-address}:8192.


### PR DESCRIPTION
due to podman-compose behavior change, no pods are created automatically in the newer (default) version. This results in network issues between the containers. Therefore we require to use an older version. `0.1.11`