### PR TITLE
typo download typ

### DIFF
--- a/docs/getting-started/part-3/custom-webservice.md
+++ b/docs/getting-started/part-3/custom-webservice.md
@@ -86,7 +86,7 @@ download-departures {
   inputId = ext-departures
   outputId = stg-departures
   metadata {
-    feed = compute
+    feed = download
   }
 }
 ```


### PR DESCRIPTION
in that present stage the download-departures actions is still a of typ download. Just to stay consistent and prevent readers confusion.
