### PR TITLE
part3 typo .get

### DIFF
--- a/docs/getting-started/part-3/incremental-mode.md
+++ b/docs/getting-started/part-3/incremental-mode.md
@@ -132,7 +132,7 @@ private val now = Instant.now.getEpochSecond
 just below the `nextState` variable. Then modify the `currentQueryParameters` variable according to
 ```scala
 // if we have query parameters in the state we will use them from now on
-val currentQueryParameters = if (previousState.isEmpty) checkQueryParameters(queryParameters.get) else checkQueryParameters(previousState.map{
+val currentQueryParameters = if (previousState.isEmpty) checkQueryParameters(queryParameters) else checkQueryParameters(previousState.map{
   x => DepartureQueryParameters(x.airport, x.nextBegin, now)
 })
 ```


### PR DESCRIPTION
The `DepartureQueryParameters` do not have a method `get`. 
The solutions file is correct, but the code snipped is not. Corrected now.

### What changes are included in the pull request?
Call to `DepartureQueryParameters` is corrected, now without `get`

### Why are the changes needed?
otherwise the compiler throws an error
