### PR TITLE
doku: Tab switchting podman docker

### DIFF
--- a/docs/getting-started/part-1/compute-distances.md
+++ b/docs/getting-started/part-1/compute-distances.md
@@ -2,6 +2,9 @@
 title: Compute Distances
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Goal
 
 In this part, we will compute the distances between departure and arrival airports
@@ -66,8 +69,29 @@ but this would have resulted in more complex code working with lists of inputs, 
 To use the Java Code in our sdl-spark docker image, we have to compile it. 
 You have already done this in the [setup](../setup.md), but lets review this step again. It can be done by using a maven docker image as follows
 
-    mkdir .mvnrepo
-    docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+mkdir .mvnrepo
+docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+mkdir .mvnrepo
+podman run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+```
+
+</TabItem>
+</Tabs>
 
 or you can also use maven directly if you have Java SDK and Maven installed
 
@@ -78,7 +102,27 @@ The *docker run* includes a parameter to mount ./target into the docker image, w
 
 Now you can start SDL again:
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel compute
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel compute
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel compute
+```
+
+</TabItem>
+</Tabs>
 
 Under *data/btl-distances* you can now see the final result. 
 
@@ -126,8 +170,28 @@ Just from the definitions of DataObjects and Actions alone, SDL builds a DAG and
 ### The Execution DAG of the .* feed
 
 You can also execute the entire data pipeline by selecting all feeds:
-        
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+```
+
+</TabItem>
+</Tabs>        
 
 The successful execution DAG looks like this
 

--- a/docs/getting-started/part-1/get-departures.md
+++ b/docs/getting-started/part-1/get-departures.md
@@ -2,6 +2,9 @@
 title: Get Departures
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Goal
 
 In this step, we will download plane departure data from the REST-Interface described in the previous step using Smart Data Lake Builder.
@@ -129,7 +132,27 @@ Before, we only mounted the data folder so that you could see the results of the
 The config file that was being used was located inside the docker image.
 This time, we add another volume with your config-file and tell SDL to use it with the *--config* option.
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel download
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel download
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel download
+```
+
+</TabItem>
+</Tabs>
 
 After executing it, you will see the file *data/stg_departures/result.json* has been replaced with the output of your pipeline.
 

--- a/docs/getting-started/part-1/joining-it-together.md
+++ b/docs/getting-started/part-1/joining-it-together.md
@@ -2,6 +2,9 @@
 title: Joining It Together
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Goal
 So now we have data from departures in our stage layer, and we have cleaned data for airports in our integration layer.
 In this step we will finally join both data sources together.
@@ -65,7 +68,27 @@ Always using one Data Object as output will make your data lineage more detailed
 ## Try it out
 You can run the usual *docker run* command:
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel compute
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel compute
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel compute
+```
+
+</TabItem>
+</Tabs>
 
 You should now see the resulting files in *data/btl-connected-airports*.
 Great! Now we have names and coordinates of destination airports.

--- a/docs/getting-started/part-1/select-columns.md
+++ b/docs/getting-started/part-1/select-columns.md
@@ -113,10 +113,10 @@ podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 If you encounter an error that looks like this:
 
     Exception in thread "main" io.smartdatalake.util.dag.TaskFailedException: Task select-airport-cols failed. 
-			Root cause is 'IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema 
-			is undefined. A schema must be defined if there are no existing files.'
+	Root cause is 'IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema 
+	is undefined. A schema must be defined if there are no existing files.'
     Caused by: java.lang.IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject 
-			schema is undefined. A schema must be defined if there are no existing files.
+	schema is undefined. A schema must be defined if there are no existing files.
 
 Execute the **`download`**-feed again. After that feed was successfully executed, the execution of the feed `.*` or `compute` will work.
 More on this problem in the list of [Common Problems](../troubleshooting/common-problems.md).

--- a/docs/getting-started/part-1/select-columns.md
+++ b/docs/getting-started/part-1/select-columns.md
@@ -2,6 +2,9 @@
 title: Select Columns
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Goal
 
 In this step we write our first Action that modifies data.
@@ -56,7 +59,7 @@ with some optional transformations of the data along the way.
 - To define the transformations of an action, you define a list of HOCON Objects.
 HOCON-Objects are just like JSON-Objects (with a few added features, but more on that later).
 - Instead of allowing for just one transformer, we could potentially have multiple transformers within the same action that
-  get executed one after the other. That's why we have the bracket followed by the curly brace "[{" :
+  get executed one after the other. That's why we have the bracket followed by the curly brace `[{` :
   the CustomSparkAction expects it's field *transformers* to be a list of HOCON Objects.
 - There's different kinds of transformers, in this case we defined a *SQLDfTransformer* and provided it with a custom SQL-Code.
 There are other transformer types such as *ScalaCodeDfTransformer*, *PythonCodeDfTransformer*... More on that later.
@@ -67,7 +70,7 @@ Notice that we call our input DataObject stg-airports with a hyphen "-", but in 
 This is due to the SQL standard not allowing "-" in unquoted identifiers (e.g. table names). 
 Under the hood, Apache Spark SQL is used to execute the query, which implements SQL standard.
 SDL works around this by replacing special chars in DataObject names used in SQL statements for you. 
-In this case, it automatically replaced "-" with "_"
+In this case, it automatically replaced "-" with `_`
 
 :::
 
@@ -83,15 +86,37 @@ try out our new actions.
 
 To execute the pipeline, use the same command as before, but change the feed to compute:
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel compute
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel compute
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel compute
+```
+
+</TabItem>
+</Tabs>
 
 :::caution
 
 If you encounter an error that looks like this:
 
-    Exception in thread "main" io.smartdatalake.util.dag.TaskFailedException: Task select-airport-cols failed. Root cause is 'IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema is undefined. A sche
-    ma must be defined if there are no existing files.'
-    Caused by: java.lang.IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema is undefined. A schema must be defined if there are no existing files.
+    Exception in thread "main" io.smartdatalake.util.dag.TaskFailedException: Task select-airport-cols failed. 
+			Root cause is 'IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema 
+			is undefined. A schema must be defined if there are no existing files.'
+    Caused by: java.lang.IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject 
+			schema is undefined. A schema must be defined if there are no existing files.
 
 Execute the **`download`**-feed again. After that feed was successfully executed, the execution of the feed `.*` or `compute` will work.
 More on this problem in the list of [Common Problems](../troubleshooting/common-problems.md).
@@ -108,13 +133,53 @@ We might work on a small data set for now, but keep in mind that this would scal
 SDL gives you precise control on which actions you want to execute. 
 For instance if you only want to execute the action that we just wrote, you can type
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ids:select-airport-cols
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ids:select-airport-cols
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ids:select-airport-cols
+```
+
+</TabItem>
+</Tabs>
 
 Of course, at this stage, the feed *compute* only contains this one action, so the result will be the same.
 
 SDL also allows you to use combinations of expressions to select the actions you want to execute. You can run
 
-    docker run --rm sdl-spark:latest --help
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm sdl-spark:latest --help
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm sdl-spark:latest --help
+```
+
+</TabItem>
+</Tabs>
 
 to see all options that are available. For your convenience, here is the current output of the help command:
 
@@ -163,7 +228,27 @@ to see all options that are available. For your convenience, here is the current
 One popular option is to use regular expressions to execute multiple feeds together.
 In our case, we can run the entire data pipeline with the following command : 
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+```
+
+</TabItem>
+</Tabs>
 
 
 

--- a/docs/getting-started/part-1/select-columns.md
+++ b/docs/getting-started/part-1/select-columns.md
@@ -70,7 +70,7 @@ Notice that we call our input DataObject stg-airports with a hyphen "-", but in 
 This is due to the SQL standard not allowing "-" in unquoted identifiers (e.g. table names). 
 Under the hood, Apache Spark SQL is used to execute the query, which implements SQL standard.
 SDL works around this by replacing special chars in DataObject names used in SQL statements for you. 
-In this case, it automatically replaced "-" with `_`
+In this case, it automatically replaced `-` with `_`
 
 :::
 

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -214,10 +214,6 @@ podman run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/
 </TabItem>
 </Tabs>
 
-:::info Podman pod specification
-When using podman you need to join the pod where the metastore is located with `--pod getting-started`:
-:::
-
 :::info Hostname specification
 Without specifying the hostname, the containter name (by default the docker/podman container ID) can not be resolved to localhost. If you need to name your container differently, the following arguments can be used alternatively: `--hostname myhost --add-host myhost:127.0.0.1 -rm ...`
 :::

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -2,6 +2,9 @@
 title: Delta Lake - a better data format
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Goal
 
 Up to now we have used CSV with CsvFileDataObject as file format. We will switch to a more modern data format in this step which supports a catalog, compression and even transactions.
@@ -88,9 +91,31 @@ Finally, adapt the action definition for `join-departures-airports`:
 To run our data pipeline, first delete the data directory - otherwise DeltaLakeTableDataObject will fail because of existing files in different format.
 Then you can execute the usual *docker run* command for all feeds:
 
-    mkdir -f data
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel 'download*'
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel '^(?!download).*'
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+mkdir -f data
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel 'download*'
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel '^(?!download).*'
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+mkdir -f data
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel 'download*'
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest -c /mnt/config --feed-sel '^(?!download).*'
+```
+
+</TabItem>
+</Tabs>
 
 :::info
 Why two separate commands?   
@@ -114,10 +139,32 @@ One of the most advanced notebooks for Scala code we found is Polynote, see [pol
 
 We will now start Polynote in a docker container, and an external Metastore (Derby database) in another container to share the catalog between our experiments and the notebook.
 To do so you need to add additional files to the project. Change to the projects root directory and **unzip part2.additional-files.zip** into the project's root directoy, then run the following commands in the projects root directory:
-    
-    docker-compose build
-    mkdir -p data/_metastore
-    docker-compose up
+
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker-compose build
+mkdir -p data/_metastore
+docker-compose up
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman-compose build
+mkdir -p data/_metastore
+podman-compose up
+```
+
+</TabItem>
+</Tabs>
 
 This might take multiple minutes.
 You should now be able to access Polynote at `localhost:8192`. 
@@ -145,11 +192,31 @@ This instructs Spark to use the external metastore you started with docker-compo
 Your Smart Data Lake container doesn't have access to the other containers just yet. 
 So when you run your data pipeline again, you need to add a parameter `--network getting-started_default` to join the virtual network where the metastore is located:
 
-    docker run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
 
+```jsx
+docker run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel '.*'
+```
+
+</TabItem>
+</Tabs>
+
+:::info Podman pod specification
 When using podman you need to join the pod where the metastore is located with `--pod getting-started`:
-
-    podman run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel '.*'
+:::
 
 :::info Hostname specification
 Without specifying the hostname, the containter name (by default the docker/podman container ID) can not be resolved to localhost. If you need to name your container differently, the following arguments can be used alternatively: `--hostname myhost --add-host myhost:127.0.0.1 -rm ...`

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -190,7 +190,7 @@ You probably don't have a global section in your application.conf yet, so here i
 
 This instructs Spark to use the external metastore you started with docker-compose. 
 Your Smart Data Lake container doesn't have access to the other containers just yet. 
-So when you run your data pipeline again, you need to add a parameter `--network getting-started_default` to join the virtual network where the metastore is located:
+So when you run your data pipeline again, you need to add a parameter `--network`/`--pod` to join the virtual network where the metastore is located:
 
 <Tabs groupId = "docker-podman-switch"
 defaultValue="docker"

--- a/docs/getting-started/part-2/historical-data.md
+++ b/docs/getting-started/part-2/historical-data.md
@@ -2,6 +2,9 @@
 title: Keeping historical data
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Goal
 
 Data generally can be split into two groups:
@@ -66,7 +69,27 @@ Then start Action `historize-airports`.
 You may have seen that the `--feed-sel` parameter of SDL command line supports more options to select actions to execute (see command line help). 
 We will now only execute this single action by changing this parameter to `--feed-sel ids:historize-airports`:
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel ids:historize-airports
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel ids:historize-airports
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel ids:historize-airports
+```
+
+</TabItem>
+</Tabs>
 
 After successful execution you can check the schema and data of our table in Polynote. 
 It now has a time dimension through the two new columns `dl_ts_captured` and `dl_ts_delimited`.
@@ -190,7 +213,27 @@ Now, delete the table and data of the DataObject `int-departures` in Polynote, t
 
 Then start Action deduplicate-departures:
 
-    docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel ids:deduplicate-departures
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel ids:deduplicate-departures
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel ids:deduplicate-departures
+```
+
+</TabItem>
+</Tabs>
 
 After successful execution you can check the schema and data of our table in Polynote. 
 The new column `dl_ts_captured` shows the current time of the data pipeline run when this object first occurred in the input data. 

--- a/docs/getting-started/part-3/incremental-mode.md
+++ b/docs/getting-started/part-3/incremental-mode.md
@@ -3,6 +3,9 @@ id: incremental-mode
 title: Incremental Mode
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Goal
 The goal of this part is to use the DataObject's state, such that it can be used in subsequent requests. 
 This allows for more dynamic querying of the API. 
@@ -100,10 +103,30 @@ To work with a state, we need to introduce two new command line parameters: `--s
 This allows us to define the folder and name of the state file. 
 To have access to the state file, we specify the path to be in an already mounted folder.
 
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest --config /mnt/config --feed-sel ids:download-deduplicate-departures --state-path /mnt/data/state -n getting-started
 ```
-  docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
-  docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest --config /mnt/config --feed-sel ids:download-deduplicate-departures --state-path /mnt/data/state -n getting-started
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+podman run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest --config /mnt/config --feed-sel ids:download-deduplicate-departures --state-path /mnt/data/state -n getting-started
 ```
+
+</TabItem>
+</Tabs>
+
 Use this slightly modified command to run `download-deduplicate-departures` Action. 
 Nothing should have changed so far, since we only read and write an empty state.   
 You can verify this by opening the file `getting-started.<runId>.<attemptId>.json` and having a look at the field `dataObjectsState`. The stored state is currently empty. 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -19,20 +19,20 @@ To run this tutorial you just need two things:
 - Open up a terminal and change to the folder with the source, you should see a file called Dockerfile. 
 - Then run (note: this might take some time, but it's only needed once):
 
-<Tabs
-defaultValue="javascript"
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
 values={[
-{label: 'Docker', value: 'javascript'},
-{label: 'Podman', value: 'other'},
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
 ]}>
-<TabItem value="javascript">
+<TabItem value="docker">
 
 ```jsx
 docker build -t sdl-spark .
 ```
 
 </TabItem>
-<TabItem value="other">
+<TabItem value="podman">
 
 ```jsx
 podman build -t sdl-spark .
@@ -47,8 +47,31 @@ podman build -t sdl-spark .
 
 Compile included Scala classes. Note: this might take some time, but it's only needed at the beginning or if Scala code has changed.
 
-    mkdir .mvnrepo
-    docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+First compile included Java classes (note: this might take some time, but it's only needed at the beginning or if Java code has changed)
+
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+mkdir .mvnrepo
+docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+mkdir .mvnrepo
+podman run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+```
+
+</TabItem>
+</Tabs>
 
 
 ## Run SDL with Spark docker image

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 To run this tutorial you just need two things:
 
-- [Docker](https://www.docker.com/get-started), including docker-compose. If you use Windows, please read our note on [Docker for Windows](troubleshooting/docker-on-windows.md),
+- [Docker](https://www.docker.com/get-started), including docker-compose. If you use Windows, you might want to use [podman as an alternative to docker](troubleshooting/docker-on-windows.md).
 - The [source code of the example](https://github.com/smart-data-lake/getting-started).
 
 ## Build Spark docker image

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -19,20 +19,20 @@ To run this tutorial you just need two things:
 - Open up a terminal and change to the folder with the source, you should see a file called Dockerfile. 
 - Then run (note: this might take some time, but it's only needed once):
 
-<Tabs
-defaultValue="javascript"
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
 values={[
-{label: 'Docker', value: 'javascript'},
-{label: 'Podman', value: 'other'},
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
 ]}>
-<TabItem value="javascript">
+<TabItem value="docker">
 
 ```jsx
 docker build -t sdl-spark .
 ```
 
 </TabItem>
-<TabItem value="other">
+<TabItem value="podman">
 
 ```jsx
 podman build -t sdl-spark .
@@ -41,16 +41,37 @@ podman build -t sdl-spark .
 </TabItem>
 </Tabs>
 
-
-
 ## Run SDL with Spark docker image
 
 Let's see Smart Data Lake in action!
 
 First compile included Java classes (note: this might take some time, but it's only needed at the beginning or if Java code has changed)
 
-    mkdir .mvnrepo
-    docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+<Tabs groupId = "docker-podman-switch"
+defaultValue="docker"
+values={[
+{label: 'Docker', value: 'docker'},
+{label: 'Podman', value: 'podman'},
+]}>
+<TabItem value="docker">
+
+```jsx
+mkdir .mvnrepo
+docker run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+```
+
+</TabItem>
+<TabItem value="podman">
+
+```jsx
+mkdir .mvnrepo
+podman run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
+```
+
+</TabItem>
+</Tabs>
+
+
 
 Then run
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -3,6 +3,9 @@ id: setup
 title: Technical Setup
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Requirements
 
 To run this tutorial you just need two things:
@@ -16,8 +19,28 @@ To run this tutorial you just need two things:
 - Open up a terminal and change to the folder with the source, you should see a file called Dockerfile. 
 - Then run (note: this might take some time, but it's only needed once):
 
+<Tabs
+defaultValue="javascript"
+values={[
+{label: 'Docker', value: 'javascript'},
+{label: 'Podman', value: 'other'},
+]}>
+<TabItem value="javascript">
 
-    docker build -t sdl-spark .
+```jsx
+docker build -t sdl-spark .
+```
+
+</TabItem>
+<TabItem value="other">
+
+```jsx
+podman build -t sdl-spark .
+```
+
+</TabItem>
+</Tabs>
+
 
 
 ## Compile Scala Classes

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -3,6 +3,9 @@ id: setup
 title: Technical Setup
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Requirements
 
 To run this tutorial you just need two things:
@@ -16,8 +19,28 @@ To run this tutorial you just need two things:
 - Open up a terminal and change to the folder with the source, you should see a file called Dockerfile. 
 - Then run (note: this might take some time, but it's only needed once):
 
+<Tabs
+defaultValue="javascript"
+values={[
+{label: 'Docker', value: 'javascript'},
+{label: 'Podman', value: 'other'},
+]}>
+<TabItem value="javascript">
 
-    docker build -t sdl-spark .
+```jsx
+docker build -t sdl-spark .
+```
+
+</TabItem>
+<TabItem value="other">
+
+```jsx
+podman build -t sdl-spark .
+```
+
+</TabItem>
+</Tabs>
+
 
 
 ## Run SDL with Spark docker image


### PR DESCRIPTION
### What changes are included in the pull request?

All docker src snippeds are now implemented with enabling the reader to select docker or podman commands. The commands are adapted to use `--pod` instead of `--network` where necessary.

### Why are the changes needed?
Now the user can easily copy and paste all commands ever if podman is used. 