### PR TITLE
Bugfix/spark session per job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 			<id>fat-jar-for-spark-3.1</id>
 			<properties>
 				<spark.version>3.1.1</spark.version>
-				<spark-extensions.version>3.1.1-SNAPSHOT</spark-extensions.version>
+				<spark-extensions.version>3.1.2</spark-extensions.version>
 				<delta.version>1.0.1</delta.version>
 				<json4s.version>3.7.0-M5</json4s.version>
 

--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -36,6 +36,9 @@ import org.apache.spark.util.PrivateAccessor
 /**
  * Global configuration options
  *
+ * Note that global configuration is responsible to hold SparkSession, so that its created once and only once per SDLB job.
+ * This is especially important if JVM is shared between different SDL jobs (e.g. Databricks cluster), because sharing SparkSession in object Environment survives the current SDLB job.
+ *
  * @param kryoClasses                                       classes to register for spark kryo serialization
  * @param sparkOptions                                      spark options
  * @param statusInfo                                        enable a REST API providing live status info, see detailed configuration [[StatusInfoRestApiConfig]]
@@ -52,8 +55,6 @@ import org.apache.spark.util.PrivateAccessor
  *                       which are allowed to overwrite the all partitions of a table if no partition values are set.
  *                       This is used to override/avoid a protective error when using SDLSaveMode.OverwriteOptimized|OverwritePreserveDirectories.
  *                       Define it as a list of DataObject id's.
- * @param runtimeDataNumberOfExecutionsToKeep Number of Executions to keep runtime data for in streaming mode (default = 10).
- *                       Must be bigger than 1.
  * @param synchronousStreamingTriggerIntervalSec Trigger interval for synchronous actions in streaming mode in seconds (default = 60 seconds)
  *                       The synchronous actions of the DAG will be executed with this interval if possile.
  *                       Note that for asynchronous actions there are separate settings, e.g. SparkStreamingMode.triggerInterval.
@@ -69,11 +70,9 @@ case class GlobalConfig(kryoClasses: Option[Seq[String]] = None
                         , pythonUDFs: Option[Map[String, PythonUDFCreatorConfig]] = None
                         , secretProviders: Option[Map[String, SecretProviderConfig]] = None
                         , allowOverwriteAllPartitionsWithoutPartitionValues: Seq[DataObjectId] = Seq()
-                        , runtimeDataNumberOfExecutionsToKeep: Int = 10
                         , synchronousStreamingTriggerIntervalSec: Int = 60
                        )
 extends SmartDataLakeLogger {
-  assert(runtimeDataNumberOfExecutionsToKeep>1, "GlobalConfig.runtimeDataNumberOfExecutionsToKeep must be bigger than 1.")
 
   // start memory logger, else log memory once
   if (memoryLogTimer.isDefined) {
@@ -100,46 +99,63 @@ extends SmartDataLakeLogger {
   /**
    * Create a spark session using settings from this global config
    */
-  def createSparkSession(appName: String, master: Option[String], deployMode: Option[String] = None): SparkSession = {
-    if (Environment._sparkSession != null) {
-      logger.warn("Your SparkSession was already set, that should not happen. We will re-register UDFs and set spark options.")
-      setSparkOptions(Environment._sparkSession)
-      registerUdf(Environment._sparkSession)
-    } else {
-      // prepare additional spark options
-      // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
-      val executorPlugins = sparkOptions.flatMap(_.get("spark.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq())
-      val executorPluginOptions = if (executorPlugins.nonEmpty) Map("spark.executor.plugins" -> executorPlugins.mkString(",")) else Map[String, String]()
-      // config for MemoryLoggerExecutorPlugin can only be transferred to Executor by spark-options
-      val memoryLogOptions = memoryLogTimer.map(_.getAsMap).getOrElse(Map())
-      // get additional options from modules
-      val moduleOptions = ModulePlugin.modules.map(_.additionalSparkProperties()).reduceOption(mergeSparkOptions).getOrElse(Map())
-      // combine all options: custom options will override framework options
-      val sparkOptionsExtended = Seq(moduleOptions, memoryLogOptions, executorPluginOptions).reduceOption(mergeSparkOptions).getOrElse(Map()) ++ sparkOptions.getOrElse(Map())
-      Environment._sparkSession = AppUtil.createSparkSession(appName, master, deployMode, kryoClasses, sparkOptionsExtended, enableHive)
-      registerUdf(Environment._sparkSession)
-      // adjust log level
-      LogUtil.setLogLevel(Environment._sparkSession.sparkContext)
-    }
+  private def createSparkSession(appName: String, master: Option[String], deployMode: Option[String] = None): SparkSession = {
+    // prepare additional spark options
+    // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
+    val executorPlugins = sparkOptions.flatMap(_.get("spark.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq())
+    val executorPluginOptions = if (executorPlugins.nonEmpty) Map("spark.executor.plugins" -> executorPlugins.mkString(",")) else Map[String, String]()
+    // config for MemoryLoggerExecutorPlugin can only be transferred to Executor by spark-options
+    val memoryLogOptions = memoryLogTimer.map(_.getAsMap).getOrElse(Map())
+    // get additional options from modules
+    val moduleOptions = ModulePlugin.modules.map(_.additionalSparkProperties()).reduceOption(mergeSparkOptions).getOrElse(Map())
+    // combine all options: custom options will override framework options
+    val sparkOptionsExtended = Seq(moduleOptions, memoryLogOptions, executorPluginOptions).reduceOption(mergeSparkOptions).getOrElse(Map()) ++ sparkOptions.getOrElse(Map())
+    val sparkSession = AppUtil.createSparkSession(appName, master, deployMode, kryoClasses, sparkOptionsExtended, enableHive)
+    registerUdf(sparkSession)
+    // adjust log level
+    LogUtil.setLogLevel(sparkSession.sparkContext)
+    // set sparkSession in environment
+    // Attention: if JVM is shared between different SDL jobs (e.g. Databricks cluster), this overrides values from earlier jobs!
+    // Environment._sparkSession is a workaround for accessing it in custom code. It should not be used inside SDLB code.
+    Environment._sparkSession = sparkSession
     // return
-    Environment._sparkSession
+    sparkSession
   }
 
+  // private holder for spark session
+  private[smartdatalake] var _sparkSession: Option[SparkSession] = None
+
+  /**
+   * Return SparkSession
+   * Create SparkSession if not yet done, but only if it is used.
+   */
+  def sparkSession(appName: String, master: Option[String], deployMode: Option[String] = None): SparkSession = {
+    if (_sparkSession.isEmpty) {
+      _sparkSession = Some(createSparkSession(appName, master, deployMode))
+    }
+    _sparkSession.get
+  }
+
+  /**
+   * True if a SparkSession has been created in this job
+   */
+  def hasSparkSession: Boolean = _sparkSession.isDefined
+
   private[smartdatalake] def setSparkOptions(session:SparkSession): Unit = {
-    sparkOptions.getOrElse(Map()).foreach{ case (k,v) => Environment._sparkSession.conf.set(k,v)}
+    sparkOptions.getOrElse(Map()).foreach{ case (k,v) => session.conf.set(k,v)}
   }
 
   private[smartdatalake] def registerUdf(session: SparkSession): Unit = {
     sparkUDFs.getOrElse(Map()).foreach { case (name,config) =>
       val udf = config.getUDF
       // register in SDL spark session
-      Environment._sparkSession.udf.register(name, udf)
+      session.udf.register(name, udf)
       // register for use in expression evaluation
       ExpressionEvaluator.registerUdf(name, udf)
     }
     pythonUDFs.getOrElse(Map()).foreach { case (name,config) =>
       // register in SDL spark session
-      config.registerUDF(name, Environment._sparkSession)
+      config.registerUDF(name, session)
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -281,7 +281,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
    */
   def startSimulation(appConfig: SmartDataLakeBuilderConfig, initialSubFeeds: Seq[SparkSubFeed], dataObjectsState: Seq[DataObjectState] = Seq())(implicit instanceRegistry: InstanceRegistry, session: SparkSession): (Seq[SparkSubFeed], Map[RuntimeEventState,Int]) = {
     implicit val hadoopConf: Configuration = session.sparkContext.hadoopConfiguration
-    val (subFeeds, stats) = exec(appConfig, SDLExecutionId.executionId1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionsToSkip = Map(), initialSubFeeds = initialSubFeeds, dataObjectsState = dataObjectsState, stateStore = None, stateListeners = Seq(), simulation = true)
+    val (subFeeds, stats) = exec(appConfig, SDLExecutionId.executionId1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionsToSkip = Map(), initialSubFeeds = initialSubFeeds, dataObjectsState = dataObjectsState, stateStore = None, stateListeners = Seq(), simulation = true, globalConfig = GlobalConfig())
     (subFeeds.map(_.asInstanceOf[SparkSubFeed]), stats)
   }
 
@@ -308,20 +308,25 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     require(config.hasPath("dataObjects"), s"No configuration parsed or it does not have a section called dataObjects")
 
     // parse config objects
-    Environment._globalConfig = GlobalConfig.from(config)
-    Environment._instanceRegistry = ConfigParser.parse(config, instanceRegistry) // share instance registry for custom code
+    val globalConfig = GlobalConfig.from(config)
+    ConfigParser.parse(config, instanceRegistry) // share instance registry for custom code
+
+    // set environment
+    // Attention: if JVM is shared between different SDL jobs (e.g. Databricks cluster), this overrides values from earlier jobs!
+    Environment._globalConfig = globalConfig
+    Environment._instanceRegistry = instanceRegistry
 
     val statusInfoListeners = if (Environment._globalConfig.statusInfo.isDefined) Seq(new StatusInfoListener()) else Nil
     val stateListeners =
-      Environment.globalConfig.stateListeners.map(_.listener) ++ Environment._additionalStateListeners ++ statusInfoListeners
+      globalConfig.stateListeners.map(_.listener) ++ Environment._additionalStateListeners ++ statusInfoListeners
 
     if (Environment._globalConfig.statusInfo.isDefined) {
       StatusInfoServer.start(statusInfoListeners.head, Environment._globalConfig.statusInfo.get)
     }
-    exec(appConfig, executionId, runStartTime, attemptStartTime, actionsToSkip, initialSubFeeds, dataObjectsState, stateStore, stateListeners, simulation)(Environment._instanceRegistry)
+    exec(appConfig, executionId, runStartTime, attemptStartTime, actionsToSkip, initialSubFeeds, dataObjectsState, stateStore, stateListeners, simulation, globalConfig)(instanceRegistry)
   }
 
-  private[smartdatalake] def exec(appConfig: SmartDataLakeBuilderConfig, executionId: SDLExecutionId, runStartTime: LocalDateTime, attemptStartTime: LocalDateTime, actionsToSkip: Map[ActionId, RuntimeInfo], initialSubFeeds: Seq[SubFeed], dataObjectsState: Seq[DataObjectState], stateStore: Option[ActionDAGRunStateStore[_]], stateListeners: Seq[StateListener], simulation: Boolean)(implicit instanceRegistry: InstanceRegistry) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
+  private[smartdatalake] def exec(appConfig: SmartDataLakeBuilderConfig, executionId: SDLExecutionId, runStartTime: LocalDateTime, attemptStartTime: LocalDateTime, actionsToSkip: Map[ActionId, RuntimeInfo], initialSubFeeds: Seq[SubFeed], dataObjectsState: Seq[DataObjectState], stateStore: Option[ActionDAGRunStateStore[_]], stateListeners: Seq[StateListener], simulation: Boolean, globalConfig: GlobalConfig)(implicit instanceRegistry: InstanceRegistry) : (Seq[SubFeed], Map[RuntimeEventState,Int]) = {
 
     // select actions by feedSel
     val actionsSelected = AppUtil.filterActionList(appConfig.feedSel, instanceRegistry.getActions.toSet).toSeq
@@ -344,8 +349,8 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
     // create and execute DAG
     logger.info(s"starting application ${appConfig.appName} runId=${executionId.runId} attemptId=${executionId.attemptId}")
-    val serializableHadoopConf = new SerializableHadoopConfiguration(Environment.globalConfig.getHadoopConfiguration)
-    val context = ActionPipelineContext(appConfig.feedSel, appConfig.appName, executionId, instanceRegistry, referenceTimestamp = Some(LocalDateTime.now), appConfig, runStartTime, attemptStartTime, simulation, actionsSelected = actionIdsSelected, actionsSkipped = actionIdsSkipped, serializableHadoopConf = serializableHadoopConf)
+    val serializableHadoopConf = new SerializableHadoopConfiguration(globalConfig.getHadoopConfiguration)
+    val context = ActionPipelineContext(appConfig.feedSel, appConfig.appName, executionId, instanceRegistry, referenceTimestamp = Some(LocalDateTime.now), appConfig, runStartTime, attemptStartTime, simulation, actionsSelected = actionIdsSelected, actionsSkipped = actionIdsSkipped, serializableHadoopConf = serializableHadoopConf, globalConfig = globalConfig)
     val actionDAGRun = ActionDAGRun(actionsToExec, actionsToSkip, appConfig.getPartitionValues.getOrElse(Seq()), appConfig.parallelism, initialSubFeeds, dataObjectsState, stateStore, stateListeners)(context)
     val finalSubFeeds = try {
       if (simulation) {
@@ -391,7 +396,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
       // wait for trigger interval
       lastStartTime.foreach { t =>
-        val nextStartTime = t.plusSeconds(Environment.globalConfig.synchronousStreamingTriggerIntervalSec)
+        val nextStartTime = t.plusSeconds(context.globalConfig.synchronousStreamingTriggerIntervalSec)
         val waitTimeSec = Duration.between(LocalDateTime.now, nextStartTime).getSeconds
         if (waitTimeSec > 0) {
           logger.info(s"sleeping $waitTimeSec seconds for synchronous streaming trigger interval")

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigToolbox.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigToolbox.scala
@@ -57,8 +57,9 @@ object ConfigToolbox {
   def getDefaultActionPipelineContext(implicit sparkSession : org.apache.spark.sql.SparkSession, instanceRegistry : io.smartdatalake.config.InstanceRegistry) : ActionPipelineContext = {
     val defaultHadoopConf = new SerializableHadoopConfiguration(new Configuration())
     val name = "interactive"
-    val context = ActionPipelineContext(name, name, SDLExecutionId.executionId1, instanceRegistry, Some(LocalDateTime.now()), SmartDataLakeBuilderConfig(name, Some(name)), phase = ExecutionPhase.Exec, serializableHadoopConf = defaultHadoopConf)
-    context._sparkSession = Some(sparkSession)
+    val globalConfig = GlobalConfig()
+    val context = ActionPipelineContext(name, name, SDLExecutionId.executionId1, instanceRegistry, Some(LocalDateTime.now()), SmartDataLakeBuilderConfig(name, Some(name)), phase = ExecutionPhase.Exec, serializableHadoopConf = defaultHadoopConf, globalConfig = globalConfig)
+    globalConfig._sparkSession = Some(sparkSession)
     context
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -173,6 +173,18 @@ object Environment {
       .map(_.toBoolean).getOrElse(true)
   }
 
+  /**
+   * Number of Executions to keep runtime data for in streaming mode (default = 10).
+   * Must be bigger than 1.
+   */
+  var runtimeDataNumberOfExecutionsToKeep: Int = {
+    val nb = EnvironmentUtil.getSdlParameter("runtimeDataNumberOfExecutionsToKeep")
+      .map(_.toInt).getOrElse(10)
+    assert(nb>1, "runtimeDataNumberOfExecutionsToKeep must be bigger than 1.")
+    // return
+    nb
+  }
+
   // static configurations
   val configPathsForLocalSubstitution: Seq[String] = Seq(
       "path", "table.name"
@@ -187,12 +199,15 @@ object Environment {
   }
 
   // dynamically shared environment for custom code (see also #106)
+  // attention: if JVM is shared between different SDL jobs (e.g. Databricks cluster), these variables will be overwritten by the current job. Therefore they should not been used in SDL code, but might be used in custom code on your own risk.
   def sparkSession: SparkSession = _sparkSession
   private [smartdatalake] var _sparkSession: SparkSession = _
   def instanceRegistry: InstanceRegistry = _instanceRegistry
   private [smartdatalake] var _instanceRegistry: InstanceRegistry = _
   def globalConfig: GlobalConfig = _globalConfig
   private [smartdatalake] var _globalConfig: GlobalConfig = _
+
+  // this class loader is needed to find custom classes in some environments (e.g. Polynote)
   def classLoader: ClassLoader = _classLoader
   private [smartdatalake] var _classLoader: ClassLoader = this.getClass.getClassLoader // initialize with default classloader
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -237,7 +237,7 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], executionId: SD
     }
     override def onNodeFailure(exception: Throwable)(node: Action): Unit = {
       // only first line of message included as logical plan of AnalysisException might have several 100 lines...
-      val exceptionMsg = s"${exception.getClass.getSimpleName}: ${exception.getMessage.linesIterator.next}"
+      val exceptionMsg = s"${exception.getClass.getSimpleName}: ${Option(exception.getMessage).map(_.linesIterator.next).getOrElse("null")}"
       node.addRuntimeEvent(executionId, phase, RuntimeEventState.FAILED, Some(exceptionMsg))
       logger.warn(s"${node.toStringShort}: $phase failed with $exceptionMsg")
       saveState(phase, Some(node.id))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -18,10 +18,9 @@
  */
 package io.smartdatalake.workflow
 
-import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.app.{GlobalConfig, SmartDataLakeBuilderConfig}
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
-import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{SerializableHadoopConfiguration, SmartDataLakeLogger}
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
@@ -67,15 +66,18 @@ case class ActionPipelineContext (
                                    actionsSelected: Seq[ActionId] = Seq(),
                                    actionsSkipped: Seq[ActionId] = Seq(),
                                    @transient // Prevent polluting output with contents of classLoader field
-                                   serializableHadoopConf: SerializableHadoopConfiguration
+                                   serializableHadoopConf: SerializableHadoopConfiguration,
+                                   globalConfig: GlobalConfig
                                  ) extends SmartDataLakeLogger {
   private[smartdatalake] def getReferenceTimestampOrNow: LocalDateTime = referenceTimestamp.getOrElse(LocalDateTime.now)
+
   private[smartdatalake] def rememberDataFrameReuse(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], actionId: ActionId): Int = dataFrameReuseStatistics.synchronized {
     val key = (dataObjectId, partitionValues)
     val newValue = dataFrameReuseStatistics.getOrElse(key, Seq()) :+ actionId
     dataFrameReuseStatistics.update(key, newValue)
     newValue.size
   }
+
   private[smartdatalake] def forgetDataFrameReuse(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], actionId: ActionId): Option[Int] = dataFrameReuseStatistics.synchronized {
     val key = (dataObjectId, partitionValues)
     val existingValue = dataFrameReuseStatistics.get(key)
@@ -86,37 +88,24 @@ case class ActionPipelineContext (
       newValue.size
     }
   }
+
   // manage executionId
   private[smartdatalake] def incrementRunId = this.copy(executionId = this.executionId.incrementRunId, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now)
+
   private[smartdatalake] def incrementAttemptId = this.copy(executionId = this.executionId.incrementAttemptId, attemptStartTime = LocalDateTime.now)
-  // helper method to access hadoop configuration
+
+  /**
+   * helper method to access hadoop configuration
+   */
   def hadoopConf: Configuration = serializableHadoopConf.get
 
-  // private holder for spark session
-  private[smartdatalake] var _sparkSession: Option[SparkSession] = None
+  /**
+   * helper method to access spark session
+   */
+  def sparkSession: SparkSession = globalConfig.sparkSession(appConfig.appName, appConfig.master, appConfig.deployMode)
 
   /**
-   * Return SparkSession
-   * Create SparkSession if not yet done, but only if it is used.
+   * True if a SparkSession has been created in this job
    */
-  def sparkSession: SparkSession = {
-    if (_sparkSession.isEmpty) {
-      if (Environment.sparkSession != null) { // take spark session from environment if initialized
-        _sparkSession = Some(Environment.sparkSession)
-        if (Environment.globalConfig != null) { // update spark options and udfs in existing session (needed for unit tests)
-          Environment.globalConfig.setSparkOptions(_sparkSession.get)
-          Environment.globalConfig.registerUdf(_sparkSession.get)
-        }
-      } else {
-        assert(Environment.globalConfig != null, "Cannot create SparkSession because Environment.globalConfig is not initialized.")
-        _sparkSession = Some(Environment.globalConfig.createSparkSession(appConfig.appName, appConfig.master, appConfig.deployMode))
-      }
-    }
-    _sparkSession.get
-  }
-
-  /**
-   * Check if a SparkSession has been created
-   */
-  def hasSparkSession: Boolean = _sparkSession.isDefined
+  def hasSparkSession: Boolean = globalConfig.hasSparkSession
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -369,7 +369,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    */
   private[smartdatalake] val runtimeData: RuntimeData = getRuntimeDataImpl
   protected def getRuntimeDataImpl: RuntimeData = {
-    SynchronousRuntimeData(Option(Environment.globalConfig).map(_.runtimeDataNumberOfExecutionsToKeep).getOrElse(10))
+    SynchronousRuntimeData(Environment.runtimeDataNumberOfExecutionsToKeep)
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/SparkActionImpl.scala
@@ -75,7 +75,7 @@ private[smartdatalake] abstract class SparkActionImpl extends ActionSubFeedsImpl
 
   override def getRuntimeDataImpl: RuntimeData = {
     // override runtime data implementation for SparkStreamingMode
-    if (executionMode.exists(_.isInstanceOf[SparkStreamingMode])) AsynchronousRuntimeData(Option(Environment.globalConfig).map(_.runtimeDataNumberOfExecutionsToKeep).getOrElse(10))
+    if (executionMode.exists(_.isInstanceOf[SparkStreamingMode])) AsynchronousRuntimeData(Environment.runtimeDataNumberOfExecutionsToKeep)
     else super.getRuntimeDataImpl
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -183,7 +183,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
       case SDLSaveMode.OverwriteOptimized =>
         if (partitionValues.nonEmpty) { // delete concerned partitions if existing, as append mode is used later
           deletePartitionsIfExisting(partitionValues)
-        } else if (partitions.isEmpty || Environment.globalConfig.allowOverwriteAllPartitionsWithoutPartitionValues.contains(id)) { // delete table if existing, as append mode is used later
+        } else if (partitions.isEmpty || context.globalConfig.allowOverwriteAllPartitionsWithoutPartitionValues.contains(id)) { // delete table if existing, as append mode is used later
           dropTable
         } else {
           throw new ProcessingLogicException(s"($id) OverwriteOptimized without partition values is not allowed on a partitioned DataObject. This is a protection from unintentionally deleting all partition data.")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -212,7 +212,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
       case SDLSaveMode.OverwriteOptimized =>
         if (partitionValues.nonEmpty) { // delete concerned partitions if existing, as append mode is used later
           deletePartitions(filterPartitionsExisting(partitionValues))
-        } else if (partitions.isEmpty || Environment.globalConfig.allowOverwriteAllPartitionsWithoutPartitionValues.contains(id)) { // delete all data if existing, as append mode is used later
+        } else if (partitions.isEmpty || context.globalConfig.allowOverwriteAllPartitionsWithoutPartitionValues.contains(id)) { // delete all data if existing, as append mode is used later
           deleteAll
         } else {
           throw new ProcessingLogicException(s"($id) OverwriteOptimized without partition values is not allowed on a partitioned DataObject. This is a protection from unintentionally deleting all partition data.")
@@ -220,7 +220,7 @@ private[smartdatalake] trait SparkFileDataObject extends HadoopFileDataObject wi
       case SDLSaveMode.OverwritePreserveDirectories => // only delete files but not directories
         if (partitionValues.nonEmpty) { // delete concerned partitions files if existing, as append mode is used later
           deletePartitionsFiles(filterPartitionsExisting(partitionValues))
-        } else if (partitions.isEmpty || Environment.globalConfig.allowOverwriteAllPartitionsWithoutPartitionValues.contains(id)) { // delete all data if existing, as append mode is used later
+        } else if (partitions.isEmpty || context.globalConfig.allowOverwriteAllPartitionsWithoutPartitionValues.contains(id)) { // delete all data if existing, as append mode is used later
           deleteAllFiles(hadoopPath)
         } else {
           throw new ProcessingLogicException(s"($id) OverwritePreserveDirectories without partition values is not allowed on a partitioned DataObject. This is a protection from unintentionally deleting all partition data.")

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
@@ -686,7 +686,7 @@ class PartitionStreamingTestStateListener2(runIdToAddData: Int) extends StateLis
   }
   override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId : Option[ActionId]): Unit = {
     implicit val _context = context
-    implicit val _sparkSession = Environment.sparkSession
+    implicit val _sparkSession = context.sparkSession
     import _sparkSession.implicits._
     assert(state.runId == context.executionId.runId && state.attemptId == context.executionId.attemptId)
     logger.info(s"Received metrics for runId=${state.runId} attemptId=${state.attemptId} final=${state.isFinal}")

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -369,29 +369,29 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     HdfsUtil.deleteFiles(new Path(statePath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
     val srcTable = Table(Some("default"), "ap_input")
     // source table has partitions columns dt and type
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), partitions = Seq("dt", "type"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgt1Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
+    val tgt1Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname", "firstname")))
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = TickTockHiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = TickTockHiveTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), partitions = Seq("dt", "type"), table = tgt1Table, numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
 
     // fill src table with first partition
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(dfSrc1, Seq())
 
     // start first dag run
     // use only first partition col (dt) for partition diff mode
-    val action1 = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
-                            , transformers = Seq(SQLDfTransformer(code = "select dt, type, lastname, firstname, udfAddX(rating) rating from src1")))
+    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+      , transformers = Seq(SQLDfTransformer(code = "select dt, type, lastname, firstname, udfAddX(rating) rating from src1")))
     instanceRegistry.register(action1.copy())
     val sdlConfig = SmartDataLakeBuilderConfig(feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
     sdlb.run(sdlConfig)
@@ -407,13 +407,13 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       assert(runState.runId == 1)
       assert(runState.attemptId == 1)
       val resultActionsState = runState.actionsState.mapValues(_.state)
-      val expectedActionsState = Map((action1.id , RuntimeEventState.SUCCEEDED))
+      val expectedActionsState = Map((action1.id, RuntimeEventState.SUCCEEDED))
       assert(resultActionsState == expectedActionsState)
-      assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt"->"20180101"))))
+      assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt" -> "20180101"))))
     }
 
     // now fill src table with second partitions
-    val dfSrc2 = Seq(("20190101", "company", "olmo","-",10)) // second partition 20190101
+    val dfSrc2 = Seq(("20190101", "company", "olmo", "-", 10)) // second partition 20190101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeDataFrame(dfSrc2, Seq())
 
@@ -427,7 +427,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     sdlb.run(sdlConfig)
 
     // check results
-    assert(tgt1DO.getDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6,11)) // +1 because of udfAddX
+    assert(tgt1DO.getDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6, 11)) // +1 because of udfAddX
 
     // check latest state
     {
@@ -437,11 +437,16 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       assert(runState.runId == 2)
       assert(runState.attemptId == 1)
       val resultActionsState = runState.actionsState.mapValues(_.state)
-      val expectedActionsState = Map((action1.id , RuntimeEventState.SUCCEEDED))
+      val expectedActionsState = Map((action1.id, RuntimeEventState.SUCCEEDED))
       assert(resultActionsState == expectedActionsState)
-      assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt"->"20190101"))))
+      assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt" -> "20190101"))))
       if (!EnvironmentUtil.isWindowsOS) assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty) // doesnt work on windows
-      val stateListener = Environment.globalConfig.stateListeners.head.listener.asInstanceOf[TestStateListener]
+    }
+
+    // check state listener
+    {
+      assert(TestStateListener.context.isDefined)
+      val stateListener = TestStateListener.context.get.globalConfig.stateListeners.head.listener.asInstanceOf[TestStateListener]
       assert(stateListener.firstState.isDefined && !stateListener.firstState.get.isFinal)
       assert(stateListener.finalState.isDefined && stateListener.finalState.get.isFinal)
     }
@@ -563,10 +568,13 @@ class TestStateListener(options: Map[String,String]) extends StateListener {
   var firstState: Option[ActionDAGRunState] = None
   var finalState: Option[ActionDAGRunState] = None
   override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId : Option[ActionId]): Unit = {
+    if (TestStateListener.context.isEmpty) TestStateListener.context = Some(context)
     if (firstState.isEmpty) firstState = Some(state)
     finalState = Some(state)
   }
-
+}
+object TestStateListener {
+  var context: Option[ActionPipelineContext] = None
 }
 
 class TestUDFAddXCreator() extends SparkUDFCreator {

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -81,14 +81,15 @@ object TestUtil extends SmartDataLakeLogger {
   lazy val sessionWithoutHive : SparkSession = sparkSessionBuilder().getOrCreate
 
   def getDefaultActionPipelineContext(implicit instanceRegistry: InstanceRegistry): ActionPipelineContext = {
-    if (Environment.globalConfig == null) Environment._globalConfig = GlobalConfig()
     getDefaultActionPipelineContext(sessionHiveCatalog) // initialize with Spark session incl. Hive support
   }
 
   def getDefaultActionPipelineContext(sparkSession: SparkSession)(implicit instanceRegistry: InstanceRegistry): ActionPipelineContext = {
     val defaultHadoopConf = new SerializableHadoopConfiguration(new Configuration())
-    val context = ActionPipelineContext("feedTest", "appTest", SDLExecutionId.executionId1, instanceRegistry, Some(LocalDateTime.now()), SmartDataLakeBuilderConfig("feedTest", Some("appTest")), phase = ExecutionPhase.Init, serializableHadoopConf = defaultHadoopConf)
-    context._sparkSession = Some(sparkSession)
+    val globalConfig = GlobalConfig()
+    val context = ActionPipelineContext("feedTest", "appTest", SDLExecutionId.executionId1, instanceRegistry, Some(LocalDateTime.now()), SmartDataLakeBuilderConfig("feedTest", Some("appTest")), phase = ExecutionPhase.Init, serializableHadoopConf = defaultHadoopConf, globalConfig = globalConfig)
+    // reuse existing spark session
+    globalConfig._sparkSession = Some(sparkSession)
     context
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow
 import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.{Instant, LocalDateTime}
-import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, SmartDataLakeBuilderConfig}
+import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, GlobalConfig, SmartDataLakeBuilderConfig}
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.definitions._
@@ -245,7 +245,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // exec dag
     val sdlb = new DefaultSmartDataLakeBuilder
     val appConfig = SmartDataLakeBuilderConfig(feedSel=feed)
-    sdlb.exec(appConfig, SDLExecutionId.executionId1, LocalDateTime.now(), LocalDateTime.now(), Map(), Seq(), Seq(), None, Seq(), simulation = false)
+    sdlb.exec(appConfig, SDLExecutionId.executionId1, LocalDateTime.now(), LocalDateTime.now(), Map(), Seq(), Seq(), None, Seq(), simulation = false, globalConfig = GlobalConfig())
 
     val r1 = tgtBDO.getDataFrame()
       .select($"rating")


### PR DESCRIPTION
### What changes are included in the pull request?
move sparkSession from object Environment to GlobalConfig

### Why are the changes needed?
If JVM is shared between different SDL jobs (e.g. Databricks cluster), Environment.sparkSession will survive the current SDLB job and further jobs will fail because the sessions catalog is no longer valid.
