### PR TITLE
Airbyte parser issue

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObject.scala
@@ -90,7 +90,7 @@ case class AirbyteDataObject(override val id: DataObjectId,
     configuredStream = Some(
       ConfiguredAirbyteStream(stream.get, SyncModeEnum.full_refresh, if (incrementalCursorFields.nonEmpty) Some(incrementalCursorFields) else None, DestinationSyncModeEnum.append, primary_key = None)
     )
-    schema = Some(SchemaConverter.convert(jsonToString(configuredStream.get.stream.json_schema \ "properties")))
+    schema = Some(SchemaConverter.convert(jsonToString(configuredStream.get.stream.json_schema)))
     logger.info(s"($id) got schema: ${schema.get.simpleString}")
   }
 

--- a/sdl-core/src/test/resources/airbyteConnectorMock.sh
+++ b/sdl-core/src/test/resources/airbyteConnectorMock.sh
@@ -37,7 +37,7 @@ case $op in
       echo '{"type": "LOG", "log": {"level": "ERROR", "message": "1 jsonfile parameter expected, got '$JSONFILE_PARAM_CNT'"}}'
       exit -1
     fi
-    echo '{"type": "CATALOG", "catalog": {"streams": [{"name": "mystream", "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object", "required": ["produkttyp", "flag", "artikelID"], "properties": {"produkttyp": {"type": "string"}, "flag": {"type": "string"}, "artikelID": {"type": "string"}, "artikelbezeichnung": {"type": "string"}}}}, "supported_sync_modes": ["full_refresh"]}]}}'
+    echo '{ "type": "CATALOG", "catalog": { "streams": [ { "name": "mystream", "json_schema": { "$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": { "produkttyp": { "type":         "string" }, "flag": { "type": "string" }, "artikelID": { "type": "string" }, "artikelbezeichnung": { "type": "string" } } }, "supported_sync_modes": [ "full_refresh" ] } ] } }'
     ;;
 
   read)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObjectTest.scala
@@ -76,7 +76,7 @@ class AirbyteDataObjectTest extends DataObjectTestSuite {
   }
 
   test("parse catalog") {
-    val msg = parseMessage("""{"type": "CATALOG", "catalog": {"streams": [{"name": "mystream", "json_schema": {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {"$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object", "required": ["produkttyp", "flag", "artikelID"], "properties": {"produkttyp": {"type": "string"}, "flag": {"type": "string"}, "artikelID": {"type": "string"}, "artikelbezeichnung": {"type": "string"}}}}, "supported_sync_modes": ["full_refresh"]}]}}""")
+    val msg = parseMessage("""{ "type": "CATALOG", "catalog": { "streams": [ { "name": "assignees", "json_schema": { "$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": { "repository": { "type": [ "string" ] }, "login": { "type": [ "null", "string" ] }, "id": { "type": [ "null", "integer" ] } } }, "supported_sync_modes": [ "full_refresh" ], "source_defined_primary_key": [ [ "id" ] ] } ] } }""")
     val stream = AirbyteStream("mystream",
       json_schema = JObject(List(("$schema",JString("http://json-schema.org/draft-07/schema#")), ("type",JString("object")), ("properties",JObject(List(("$schema",JString("https://json-schema.org/draft/2020-12/schema")), ("type",JString("object")), ("required",JArray(List(JString("produkttyp"), JString("flag"), JString("artikelID")))), ("properties",JObject(List(("produkttyp",JObject(List(("type",JString("string"))))), ("flag",JObject(List(("type",JString("string"))))), ("artikelID",JObject(List(("type",JString("string"))))), ("artikelbezeichnung",JObject(List(("type",JString("string"))))))))))))),
       supported_sync_modes = Seq(SyncModeEnum.full_refresh)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObjectTest.scala
@@ -76,9 +76,9 @@ class AirbyteDataObjectTest extends DataObjectTestSuite {
   }
 
   test("parse catalog") {
-    val msg = parseMessage("""{ "type": "CATALOG", "catalog": { "streams": [ { "name": "assignees", "json_schema": { "$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": { "repository": { "type": [ "string" ] }, "login": { "type": [ "null", "string" ] }, "id": { "type": [ "null", "integer" ] } } }, "supported_sync_modes": [ "full_refresh" ], "source_defined_primary_key": [ [ "id" ] ] } ] } }""")
+   	val msg = parseMessage("""{ "type": "CATALOG", "catalog": { "streams": [ { "name": "mystream", "json_schema": { "$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": { "produkttyp": { "type": "string" }, "flag": { "type": "string" }, "artikelID": { "type": "string" }, "artikelbezeichnung": { "type": "string" } } }, "supported_sync_modes": [ "full_refresh" ]} ] } }""")
     val stream = AirbyteStream("mystream",
-      json_schema = JObject(List(("$schema",JString("http://json-schema.org/draft-07/schema#")), ("type",JString("object")), ("properties",JObject(List(("$schema",JString("https://json-schema.org/draft/2020-12/schema")), ("type",JString("object")), ("required",JArray(List(JString("produkttyp"), JString("flag"), JString("artikelID")))), ("properties",JObject(List(("produkttyp",JObject(List(("type",JString("string"))))), ("flag",JObject(List(("type",JString("string"))))), ("artikelID",JObject(List(("type",JString("string"))))), ("artikelbezeichnung",JObject(List(("type",JString("string"))))))))))))),
+      json_schema = JObject(List(("$schema",JString("http://json-schema.org/draft-07/schema#")), ("type",JString("object")), ("properties",JObject(("produkttyp",JObject(List(("type",JString("string"))))), ("flag",JObject(List(("type",JString("string"))))), ("artikelID",JObject(List(("type",JString("string"))))), ("artikelbezeichnung",JObject(List(("type",JString("string"))))))))),
       supported_sync_modes = Seq(SyncModeEnum.full_refresh)
     )
     val catalog = AirbyteCatalog(Seq(stream))
@@ -96,7 +96,7 @@ class AirbyteDataObjectTest extends DataObjectTestSuite {
 
   test("de/serialization round-trip") {
     implicit val jsonFormats: Formats = AirbyteMessage.formats
-    val stream = AirbyteStream("mystream",JObject(List(("$schema",JString("http://json-schema.org/draft-07/schema#")), ("type",JString("object")), ("properties",JObject(List(("$schema",JString("https://json-schema.org/draft/2020-12/schema")), ("type",JString("object")), ("required",JArray(List(JString("produkttyp"), JString("flag"), JString("artikelID")))), ("properties",JObject(List(("produkttyp",JObject(List(("type",JString("string"))))), ("flag",JObject(List(("type",JString("string"))))), ("artikelID",JObject(List(("type",JString("string"))))), ("artikelbezeichnung",JObject(List(("type",JString("string"))))))))))))),Seq())
+    val stream = AirbyteStream("mystream",JObject(List(("$schema",JString("http://json-schema.org/draft-07/schema#")), ("type",JString("object")), ("properties",JObject(List(("produkttyp",JObject(List(("type",JString("string"))))), ("flag",JObject(List(("type",JString("string"))))), ("artikelID",JObject(List(("type",JString("string"))))), ("artikelbezeichnung",JObject(List(("type",JString("string")))))))))),Seq())
     val catalog = AirbyteCatalog(Seq(stream))
     val jsonMsg = """{"type": "CATALOG", "catalog": """ + JsonUtils.caseClassToJsonString(catalog) + """}"""
     val parsedCatalog = parseMessage(jsonMsg)


### PR DESCRIPTION
Fixes #482 

### What changes are included in the pull request?

* The airbyte catalog Json parser does not select subsection `repository` anymore. 
* The airbyte test is updated to reflect the proper airbyte catalog structure.

### Why are the changes needed?
The actually use official airbyte connectors.

### Notes
Due to a not fully well configured setup in WSL, I still get error when running the tests, but also with the unmodified version. 