### PR TITLE
fix naming of input views when chaining SQL transformations

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -190,8 +190,7 @@ object Environment {
    * This is enabled by default for backward compatibility.
    */
   var replaceSqlTransformersOldTempViewName: Boolean = {
-    EnvironmentUtil.getSdlParameter("replaceSqlTransformersOldTempViewName")
-      .map(_.toBoolean).getOrElse(true)
+    EnvironmentUtil.getSdlParameter("replaceSqlTransformersOldTempViewName").forall(_.toBoolean)
   }
 
   // static configurations

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -185,6 +185,15 @@ object Environment {
     nb
   }
 
+  /**
+   * If enabled the temp view name from versions <= 2.2.x is replaced with the new temp view name including a postfix.
+   * This is enabled by default for backward compatibility.
+   */
+  var replaceSqlTransformersOldTempViewName: Boolean = {
+    EnvironmentUtil.getSdlParameter("replaceSqlTransformersOldTempViewName")
+      .map(_.toBoolean).getOrElse(true)
+  }
+
   // static configurations
   val configPathsForLocalSubstitution: Seq[String] = Seq(
       "path", "table.name"

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -131,5 +131,20 @@ private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
     val invalidCharacters = "[^a-zA-Z0-9_]".r
     invalidCharacters.replaceAllIn(str, "_")
   }
+
+  /**
+   * Create a valid temporary view name for SQL transformation.
+   * Apart from replacing special characters, a postfix is added to make the name unique in case the input name is also an existing table.
+   * @param inputName name of the input the temporary view should be created for
+   */
+  def createTemporaryViewName(inputName: String) : String = {
+    replaceSpecialCharactersWithUnderscore(inputName) + TEMP_VIEW_POSTFIX
+  }
+
+  def replaceLegacyViewName(sql: String, inputViewName: String): String = {
+    sql.replaceAll("\\s"+inputViewName.stripSuffix(ActionHelper.TEMP_VIEW_POSTFIX)+"(\\s|\\.|$)", s" $inputViewName" + "$1")
+  }
+
+  val TEMP_VIEW_POSTFIX = "_sdltemp"
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -39,7 +39,7 @@ import scala.util.{Failure, Success, Try}
  * @param outputId output DataObject
  * @param deleteDataAfterRead a flag to enable deletion of input partitions after copying.
  * @param transformer optional custom transformation to apply.
- * @param transformers optional list of transformations to apply. See [[sparktransformer]] for a list of included Transformers.
+ * @param transformers optional list of transformations to apply. See [[spark.transformer]] for a list of included Transformers.
  *                     The transformations are applied according to the lists ordering.
  * @param executionMode optional execution mode for this Action
  * @param executionCondition     optional spark sql expression evaluated against [[SubFeedsExpressionData]]. If true Action is executed, otherwise skipped. Details see [[Condition]].

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
@@ -37,7 +37,11 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  *
  * @param inputIds               input DataObject's
  * @param outputIds              output DataObject's
- * @param transformer            custom transformation for multiple dataframes to apply
+ * @param transformer            optional custom transformation for multiple dataframes to apply
+ * @param transformers           list of transformations to apply. See [[spark.transformer]] for a list of included Transformers.
+ *                               The transformations are applied according to the lists ordering.
+ *                               Note that all outputs of previous transformers are kept as input for next transformer,
+ *                               but in the end only outputs of the last transformer are mapped to output DataObjects.
  * @param mainInputId            optional selection of main inputId used for execution mode and partition values propagation. Only needed if there are multiple input DataObject's.
  * @param mainOutputId           optional selection of main outputId used for execution mode and partition values propagation. Only needed if there are multiple output DataObject's.
  * @param executionMode          optional execution mode for this Action
@@ -50,6 +54,7 @@ import scala.reflect.runtime.universe.{Type, typeOf}
 case class CustomDataFrameAction(override val id: ActionId,
                                  inputIds: Seq[DataObjectId],
                                  outputIds: Seq[DataObjectId],
+                                 @Deprecated @deprecated("Use transformers instead.", "2.0.5")
                                  transformer: Option[CustomDfsTransformerConfig] = None,
                                  transformers: Seq[GenericDfsTransformer] = Seq(),
                                  override val breakDataFrameLineage: Boolean = false,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
@@ -28,7 +28,6 @@ import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformerCo
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
-import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe.{Type, typeOf}
 
 /**
@@ -38,10 +37,10 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param inputIds               input DataObject's
  * @param outputIds              output DataObject's
  * @param transformer            optional custom transformation for multiple dataframes to apply
- * @param transformers           list of transformations to apply. See [[spark.transformer]] for a list of included Transformers.
- *                               The transformations are applied according to the lists ordering.
- *                               Note that all outputs of previous transformers are kept as input for next transformer,
- *                               but in the end only outputs of the last transformer are mapped to output DataObjects.
+ * @param transformers list of transformations to apply. See [[spark.transformer]] for a list of included Transformers.
+ *                     The transformations are applied according to the ordering of the list.
+ *                     Note that all outputs of previous transformers are kept as input for next transformer,
+ *                     but in the end only outputs of the last transformer are mapped to output DataObjects.
  * @param mainInputId            optional selection of main inputId used for execution mode and partition values propagation. Only needed if there are multiple input DataObject's.
  * @param mainOutputId           optional selection of main outputId used for execution mode and partition values propagation. Only needed if there are multiple output DataObject's.
  * @param executionMode          optional execution mode for this Action

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameOneToOneActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameOneToOneActionImpl.scala
@@ -91,8 +91,8 @@ abstract class DataFrameOneToOneActionImpl extends DataFrameActionImpl {
    * apply transformer to SubFeed
    */
   protected def applyTransformers(transformers: Seq[GenericDfTransformerDef], inputSubFeed: DataFrameSubFeed, outputSubFeed: DataFrameSubFeed)(implicit context: ActionPipelineContext): DataFrameSubFeed = {
-    val transformedSubFeed = transformers.foldLeft(inputSubFeed){
-      case (subFeed, transformer) => transformer.applyTransformation(id, subFeed)
+    val (transformedSubFeed, _) = transformers.foldLeft((inputSubFeed,Option.empty[String])){
+      case ((subFeed,previousTransformerName), transformer) => (transformer.applyTransformation(id, subFeed, previousTransformerName), Some(transformer.name))
     }
     // Note that transformed partition values are set by execution mode.
     outputSubFeed.withDataFrame(transformedSubFeed.dataFrame)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameOneToOneActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameOneToOneActionImpl.scala
@@ -18,12 +18,10 @@
  */
 package io.smartdatalake.workflow.action
 
-import io.smartdatalake.workflow.action.generic.transformer.GenericDfTransformerDef
-import io.smartdatalake.workflow.action.spark.customlogic.CustomDfTransformerConfig
-import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanCreateSparkDataFrame, CanWriteDataFrame, CanWriteSparkDataFrame, DataObject}
+import io.smartdatalake.workflow.action.generic.transformer.{GenericDfTransformerDef, SQLDfTransformer}
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
+import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanWriteDataFrame, DataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, SubFeed}
-import org.apache.spark.sql.Column
 
 import scala.reflect.runtime.universe.{Type, typeOf}
 
@@ -91,6 +89,8 @@ abstract class DataFrameOneToOneActionImpl extends DataFrameActionImpl {
    * apply transformer to SubFeed
    */
   protected def applyTransformers(transformers: Seq[GenericDfTransformerDef], inputSubFeed: DataFrameSubFeed, outputSubFeed: DataFrameSubFeed)(implicit context: ActionPipelineContext): DataFrameSubFeed = {
+    val duplicateTransformerNames = transformers.groupBy(_.name).values.filter(_.size>1).map(_.head.name)
+    assert(!transformers.exists(_.isInstanceOf[SQLDfTransformer]) || duplicateTransformerNames.isEmpty, s"($id) transformers.name must be unique if SQLDfTransformer is used, but duplicate (default?) names ${duplicateTransformerNames.mkString(", ")} where detected")
     val (transformedSubFeed, _) = transformers.foldLeft((inputSubFeed,Option.empty[String])){
       case ((subFeed,previousTransformerName), transformer) => (transformer.applyTransformation(id, subFeed, previousTransformerName), Some(transformer.name))
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/AdditionalColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/AdditionalColumnsTransformer.scala
@@ -35,7 +35,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  *                          The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  */
 case class AdditionalColumnsTransformer(override val name: String = "additionalColumns", override val description: Option[String] = None, additionalColumns: Map[String,String]) extends GenericDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): GenericDataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     val functions = DataFrameSubFeed.getFunctions(df.subFeedType)
     import functions._
     val data = DefaultExpressionData.from(context, partitionValues)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/BlacklistTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/BlacklistTransformer.scala
@@ -33,7 +33,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * @param columnBlacklist List of columns to exclude from DataFrame
  */
 case class BlacklistTransformer(override val name: String = "blacklist", override val description: Option[String] = None, columnBlacklist: Seq[String]) extends GenericDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): GenericDataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     val functions = DataFrameSubFeed.getFunctions(df.subFeedType)
     import functions._
     val colsToSelect = df.schema.columns.filter(colName => !columnBlacklist.contains(colName.toLowerCase))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DataValidationTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DataValidationTransformer.scala
@@ -42,7 +42,7 @@ case class DataValidationTransformer(override val name: String = "dataValidation
   private val validationHelper: DataFrameSubFeedCompanion = DataFrameSubFeed.getCompanion(subFeedTypeForValidation)
   // check that rules are parsable
   rules.foreach(_.getValidationColumn(validationHelper))
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): GenericDataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
     import functions._
     df.withColumn(errorsColumn, array_construct_compact(rules.map(rule => rule.getValidationColumn): _*))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DfTransformerWrapperDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DfTransformerWrapperDfsTransformer.scala
@@ -38,8 +38,8 @@ case class DfTransformerWrapperDfsTransformer(transformer: GenericDfTransformer,
   override def description: Option[String] = transformer.description
   override def transform(actionId: SdlConfigObject.ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String, GenericDataFrame])(implicit context: ActionPipelineContext): Map[String, GenericDataFrame] = {
     val missingSubFeeds = subFeedsToApply.toSet.diff(dfs.keySet)
-    assert(missingSubFeeds.isEmpty, s"($actionId) [transformation.$name] subFeedsToApply to apply not found in input dfs: ${missingSubFeeds.mkString(", ")}")
-    dfs.map { case (subFeedName,df) => if (subFeedsToApply.contains(subFeedName)) (subFeedName, transformer.transform(actionId, partitionValues, df, DataObjectId(subFeedName))) else (subFeedName, df)}.toMap
+    assert(missingSubFeeds.isEmpty, s"($actionId) [transformation.$name] subFeedsToApply ${missingSubFeeds.mkString(", ")} not found in input dfs. Available subFeeds are ${dfs.keys.mkString(", ")}.")
+    dfs.map { case (subFeedName,df) => if (subFeedsToApply.contains(subFeedName)) (subFeedName, transformer.transform(actionId, partitionValues, df, DataObjectId(subFeedName), Some(subFeedName))) else (subFeedName, df)}
   }
   override def transformPartitionValues(actionId: SdlConfigObject.ActionId, partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Option[Map[PartitionValues, PartitionValues]] = {
     transformer.transformPartitionValues(actionId, partitionValues)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/FilterTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/FilterTransformer.scala
@@ -46,7 +46,7 @@ case class FilterTransformer(override val name: String = "filter", override val 
     case Success(result) => result
     case Failure(e) => throw new ConfigurationException(s"Error parsing filterClause parameter as expression: ${e.getClass.getSimpleName}: ${e.getMessage}")
   }
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): GenericDataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     val functions = DataFrameSubFeed.getFunctions(df.subFeedType)
     import functions._
     df.filter(expr(filterClause))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
@@ -22,38 +22,57 @@ package io.smartdatalake.workflow.action.generic.transformer
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.util.spark.{DefaultExpressionData, SparkExpressionUtil}
 import io.smartdatalake.workflow.action.ActionHelper
+import io.smartdatalake.workflow.action.generic.transformer.OptionsGenericDfTransformer.PREVIOUS_TRANSFORMER_NAME
+import io.smartdatalake.workflow.action.generic.transformer.SQLDfTransformer.INPUT_VIEW_NAME
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
 /**
  * Configuration of a custom GenericDataFrame transformation between one input and one output (1:1) as SQL code.
- * The input data is available as temporary view in SQL. As name for the temporary view the input DataObjectId is used
- * (special characters are replaces by underscores). A special token '%{inputViewName}' will be replaced with the name of
- * the temporary view at runtime.
+ * The input data is available as temporary view in SQL. The inputs name is either the name of the DataObject,
+ * or the name of the previous transformation, if this is not the first transformation of the chain. Also note that to create
+ * the name of temporary view, special characters are replaces by underscores and a postfix "_sdltemp" is added.
+ * It is therefore recommended to use special token %{inputViewName} or ${inputViewName_<input name>} that will be
+ * replaced with the name of the temporary view at runtime.
  *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param code           SQL code for transformation.
  *                       Use tokens %{<key>} to replace with runtimeOptions in SQL code.
  *                       Example: "select * from test where run = %{runId}"
- *                       A special token %{inputViewName} can be used to insert the temporary view name.
+ *                       The special token %{inputViewName} or ${inputViewName_<input_name>} can be used to insert the temporary view name.
+ *                       The input name is either the name of the DataObject, or the name of the previous transformation
+ *                       if this is not the first transformation of the chain. Make sure to change the standard name of
+ *                       the previous transformation in that case.
  * @param options        Options to pass to the transformation
  * @param runtimeOptions optional tuples of [key, spark sql expression] to be added as additional options when executing transformation.
  *                       The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  */
-case class SQLDfTransformer(override val name: String = "sqlTransform", override val description: Option[String] = None, code: String, options: Map[String, String] = Map(), runtimeOptions: Map[String, String] = Map()) extends OptionsGenericDfTransformer {
+case class SQLDfTransformer(override val name: String = "sqlTransform", override val description: Option[String] = None, code: String, options: Map[String, String] = Map(), runtimeOptions: Map[String, String] = Map())
+  extends OptionsGenericDfTransformer with SmartDataLakeLogger {
   override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, options: Map[String, String])(implicit context: ActionPipelineContext): GenericDataFrame = {
-    val functions = DataFrameSubFeed.getFunctions(df.subFeedType)
-    val inputViewName = ActionHelper.replaceSpecialCharactersWithUnderscore(dataObjectId.id)
-    val preparedSql = SparkExpressionUtil.substituteOptions(actionId, Some(s"transformers.$name.sqlCode"), code, options + ("inputViewName" -> inputViewName))
+    val function = DataFrameSubFeed.getFunctions(df.subFeedType)
+    val inputName = options.getOrElse(PREVIOUS_TRANSFORMER_NAME, dataObjectId.id)
+    val inputViewName = ActionHelper.createTemporaryViewName(inputName)
+    val inputViewNameOptions = Map(INPUT_VIEW_NAME -> inputViewName, s"${INPUT_VIEW_NAME}_$inputName" -> inputViewName)
+    var preparedSql = SparkExpressionUtil.substituteOptions(actionId, Some(s"transformers.$name.sqlCode"), code, options ++ inputViewNameOptions)
     try {
+      // Using createTempView does not work because the same temporary view is created more than once (Init & Exec phase...)
       df.createOrReplaceTempView(s"$inputViewName")
-      functions.sql(preparedSql,dataObjectId)
+      // for backward compatibility the temp view name from versions <= 2.2.x is replaced with the new temp view name including a postfix.
+      if (Environment.replaceSqlTransformersOldTempViewName) {
+        preparedSql = ActionHelper.replaceLegacyViewName(preparedSql, inputViewName)
+      }
+      // create DataFrame from SQL
+      logger.info(s"($actionId.transformers.$name) Preparing DataFrame from SQL statement: $preparedSql")
+      function.sql(preparedSql,dataObjectId)
     } catch {
-      case e: Throwable => throw new SQLTransformationException(s"($actionId.transformers.$name) Could not execute SQL query. Check your query and make sure to use '$inputViewName' or token '%{inputViewName}' as temporary view in the SQL statement (special characters are replaces by underscores). Error: ${e.getMessage}")
+      case e: Throwable => throw new SQLTransformationException(s"($actionId.transformers.$name) SQL query error: ${e.getMessage}. Also note to use token '%{inputViewName}' or '$inputViewName' as temporary view name in the SQL statement.", e)
     }
   }
   override def factory: FromConfigFactory[GenericDfTransformer] = SQLDfTransformer
@@ -63,10 +82,11 @@ object SQLDfTransformer extends FromConfigFactory[GenericDfTransformer] {
   override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): SQLDfTransformer = {
     extract[SQLDfTransformer](config)
   }
+  private[smartdatalake] val INPUT_VIEW_NAME = "inputViewName"
 }
 
 
 /**
  * Exception is thrown if the SQL transformation can not be executed correctly
  */
-private[smartdatalake] class SQLTransformationException(message: String) extends RuntimeException(message) {}
+private[smartdatalake] class SQLTransformationException(message: String, cause: Throwable) extends RuntimeException(message, cause) {}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
@@ -36,7 +36,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Configuration of a custom GenericDataFrame transformation between one input and one output (1:1) as SQL code.
  * The input data is available as temporary view in SQL. The inputs name is either the name of the DataObject,
  * or the name of the previous transformation, if this is not the first transformation of the chain. Also note that to create
- * the name of temporary view, special characters are replaces by underscores and a postfix "_sdltemp" is added.
+ * the name of temporary view, special characters are replaced by underscores and a postfix "_sdltemp" is added.
  * It is therefore recommended to use special token %{inputViewName} or ${inputViewName_<input name>} that will be
  * replaced with the name of the temporary view at runtime.
  *

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
@@ -62,7 +62,6 @@ case class SQLDfTransformer(override val name: String = "sqlTransform", override
     val inputViewNameOptions = Map(INPUT_VIEW_NAME -> inputViewName, s"${INPUT_VIEW_NAME}_$inputName" -> inputViewName)
     var preparedSql = SparkExpressionUtil.substituteOptions(actionId, Some(s"transformers.$name.sqlCode"), code, options ++ inputViewNameOptions)
     try {
-      // Using createTempView does not work because the same temporary view is created more than once (Init & Exec phase...)
       df.createOrReplaceTempView(s"$inputViewName")
       // for backward compatibility the temp view name from versions <= 2.2.x is replaced with the new temp view name including a postfix.
       if (Environment.replaceSqlTransformersOldTempViewName) {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
@@ -69,7 +69,7 @@ case class SQLDfTransformer(override val name: String = "sqlTransform", override
         preparedSql = ActionHelper.replaceLegacyViewName(preparedSql, inputViewName)
       }
       // create DataFrame from SQL
-      logger.info(s"($actionId.transformers.$name) Preparing DataFrame from SQL statement: $preparedSql")
+      logger.debug(s"($actionId.transformers.$name) Preparing DataFrame from SQL statement: $preparedSql")
       function.sql(preparedSql,dataObjectId)
     } catch {
       case e: Throwable => throw new SQLTransformationException(s"($actionId.transformers.$name) SQL query error: ${e.getMessage}. Also note to use token '%{inputViewName}' or '$inputViewName' as temporary view name in the SQL statement.", e)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
@@ -20,14 +20,14 @@
 package io.smartdatalake.workflow.action.generic.transformer
 
 import com.typesafe.config.Config
-import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
+import io.smartdatalake.config.SdlConfigObject.ActionId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.util.spark.{DefaultExpressionData, SparkExpressionUtil}
-import io.smartdatalake.workflow.action.{Action, ActionHelper}
 import io.smartdatalake.workflow.action.generic.transformer.SQLDfTransformer.INPUT_VIEW_NAME
+import io.smartdatalake.workflow.action.{Action, ActionHelper}
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
@@ -37,12 +37,12 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * (special characters are replaces by underscores).
  * The input data is available as temporary view in SQL. The input name is either an id of the input DataObject,
  * or the name of an output of the previous transformation if this is not the first transformation of the chain.
- * Also note that to create the name of temporary view, special characters are replaces by underscores and a postfix "_sdltemp" is added.
+ * Also note that to create the name of temporary view, special characters are replaced by underscores and a postfix "_sdltemp" is added.
  * It is therefore recommended to use the special token ${inputViewName_<input name>}, that will be replaced with the name
  * of the temporary view at runtime.
  *
  * Note that you can access arbitrary tables from the metastore in the SQL code, but this is against the principle of SDLB
- * to access data through DataObjects. Access tables directly in SQL code has a negative impact on the maintainability of the project.
+ * to access data through DataObjects. Accessing tables directly in SQL code has a negative impact on the maintainability of the project.
  *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
@@ -63,9 +63,9 @@ case class SQLDfsTransformer(override val name: String = "sqlTransform", overrid
   override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,GenericDataFrame], options: Map[String, String])(implicit context: ActionPipelineContext): Map[String,GenericDataFrame] = {
     val functions = DataFrameSubFeed.getFunctions(dfs.values.head.subFeedType)
     // register all inputs as temporary table
-    val inputViewNameOptions = dfs.map {
-      case (inputName,df) =>
-        val inputViewName =  ActionHelper.createTemporaryViewName(inputName)
+    val inputViewNameOptions: Map[String, String] = dfs.map {
+      case (inputName, df) =>
+        val inputViewName = ActionHelper.createTemporaryViewName(inputName)
         df.createOrReplaceTempView(inputViewName)
         (s"${INPUT_VIEW_NAME}_$inputName" -> inputViewName)
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
@@ -22,9 +22,12 @@ package io.smartdatalake.workflow.action.generic.transformer
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.util.spark.{DefaultExpressionData, SparkExpressionUtil}
-import io.smartdatalake.workflow.action.ActionHelper
+import io.smartdatalake.workflow.action.{Action, ActionHelper}
+import io.smartdatalake.workflow.action.generic.transformer.SQLDfTransformer.INPUT_VIEW_NAME
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
@@ -32,37 +35,59 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Configuration of a custom GenericDataFrame transformation between many inputs and many outputs (n:m) as SQL code.
  * The input data is available as temporary views in SQL. As name for the temporary views the input DataObjectId is used
  * (special characters are replaces by underscores).
+ * The input data is available as temporary view in SQL. The input name is either an id of the input DataObject,
+ * or the name of an output of the previous transformation if this is not the first transformation of the chain.
+ * Also note that to create the name of temporary view, special characters are replaces by underscores and a postfix "_sdltemp" is added.
+ * It is therefore recommended to use the special token ${inputViewName_<input name>}, that will be replaced with the name
+ * of the temporary view at runtime.
+ *
+ * Note that you can access arbitrary tables from the metastore in the SQL code, but this is against the principle of SDLB
+ * to access data through DataObjects. Access tables directly in SQL code has a negative impact on the maintainability of the project.
  *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
- * @param code           SQL code for transformation.
+ * @param code           Map of output names and corresponding SQL code for transformation.
+ *                       If this is the last transformation in the chain, the output name has to match an output DataObject id,
+ *                       otherwise it can be any name which will then be available in the next transformation.
  *                       Use tokens %{<key>} to replace with runtimeOptions in SQL code.
  *                       Example: "select * from test where run = %{runId}"
- *                       A special token %{inputViewName} can be used to insert the temporary view name.
+ *                       The special token ${inputViewName_<input_name>} can be used to insert the name of temporary views.
+ *                       The input name is either the id of an input DataObject, or the name of an output of the previous transformation
+ *                       if this is not the first transformation of the chain.
  * @param options        Options to pass to the transformation
  * @param runtimeOptions optional tuples of [key, spark sql expression] to be added as additional options when executing transformation.
  *                       The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  */
-case class SQLDfsTransformer(override val name: String = "sqlTransform", override val description: Option[String] = None, code: Map[DataObjectId,String], options: Map[String, String] = Map(), runtimeOptions: Map[String, String] = Map()) extends OptionsGenericDfsTransformer {
+case class SQLDfsTransformer(override val name: String = "sqlTransform", override val description: Option[String] = None, code: Map[String,String], options: Map[String, String] = Map(), runtimeOptions: Map[String, String] = Map())
+  extends OptionsGenericDfsTransformer with SmartDataLakeLogger {
   override def transformWithOptions(actionId: ActionId, partitionValues: Seq[PartitionValues], dfs: Map[String,GenericDataFrame], options: Map[String, String])(implicit context: ActionPipelineContext): Map[String,GenericDataFrame] = {
     val functions = DataFrameSubFeed.getFunctions(dfs.values.head.subFeedType)
-    // register all input DataObjects as temporary table
-    dfs.foreach {
-      case (dataObjectId,df) =>
-        val objectId =  ActionHelper.replaceSpecialCharactersWithUnderscore(dataObjectId)
-        // Using createTempView does not work because the same data object might be created more than once
-        df.createOrReplaceTempView(objectId)
+    // register all inputs as temporary table
+    val inputViewNameOptions = dfs.map {
+      case (inputName,df) =>
+        val inputViewName =  ActionHelper.createTemporaryViewName(inputName)
+        // Using createTempView does not work because the same temporary view is created more than once (Init & Exec phase...)
+        df.createOrReplaceTempView(inputViewName)
+        (s"${INPUT_VIEW_NAME}_$inputName" -> inputViewName)
     }
-    // execute all queries and return them under corresponding dataObjectId
+    // get an output DataObject from the Action to use to creating DataFrame from SQL. Note that this DataObject is only used to get connection information.
+    val outputDataObjectId = context.instanceRegistry.get[Action](actionId).outputs.head.id
+    // execute all queries and return them under corresponding output name
     code.map {
-      case (dataObjectId,sql) =>
+      case (outputName,sql) =>
         val df = try {
-          val preparedSql = SparkExpressionUtil.substituteOptions(dataObjectId, Some(s"transformers.$name.code"), sql, options)
-          functions.sql(preparedSql,dataObjectId)
+          var preparedSql = SparkExpressionUtil.substituteOptions(actionId, Some(s"transformers.$name.code"), sql, options ++ inputViewNameOptions)
+          // for backward compatibility the temp view name from versions <= 2.2.x is replaced with the new temp view name including a postfix.
+          if (Environment.replaceSqlTransformersOldTempViewName) {
+            inputViewNameOptions.values.foreach(inputViewName => preparedSql = ActionHelper.replaceLegacyViewName(preparedSql, inputViewName))
+          }
+          // create DataFrame from SQL
+          logger.info(s"($actionId.transformers.$name) Preparing DataFrame $outputName from SQL statement: $preparedSql")
+          functions.sql(preparedSql, outputDataObjectId)
         } catch {
-          case e: Throwable => throw new SQLTransformationException(s"($actionId.transformers.$name) Could not execute SQL query for $dataObjectId. Check your query and remember remember that special characters are replaced by underscores for temporary view names in the SQL statement. Error: ${e.getMessage}")
+          case e: Throwable => throw new SQLTransformationException(s"($actionId.transformers.$name) SQL query error for $outputName: ${e.getMessage}. Also note to use tokens '%{inputViewName_<inputName>}' as temporary view names in the SQL statement.", e)
         }
-        (dataObjectId.id, df)
+        (outputName, df)
     }
   }
   override def factory: FromConfigFactory[GenericDfsTransformer] = SQLDfsTransformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
@@ -82,7 +82,7 @@ case class SQLDfsTransformer(override val name: String = "sqlTransform", overrid
             inputViewNameOptions.values.foreach(inputViewName => preparedSql = ActionHelper.replaceLegacyViewName(preparedSql, inputViewName))
           }
           // create DataFrame from SQL
-          logger.info(s"($actionId.transformers.$name) Preparing DataFrame $outputName from SQL statement: $preparedSql")
+          logger.debug(s"($actionId.transformers.$name) Preparing DataFrame $outputName from SQL statement: $preparedSql")
           functions.sql(preparedSql, outputDataObjectId)
         } catch {
           case e: Throwable => throw new SQLTransformationException(s"($actionId.transformers.$name) SQL query error for $outputName: ${e.getMessage}. Also note to use tokens '%{inputViewName_<inputName>}' as temporary view names in the SQL statement.", e)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/WhitelistTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/WhitelistTransformer.scala
@@ -34,7 +34,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  */
 
 case class WhitelistTransformer(override val name: String = "whitelist", override val description: Option[String] = None, columnWhitelist: Seq[String]) extends GenericDfTransformer {
-  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): GenericDataFrame = {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     val functions = DataFrameSubFeed.getFunctions(df.subFeedType)
     import functions._
     val colsToSelect = df.schema.columns.filter(colName => columnWhitelist.contains(colName.toLowerCase))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/customlogic/CustomDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/customlogic/CustomDfsTransformer.scala
@@ -18,11 +18,10 @@
  */
 package io.smartdatalake.workflow.action.spark.customlogic
 
-import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.spark.DefaultExpressionData
-import CustomDfsTransformerConfig.fnTransformType
 import io.smartdatalake.workflow.action.generic.transformer.{GenericDfsTransformerDef, SQLDfsTransformer}
+import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformerConfig.fnTransformType
 import io.smartdatalake.workflow.action.spark.transformer.{ScalaClassSparkDfsTransformer, ScalaCodeSparkDfsTransformer}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -65,7 +64,7 @@ trait CustomDfsTransformer extends Serializable {
  * @param className Optional class name implementing trait [[CustomDfsTransformer]]
  * @param scalaFile Optional file where scala code for transformation is loaded from. The scala code in the file needs to be a function of type [[fnTransformType]].
  * @param scalaCode Optional scala code for transformation. The scala code needs to be a function of type [[fnTransformType]].
- * @param sqlCode Optional map of DataObjectId and corresponding SQL Code.
+ * @param sqlCode Optional map of output DataObject id and corresponding SQL Code.
  *                Use tokens %{<key>} to replace with runtimeOptions in SQL code.
  *                Example: "select * from test where run = %{runId}"
  * @param options Options to pass to the transformation
@@ -73,7 +72,7 @@ trait CustomDfsTransformer extends Serializable {
  *                       The spark sql expressions are evaluated against an instance of [[DefaultExpressionData]].
  */
 @deprecated("use transformers instead")
-case class CustomDfsTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, sqlCode: Option[Map[DataObjectId,String]] = None, options: Option[Map[String,String]] = None, runtimeOptions: Option[Map[String,String]] = None) {
+case class CustomDfsTransformerConfig( className: Option[String] = None, scalaFile: Option[String] = None, scalaCode: Option[String] = None, sqlCode: Option[Map[String,String]] = None, options: Option[Map[String,String]] = None, runtimeOptions: Option[Map[String,String]] = None) {
   require(className.isDefined || scalaFile.isDefined || scalaCode.isDefined || sqlCode.isDefined, "Either className, scalaFile, scalaCode or sqlCode must be defined for CustomDfsTransformer")
 
   // Load Transformer code from appropriate location

--- a/sdl-core/src/test/scala/io/smartdatalake/app/AppUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/AppUtilTest.scala
@@ -48,7 +48,7 @@ class AppUtilTest extends FunSuite {
   instanceRegistry.register(Seq(do1,do2,do3,do4,do5,do6))
   private val actionA = CopyAction("a", "do1", "do2", metadata = Some(ActionMetadata(name = Some("actionA"), feed = Some("test1"))))
   private val actionB = CopyAction("b", "do1", "do3", metadata = Some(ActionMetadata(name = Some("actionB"), feed = Some("test2"))))
-  private val actionC = CustomDataFrameAction("c", Seq("do2","do3","do4"), Seq("do5"), transformer = Some(CustomDfsTransformerConfig(sqlCode = Some(Map(do5.id -> "select * from do2"))))
+  private val actionC = CustomDataFrameAction("c", Seq("do2","do3","do4"), Seq("do5"), transformer = Some(CustomDfsTransformerConfig(sqlCode = Some(Map(do5.id.id -> "select * from do2"))))
     , metadata = Some(ActionMetadata(name = Some("actionC"), feed = Some("test1")))
   )
   private val actionD = CopyAction("d", "do5", "do6", metadata = Some(ActionMetadata(name = Some("actionD"), feed = Some("test1"))))

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -302,7 +302,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(action3.copy())
     // action4 is cancelled because action3 is cancelled (cancelled has higher prio than skipped from action1)
     val action4 = CustomDataFrameAction("d", Seq(tgt1DO.id, tgt3DO.id), Seq(tgt4DO.id), metadata = Some(ActionMetadata(feed = Some(feedName)))
-      , transformers = Seq(SQLDfsTransformer(code = Map(tgt4DO.id -> "select * from c"))))
+      , transformers = Seq(SQLDfsTransformer(code = Map(tgt4DO.id.id -> "select * from c"))))
     instanceRegistry.register(action4.copy())
     val sdlConfig = SmartDataLakeBuilderConfig(feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
     intercept[TaskFailedException](sdlb.run(sdlConfig))

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
@@ -129,7 +129,7 @@ private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
       inputIds = Seq("tdo1"),
       outputIds = Seq("tdo2"),
       transformers = Seq(
-        SQLDfsTransformer(code = Map(DataObjectId("test") -> "select * from test")),
+        SQLDfsTransformer(code = Map("test" -> "select * from test")),
         DfTransformerWrapperDfsTransformer(subFeedsToApply = Seq("test"), transformer = FilterTransformer(filterClause = "1 = 1"))
       )
     )

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -997,7 +997,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
       , executionMode = Some(DataFrameIncrementalMode(compareCol = "tstmp")))
     val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id)
       , executionCondition = Some(Condition("true")), executionMode = Some(ProcessAllMode()) // process everything, also if predecessor skipped
-      , transformer = Some(CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)")))))
+      , transformer = Some(CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id.id -> "select * from src2 join tgt1 using (lastname, firstname)")))))
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2))
 
     // first dag run, first file processed
@@ -1053,7 +1053,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val df2 = Seq(("doe","john","waikiki beach")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df2, Seq())
 
-    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)")))
+    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id.id -> "select * from src2 join tgt1 using (lastname, firstname)")))
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(DataFrameIncrementalMode(compareCol = "tstmp")))
     val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id), Some(transformation), executionCondition = Some(Condition("true")))
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2))
@@ -1108,7 +1108,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val df2 = Seq(("doe","john","waikiki beach")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df2, Seq())
 
-    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id -> "select * from src2 join tgt1 using (lastname, firstname)")))
+    val transformation = CustomDfsTransformerConfig.apply(sqlCode = Some(Map(tgt2DO.id.id -> "select * from src2 join tgt1 using (lastname, firstname)")))
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(DataFrameIncrementalMode(compareCol = "tstmp")))
     val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id), Some(transformation), executionCondition = Some(Condition("true")), executionMode = Some(ProcessAllMode()))
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ActionHelperTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ActionHelperTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2022 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action
+
+import org.scalatest.FunSuite
+
+class ActionHelperTest extends FunSuite {
+
+  test("replaceSpecialCharactersWithUnderscore") {
+    assert(ActionHelper.replaceSpecialCharactersWithUnderscore("1-x.y+z!9") == "1_x_y_z_9")
+  }
+
+  test("createTemporaryViewName") {
+    assert(ActionHelper.createTemporaryViewName("1-x.y+z!9") == "1_x_y_z_9_sdltemp")
+  }
+
+  test("replaceLegacyViewName") {
+    assert(ActionHelper.replaceLegacyViewName("select * from src1", "src1_sdltemp") == "select * from src1_sdltemp")
+    assert(ActionHelper.replaceLegacyViewName("select src1.* from src1", "src1_sdltemp") == "select src1_sdltemp.* from src1_sdltemp")
+    assert(ActionHelper.replaceLegacyViewName("select s.* from src1 as s", "src1_sdltemp") == "select s.* from src1_sdltemp as s")
+  }
+
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -132,8 +132,9 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val customTransformerConfig = SQLDfTransformer(code = "select * from copy_input where rating = 5")
-    val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformers = Seq(customTransformerConfig))
+    val customTransformerConfig1 = SQLDfTransformer(name = "sql1", code = "select * from copy_input where rating = 5")
+    val customTransformerConfig2 = SQLDfTransformer(name = "sql2", code = "select * from copy_input where rating = 5")
+    val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformers = Seq(customTransformerConfig1, customTransformerConfig2))
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DataValidationTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DataValidationTransformerTest.scala
@@ -42,7 +42,7 @@ class DataValidationTransformerTest extends FunSuite {
       RowLevelValidationRule("rating is not null", Some("rating should not be empty")),
       RowLevelValidationRule("firstname != 'bob'", Some("first should not be 'bob'"))
     ))
-    val dfValidated = validator.transform("testAction", Seq(), SparkDataFrame(df), "testDO" ).asInstanceOf[SparkDataFrame]
+    val dfValidated = validator.transform("testAction", Seq(), SparkDataFrame(df), "testDO", None).asInstanceOf[SparkDataFrame]
     import SparkSubFeed._
     assert(dfValidated.filter(col("firstname") === lit("bob")).select(explode(col("errors"))).asInstanceOf[SparkDataFrame].inner.as[String].collect.toSet == Set("rating should not be empty", "first should not be 'bob'"))
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformerTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2022 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.generic.transformer
+
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.action.{CopyAction, CustomDataFrameAction}
+import io.smartdatalake.workflow.connection.JdbcTableConnection
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import io.smartdatalake.workflow.dataobject.{JdbcTableDataObject, Table}
+import org.apache.spark.sql.SparkSession
+import org.scalatest.FunSuite
+
+class SQLDfTransformerTest extends FunSuite {
+
+  protected implicit val session: SparkSession = TestUtil.sessionHiveCatalog
+  import session.implicits._
+
+  implicit val instanceRegistry = new InstanceRegistry()
+  implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+
+  val con1 = JdbcTableConnection("con1", url = "123", driver = "driver") // dummy
+  instanceRegistry.register(con1)
+
+  val srcTable1 = Table(Some("default"), "src1")
+  val srcDO1 = JdbcTableDataObject("src1", table = srcTable1, connectionId = "con1")
+  instanceRegistry.register(srcDO1)
+
+  val tgtTable1 = Table(Some("default"), "tgt1")
+  val tgtDO1 = JdbcTableDataObject("tgt1", table = tgtTable1, connectionId = "con1")
+  instanceRegistry.register(tgtDO1)
+
+  val action1 = CopyAction("action1", srcDO1.id, tgtDO1.id)
+  instanceRegistry.register(action1)
+
+  val emptyDf = Seq((1,"a")).toDF("num","str")
+
+  test("options and view name token are replaced") {
+    val customTransformer = SQLDfTransformer(code = s"select num, %{option1} from %{inputViewName_src1}")
+    customTransformer.transformWithOptions(action1.id, Seq(), SparkDataFrame(emptyDf), srcDO1.id, Map("option1" -> "str"))
+  }
+
+  test("view name token without input name is replaced") {
+    val customTransformer = SQLDfTransformer(code = s"select num, %{option1} from %{inputViewName}")
+    customTransformer.transformWithOptions(action1.id, Seq(), SparkDataFrame(emptyDf), srcDO1.id, Map("option1" -> "str"))
+  }
+
+  test("legacy view name without postfix is still supported") {
+    val customTransformer = SQLDfTransformer(code = s"select src1.num, %{option1} from src1")
+    customTransformer.transformWithOptions(action1.id, Seq(), SparkDataFrame(emptyDf), srcDO1.id, Map("option1" -> "str"))
+  }
+
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformerTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2022 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.generic.transformer
+
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.action.CustomDataFrameAction
+import io.smartdatalake.workflow.connection.JdbcTableConnection
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import io.smartdatalake.workflow.dataobject.{JdbcTableDataObject, Table}
+import org.apache.spark.sql.SparkSession
+import org.scalatest.FunSuite
+
+class SQLDfsTransformerTest extends FunSuite {
+
+  protected implicit val session: SparkSession = TestUtil.sessionHiveCatalog
+  import session.implicits._
+
+  implicit val instanceRegistry = new InstanceRegistry()
+  implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+
+  val con1 = JdbcTableConnection("con1", url = "123", driver = "driver") // dummy
+  instanceRegistry.register(con1)
+
+  val srcTable1 = Table(Some("default"), "src1")
+  val srcDO1 = JdbcTableDataObject("src1", table = srcTable1, connectionId = "con1")
+  instanceRegistry.register(srcDO1)
+
+  val tgtTable1 = Table(Some("default"), "tgt1")
+  val tgtDO1 = JdbcTableDataObject("tgt1", table = tgtTable1, connectionId = "con1")
+  instanceRegistry.register(tgtDO1)
+
+  val action1 = CustomDataFrameAction("action1", List(srcDO1.id), List(tgtDO1.id))
+  instanceRegistry.register(action1)
+
+  val emptyDf = Seq((1,"a")).toDF("num","str")
+
+  test("options and view name token are replaced") {
+    val customTransformer = SQLDfsTransformer(code = Map(tgtDO1.id.id -> s"select %{inputViewName_src1}.num, %{option1} from %{inputViewName_src1}"))
+    customTransformer.transformWithOptions(action1.id, Seq(), Map(srcDO1.id.id -> SparkDataFrame(emptyDf)), Map("option1" -> "str"))
+  }
+
+  test("legacy view name without postfix is still supported") {
+    val customTransformer = SQLDfsTransformer(code = Map(tgtDO1.id.id -> s"select src1.num, %{option1} from src1"))
+    customTransformer.transformWithOptions(action1.id, Seq(), Map(srcDO1.id.id -> SparkDataFrame(emptyDf)), Map("option1" -> "str"))
+  }
+
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformerTest.scala
@@ -53,12 +53,12 @@ class SQLDfsTransformerTest extends FunSuite {
 
   val emptyDf = Seq((1,"a")).toDF("num","str")
 
-  test("options and view name token are replaced") {
+  test("options and view name token are replaced and sql can be parsed") {
     val customTransformer = SQLDfsTransformer(code = Map(tgtDO1.id.id -> s"select %{inputViewName_src1}.num, %{option1} from %{inputViewName_src1}"))
     customTransformer.transformWithOptions(action1.id, Seq(), Map(srcDO1.id.id -> SparkDataFrame(emptyDf)), Map("option1" -> "str"))
   }
 
-  test("legacy view name without postfix is still supported") {
+  test("legacy view name without postfix is still supported and sql can be parsed") {
     val customTransformer = SQLDfsTransformer(code = Map(tgtDO1.id.id -> s"select src1.num, %{option1} from src1"))
     customTransformer.transformWithOptions(action1.id, Seq(), Map(srcDO1.id.id -> SparkDataFrame(emptyDf)), Map("option1" -> "str"))
   }

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SparkAndSnowparkDataPipelineIT.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SparkAndSnowparkDataPipelineIT.scala
@@ -24,9 +24,9 @@ import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, SmartDataLakeBuilderCo
 import io.smartdatalake.config.ConfigToolbox
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.DataFrameSubFeed
-import io.smartdatalake.workflow.action.CopyAction
+import io.smartdatalake.workflow.action.{CopyAction, CustomDataFrameAction}
 import io.smartdatalake.workflow.action.generic.customlogic.CustomGenericDfTransformer
-import io.smartdatalake.workflow.action.generic.transformer.{AdditionalColumnsTransformer, FilterTransformer, ScalaClassGenericDfTransformer}
+import io.smartdatalake.workflow.action.generic.transformer.{AdditionalColumnsTransformer, FilterTransformer, SQLDfTransformer, SQLDfsTransformer, ScalaClassGenericDfTransformer}
 import io.smartdatalake.workflow.action.snowflake.customlogic.CustomSnowparkDfTransformer
 import io.smartdatalake.workflow.action.snowflake.transformer.ScalaClassSnowparkDfTransformer
 import io.smartdatalake.workflow.dataframe.{DataFrameFunctions, GenericDataFrame}
@@ -85,10 +85,24 @@ object SparkAndSnowparkDataPipelineIT extends App {
       FilterTransformer(filterClause = "lastname='jonson'"),
       AdditionalColumnsTransformer(additionalColumns = Map("run_id" -> "runId")),
       // a custom generic transformer
-      ScalaClassGenericDfTransformer(className = classOf[TestAdd1GenericDfTransformer].getName, options = Map("column" -> "rating"))
+      ScalaClassGenericDfTransformer(className = classOf[TestAdd1GenericDfTransformer].getName, options = Map("column" -> "rating")),
+      SQLDfTransformer(code = "select %{inputViewName}.*, run_id + 1 as run_id2 from %{inputViewName}"),
+      SQLDfTransformer(code = "select %{inputViewName}.*, run_id2 + 1 as run_id3 from %{inputViewName}")
     )
   )
   instanceRegistry.register(action2)
+  val action3 = CustomDataFrameAction("customSnowpark", Seq(tgt1DO.id, tgt2DO.id), Seq(tgt3DO.id),
+    transformers = Seq(
+      SQLDfsTransformer(code = Map(
+        tgt3DO.id -> """
+          select tgt1.*, run_id2 + 1 as run_id3
+          from %{inputViewName_tgt1} as tgt1
+          join %{inputViewName_tgt2} as tgt2 on tgt1.firstname=tgt2.firstname and tgt1.lastname=tgt2.lastname
+        """
+      )),
+    )
+  )
+  instanceRegistry.register(action3)
 
   // prepare data
   import sparkSession.implicits._
@@ -96,7 +110,7 @@ object SparkAndSnowparkDataPipelineIT extends App {
   srcDO.writeSparkDataFrame(l1, Seq())
 
   // run
-  val sdlConfig = SmartDataLakeBuilderConfig(feedSel = "ids:copy.*", applicationName = Some(feed))
+  val sdlConfig = SmartDataLakeBuilderConfig(feedSel = "ids:.*", applicationName = Some(feed))
   sdlb.run(sdlConfig)
 
 }

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SparkAndSnowparkDataPipelineIT.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SparkAndSnowparkDataPipelineIT.scala
@@ -98,7 +98,7 @@ object SparkAndSnowparkDataPipelineIT extends App {
   val action3 = CustomDataFrameAction("customSnowpark", Seq(tgt1DO.id, tgt2DO.id), Seq(tgt3DO.id),
     transformers = Seq(
       SQLDfsTransformer(code = Map(
-        tgt3DO.id -> """
+        tgt3DO.id.id -> """
           select tgt1.*, run_id2 + 1 as run_id3
           from %{inputViewName_tgt1} as tgt1
           join %{inputViewName_tgt2} as tgt2 on tgt1.firstname=tgt2.firstname and tgt1.lastname=tgt2.lastname

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SparkAndSnowparkDataPipelineIT.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SparkAndSnowparkDataPipelineIT.scala
@@ -71,6 +71,10 @@ object SparkAndSnowparkDataPipelineIT extends App {
   val tgt2DO = SnowflakeTableDataObject("tgt2", tgt2Table, connectionId = "sfCon")
   tgt2DO.dropTable
   instanceRegistry.register(tgt2DO)
+  val tgt3Table = Table(Some(System.getenv("SNOWFLAKE_SCHEMA")), "tgt3", None, Some(Seq("lastname")))
+  val tgt3DO = SnowflakeTableDataObject("tgt3", tgt3Table, connectionId = "sfCon")
+  tgt3DO.dropTable
+  instanceRegistry.register(tgt3DO)
 
 
   // first action copy with Spark from Hive to Snowflake


### PR DESCRIPTION
### What changes are included in the pull request?
Temporary views created by SQL transformers are postfixed with "_sdltemp" to avoid naming conflicts.
It's implemented in backward compatible way - old naming convention is replaced with the new one if Environment.replaceSqlTransformersOldTempViewName=true - default is true.

### Why are the changes needed?
Using the DataObject id as name for the temporary views in SQL transformers could have strange side effects if the name after replacing special chars was the same as a potential table in the metastore. Should SQL choose the temporary view or the table to read from? With Snowpark it's even not possible to create such views.