### PR TITLE
revert intellij code suggestion to make default value more transparent

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -190,7 +190,8 @@ object Environment {
    * This is enabled by default for backward compatibility.
    */
   var replaceSqlTransformersOldTempViewName: Boolean = {
-    EnvironmentUtil.getSdlParameter("replaceSqlTransformersOldTempViewName").forall(_.toBoolean)
+    EnvironmentUtil.getSdlParameter("replaceSqlTransformersOldTempViewName")
+      .map(_.toBoolean).getOrElse(true)
   }
 
   // static configurations


### PR DESCRIPTION
I dont like the following code suggestion from Intellij's too much, as it hides the default value to be used, e,g, its not obvious to me that None.forall(_.toBoolean) == true.
I think the following is better:
.map(_.toBoolean).getOrElse(true)