### PR TITLE
Remove converting columns to lowercase by default

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ColNamesLowercaseTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ColNamesLowercaseTransformer.scala
@@ -1,0 +1,40 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2022 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.generic.transformer
+
+import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.dataframe.{DataFrameFunctions, GenericDataFrame}
+import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
+
+/**
+ * Convert all column names to lowercase.
+ * @param name         name of the transformer
+ * @param description  Optional description of the transformer
+ */
+case class ColNamesLowercaseTransformer(override val name: String = "colNamesLowercase", override val description: Option[String] = None) extends GenericDfTransformer {
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String])(implicit context: ActionPipelineContext): GenericDataFrame = {
+    implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
+    df.colNamesLowercase
+  }
+  override def factory: FromConfigFactory[GenericDfTransformer] = BlacklistTransformer
+}
+

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -22,7 +22,7 @@ package io.smartdatalake.workflow.dataframe
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SchemaUtil
-import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, DataFrameSubFeedCompanion}
+import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
 import scala.reflect.runtime.universe.Type
 
@@ -112,8 +112,8 @@ trait GenericDataFrame extends GenericTypedObject {
   /**
    * Move partition columns at end of DataFrame as required when writing to Hive in Spark > 2.x
    */
-  def movePartitionColsLast(partitions: Seq[String])(implicit helper: DataFrameSubFeedCompanion): GenericDataFrame = {
-    import helper._
+  def movePartitionColsLast(partitions: Seq[String])(implicit function: DataFrameFunctions): GenericDataFrame = {
+    import function._
     val (partitionCols, nonPartitionCols) = schema.columns.partition(c => partitions.contains(c))
     val newColOrder = nonPartitionCols ++ partitionCols
     select(newColOrder.map(col))
@@ -122,8 +122,8 @@ trait GenericDataFrame extends GenericTypedObject {
   /**
    * Convert column names to lower case
    */
-  def colNamesLowercase(implicit helper: DataFrameSubFeedCompanion): GenericDataFrame = {
-    import helper._
+  def colNamesLowercase(implicit function: DataFrameFunctions): GenericDataFrame = {
+    import function._
     select(schema.columns.map(c => col(c).as(c.toLowerCase())))
   }
 


### PR DESCRIPTION
### What changes are included in the pull request?
Dont convert anymore columns to lowercase by default.

### Why are the changes needed?
It was not implemented consequently and made problem in HistorizeAction.
Further SDLB should be able to handle and preserve schemas not in lowercase.
There is a new ColNamesLowercaseTransformer to convert columns to lowercase if needed.