### PR TITLE
updated getting-started with SDL2.3.0 changes

### DIFF
--- a/docs/getting-started/config-examples/CustomWebserviceDataObject-1.scala
+++ b/docs/getting-started/config-examples/CustomWebserviceDataObject-1.scala
@@ -8,6 +8,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.util.webservice.WebserviceMethod.WebserviceMethod
 import io.smartdatalake.util.webservice.{ScalaJWebserviceClient, WebserviceException, WebserviceMethod}
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.DataType
@@ -35,7 +36,7 @@ case class CustomWebserviceDataObject(override val id: DataObjectId,
                                       override val metadata: Option[DataObjectMetadata] = None
                                      )
                                      (@transient implicit val instanceRegistry: InstanceRegistry)
-  extends DataObject with CanCreateDataFrame with SmartDataLakeLogger {
+  extends DataObject with CanCreateSparkDataFrame with SmartDataLakeLogger {
 
   @tailrec
   private def request(url: String, method: WebserviceMethod = WebserviceMethod.Get, body: String = "", retry: Int = nRetry) : Array[Byte] = {
@@ -58,7 +59,7 @@ case class CustomWebserviceDataObject(override val id: DataObjectId,
     }
   }
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): DataFrame = {
+  override def getSparkDataFrame(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): DataFrame = {
     import org.apache.spark.sql.functions._
     implicit val formats: Formats = DefaultFormats
     val session = context.sparkSession

--- a/docs/getting-started/config-examples/CustomWebserviceDataObject-2.scala
+++ b/docs/getting-started/config-examples/CustomWebserviceDataObject-2.scala
@@ -8,6 +8,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.util.webservice.WebserviceMethod.WebserviceMethod
 import io.smartdatalake.util.webservice.{ScalaJWebserviceClient, WebserviceException, WebserviceMethod}
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.DataType
@@ -37,7 +38,7 @@ case class CustomWebserviceDataObject(override val id: DataObjectId,
                                       override val metadata: Option[DataObjectMetadata] = None
                                      )
                                      (@transient implicit val instanceRegistry: InstanceRegistry)
-  extends DataObject with CanCreateDataFrame with CanCreateIncrementalOutput with SmartDataLakeLogger {
+  extends DataObject with CanCreateSparkDataFrame with CanCreateIncrementalOutput with SmartDataLakeLogger {
 
   private var previousState : Seq[State] = Seq()
   private var nextState : Seq[State] = Seq()
@@ -65,7 +66,7 @@ case class CustomWebserviceDataObject(override val id: DataObjectId,
     }
   }
 
-  override def getDataFrame(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): DataFrame = {
+  override def getSparkDataFrame(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): DataFrame = {
     import org.apache.spark.sql.functions._
     implicit val formats: Formats = DefaultFormats
     val session = context.sparkSession

--- a/docs/getting-started/config-examples/application-part1-compute-dep-arr.conf
+++ b/docs/getting-started/config-examples/application-part1-compute-dep-arr.conf
@@ -72,7 +72,7 @@ actions {
   }
 
   join_departures_airports {
-    type = CustomSparkAction
+    type = CustomDataFrameAction
     inputIds = [stg-departures, int-airports]
     outputIds = [btl-departures-arrivals-airports]
     transformers = [{

--- a/docs/getting-started/config-examples/application-part1-compute-final.conf
+++ b/docs/getting-started/config-examples/application-part1-compute-final.conf
@@ -77,7 +77,7 @@ actions {
   }
 
   join-departures-airports {
-    type = CustomSparkAction
+    type = CustomDataFrameAction
     inputIds = [stg-departures, int-airports]
     outputIds = [btl-departures-arrivals-airports]
     transformers = [{
@@ -108,7 +108,7 @@ actions {
     inputId = btl-departures-arrivals-airports
     outputId = btl-distances
     transformers = [{
-      type = ScalaClassDfTransformer
+      type = ScalaClassSparkDfTransformer
       className = com.sample.ComputeDistanceTransformer
     }]
     metadata {

--- a/docs/getting-started/config-examples/application-part1-compute-join.conf
+++ b/docs/getting-started/config-examples/application-part1-compute-join.conf
@@ -72,7 +72,7 @@ actions {
   }
 
   join_departures_airports {
-    type = CustomSparkAction
+    type = CustomDataFrameAction
     inputIds = [stg-departures, int-airports]
     outputIds = [btl-connected-airports]
     transformers = [{

--- a/docs/getting-started/config-examples/application-part2-deltalake.conf
+++ b/docs/getting-started/config-examples/application-part2-deltalake.conf
@@ -111,7 +111,7 @@ actions {
   }
 
   join-departures-airports {
-    type = CustomSparkAction
+    type = CustomDataFrameAction
     inputIds = [int-departures, int-airports]
     outputIds = [btl-departures-arrivals-airports]
     transformers = [{
@@ -145,7 +145,7 @@ actions {
     inputId = btl-departures-arrivals-airports
     outputId = btl-distances
     transformers = [{
-      type = ScalaClassDfTransformer
+      type = ScalaClassSparkDfTransformer
       className = com.sample.ComputeDistanceTransformer
     }]
     metadata {

--- a/docs/getting-started/config-examples/application-part2-historical.conf
+++ b/docs/getting-started/config-examples/application-part2-historical.conf
@@ -98,7 +98,7 @@ actions {
       type = SQLDfTransformer
       code = "select stg_departures.*, date_format(from_unixtime(firstseen),'yyyyMMdd') dt from stg_departures"
     },{
-      type = ScalaCodeDfTransformer
+      type = ScalaCodeSparkDfTransformer
       code = """
         import org.apache.spark.sql.{DataFrame, SparkSession}
         def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
@@ -128,7 +128,7 @@ actions {
   }
 
   join-departures-airports {
-    type = CustomSparkAction
+    type = CustomDataFrameAction
     inputIds = [int-departures, int-airports]
     outputIds = [btl-departures-arrivals-airports]
     transformers = [{
@@ -162,7 +162,7 @@ actions {
     inputId = btl-departures-arrivals-airports
     outputId = btl-distances
     transformers = [{
-      type = ScalaClassDfTransformer
+      type = ScalaClassSparkDfTransformer
       className = com.sample.ComputeDistanceTransformer
     }]
     metadata {

--- a/docs/getting-started/config-examples/application-part3-download-custom-webservice.conf
+++ b/docs/getting-started/config-examples/application-part3-download-custom-webservice.conf
@@ -100,7 +100,7 @@ actions {
       type = SQLDfTransformer
       code = "select ext_departures.*, date_format(from_unixtime(firstseen),'yyyyMMdd') dt from ext_departures"
     },{
-      type = ScalaCodeDfTransformer
+      type = ScalaCodeSparkDfTransformer
       code = """
         import org.apache.spark.sql.{DataFrame, SparkSession}
         def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
@@ -130,7 +130,7 @@ actions {
   }
 
   join-departures-airports {
-    type = CustomSparkAction
+    type = CustomDataFrameAction
     inputIds = [int-departures, int-airports]
     outputIds = [btl-departures-arrivals-airports]
     transformers = [{
@@ -164,7 +164,7 @@ actions {
     inputId = btl-departures-arrivals-airports
     outputId = btl-distances
     transformers = [{
-      type = ScalaClassDfTransformer
+      type = ScalaClassSparkDfTransformer
       className = com.sample.ComputeDistanceTransformer
     }]
     metadata {

--- a/docs/getting-started/config-examples/application-part3-download-incremental-mode.conf
+++ b/docs/getting-started/config-examples/application-part3-download-incremental-mode.conf
@@ -106,7 +106,7 @@ actions {
       type = SQLDfTransformer
       code = "select ext_departures.*, date_format(from_unixtime(firstseen),'yyyyMMdd') dt from ext_departures"
     },{
-      type = ScalaCodeDfTransformer
+      type = ScalaCodeSparkDfTransformer
       code = """
         import org.apache.spark.sql.{DataFrame, SparkSession}
         def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
@@ -136,7 +136,7 @@ actions {
   }
 
   join-departures-airports {
-    type = CustomSparkAction
+    type = CustomDataFrameAction
     inputIds = [int-departures, int-airports]
     outputIds = [btl-departures-arrivals-airports]
     transformers = [{
@@ -170,7 +170,7 @@ actions {
     inputId = btl-departures-arrivals-airports
     outputId = btl-distances
     transformers = [{
-      type = ScalaClassDfTransformer
+      type = ScalaClassSparkDfTransformer
       className = com.sample.ComputeDistanceTransformer
     }]
     metadata {

--- a/docs/getting-started/part-1/compute-distances.md
+++ b/docs/getting-started/part-1/compute-distances.md
@@ -49,7 +49,7 @@ In order to wire this CustomTransformation into our config, we add the following
         inputId = btl-departures-arrivals-airports
         outputId = btl-distances
         transformers = [{
-          type = ScalaClassDfTransformer
+          type = ScalaClassSparkDfTransformer
           className = com.sample.ComputeDistanceTransformer
         }]
         metadata {
@@ -58,7 +58,7 @@ In order to wire this CustomTransformation into our config, we add the following
       }
 
 We used a CopyAction and told it to execute the code in the class *com.sample.ComputeDistanceTransformer* to transform the data.
-We could also have used a CustomSparkAction like in the previous step, 
+We could also have used a CustomDataFrameAction like in the previous step, 
 but this would have resulted in more complex code working with lists of inputs, outputs and transformers.
 
 
@@ -180,18 +180,22 @@ values={[
 <TabItem value="docker">
 
 ```jsx
-docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ".*"
 ```
 
 </TabItem>
 <TabItem value="podman">
 
 ```jsx
-podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ".*"
 ```
 
 </TabItem>
 </Tabs>        
+
+:::warning
+  Note the regex feed selection .* need to be specified in quotation marks (`'.*'` or `".*"`), otherwise our system would substitute the asterics.
+:::
 
 The successful execution DAG looks like this
 

--- a/docs/getting-started/part-1/get-airports.md
+++ b/docs/getting-started/part-1/get-airports.md
@@ -20,14 +20,14 @@ since this is what the second webservice answers with.
 Note that you would not get an error at this point if you had chosen another file format. 
 Since we use *FileTransferAction* in both cases, the files are copied without the content being interpreted yet.
 
-You can start the same *docker run* command as before and you should see that both directories
+You can start the same `docker run` command as before and you should see that both directories
 *stg-airports* and *stg-departures* have new files now.
-Notice that since both actions have the same feed, the option *--feed-sel download* executes both of them.
+Notice that since both actions have the same feed, the option `--feed-sel download` executes both of them.
 
 ## Mess Up the Solution
 Now let's see what happens when things don't go as planned. 
 For that, replace your config file with the contents of [this](../config-examples/application-part1-download-errors.conf) file.
-When you start the *docker run* command again, you will see two errors:
+When you start the `docker run` command again, you will see two errors:
 
 1. The name of the DataObject "NOPEext-departures" does not match with the inputId of the action download-departures.
 This is a very common error and the stacktrace should help you to quickly find and correct it

--- a/docs/getting-started/part-1/get-departures.md
+++ b/docs/getting-started/part-1/get-departures.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 In this step, we will download plane departure data from the REST-Interface described in the previous step using Smart Data Lake Builder.
 
 :::info Smart Data Lake = SDL
-Throughout this documentation, we will mostly refer to *SDL* which is just short for *Smart Data Lake*
+Throughout this documentation, we will mostly refer to *SDL* which is just short for *Smart Data Lake*. Further, we use **SDLB** as abbreviation for Smart Data Lake Builder, the automation tool.
 :::
 
 ## Config File

--- a/docs/getting-started/part-1/joining-departures-and-arrivals.md
+++ b/docs/getting-started/part-1/joining-departures-and-arrivals.md
@@ -15,7 +15,7 @@ We'll do it in a generic way by adding another transformer into the action *join
 Let's start in an unusual way by first changing the action. You'll see why shortly.
 
       join-departures-airports {
-        type = CustomSparkAction
+        type = CustomDataFrameAction
         inputIds = [stg-departures, int-airports]
         outputIds = [btl-departures-arrivals-airports]
         transformers = [{

--- a/docs/getting-started/part-1/joining-it-together.md
+++ b/docs/getting-started/part-1/joining-it-together.md
@@ -24,7 +24,7 @@ Like in the previous step, we need one more action and one DataObject for our ou
 ## Define join_departures_airports action
 
       join-departures-airports {
-        type = CustomSparkAction
+        type = CustomDataFrameAction
         inputIds = [stg-departures, int-airports]
         outputIds = [btl-connected-airports]
         transformers = [{
@@ -42,8 +42,8 @@ Like in the previous step, we need one more action and one DataObject for our ou
       }
 
 Now it gets interesting, a couple of things to note here:
-- This time, we changed the Action Type from CopyAction to CustomSparkAction.
-Use CustomSparkAction when you need to do complex operations. For instance, CustomSparkAction allows multiple inputs,
+- This time, we changed the Action Type from CopyAction to CustomDataFrameAction.
+Use CustomDataFrameAction when you need to do complex operations. For instance, CustomDataFrameAction allows multiple inputs,
 which CopyAction does not.
 - Our input/output fields are now called inputId**s** and outputId**s** and they take a list of DataObject ids.
 Similarly, our transformer is now of type SQLDf**s**Transformer.
@@ -57,11 +57,11 @@ The SQL-Code itself is just a join between the two input Data Objects on the ICA
 Note that we can just select all columns from airports, since we selected the ones that interest us in the previous step.
 
 :::tip Tip: Use only one output
-As you can see, with CustomSparkAction it's possible to read from multiple inputs and write to multiple outputs.
+As you can see, with CustomDataFrameAction it's possible to read from multiple inputs and write to multiple outputs.
 We usually discourage writing to multiple Data Objects in one action though. 
-At some point, you will want to use the metadata from SDL to analyze your data lineage. If you have a CustomSparkAction
+At some point, you will want to use the metadata from SDL to analyze your data lineage. If you have a CustomDataFrameAction
 with multiple inputs and multiple outputs (an M:N-relationship), SDL assumes that all outputs depend on all inputs. This might add
-some dependencies between DataObjects that don't really exist in the CustomSparkAction.
+some dependencies between DataObjects that don't really exist in the CustomDataFrameAction.
 Always using one Data Object as output will make your data lineage more detailed and clear.
 :::
 

--- a/docs/getting-started/part-1/select-columns.md
+++ b/docs/getting-started/part-1/select-columns.md
@@ -34,7 +34,7 @@ Put this in the existing dataObjects section:
         path = "~{id}"
       }
 
-## Define select-airport-cols action 
+## Define select-airport-cols action
 
 Next, add these lines in the existing actions section:
 
@@ -60,9 +60,9 @@ with some optional transformations of the data along the way.
 HOCON-Objects are just like JSON-Objects (with a few added features, but more on that later).
 - Instead of allowing for just one transformer, we could potentially have multiple transformers within the same action that
   get executed one after the other. That's why we have the bracket followed by the curly brace `[{` :
-  the CustomSparkAction expects it's field *transformers* to be a list of HOCON Objects.
+  the CustomDataFrameAction expects it's field *transformers* to be a list of HOCON Objects.
 - There's different kinds of transformers, in this case we defined a *SQLDfTransformer* and provided it with a custom SQL-Code.
-There are other transformer types such as *ScalaCodeDfTransformer*, *PythonCodeDfTransformer*... More on that later.
+There are other transformer types such as *ScalaCodeSparkDfTransformer*, *PythonCodeDfTransformer*... More on that later.
 
 :::caution
 
@@ -107,22 +107,6 @@ podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 
 </TabItem>
 </Tabs>
-
-:::caution
-
-If you encounter an error that looks like this:
-
-    Exception in thread "main" io.smartdatalake.util.dag.TaskFailedException: Task select-airport-cols failed. 
-	Root cause is 'IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema 
-	is undefined. A schema must be defined if there are no existing files.'
-    Caused by: java.lang.IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject 
-	schema is undefined. A schema must be defined if there are no existing files.
-
-Execute the **`download`**-feed again. After that feed was successfully executed, the execution of the feed `.*` or `compute` will work.
-More on this problem in the list of [Common Problems](../troubleshooting/common-problems.md).
-
-
-:::
 
 Now you should see multiple files in the folder *data/int-airports*. Why is it split accross multiple files?
 This is due to the fact that the query runs with Apache Spark under the hood which computes the query in parallel for different portions of the data.

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -138,7 +138,7 @@ But state-of-the-art is to use notebooks like Jupyter for this.
 One of the most advanced notebooks for Scala code we found is Polynote, see [polynote.org](https://polynote.org/).
 
 We will now start Polynote in a docker container, and an external Metastore (Derby database) in another container to share the catalog between our experiments and the notebook.
-To do so you need to add additional files to the project. Change to the projects root directory and **unzip part2.additional-files.zip** into the project's root directoy, then run the following commands in the projects root directory:
+To do so you need to add additional files to the project. Change to the projects root directory and `unzip part2.additional-files.zip` into the project's root directoy, then run the following commands in the projects root directory:
 
 <Tabs groupId = "docker-podman-switch"
 defaultValue="docker"

--- a/docs/getting-started/part-2/historical-data.md
+++ b/docs/getting-started/part-2/historical-data.md
@@ -85,7 +85,7 @@ docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 <TabItem value="podman">
 
 ```jsx
-podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel ids:historize-airports
+podman run --hostname=localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel ids:historize-airports
 ```
 
 </TabItem>
@@ -229,7 +229,7 @@ docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 <TabItem value="podman">
 
 ```jsx
-podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel ids:deduplicate-departures
+podman run --rm --hostname=localhost -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel ids:deduplicate-departures
 ```
 
 </TabItem>
@@ -287,7 +287,7 @@ This would be the case for example, in a messaging context, if you were to recei
 DeduplicateAction doesn't deduplicate your input data again, because deduplication is costly and data often is already unique.
 But in our example we have duplicates in the input data set, and we need to add some deduplication logic to our input data (this will probably become a configuration flag in future SDL version, see issue [#428](https://github.com/smart-data-lake/smart-data-lake/issues/428)).
 
-As the easiest way to do this is by using the Scala Spark API, we will add a second ScalaCodeDfTransformer as follows (make sure you get the brackets right): 
+As the easiest way to do this is by using the Scala Spark API, we will add a second ScalaCodeSparkDfTransformer as follows (make sure you get the brackets right): 
 
     deduplicate-departures {
       type = DeduplicateAction
@@ -296,7 +296,7 @@ As the easiest way to do this is by using the Scala Spark API, we will add a sec
         type = SQLDfTransformer
         code = "select stg_departures.*, date_format(from_unixtime(firstseen),'yyyyMMdd') dt from stg_departures"
       },{
-        type = ScalaCodeDfTransformer
+        type = ScalaCodeSparkDfTransformer
         code = """
           import org.apache.spark.sql.{DataFrame, SparkSession}
           def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
@@ -315,7 +315,7 @@ If you run Action `deduplicate-departures` again and check the result in Polynot
 :::info
 Note how we have used a third way of defining transformation logic now:  
 In part 1 we first used a SQLDfsTransformer writing SQL code.   
-Then for the more complex example of computing distances, we used a  ScalaClassDfTransformer pointing to a Scala class.   
+Then for the more complex example of computing distances, we used a  ScalaClassSparkDfTransformer pointing to a Scala class.   
 Here, we simply include Scala code in our configuration file directly.
 :::
 
@@ -328,7 +328,7 @@ Scala is a compiled language. The compiler creates bytecode which can be run on 
 Normally compilation takes place before execution. So how does it work with scala code in the configuration as in our deduplication logic above?
 
 With Scala, you can compile code on the fly. This is actually what the Scala Shell/REPL is doing as well. 
-The Scala code in the configuration above gets compiled when ScalaCodeDfTransformer is instantiated during startup of SDL.
+The Scala code in the configuration above gets compiled when ScalaCodeSparkDfTransformer is instantiated during startup of SDL.
 :::
 
 ## Summary

--- a/docs/getting-started/part-3/custom-webservice.md
+++ b/docs/getting-started/part-3/custom-webservice.md
@@ -74,7 +74,7 @@ Hence, our `CustomWebserviceDataObject` will enforce the rule that if the chosen
 
 Note that we changed the type to `CustomWebserviceDataObject`.
 This is a custom DataObject type, not included in standard Smart Data Lake Builder. 
-To make it work please go to the project's root directory and **unzip part3.additional-files.zip** into the project's root folder.
+To make it work please go to the project's root directory and `unzip part3.additional-files.zip` into the project's root folder.
 It includes the following file for you:
 
   - ./src/scala/io/smartdatalake/workflow/dataobject/CustomWebserviceDataObject.scala
@@ -126,7 +126,7 @@ docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 ```jsx
 mkdir .mvnrepo
 podman run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
-podmanrun --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ids:download-departures
+podman run --rm --hostname=localhost --pod getting-started -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ids:download-departures
 ```
 
 </TabItem>
@@ -235,7 +235,7 @@ If you re-compile the code of this project and then restart the program with the
 you should see that we do not query the API twice anymore.
 
 :::tip
-Use the information of the `ExecutionPhase` in your custom implementations whenever you need to have different logic during the different phases.
+  Use the information of the `ExecutionPhase` in your custom implementations whenever you need to have different logic during the different phases.
 :::
 
 ## Preserve schema
@@ -277,7 +277,7 @@ docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 
 ```jsx
 mkdir -f data
-podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest --config /mnt/config --feed-sel ids:download-deduplicate-departures
+podman run --rm --hostname=localhost -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest --config /mnt/config --feed-sel ids:download-deduplicate-departures
 ```
 
 </TabItem>

--- a/docs/getting-started/part-3/incremental-mode.md
+++ b/docs/getting-started/part-3/incremental-mode.md
@@ -28,7 +28,7 @@ download-deduplicate-departures {
     type = SQLDfTransformer
     code = "select ext_departures.*, date_format(from_unixtime(firstseen),'yyyyMMdd') dt from ext_departures"
   },{
-    type = ScalaCodeDfTransformer
+    type = ScalaCodeSparkDfTransformer
     code = """
       import org.apache.spark.sql.{DataFrame, SparkSession}
       def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
@@ -121,7 +121,7 @@ docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 
 ```jsx
 podman run -v ${PWD}:/mnt/project -v ${PWD}/.mvnrepo:/mnt/.mvnrepo maven:3.6.0-jdk-11-slim -- mvn -f /mnt/project/pom.xml "-Dmaven.repo.local=/mnt/.mvnrepo" package
-podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest --config /mnt/config --feed-sel ids:download-deduplicate-departures --state-path /mnt/data/state -n getting-started
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --hostname=localhost --pod getting-started sdl-spark:latest --config /mnt/config --feed-sel ids:download-deduplicate-departures --state-path /mnt/data/state -n getting-started
 ```
 
 </TabItem>

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -111,7 +111,7 @@ When the execution is complete, you should see the two files in the *data* folde
 Wonder what happened ? You will create the data pipeline that does just this in the first steps of this guide.
 
 If you wish, you can start with [part 1](get-input-data) right away.
-For parts 2 and later, it is recommended to setup a Development Environment.
+For [part 2](part-3/industrializing.md) and [part 3](part-3/custom-webservice.md), it is recommended to setup a Development Environment.
 
 ## Development Environment
 For some parts of this tutorial it is beneficial to have a working development environment ready. In the following we will mainly explain how one can configure a working evironment for 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -111,7 +111,7 @@ When the execution is complete, you should see the two files in the *data* folde
 Wonder what happened ? You will create the data pipeline that does just this in the first steps of this guide.
 
 If you wish, you can start with [part 1](get-input-data) right away.
-For [part 2](part-3/industrializing.md) and [part 3](part-3/custom-webservice.md), it is recommended to setup a Development Environment.
+For [part 2](part-2/industrializing.md) and [part 3](part-3/custom-webservice.md), it is recommended to setup a Development Environment.
 
 ## Development Environment
 For some parts of this tutorial it is beneficial to have a working development environment ready. In the following we will mainly explain how one can configure a working evironment for 

--- a/docs/getting-started/troubleshooting/common-problems.md
+++ b/docs/getting-started/troubleshooting/common-problems.md
@@ -11,17 +11,14 @@ If you encounter an error that looks like this:
     ma must be defined if there are no existing files.'
     Caused by: java.lang.IllegalArgumentException: requirement failed: (DataObject~stg-airports) DataObject schema is undefined. A schema must be defined if there are no existing files.
 
-This is likely due to the fact that you did not execute the `download` feed from the previous step.
-Executing the `compute` feed will only work if you already have some files under *data/stg-airports* and data/stg-departures.
-This is because in the first step, we download files of which SDL doesn't know the schema of in advance.
-The init-phase will require that for all Data Objects, the schema is known so that it can check for inconsistencies.
-When we already have some files, it will infer the schema based on the files.
+The init-phase will require to know the schema for all Data Objects to check for inconsistencies. If downloaded files already exist, the schema can be inferred. 
+In SDL version *< 2.3.0* the *download* action was typically defined in a separate feed, separated from further transformation actions. This download feeds needed to be run upfront, before running further feeds like *compute*. Once the downloaded files are present, the schema can be inferred. 
 
-To work around this, execute the feed `download` again. After that feed was successfully executed, the execution of
+To work around this issue, execute the feed `download` again. After that feed was successfully executed, the execution of
 the feed `.*` or `compute` will work.
+One way to prevent this problem is to explicitly provide the schema for the JSON and for the CSV-File.
 
-One way to prevent this problem is to explicitly provide the schema for the JSON and for the CSV-File,
-which is out of the scope for this part of the tutorial.
+This issue should not occur in SDL versions *> 2.3.0*.
 
 ## download-departures fails because of a Timeout
 If you encounter an error that looks like this:

--- a/docs/reference/transformations.md
+++ b/docs/reference/transformations.md
@@ -12,7 +12,7 @@ To implement custom transformation logic, define the **transformers** attribute 
 where output SubFeeds from one transformation are use as input for the next.  
 Note that the definition of the transformations looks different for:
 * **1-to-1** transformations (\*DfTransformer): One input DataFrame is transformed into one output DataFrame. This is the case for CopyAction, DeduplicateAction and HistorizeAction.
-* **many-to-many** transformations (\*DfsTransformer): Many input DataFrames can be transformed into many output DataFrames. This is the case for CustomSparkAction.
+* **many-to-many** transformations (\*DfsTransformer): Many input DataFrames can be transformed into many output DataFrames. This is the case for CustomDataFrameAction.
 
 The configuration allows you to use predefined standard transformations or to define custom transformation in various languages.
 
@@ -36,10 +36,10 @@ Specifying options allows to reuse a transformation in different settings.
 #### Java/Scala
 You can use Spark Dataset API in Java/Scala to define custom transformations.
 If you have a Java project, create a class that extends CustomDfTransformer or CustomDfsTransformer and implement `transform` method.
-Then use **type = ScalaClassDfTransformer** or **type = ScalaClassDfsTransformer** and configure **className** attribute.
+Then use **type = ScalaClassSparkDfTransformer** or **type = ScalaClassDfsTransformer** and configure **className** attribute.
 
 If you work without Java project, it's still possible to define your transformation in Java/Scala and compile it at runtime.
-For a 1-to-1 transformation use **type = ScalaCodeDfTransformer** and configure **code** or **file** as a function that takes `session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectName: String` as parameters and returns a `DataFrame`.
+For a 1-to-1 transformation use **type = ScalaCodeSparkDfTransformer** and configure **code** or **file** as a function that takes `session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectName: String` as parameters and returns a `DataFrame`.
 For many-to-many transformations use **type = ScalaCodeDfsTransformer** and configure **code** or **file** as a function that takes `session: SparkSession, options: Map[String,String], dfs: Map[String,DataFrame]` with DataFrames per input DataObject as parameter, and returns a `Map[String,DataFrame]` with the DataFrame per output DataObject.
 
 See [sdl-examples](https://github.com/smart-data-lake/sdl-examples) for details.

--- a/docs/reference/transformations.md
+++ b/docs/reference/transformations.md
@@ -36,11 +36,11 @@ Specifying options allows to reuse a transformation in different settings.
 #### Java/Scala
 You can use Spark Dataset API in Java/Scala to define custom transformations.
 If you have a Java project, create a class that extends CustomDfTransformer or CustomDfsTransformer and implement `transform` method.
-Then use **type = ScalaClassSparkDfTransformer** or **type = ScalaClassDfsTransformer** and configure **className** attribute.
+Then use **type = ScalaClassSparkDfTransformer** or **type = ScalaClassSparkDfsTransformer** and configure **className** attribute.
 
 If you work without Java project, it's still possible to define your transformation in Java/Scala and compile it at runtime.
 For a 1-to-1 transformation use **type = ScalaCodeSparkDfTransformer** and configure **code** or **file** as a function that takes `session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectName: String` as parameters and returns a `DataFrame`.
-For many-to-many transformations use **type = ScalaCodeDfsTransformer** and configure **code** or **file** as a function that takes `session: SparkSession, options: Map[String,String], dfs: Map[String,DataFrame]` with DataFrames per input DataObject as parameter, and returns a `Map[String,DataFrame]` with the DataFrame per output DataObject.
+For many-to-many transformations use **type = ScalaCodeSparkDfsTransformer** and configure **code** or **file** as a function that takes `session: SparkSession, options: Map[String,String], dfs: Map[String,DataFrame]` with DataFrames per input DataObject as parameter, and returns a `Map[String,DataFrame]` with the DataFrame per output DataObject.
 
 See [sdl-examples](https://github.com/smart-data-lake/sdl-examples) for details.
 


### PR DESCRIPTION
### What changes are included in the pull request?
After [updating the getting-started version](https://github.com/smart-data-lake/getting-started/issues/7#issue-1240141531) the getting-started guide need to be changed: 
* [x] no **additional** / **separate** `download` is necessary before running the `compute` feed. Thus, both feeds can be run in one go, without separation.
* The Actions need to be renamed:
   -  [x] join-departure-airport is now a `CustomDataFrameAction` 
   - [x] compute-distances utilizes a transformer of type `ScalaClassSparkDfTransformer`
   - [x] download-deduplicate-departures (part3) now utilizes `ScalaCodeSparkDfTransformer`
* [x] fix on [compute-distances](https://smartdatalake.ch/docs/getting-started/part-1/compute-distances) the .* in the commands need tp be `".*"`
* [x] on page [data-lake-format](https://smartdatalake.ch/docs/getting-started/part-2/delta-lake-format) set `unzip part2.additional-files.zip` as real command
* [x] typo `podmanrun` on [customWebservice](https://smartdatalake.ch/docs/getting-started/part-3/custom-webservice)
* [x] part 3 has changes in the custom action sources
* [x] in [part3](https://smartdatalake.ch/docs/getting-started/part-3/incremental-mode) need `--hostname=localhost` to be added to the SDLB command

### Why are the changes needed?
Since the getting-started source will be updated using SDL 2.3.0. Thus the documentation should follow. 

fixes #530 