### PR TITLE
Bugfix transformer dataframe output mapping and input partitionvalues

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionSubFeedsImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionSubFeedsImpl.scala
@@ -79,10 +79,12 @@ abstract class ActionSubFeedsImpl[S <: SubFeed : TypeTag] extends Action {
 
   def prepareInputSubFeeds(subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): (Seq[S],Seq[S]) = {
     val mainInput = getMainInput(subFeeds)
-    // convert subfeeds to SparkSubFeed type or initialize if not yet existing
-    var inputSubFeeds: Seq[S] = subFeeds.map( subFeed =>
-      updateInputPartitionValues(inputMap(subFeed.dataObjectId), subFeedConverter.fromSubFeed(subFeed))
-    )
+    val mainSubFeed = subFeeds.find(_.dataObjectId == mainInput.id).get
+    // convert subfeeds to this Actions SubFeed type or initialize if not yet existing
+    var inputSubFeeds: Seq[S] = subFeeds.map { subFeed =>
+      val partitionValues = if (subFeed.partitionValues.isEmpty && mainSubFeed.partitionValues.nonEmpty) Some(mainSubFeed.partitionValues) else None
+      updateInputPartitionValues(inputMap(subFeed.dataObjectId), subFeedConverter.fromSubFeed(subFeed), partitionValues)
+    }
     val mainInputSubFeed = inputSubFeeds.find(_.dataObjectId == mainInput.id).get
     // create output subfeeds with transformed partition values from main input
     var outputSubFeeds: Seq[S] = outputs.map(output =>
@@ -215,11 +217,11 @@ abstract class ActionSubFeedsImpl[S <: SubFeed : TypeTag] extends Action {
    * Updates the partition values of a SubFeed to the partition columns of the given input data object:
    * - remove not existing columns from the partition values
    */
-  private def updateInputPartitionValues(dataObject: DataObject, subFeed: S)(implicit context: ActionPipelineContext): S = {
+  private def updateInputPartitionValues(dataObject: DataObject, subFeed: S, partitionValues: Option[Seq[PartitionValues]] = None)(implicit context: ActionPipelineContext): S = {
     dataObject match {
       case partitionedDO: CanHandlePartitions =>
         // remove superfluous partitionValues
-        subFeed.updatePartitionValues(partitionedDO.partitions, newPartitionValues = Some(subFeed.partitionValues)).asInstanceOf[S]
+        subFeed.updatePartitionValues(partitionedDO.partitions, newPartitionValues = partitionValues).asInstanceOf[S]
       case _ =>
         subFeed.clearPartitionValues().asInstanceOf[S]
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -69,7 +69,7 @@ case class CustomFileAction(override val id: ActionId,
     outputSubFeed.copy(fileRefMapping = Some(output.translateFileRefs(inputFileRefs)))
   }
 
-  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult = {
+  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult[FileSubFeed] = {
     val fileRefMapping = subFeed.fileRefMapping.getOrElse(throw new IllegalStateException(s"($id) file mapping is not defined"))
     output.startWritingOutputStreams(subFeed.partitionValues)
     if (fileRefMapping.nonEmpty) {
@@ -106,7 +106,7 @@ case class CustomFileAction(override val id: ActionId,
     output.endWritingOutputStreams(subFeed.partitionValues)
     // return metric to action
     val metrics = Map("files_written"->fileRefMapping.size.toLong)
-    WriteSubFeedResult(Some(fileRefMapping.isEmpty), Some(metrics))
+    WriteSubFeedResult(subFeed, Some(fileRefMapping.isEmpty), Some(metrics))
   }
 
   override def postprocessOutputSubFeedCustomized(subFeed: FileSubFeed)(implicit context: ActionPipelineContext): FileSubFeed = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
@@ -26,8 +26,8 @@ import io.smartdatalake.util.evolution.SchemaEvolution
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.generic.transformer.{GenericDfTransformer, GenericDfTransformerDef, SparkDfTransformerFunctionWrapper}
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfTransformerConfig
-import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanMergeDataFrame, DataObject, TransactionalSparkTableDataObject}
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, CanMergeDataFrame, DataObject, TransactionalSparkTableDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
@@ -114,6 +114,9 @@ case class DeduplicateAction(override val id: ActionId,
   override val recursiveInputs: Seq[TransactionalSparkTableDataObject] = if (!mergeModeEnable) Seq(output) else Seq()
 
   private[smartdatalake] override val handleRecursiveInputsAsSubFeeds: Boolean = false
+
+  // DataFrame created by DeduplicateAction should not be passed on to the next Action, but must be recreated from the DataObject.
+  override val breakDataFrameOutputLineage: Boolean = true
 
   // check preconditions
   require(output.table.primaryKey.isDefined, s"($id) Primary key must be defined for output DataObject")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -65,14 +65,14 @@ case class FileTransferAction(override val id: ActionId,
     outputSubFeed.copy(fileRefMapping = Some(fileTransfer.getFileRefMapping(inputFileRefs)))
   }
 
-  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult = {
+  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult[FileSubFeed] = {
     val fileRefMapping = subFeed.fileRefMapping.getOrElse(throw new IllegalStateException(s"($id) file mapping is not defined"))
     output.startWritingOutputStreams(subFeed.partitionValues)
     if (fileRefMapping.nonEmpty) fileTransfer.exec(fileRefMapping)
     output.endWritingOutputStreams(subFeed.partitionValues)
     // return metric to action
     val metrics = Map("files_written"->fileRefMapping.size.toLong)
-    WriteSubFeedResult(Some(fileRefMapping.isEmpty), Some(metrics))
+    WriteSubFeedResult(subFeed, Some(fileRefMapping.isEmpty), Some(metrics))
   }
 
   override def postprocessOutputSubFeedCustomized(subFeed: FileSubFeed)(implicit context: ActionPipelineContext): FileSubFeed = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
@@ -169,7 +169,7 @@ case class HistorizeAction(
 
   private[smartdatalake] override val handleRecursiveInputsAsSubFeeds: Boolean = false
 
-  // DataFrame created by DeduplicateAction should not be passed on to the next Action, but must be recreated from the DataObject.
+  // DataFrame created by HistorizeAction should not be passed on to the next Action, but must be recreated from the DataObject.
   override val breakDataFrameOutputLineage: Boolean = true
 
   // historize black/white list

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
@@ -169,6 +169,9 @@ case class HistorizeAction(
 
   private[smartdatalake] override val handleRecursiveInputsAsSubFeeds: Boolean = false
 
+  // DataFrame created by DeduplicateAction should not be passed on to the next Action, but must be recreated from the DataObject.
+  override val breakDataFrameOutputLineage: Boolean = true
+
   // historize black/white list
   require(historizeWhitelist.isEmpty || historizeBlacklist.isEmpty, s"(${id}) HistorizeWhitelist and historizeBlacklist mustn't be used at the same time")
   // primary key

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
@@ -48,9 +48,9 @@ abstract class ScriptActionImpl extends ActionSubFeedsImpl[ScriptSubFeed] {
     } else outputSubFeeds
   }
 
-  override def writeSubFeed(subFeed: ScriptSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult = {
+  override def writeSubFeed(subFeed: ScriptSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult[ScriptSubFeed] = {
     val output = outputs.find(_.id == subFeed.dataObjectId).getOrElse(throw new IllegalStateException(s"($id) output for subFeed ${subFeed.dataObjectId} not found"))
     output.scriptNotification(subFeed.parameters.getOrElse(Map()))
-    WriteSubFeedResult(noData = None) // unknown if there is data
+    WriteSubFeedResult(subFeed, noData = None) // unknown if there is data
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -159,7 +159,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
       .options(queryOrTable)
       .load()
     incrementalOutputState.foreach { case (lastExpr, lastHighWatermark)  =>
-      assert(incrementalOutputExpr.isDefined)
+      assert(incrementalOutputExpr.isDefined, s"($id) incrementalOutputExpr must be set to use DataObjectStateIncrementalMode")
       if (lastExpr != incrementalOutputExpr.get) logger.warn(s"($id) incrementalOutputState has different column as incrementalOutputExpr ($lastExpr != ${incrementalOutputExpr.get}")
       val newDataType = ExpressionEvaluator.resolveExpression(expr(incrementalOutputExpr.get), df.schema, caseSensitive = false).dataType
       if (context.phase == ExecutionPhase.Exec) {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SchemaValidation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SchemaValidation.scala
@@ -82,7 +82,7 @@ private[smartdatalake] trait SchemaValidation { this: DataObject =>
            |- missingCols=${missingCols.map(_.columns).getOrElse(Seq()).mkString(", ")}
            |- superfluousCols=${superfluousCols.map(_.columns).getOrElse(Seq()).mkString(", ")}
            |- schemaExpected: ${schemaExpected.sql}
-           |- schema: ${schema.sql.mkString(", ")}""".stripMargin)
+           |- schema: ${schema.sql}""".stripMargin)
     }
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -212,21 +212,27 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val feed = "actionpipeline"
-    val srcTableA = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "A", Some(tempPath+s"/${srcTableA.fullName}"), table = srcTableA, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
-    srcDO.dropTable
-    instanceRegistry.register(srcDO)
-    val tgtATable = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
+    val srcTableA = Table(Some("default"), "input_a")
+    val srcADO = HiveTableDataObject( "src_A", Some(tempPath+s"/${srcTableA.fullName}"), table = srcTableA, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    srcADO.dropTable
+    instanceRegistry.register(srcADO)
+
+    val srcTableB = Table(Some("default"), "input_b")
+    val srcBDO = HiveTableDataObject( "src_B", Some(tempPath+s"/${srcTableB.fullName}"), table = srcTableB, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    srcBDO.dropTable
+    instanceRegistry.register(srcBDO)
+
+    val tgtATable = Table(Some("default"), "tgt_a", None, Some(Seq("lastname","firstname")))
     val tgtADO = TickTockHiveTableDataObject("tgt_A", Some(tempPath+s"/${tgtATable.fullName}"), table = tgtATable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     tgtADO.dropTable
     instanceRegistry.register(tgtADO)
 
-    val tgtBTable = Table(Some("default"), "ap_copy1", None, Some(Seq("lastname","firstname")))
+    val tgtBTable = Table(Some("default"), "tgt_b", None, Some(Seq("lastname","firstname")))
     val tgtBDO = HiveTableDataObject( "tgt_B", Some(tempPath+s"/${tgtBTable.fullName}"), table = tgtBTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     tgtBDO.dropTable
     instanceRegistry.register(tgtBDO)
 
-    val tgtCTable = Table(Some("default"), "ap_copy2", None, Some(Seq("lastname","firstname")))
+    val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname","firstname")))
     val tgtCDO = HiveTableDataObject( "tgt_C", Some(tempPath+s"/${tgtCTable.fullName}"), table = tgtCTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     tgtCDO.dropTable
     instanceRegistry.register(tgtCDO)
@@ -237,13 +243,19 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDDO)
 
     // prepare DAG
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    srcDO.writeSparkDataFrame(l1, Seq())
-    tgtDDO.writeSparkDataFrame(l1, Seq()) // we populate tgtD so there should be no partitions to process
-    instanceRegistry.register(DeduplicateAction("a", srcDO.id, tgtADO.id, executionMode = Some(PartitionDiffMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
-    instanceRegistry.register(CopyAction("b", tgtADO.id, tgtBDO.id, executionMode = Some(FailIfNoPartitionValuesMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
+    val dataA = Seq(("doe","john",5),("dau","bob",3)).toDF("lastname", "firstname", "rating")
+    val dataB = Seq(("doe","john",10),("dau","bob",6)).toDF("lastname", "firstname", "rating")
+    srcADO.writeSparkDataFrame(dataA, Seq())
+    srcBDO.writeSparkDataFrame(dataB, Seq())
+    tgtADO.writeSparkDataFrame(dataA.where($"lastname"==="doe").withColumn("dl_ts_captured", current_timestamp()), Seq()) // populate tgtA with "doe", so there should be only 1 partition to process (dau)
+    tgtDDO.writeSparkDataFrame(dataA, Seq()) // populate tgtD so there should be no partitions left to process
+    instanceRegistry.register(DeduplicateAction("a", srcADO.id, tgtADO.id, executionMode = Some(PartitionDiffMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
+    // srcB should be filtered with partition values received from tgtA. Transformer selects records from srcB, so "doe, bob, 6" should be inserted in tgtB, but "doe, john, 3" should remain.
+    instanceRegistry.register(CustomDataFrameAction("b", Seq(tgtADO.id,srcBDO.id), Seq(tgtBDO.id), executionMode = Some(FailIfNoPartitionValuesMode()), metadata = Some(ActionMetadata(feed = Some(feed))),
+      transformers = Seq(SQLDfsTransformer(code = Map(tgtBDO.id.id -> "select * from src_B"))), mainInputId = Some(tgtADO.id)
+    ))
     instanceRegistry.register(CopyAction("c", tgtADO.id, tgtCDO.id, metadata = Some(ActionMetadata(feed = Some(feed)))))
-    instanceRegistry.register(CopyAction("d", srcDO.id, tgtDDO.id, executionMode = Some(PartitionDiffMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
+    instanceRegistry.register(CopyAction("d", srcADO.id, tgtDDO.id, executionMode = Some(PartitionDiffMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
 
     // exec dag
     val sdlb = new DefaultSmartDataLakeBuilder
@@ -253,20 +265,17 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val r1 = tgtBDO.getSparkDataFrame()
       .select($"rating")
       .as[Int].collect.toSeq
-    assert(r1.size == 1)
-    assert(r1.head == 5)
+    assert(r1.toSet == Set(6))
 
     val r2 = tgtCDO.getSparkDataFrame()
       .select($"rating")
       .as[Int].collect.toSeq
-    assert(r2.size == 1)
-    assert(r2.head == 5)
+    assert(r2.toSet == Set(3))
 
     val r3 = tgtDDO.getSparkDataFrame()
       .select($"rating")
       .as[Int].collect.toSeq
-    assert(r3.size == 1)
-    assert(r3.head == 5)
+    assert(r3.toSet == Set(3,5))
   }
 
   test("action dag where first actions has multiple input subfeeds, one should ignore filters") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
@@ -18,16 +18,15 @@
  */
 package io.smartdatalake.workflow.action
 
-import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.definitions.TechnicalTableColumn
 import io.smartdatalake.testutils.DataFrameTestHelper._
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
+import io.smartdatalake.workflow.ExecutionPhase
 import io.smartdatalake.workflow.action.generic.transformer.FilterTransformer
+import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, TickTockHiveTableDataObject}
-import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
@@ -73,6 +72,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
+    assert(tgtSubFeed.asInstanceOf[SparkSubFeed].isDummy) // should return a dummy DataFrame as breakDataFrameOutputLineage is set to true
 
     {
       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1)), ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1)), ("hans", "muster", 5, Timestamp.valueOf(refTimestamp1)))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
@@ -73,6 +73,7 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(context1).head
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
+    assert(tgtSubFeed.asInstanceOf[SparkSubFeed].isDummy) // should return a dummy DataFrame as breakDataFrameOutputLineage is set to true
 
     {
       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(definitions.HiveConventions.getHistorizationSurrogateTimestamp)))


### PR DESCRIPTION
### What changes are included in the pull request?

CustomDataFrameAction:
- allow using intermediate DataFrames as Action output 
- allow  last transformer output to be unused in Action outputs
-> These restrictions are not really usefull.

Fix applying mainInput partitionValues to other inputs
-> This is how it should work. PartitionValues from mainInput should be applyed to other inputs of an Action if possible and those inputs have no partitionValues yet.

Implement DataFrameActionImpl.breakDataFrameOutputLineage
-> This is needed because Deduplicate- and HistorizeAction write different data than what they got as input. It depends on incrementalMode setting and might be different from partitionValues for DeduplicateAction. Its cleaner to force the next action to request a new DataFrame from the source.
