### PR TITLE
add FinalStateWriter

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/FinalStateWriter.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/FinalStateWriter.scala
@@ -1,0 +1,26 @@
+package io.smartdatalake.util.misc
+
+import io.smartdatalake.app.StateListener
+import io.smartdatalake.config.SdlConfigObject
+import io.smartdatalake.workflow.{ActionDAGRunState, ActionPipelineContext, HadoopFileActionDAGRunStateStore}
+
+/**
+ * Write final state to given hadoop path to be used as notification for succeeded runs, e.g. by an Azure Function.
+ * Needs 'path' as option.
+ */
+class FinalStateWriter(options: Map[String,String]) extends StateListener {
+  var stateStore: Option[HadoopFileActionDAGRunStateStore] = None
+  override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId: Option[SdlConfigObject.ActionId]): Unit = {
+    // initialize state store
+    if (stateStore.isEmpty) {
+      val path = options.get("path").getOrElse(throw new IllegalArgumentException("Option 'path' not defined"))
+      stateStore = Some(new HadoopFileActionDAGRunStateStore(path, context.application, context.hadoopConf))
+      // check connection
+      stateStore.get.getLatestRunId
+    }
+    // write state file on final notification
+    if (state.isFinal) {
+      stateStore.get.saveState(state)
+    }
+  }
+}

--- a/sdl-core/src/test/resources/configState/WithFinalStateWriter.conf
+++ b/sdl-core/src/test/resources/configState/WithFinalStateWriter.conf
@@ -1,0 +1,46 @@
+#
+# Smart Data Lake - Build your data lake the smart way.
+#
+# Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+global {
+  stateListeners = [{
+      className = "io.smartdatalake.util.misc.FinalStateWriter"
+      options {
+        path = "ext-state/state-test"
+      }
+  }]
+}
+actions {
+  act {
+    type = CopyAction
+    inputId = src
+    outputId = tgt
+    metadata.feed = test
+  }
+}
+
+dataObjects {
+  src {
+    type = CsvFileDataObject
+    path = "target/src1"
+  }
+  tgt {
+    type = CsvFileDataObject
+    path = "target/tgt1"
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -20,7 +20,7 @@
 package io.smartdatalake.app
 
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
-import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.config.{ConfigLoader, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions._
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.dag.TaskFailedException
@@ -33,6 +33,7 @@ import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfTrans
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSubFeed}
 import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.{ActionDAGRunState, ActionPipelineContext, ExecutionPhase, HadoopFileActionDAGRunStateStore}
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
@@ -565,6 +566,28 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     assert(stats == Map(RuntimeEventState.INITIALIZED -> 2))
     assert(finalSubFeeds.head.dataFrame.get.select(dfSrc1.columns.map(SparkSubFeed.col)).symmetricDifference(SparkDataFrame(dfSrc1)).isEmpty)
   }
+
+  test("sdlb run with external state file using FinalStateWriter") {
+    //TODO
+    val feedName = "test"
+    val sdlb = new DefaultSmartDataLakeBuilder()
+
+    // setup input DataObject
+    val srcDO = CsvFileDataObject("src1", "target/src1")(sdlb.instanceRegistry)
+    val dfSrc1 = Seq("testData").toDF("testColumn")
+    srcDO.writeDataFrame(SparkDataFrame(dfSrc1), Seq())(TestUtil.getDefaultActionPipelineContext(sdlb.instanceRegistry))
+
+    val sdlConfig = SmartDataLakeBuilderConfig(feedSel = feedName, configuration = Some(Seq(
+          getClass.getResource("/configState/WithFinalStateWriter.conf").getPath)) )
+
+    // Run SDLB
+    sdlb.run(sdlConfig)
+
+    // check result
+    val fileResult = filesystem.exists(new Path("ext-state/state-test"))
+    assert(fileResult)
+  }
+
 }
 
 class FailTransformer extends CustomDfTransformer {

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -568,7 +568,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
   }
 
   test("sdlb run with external state file using FinalStateWriter") {
-    //TODO
+    
     val feedName = "test"
     val sdlb = new DefaultSmartDataLakeBuilder()
 


### PR DESCRIPTION
### What changes are included in the pull request?
An implementation of a StateListener that writes final state to a given hadoop path

### Why are the changes needed?
Useful to sync on-premise jobs with cloud jobs by, e.g. Azure Function triggered by new file arrived

Configuration:
```
global {
  stateListeners = [{
    className = "io.smartdatalake.custom.FinalStateWriter"
    options {
      path = "sdlb/state-onprem"
    }
  }]
}
```