### PR TITLE
correct test name

### DIFF
--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -617,7 +617,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
   }
 
 
-  test("sdlb run converting camel case col names to lower case with underscores") {
+  test("sdlb run converting column names to lower without additional options") {
     val feedName = "test"
     val sdlb = new DefaultSmartDataLakeBuilder()
     //implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry


### PR DESCRIPTION
sorry, just realized the incorrect test naming after merging.

### What changes are included in the pull request?
The  second test for column name conversion without additional options were first named incorrectly, due to historical reasons. 

### Why are the changes needed?
Just to have it pretty. 