### PR TITLE
Fix image references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [Features](https://github.com/smart-data-lake/smart-data-lake/blob/documenta
 ## How it works
 The following diagram shows the core concepts:
 
-![How it works](docs/images/feed.png)
+![How it works](https://github.com/smart-data-lake/smart-data-lake/blob/documentation/docs/images/feed.png)
 
 ### Data object
 A data object defines the location and format of data. 
@@ -57,10 +57,10 @@ The file format used is [HOCON](https://github.com/lightbend/config/blob/master/
 To see how all this works in action, head over to the [Getting Started](https://smartdatalake.ch/docs/getting-started/setup) page.
 
 # Major Contributors
-![SBB](docs/images/SBB_logo.png)  
+![SBB](https://github.com/smart-data-lake/smart-data-lake/blob/documentation/docs/images/SBB_logo.png)  
 [www.sbb.ch](http://www.sbb.ch) : Provided the previously developed software as a foundation for the open source project   
 
-![ELCA](docs/images/ELCA_logo.png)  
+![ELCA](https://github.com/smart-data-lake/smart-data-lake/blob/documentation/docs/images/ELCA_logo.png)  
 [www.elca.ch](http://www.elca.ch) : Did the comprehensive revision and provision as open source project 
 
 # Additional Documentation


### PR DESCRIPTION
Fixed some broken image references in README.md. The new links now reference to the `documentation` branch blobs.