### PR TITLE
sdlPlugin - NPE because classloader is null at this point

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -210,9 +210,9 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
    * @param appConfig Application configuration (parsed from command line).
    */
   def run(appConfig: SmartDataLakeBuilderConfig): Map[RuntimeEventState,Int] = {
+    // invoke SDLPlugin if configured
+    Environment.sdlPlugin.foreach(_.startup())
     val stats = try {
-      // invoke SDLPlugin if configured
-      Environment.sdlPlugin.foreach(_.startup())
       // create default hadoop configuration, as we did not yet load custom spark/hadoop properties
       implicit val defaultHadoopConf: Configuration = new Configuration()
       // handle state if defined

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigToolbox.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigToolbox.scala
@@ -42,7 +42,7 @@ object ConfigToolbox {
    */
   def loadAndParseConfig(locations: Seq[String], userClassLoader: Option[ClassLoader] = None): (InstanceRegistry, GlobalConfig) = {
     // override classloader if given
-    userClassLoader.foreach(Environment._classLoader = _)
+    userClassLoader.foreach(classLoader => Environment._classLoader = Some(classLoader))
     // load config
     val defaultHadoopConf: Configuration = new Configuration()
     val config = ConfigLoader.loadConfigFromFilesystem(locations, defaultHadoopConf)

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -255,9 +255,10 @@ object Environment {
   def globalConfig: GlobalConfig = _globalConfig
   private [smartdatalake] var _globalConfig: GlobalConfig = _
 
-  // this class loader is needed to find custom classes in some environments (e.g. Polynote)
+  // this class loader needs to be overridden to find custom classes in some environments (e.g. Polynote)
   def classLoader: ClassLoader = _classLoader
-  private [smartdatalake] var _classLoader: ClassLoader = this.getClass.getClassLoader // initialize with default classloader
+  private [smartdatalake] var _classLoader: ClassLoader = Option(this.getClass.getClassLoader)
+    .getOrElse(ClassLoader.getSystemClassLoader()) // initialize with default classloader
 
   // flag to gracefully stop repeated execution of DAG in streaming mode
   var stopStreamingGracefully: Boolean = false

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -35,6 +35,16 @@ import java.net.URI
  */
 object Environment {
 
+  // this class loader needs to be overridden to find custom classes in some environments (e.g. Polynote)
+  def classLoader(): ClassLoader = {
+    if (_classLoader.isEmpty) {
+      _classLoader = Option(this.getClass.getClassLoader)
+        .orElse(Option(ClassLoader.getSystemClassLoader))
+    }
+    _classLoader.get
+  }
+  var _classLoader: Option[ClassLoader] = None
+
   /**
    * List of hadoop authorities for which acls must be configured
    * The environment parameter can contain multiple authorities separated by comma.
@@ -241,10 +251,15 @@ object Environment {
   val runIdPartitionColumnName = "run_id"
 
   // instantiate sdl plugin if configured
-  private[smartdatalake] var sdlPlugin: Option[SDLPlugin] = {
-    EnvironmentUtil.getSdlParameter("pluginClassName")
-      .map(CustomCodeUtil.getClassInstanceByName[SDLPlugin])
+  private[smartdatalake] def sdlPlugin: Option[SDLPlugin] = {
+    if (_sdlPlugin.isEmpty) {
+      _sdlPlugin = Some(EnvironmentUtil.getSdlParameter("pluginClassName")
+        .map(CustomCodeUtil.getClassInstanceByName[SDLPlugin]))
+
+    }
+    _sdlPlugin.get
   }
+  private[smartdatalake] var _sdlPlugin: Option[Option[SDLPlugin]] = None
 
   // dynamically shared environment for custom code (see also #106)
   // attention: if JVM is shared between different SDL jobs (e.g. Databricks cluster), these variables will be overwritten by the current job. Therefore they should not been used in SDL code, but might be used in custom code on your own risk.
@@ -254,11 +269,6 @@ object Environment {
   private [smartdatalake] var _instanceRegistry: InstanceRegistry = _
   def globalConfig: GlobalConfig = _globalConfig
   private [smartdatalake] var _globalConfig: GlobalConfig = _
-
-  // this class loader needs to be overridden to find custom classes in some environments (e.g. Polynote)
-  def classLoader: ClassLoader = _classLoader
-  private [smartdatalake] var _classLoader: ClassLoader = Option(this.getClass.getClassLoader)
-    .getOrElse(ClassLoader.getSystemClassLoader()) // initialize with default classloader
 
   // flag to gracefully stop repeated execution of DAG in streaming mode
   var stopStreamingGracefully: Boolean = false

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -65,7 +65,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     val feedName = "test"
 
     // configure SDLPlugin for testing
-    Environment.sdlPlugin = Some(new TestSDLPlugin)
+    Environment._sdlPlugin = Some(Some(new TestSDLPlugin))
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     val sdlb = new DefaultSmartDataLakeBuilder()
@@ -161,7 +161,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     // test and reset SDLPlugin config
     assert(TestSDLPlugin.startupCalled)
     assert(TestSDLPlugin.shutdownCalled)
-    Environment.sdlPlugin = None
+    Environment._sdlPlugin = None
   }
 
   test("sdlb run with skipped action and recovery after action 2 failed the first time") {


### PR DESCRIPTION
Fixing potential NPE with sdlPlugin is configured.
@pgruetter: now it works - i had the ClassNotFoundException because there was a space at the end of the class name :-(

Also found the bug with SparkFileDataObject still throwing 'IllegalStateException: (...) No FileSourceScanExec found in execution plan to check if there is data to process'. This was in case of calling getDataFrame method with partition values, but no existing files for the given partitions.