### PR TITLE
589 column encryption

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
@@ -1,0 +1,133 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2022 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.generic.transformer
+
+import com.typesafe.config.Config
+import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.secrets.SecretsUtil
+import io.smartdatalake.util.spark.{DefaultExpressionData, SparkExpressionUtil}
+import io.smartdatalake.workflow.dataframe.{DataFrameFunctions, GenericDataFrame}
+import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
+import org.apache.spark.sql.DataFrame
+
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+import java.security.MessageDigest
+import java.util
+import org.apache.spark.sql.functions.{col,lit,udf}
+
+trait EncryptDecrypt {
+  val cryptUDF = udf(encrypt _)
+  def process(df: DataFrame, encryptColumns: Seq[String], key: String) = {
+
+    var df_enc = df
+    for (colName <- encryptColumns) {
+      df_enc = df_enc.withColumn(colName, cryptUDF(lit(key), col(colName)))
+      df_enc = df_enc.drop(colName.concat("key"))
+    }
+    df_enc
+  }
+
+  def encrypt(key: String, value: String): String = {
+    val cipher: Cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+    cipher.init(Cipher.ENCRYPT_MODE, keyToSpec(key))
+    org.apache.commons.codec.binary.Base64.encodeBase64String(cipher.doFinal(value.getBytes("UTF-8")))
+  }
+
+  def decrypt(key: String, encryptedValue: String): String = {
+    val cipher: Cipher = Cipher.getInstance("AES/ECB/PKCS5PADDING")
+    cipher.init(Cipher.DECRYPT_MODE, keyToSpec(key))
+    new String(cipher.doFinal(org.apache.commons.codec.binary.Base64.decodeBase64(encryptedValue)))
+  }
+
+  def keyToSpec(key: String): SecretKeySpec = {
+    var keyBytes: Array[Byte] = (SALT + key).getBytes("UTF-8")
+    val sha: MessageDigest = MessageDigest.getInstance("SHA-1")
+    keyBytes = sha.digest(keyBytes)
+    keyBytes = util.Arrays.copyOf(keyBytes, 16)
+    new SecretKeySpec(keyBytes, "AES")
+  }
+
+  //TODO define usefull SALT
+  private val SALT: String = ""
+}
+
+//TODO add more details to the description
+/**
+ * Encrypt specified columns of the DataFrame using javax.crypto.cipther algorithm.
+ * @param name         name of the transformer
+ * @param description  Optional description of the transformer
+ * @param encryptColumns List of [columnA, columnB] to be encrypted
+ * @param keyVariable contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
+ *                          e.g. ENV#<ENV_VARIABLE_NAME> to get a secret from an environment variable OR CLEAR#mYsEcReTkeY
+ */
+case class EncryptColumnsTransformer(override val name: String = "encryptColumns",
+                                     override val description: Option[String] = None,
+                                     encryptColumns: Seq[String],
+                                     keyVariable: String
+                                     )
+  extends SparkDfTransformer with EncryptDecrypt {
+  private[smartdatalake] val key: String = SecretsUtil.getSecret(keyVariable)
+
+  override val cryptUDF = udf(encrypt _)
+
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
+    process(df, encryptColumns, key)
+  }
+  override def factory: FromConfigFactory[GenericDfTransformer] = EncryptColumnsTransformer
+}
+
+object EncryptColumnsTransformer extends FromConfigFactory[GenericDfTransformer] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): EncryptColumnsTransformer = {
+    extract[EncryptColumnsTransformer](config)
+  }
+}
+
+/**
+ * Decrypt specified columns of the DataFrame using javax.crypto.cipther algorithm.
+ * @param name         name of the transformer
+ * @param description  Optional description of the transformer
+ * @param decryptColumns List of [columnA, columnB] to be decrypted
+ * @param keyVariable contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
+ *                          e.g. ENV#<ENV_VARIABLE_NAME> to get a secret from an environment variable OR CLEAR#mYsEcReTkeY
+ */
+case class DecryptColumnsTransformer(override val name: String = "encryptColumns",
+                                     override val description: Option[String] = None,
+                                     decryptColumns: Seq[String],
+                                     keyVariable: String
+                                    )
+  extends SparkDfTransformer with EncryptDecrypt {
+  private[smartdatalake] val key: String = SecretsUtil.getSecret(keyVariable)
+
+  override val cryptUDF = udf(decrypt _)
+
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
+    process(df, decryptColumns, key)
+  }
+  override def factory: FromConfigFactory[GenericDfTransformer] = DecryptColumnsTransformer
+}
+
+object DecryptColumnsTransformer extends FromConfigFactory[GenericDfTransformer] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): DecryptColumnsTransformer = {
+    extract[DecryptColumnsTransformer](config)
+  }
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
@@ -36,7 +36,7 @@ import javax.crypto.{Cipher, SecretKey}
 import org.apache.spark.sql.functions.{col, udf}
 
 trait EncryptDecrypt {
-  def key: Array[Byte] //= "test234".getBytes
+  def key: Array[Byte]
   val cryptUDF: UserDefinedFunction = udf(encrypt _)
   private val ALGORITHM_STRING: String = "AES/GCM/PKCS5Padding"
   private val IV_SIZE = 128

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
@@ -48,11 +48,11 @@ trait EncryptDecrypt {
   private val secureRandom = new SecureRandom()
 
   def process(df: DataFrame, encryptColumns: Seq[String]): DataFrame = {
-    var df_enc = df
+    var dfEnc = df
     for (colName <- encryptColumns) {
-      df_enc = df_enc.withColumn(colName, cryptUDF(col(colName)))
+      dfEnc = dfEnc.withColumn(colName, cryptUDF(col(colName)))
     }
-    df_enc
+    dfEnc
   }
 
   def encrypt(message: String): String = {
@@ -105,13 +105,12 @@ trait EncryptDecrypt {
   }
 }
 
-//TODO add more details to the description
 /**
- * Encrypt specified columns of the DataFrame using javax.crypto.cipther algorithm.
- * @param name         name of the transformer
- * @param description  Optional description of the transformer
- * @param encryptColumns List of [columnA, columnB] to be encrypted
- * @param keyVariable contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
+ * Encryption of specified columns using AES/GCM algorithm.
+ * @param name           name of the transformer
+ * @param description    Optional description of the transformer
+ * @param encryptColumns List of columns [columnA, columnB] to be encrypted
+ * @param keyVariable    contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
  *                          e.g. ENV#<ENV_VARIABLE_NAME> to get a secret from an environment variable OR CLEAR#mYsEcReTkeY
  */
 case class EncryptColumnsTransformer(override val name: String = "encryptColumns",
@@ -138,11 +137,11 @@ object EncryptColumnsTransformer extends FromConfigFactory[GenericDfTransformer]
 }
 
 /**
- * Decrypt specified columns of the DataFrame using javax.crypto.cipther algorithm.
- * @param name         name of the transformer
- * @param description  Optional description of the transformer
- * @param decryptColumns List of [columnA, columnB] to be decrypted
- * @param keyVariable contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
+ * Decryption of specified columns using AES/GCM algorithm.
+ * @param name           name of the transformer
+ * @param description    Optional description of the transformer
+ * @param decryptColumns List of columns [columnA, columnB] to be encrypted
+ * @param keyVariable    contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
  *                          e.g. ENV#<ENV_VARIABLE_NAME> to get a secret from an environment variable OR CLEAR#mYsEcReTkeY
  */
 case class DecryptColumnsTransformer(override val name: String = "encryptColumns",

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
@@ -46,11 +46,10 @@ trait EncryptDecrypt {
 
 
   def process(df: DataFrame, encryptColumns: Seq[String]): DataFrame = {
-    var dfEnc = df
-    for (colName <- encryptColumns) {
-      dfEnc = dfEnc.withColumn(colName, cryptUDF(col(colName)))
-    }
-    dfEnc
+   
+   encryptColumns.foldLeft(df){
+   case (dfTemp, colName) => dfTemp.withColumn(colName, cryptUDF(col(colName)))
+   }
   }
 
   private def generateAesKey(keyBytes: Array[Byte]): SecretKey = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformer.scala
@@ -36,7 +36,7 @@ import javax.crypto.{Cipher, SecretKey}
 import org.apache.spark.sql.functions.{col, udf}
 
 trait EncryptDecrypt {
-  val key: Array[Byte] = "test234".getBytes
+  def key: Array[Byte] //= "test234".getBytes
   val cryptUDF: UserDefinedFunction = udf(encrypt _)
   private val ALGORITHM_STRING: String = "AES/GCM/PKCS5Padding"
   private val IV_SIZE = 128
@@ -115,7 +115,7 @@ case class EncryptColumnsTransformer(override val name: String = "encryptColumns
   extends SparkDfTransformer with EncryptDecrypt {
   private[smartdatalake] val cur_key: String = SecretsUtil.getSecret(keyVariable)
 
-  override val key: Array[Byte] = cur_key.getBytes
+  override def key: Array[Byte] = cur_key.getBytes
   override val cryptUDF: UserDefinedFunction = udf(encrypt _)
 
   override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {
@@ -147,7 +147,7 @@ case class DecryptColumnsTransformer(override val name: String = "encryptColumns
   extends SparkDfTransformer with EncryptDecrypt {
   private[smartdatalake] val cur_key: String = SecretsUtil.getSecret(keyVariable)
 
-  override val key: Array[Byte] = cur_key.getBytes
+  override def key: Array[Byte] = cur_key.getBytes
   override val cryptUDF: UserDefinedFunction = udf(decrypt _)
 
   override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame = {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -1,0 +1,163 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2022 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.generic.transformer
+
+import io.smartdatalake.testutils.TestUtil
+import org.apache.spark.sql.SparkSession
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import com.typesafe.config.ConfigFactory
+import io.smartdatalake.config.SdlConfigObject.stringToDataObjectId
+import io.smartdatalake.config.{ConfigParser, InstanceRegistry}
+import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSubFeed}
+import io.smartdatalake.workflow.dataobject._
+import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, GlobalConfig, SmartDataLakeBuilderConfig}
+import io.smartdatalake.testutils.TestUtil.sparkSessionBuilder
+import io.smartdatalake.workflow.action.SDLExecutionId
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import java.nio.file.Files
+import java.time.LocalDateTime
+
+class EncryptColumnsTransformerTest extends FunSuite {
+  private val tempDir = Files.createTempDirectory("test")
+  private val tempPath = tempDir.toAbsolutePath.toString
+
+  val statePath = "target/stateTest/"
+  implicit val filesystem: FileSystem = HdfsUtil.getHadoopFsWithDefaultConf(new Path(statePath))
+
+  test("test column encryption") {
+    val feedName = "test"
+    val sdlb = new DefaultSmartDataLakeBuilder()
+
+    val config = ConfigFactory.parseString(
+      """
+        |actions = {
+        |   act = {
+        |     type = CopyAction
+        |     inputId = src
+        |     outputId = tgt
+        |     metadata {
+        |       feed = test_run
+        |     }
+        |     transformers = [{
+        |       type = EncryptColumnsTransformer
+        |       encryptColumns = ["c2","c3"]
+        |       keyVariable = "CLEAR#keyblabla"
+        |     }]
+        |   }
+        |}
+        |dataObjects {
+        |  src {
+        |    #id = ~{id}
+        |    type = CsvFileDataObject
+        |    path = "target/raw"
+        |  }
+        |  tgt {
+        |    type = ParquetFileDataObject
+        |    path = "target/column_encrypted"
+        |  }
+        |}
+        |""".stripMargin).resolve
+
+    val globalConfig = GlobalConfig.from(config)
+    implicit val instanceRegistry: InstanceRegistry = ConfigParser.parse(config)
+    implicit val session: SparkSession = sparkSessionBuilder(withHive = true, globalConfig.sparkOptions.getOrElse(Map())).getOrCreate()
+    import session.implicits._
+
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    val sdlConfig = SmartDataLakeBuilderConfig(feedSel = "ids:act")
+
+    val srcDO = instanceRegistry.get[CsvFileDataObject]("src")
+    assert(srcDO != None)
+    val dfSrc = Seq(("testData", "Foo", "ice"), ("bar", "Space", "water")).toDF("c1", "c2", "c3")
+    srcDO.writeDataFrame(SparkDataFrame(dfSrc), Seq())(TestUtil.getDefaultActionPipelineContext(sdlb.instanceRegistry))
+
+    // Run SDLB
+    implicit val hadoopConf: Configuration = session.sparkContext.hadoopConfiguration
+    val initialSubFeeds: Seq[SparkSubFeed] = Seq(SparkSubFeed(None, srcDO.id, Seq()))
+    val (subFeeds, stats) = sdlb.exec(sdlConfig, SDLExecutionId.executionId1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionsToSkip = Map(), initialSubFeeds = initialSubFeeds, dataObjectsState = Seq(), stateStore = None, stateListeners = Seq(), simulation = false, globalConfig = globalConfig)
+
+    // check result
+    val tgt = instanceRegistry.get[ParquetFileDataObject]("tgt")
+    val dfTgt = tgt.getSparkDataFrame()
+    val colName = dfTgt.columns
+    //assert(colName.toSeq == Seq("testcolumn", "secondcolumn", "thirdcolumn"))
+  }
+
+  test("test column decryption") {
+    val feedName = "test"
+    val sdlb = new DefaultSmartDataLakeBuilder()
+
+    val config = ConfigFactory.parseString(
+      """
+        |actions = {
+        |   act = {
+        |     type = CopyAction
+        |     inputId = src
+        |     outputId = tgt
+        |     metadata {
+        |       feed = test_run
+        |     }
+        |     transformers = [{
+        |       type = DecryptColumnsTransformer
+        |       decryptColumns = ["c2","c3"]
+        |       keyVariable = "CLEAR#keyblabla"
+        |     }]
+        |   }
+        |}
+        |dataObjects {
+        |  src {
+        |    #id = ~{id}
+        |    type = ParquetFileDataObject
+        |    path = "target/column_encrypted"
+        |  }
+        |  tgt {
+        |    type = ParquetFileDataObject
+        |    path = "target/decrypted"
+        |  }
+        |}
+        |""".stripMargin).resolve
+
+    val globalConfig = GlobalConfig.from(config)
+    implicit val instanceRegistry: InstanceRegistry = ConfigParser.parse(config)
+    implicit val session: SparkSession = sparkSessionBuilder(withHive = true, globalConfig.sparkOptions.getOrElse(Map())).getOrCreate()
+    import session.implicits._
+
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    val sdlConfig = SmartDataLakeBuilderConfig(feedSel = "ids:act")
+
+    val srcDO = instanceRegistry.get[ParquetFileDataObject]("src")
+
+    // Run SDLB
+    implicit val hadoopConf: Configuration = session.sparkContext.hadoopConfiguration
+    val initialSubFeeds: Seq[SparkSubFeed] = Seq(SparkSubFeed(None, srcDO.id, Seq()))
+    val (subFeeds, stats) = sdlb.exec(sdlConfig, SDLExecutionId.executionId1, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now, actionsToSkip = Map(), initialSubFeeds = initialSubFeeds, dataObjectsState = Seq(), stateStore = None, stateListeners = Seq(), simulation = false, globalConfig = globalConfig)
+
+    // check result
+    val tgt = instanceRegistry.get[ParquetFileDataObject]("tgt")
+    val dfTgt = tgt.getSparkDataFrame()
+    val testCol = dfTgt.select("c2").map(f=>f.getString(0)).collect.toList
+    assert(testCol == Seq("Foo", "Space"))
+  }
+
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -89,7 +89,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
 
     val srcDO = instanceRegistry.get[CsvFileDataObject]("src")
     assert(srcDO != None)
-    val dfSrc = Seq(("testData", "Foo", "ice"), ("bar", "Space", "water")).toDF("c1", "c2", "c3")
+    val dfSrc = Seq(("testData", "Foo", "ice"), ("bar", "Space", "water"), ("gogo", "Space", "water")).toDF("c1", "c2", "c3")
     srcDO.writeDataFrame(SparkDataFrame(dfSrc), Seq())(TestUtil.getDefaultActionPipelineContext(sdlb.instanceRegistry))
 
     // Run SDLB
@@ -157,7 +157,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
     val tgt = instanceRegistry.get[ParquetFileDataObject]("tgt")
     val dfTgt = tgt.getSparkDataFrame()
     val testCol = dfTgt.select("c2").map(f=>f.getString(0)).collect.toList
-    assert(testCol == Seq("Foo", "Space"))
+    assert(testCol == Seq("Foo", "Space", "Space"))
   }
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -62,6 +62,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = EncryptColumnsTransformer
         |       encryptColumns = ["c2","c3"]
+        |       #keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
         |       keyVariable = "CLEAR#keyblabla"
         |     }]
         |   }
@@ -121,6 +122,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = DecryptColumnsTransformer
         |       decryptColumns = ["c2","c3"]
+        |       #keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
         |       keyVariable = "CLEAR#keyblabla"
         |     }]
         |   }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -62,8 +62,8 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = EncryptColumnsTransformer
         |       encryptColumns = ["c2","c3"]
-        |       #keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
-        |       keyVariable = "CLEAR#keyblabla"
+        |       keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
+        |       #keyVariable = "CLEAR#keyblabla"
         |     }]
         |   }
         |}
@@ -122,8 +122,8 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = DecryptColumnsTransformer
         |       decryptColumns = ["c2","c3"]
-        |       #keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
-        |       keyVariable = "CLEAR#keyblabla"
+        |       keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
+        |       #keyVariable = "CLEAR#keyblabla"
         |     }]
         |   }
         |}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -21,13 +21,13 @@ package io.smartdatalake.workflow.action.generic.transformer
 
 import io.smartdatalake.testutils.TestUtil
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.FunSuite
 import com.typesafe.config.ConfigFactory
 import io.smartdatalake.config.SdlConfigObject.stringToDataObjectId
 import io.smartdatalake.config.{ConfigParser, InstanceRegistry}
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSubFeed}
 import io.smartdatalake.workflow.dataobject._
-import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
+import io.smartdatalake.util.hdfs.HdfsUtil
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, GlobalConfig, SmartDataLakeBuilderConfig}
 import io.smartdatalake.testutils.TestUtil.sparkSessionBuilder
@@ -40,13 +40,11 @@ import java.time.LocalDateTime
 
 class EncryptColumnsTransformerTest extends FunSuite {
   private val tempDir = Files.createTempDirectory("test")
-  private val tempPath = tempDir.toAbsolutePath.toString
 
   val statePath = "target/stateTest/"
   implicit val filesystem: FileSystem = HdfsUtil.getHadoopFsWithDefaultConf(new Path(statePath))
 
   test("test column encryption") {
-    val feedName = "test"
     val sdlb = new DefaultSmartDataLakeBuilder()
 
     val config = ConfigFactory.parseString(
@@ -62,7 +60,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = EncryptColumnsTransformer
         |       encryptColumns = ["c2","c3"]
-        |       keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
+        |       keyVariable = "CLEAR#A%D*G-KaPdSgVkYp"
         |       #keyVariable = "CLEAR#keyblabla"
         |     }]
         |   }
@@ -122,7 +120,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = DecryptColumnsTransformer
         |       decryptColumns = ["c2","c3"]
-        |       keyVariable = "CLEAR#keyblabla123456789123456789gerg;lkndfkgjnbq34tnafegnql5k3naklefnjqk35jnbhaefnlkq3n'akfnblkq3n4h'lkanblkwqn5h'lkne'lbknq5'lhkna'lkbnql5k3hn"
+        |       keyVariable = "CLEAR#A%D*G-KaPdSgVkYp"
         |       #keyVariable = "CLEAR#keyblabla"
         |     }]
         |   }
@@ -158,6 +156,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
     // check result
     val tgt = instanceRegistry.get[ParquetFileDataObject]("tgt")
     val dfTgt = tgt.getSparkDataFrame()
+    dfTgt.show()
     val testCol = dfTgt.select("c2").map(f=>f.getString(0)).collect.toList
     assert(testCol == Seq("Foo", "Space", "Space"))
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -74,7 +74,6 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |       type = DecryptColumnsTransformer
         |       decryptColumns = ["c2","c3"]
         |       keyVariable = "CLEAR#A%D*G-KaPdSgVkYp"
-        |       #keyVariable = "CLEAR#keyblabla"
         |     }]
         |   }
         |}


### PR DESCRIPTION
### What changes are included in the pull request?
Add a new transformer, which encrypts a list of columns in the dataFrame. 
Furthermore, the counterpart, the decryptor is implemented. Both use java cipher with. 

### Why are the changes needed?
Data security becomes more and more important. Often very sensitive data is mixed with data necessary to be analysed. Therefore, we need to hide the sensitive data by encrypting it

### Aspects to consider and to be discussed
We use a GCM method with initial vector (IV), which is stored at the beginning of the encrypted message. Therewith cells with the same value result in different ciphertexts. 