### PR TITLE
Bugfix for subsequent actions skipped with DataFrameIncrementalMode

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -40,6 +40,7 @@ import scopt.OptionParser
 import java.io.File
 import java.time.{Duration, LocalDateTime}
 import scala.annotation.tailrec
+import scala.util.Try
 
 /**
  * This case class represents a default configuration for the App.
@@ -241,9 +242,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     } catch {
       case e: Exception =>
         // try shutdown but catch potential exception
-        try {
-          shutdown
-        }
+        Try(shutdown)
         // throw original exception
         throw e
     }
@@ -460,8 +459,6 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
               logger.info(s"As all actions of run_id ${context.executionId.runId} are skipped, run_id is not incremented for next execution")
               context
             }
-            // reset execution result before new execution
-            actionsSelected.foreach(_.resetExecutionResult())
             // remove spark caches so that new data is read in next iteration
             //TODO: in the future it might be interesting to keep some DataFrames cached for performance reason...
             if (context.hasSparkSession) context.sparkSession.sqlContext.clearCache()

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -89,6 +89,8 @@ case class ActionPipelineContext (
     }
   }
 
+  def isExecPhase = phase == ExecutionPhase.Exec
+
   // manage executionId
   private[smartdatalake] def incrementRunId = this.copy(executionId = this.executionId.incrementRunId, runStartTime = LocalDateTime.now, attemptStartTime = LocalDateTime.now)
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -85,17 +85,10 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    */
   def executionCondition: Option[Condition]
 
-  // execution condition is evaluated in init phase and result must be stored for exec phase
-  protected var executionConditionResult: Option[(Boolean,Option[String])] = None
-
   /**
    * execution mode for this action.
    */
   def executionMode: Option[ExecutionMode]
-
-  // execution mode is evaluated in init phase and result must be stored for exec phase
-  protected var executionModeResult: Option[Try[Option[ExecutionModeResult]]] = None
-  def getExecutionModeResultOptions: Map[String,String] = executionModeResult.flatMap(_.get.map(_.options)).getOrElse(Map())
 
   /**
    * Spark SQL condition evaluated as where-clause against dataframe of metrics. Available columns are dataObjectId, key, value.
@@ -160,7 +153,7 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
     // call execution mode hook
     executionMode.foreach(_.preInit(subFeeds,dataObjectsState))
     // check execution condition
-    checkExecutionCondition(subFeeds)
+    //checkExecutionCondition(subFeeds)
   }
 
   /**
@@ -168,46 +161,26 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    * @throws TaskSkippedDontStopWarning if no data to process
    */
   private def checkExecutionCondition(subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
-    // evaluate execution condition in init phase or streaming iteration and store result
-    if (executionConditionResult.isEmpty) {
-      //noinspection MapGetOrElseBoolean
-      executionConditionResult = Some(executionCondition.map { c =>
-        // evaluate condition if existing
-        val data = SubFeedsExpressionData.fromSubFeeds(subFeeds)
-        if (!c.evaluate(id, Some("executionCondition"), data)) {
-          val descriptionText = c.description.map(d => s""""$d" """).getOrElse("")
-          val msg = s"""($id) execution skipped because of failed executionCondition ${descriptionText} expression="${c.expression}" $data"""
-          (false, Some(msg))
-        } else (true, None)
-      }.getOrElse {
-        // default behaviour: if no executionCondition is defined, Action is executed if no input subFeed is skipped.
-        val skippedSubFeeds = subFeeds.filter(_.isSkipped)
-        if (skippedSubFeeds.nonEmpty) {
-          val msg = s"""($id) execution skipped because input subFeeds are skipped: ${subFeeds.map(_.dataObjectId).mkString(", ")}"""
-          (false, Some(msg))
-        } else (true, None)
-      })
+    //noinspection MapGetOrElseBoolean
+    val skipMsg = executionCondition.map { c =>
+      // evaluate condition if existing
+      val data = SubFeedsExpressionData.fromSubFeeds(subFeeds)
+      if (!c.evaluate(id, Some("executionCondition"), data)) {
+        val descriptionText = c.description.map(d => s""""$d" """).getOrElse("")
+        Some(s"""($id) execution skipped because of failed executionCondition ${descriptionText} expression="${c.expression}" $data""")
+      } else None
+    }.getOrElse {
+      // default behaviour: if no executionCondition is defined, Action is executed if no input subFeed is skipped.
+      val skippedSubFeeds = subFeeds.filter(_.isSkipped)
+      if (skippedSubFeeds.nonEmpty) {
+        Some(s"""($id) execution skipped because input subFeeds are skipped: ${subFeeds.map(_.dataObjectId).mkString(", ")}""")
+      } else None
     }
     // check execution condition result
-    if (!executionConditionResult.get._1 && !context.appConfig.isDryRun) {
-      throw new TaskSkippedDontStopWarning(id.id, executionConditionResult.get._2.get, Some(ActionHelper.createSkippedSubFeeds(outputs)))
+    if (skipMsg.nonEmpty && !context.appConfig.isDryRun) {
+      throw new TaskSkippedDontStopWarning(id.id, skipMsg.get, Some(ActionHelper.createSkippedSubFeeds(outputs)))
     }
   }
-
-  /**
-   * Applies the executionMode and stores result in executionModeResult variable
-   */
-  protected def applyExecutionMode(mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
-                                  , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues,PartitionValues])
-                                  (implicit context: ActionPipelineContext): Unit = {
-    executionModeResult = Some(Try(
-      executionMode.flatMap(_.apply(id, mainInput, mainOutput, subFeed, partitionValuesTransform))
-    ).recover {
-      // throw exception with skipped output subfeeds if "no data"
-      case ex: NoDataToProcessWarning if ex.results.isEmpty => throw ex.copy(results = Some(ActionHelper.createSkippedSubFeeds(outputs)))
-    })
-  }
-
 
   /**
    * Initialize Action with [[SubFeed]]'s to be processed.
@@ -228,15 +201,10 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    */
   def preExec(subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
     if (isAsynchronousProcessStarted) return
-    // reset execution condition if not start Action in pipeline, because input for execution results could change between init and exec phase
-    val isStartAction = subFeeds.exists(subFeed => subFeed.isInstanceOf[InitSubFeed] && !subFeed.isSkipped)
-    if (!isStartAction) resetExecutionResult()
     // check execution condition
     checkExecutionCondition(subFeeds)
-    // throw execution mode failure exception if any
-    if (executionModeResult.exists(x => x.isFailure)) executionModeResult.get.get
     // init spark jobGroupId to identify metrics
-    setSparkJobMetadata()
+    setSparkJobMetadata() // TODO: this triggers creating spark session
     // otherwise continue processing
     inputs.foreach( input => input.preRead(findSubFeedPartitionValues(input.id, subFeeds)))
     outputs.foreach(_.preWrite) // Note: transformed subFeeds don't exist yet, that's why no partition values can be passed as parameters.
@@ -399,15 +367,6 @@ private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromCon
    */
   private[smartdatalake] def reset(implicit context: ActionPipelineContext): Unit = {
     runtimeData.clear()
-    resetExecutionResult()
-  }
-
-  /**
-   * Resets execution results of this Action for repeated execution
-   */
-  private[smartdatalake] def resetExecutionResult(): Unit = {
-    executionConditionResult = None
-    executionModeResult = None
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -121,6 +121,7 @@ private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
   } catch {
     case e: IllegalArgumentException if e.getMessage.contains("DataObject schema is undefined") => None
     case e: AnalysisException if e.getMessage.contains("Table or view not found") => None
+    case _: NoDataToProcessWarning => None
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionSubFeedsImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionSubFeedsImpl.scala
@@ -91,19 +91,28 @@ abstract class ActionSubFeedsImpl[S <: SubFeed : TypeTag] extends Action {
     var outputSubFeeds: Seq[S] = outputs.map(output =>
       updateOutputPartitionValues(output, subFeedConverter.get(mainInputSubFeed.toOutput(output.id)), Some(transformPartitionValues))
     )
-    // (re-)apply execution mode in init phase, streaming iteration or if not first action in pipeline (search for calls to resetExecutionResults for details)
-    if (executionModeResult.isEmpty) applyExecutionMode(mainInput, mainOutput, mainInputSubFeed, transformPartitionValues)
-    // apply execution mode result
-    executionModeResult.get.get match { // throws exception if execution mode is Failure
-      case Some(result) =>
-        inputSubFeeds = inputSubFeeds.map { subFeed =>
-          updateInputPartitionValues(inputMap(subFeed.dataObjectId), subFeedConverter.get(subFeed.applyExecutionModeResultForInput(result, mainInput.id)))
-        }
-        outputSubFeeds = outputSubFeeds.map(subFeed =>
-          // we need to transform inputPartitionValues again to outputPartitionValues so that partition values from partitions not existing in mainOutput are not lost.
-          updateOutputPartitionValues(outputMap(subFeed.dataObjectId), subFeedConverter.get(subFeed.applyExecutionModeResultForOutput(result)), Some(transformPartitionValues))
-        )
-      case _ => Unit
+    // apply execution mode only in exec phase
+    if (context.isExecPhase) {
+      // apply execution mode
+      val executionModeResult = try {
+        executionMode.flatMap(_.apply(id, mainInput, mainOutput, mainInputSubFeed, transformPartitionValues))
+      } catch {
+        // throw exception with skipped output subfeeds if "no data"
+        case ex: NoDataToProcessWarning if ex.results.isEmpty => throw ex.copy(results = Some(ActionHelper.createSkippedSubFeeds(outputs)))
+      }
+      // apply execution mode result
+      executionModeResult match { // throws exception if execution mode is Failure
+        case Some(result) =>
+          inputSubFeeds = inputSubFeeds.map { subFeed =>
+            updateInputPartitionValues(inputMap(subFeed.dataObjectId), subFeedConverter.get(subFeed.applyExecutionModeResultForInput(result, mainInput.id)))
+          }
+          outputSubFeeds = outputSubFeeds.map(subFeed =>
+            // we need to transform inputPartitionValues again to outputPartitionValues so that partition values from partitions not existing in mainOutput are not lost.
+            updateOutputPartitionValues(outputMap(subFeed.dataObjectId), subFeedConverter.get(subFeed.applyExecutionModeResultForOutput(result)), Some(transformPartitionValues))
+          )
+          executionModeResultOptions = result.options
+        case _ => Unit
+      }
     }
     inputSubFeeds = inputSubFeeds.map{ subFeed =>
       // prepare input SubFeed
@@ -114,6 +123,9 @@ abstract class ActionSubFeedsImpl[S <: SubFeed : TypeTag] extends Action {
     outputSubFeeds = outputSubFeeds.map(subFeed => addRunIdPartitionIfNeeded(outputMap(subFeed.dataObjectId), subFeed))
     (inputSubFeeds, outputSubFeeds)
   }
+
+  // Keep execution mode result in a variable for now.
+  protected var executionModeResultOptions: Map[String,String] = Map()
 
   def postprocessOutputSubFeeds(subFeeds: Seq[S])(implicit context: ActionPipelineContext): Seq[S] = {
     // assert all outputs have a subFeed
@@ -277,7 +289,7 @@ abstract class ActionSubFeedsImpl[S <: SubFeed : TypeTag] extends Action {
 
   protected def validatePartitionValuesExisting(dataObject: DataObject with CanHandlePartitions, subFeed: SubFeed)(implicit context: ActionPipelineContext): Unit = {
     // Existing partitions can only be checked if Action is at start of the DAG or if we are in Exec phase (previous Actions have been executed)
-    if (subFeed.partitionValues.nonEmpty && (context.phase == ExecutionPhase.Exec || subFeed.isDAGStart) && !subFeed.isSkipped) {
+    if (subFeed.partitionValues.nonEmpty && (context.isExecPhase || subFeed.isDAGStart) && !subFeed.isSkipped) {
       // filter partition value with keys that are a valid init of partition columns -> otherwise it can not be checked if the partition exists
       val inits = dataObject.partitions.inits.map(_.toSet)
       val validInitPartitionValues = subFeed.partitionValues.filter(pv => inits.contains(pv.keys))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
@@ -380,7 +380,7 @@ private[smartdatalake] abstract class DataFrameActionImpl extends ActionSubFeeds
     val inputDfsMap = inputSubFeeds.map(subFeed => (subFeed.dataObjectId.id, subFeed.dataFrame.get)).toMap
     val (outputDfsMap, _) = transformers.foldLeft((inputDfsMap,inputPartitionValues)){
       case ((inputDfsMap, inputPartitionValues), transformer) =>
-        val (outputDfsMap, outputPartitionValues) = transformer.applyTransformation(id, inputPartitionValues, inputDfsMap, getExecutionModeResultOptions)
+        val (outputDfsMap, outputPartitionValues) = transformer.applyTransformation(id, inputPartitionValues, inputDfsMap, executionModeResultOptions)
         (inputDfsMap ++ outputDfsMap, outputPartitionValues)
     }
     // create output subfeeds from transformed dataframes
@@ -395,7 +395,7 @@ private[smartdatalake] abstract class DataFrameActionImpl extends ActionSubFeeds
    */
   protected def applyTransformers(transformers: Seq[PartitionValueTransformer], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Map[PartitionValues,PartitionValues] = {
     transformers.foldLeft(PartitionValues.oneToOneMapping(partitionValues)){
-      case (partitionValuesMap, transformer) => transformer.applyTransformation(id, partitionValuesMap, getExecutionModeResultOptions)
+      case (partitionValuesMap, transformer) => transformer.applyTransformation(id, partitionValuesMap, executionModeResultOptions)
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameOneToOneActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameOneToOneActionImpl.scala
@@ -92,7 +92,7 @@ abstract class DataFrameOneToOneActionImpl extends DataFrameActionImpl {
     val duplicateTransformerNames = transformers.groupBy(_.name).values.filter(_.size>1).map(_.head.name)
     assert(!transformers.exists(_.isInstanceOf[SQLDfTransformer]) || duplicateTransformerNames.isEmpty, s"($id) transformers.name must be unique if SQLDfTransformer is used, but duplicate (default?) names ${duplicateTransformerNames.mkString(", ")} where detected")
     val (transformedSubFeed, _) = transformers.foldLeft((inputSubFeed,Option.empty[String])){
-      case ((subFeed,previousTransformerName), transformer) => (transformer.applyTransformation(id, subFeed, previousTransformerName, getExecutionModeResultOptions), Some(transformer.name))
+      case ((subFeed,previousTransformerName), transformer) => (transformer.applyTransformation(id, subFeed, previousTransformerName, executionModeResultOptions), Some(transformer.name))
     }
     // Note that transformed partition values are set by execution mode.
     outputSubFeed.withDataFrame(transformedSubFeed.dataFrame)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
@@ -43,7 +43,7 @@ abstract class ScriptActionImpl extends ActionSubFeedsImpl[ScriptSubFeed] {
 
   override protected def transform(inputSubFeeds: Seq[ScriptSubFeed], outputSubFeeds: Seq[ScriptSubFeed])(implicit context: ActionPipelineContext): Seq[ScriptSubFeed] = {
     // execute scripts in exec phase
-    if (context.phase == ExecutionPhase.Exec) {
+    if (context.isExecPhase) {
       execScript(inputSubFeeds, outputSubFeeds)
     } else outputSubFeeds
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExpectationValidation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExpectationValidation.scala
@@ -63,7 +63,7 @@ private[smartdatalake] trait ExpectationValidation { this: DataObject with Smart
     val (dfJobExpectations, observation) = {
       implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
       val expectationColumns = (defaultExpectations ++ jobExpectations).flatMap(_.getAggExpressionColumns(this.id))
-      setupObservation(dfConstraints, expectationColumns, context.phase == ExecutionPhase.Exec)
+      setupObservation(dfConstraints, expectationColumns, context.isExecPhase)
     }
     // setup add caching if there are expectations with scope != job
     if (expectations.exists(_.scope != ExpectationScope.Job)) (dfJobExpectations.cache, observation)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -177,7 +177,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
         throw new IllegalStateException(s"($id) incrementalOutputExpr can not be resolved" + (if (attrs.nonEmpty) s", unresolved attributes are ${attrs.mkString(", ")}" else ""))
       }
       val newDataType = resolvedExpr.dataType
-      if (context.phase == ExecutionPhase.Exec) {
+      if (context.isExecPhase) {
         val newHighWatermarkValue = Option(df.agg(max(expr(incrementalOutputExpr.get))).head.get(0))
           .getOrElse(throw NoDataToProcessWarning(id.id, s"No data to process found for $id by DataObjectStateIncrementalMode."))
         incrementalOutputState = Some((incrementalOutputExpr.get, Some((newHighWatermarkValue.toString, newDataType))))

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -284,11 +284,11 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(action3.copy())
     // action4 is cancelled because action3 is cancelled (cancelled has higher prio than skipped from action1)
     val action4 = CustomDataFrameAction("d", Seq(tgt1DO.id, tgt3DO.id), Seq(tgt4DO.id), metadata = Some(ActionMetadata(feed = Some(feedName)))
-      , transformers = Seq(SQLDfsTransformer(code = Map(tgt4DO.id.id -> "select * from c"))))
+      , transformers = Seq(SQLDfsTransformer(code = Map(tgt4DO.id.id -> "select * from tgt1"))))
     instanceRegistry.register(action4.copy())
     // action5 is skipped because action1 is skipped
     val action5 = CustomDataFrameAction("e", Seq(tgt1DO.id), Seq(tgt4DO.id), metadata = Some(ActionMetadata(feed = Some(feedName)))
-      , transformers = Seq(SQLDfsTransformer(code = Map(tgt4DO.id.id -> "select * from c"))))
+      , transformers = Seq(SQLDfsTransformer(code = Map(tgt4DO.id.id -> "select * from tgt1"))))
     instanceRegistry.register(action5.copy())
     val sdlConfig = SmartDataLakeBuilderConfig(feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
     intercept[TaskFailedException](sdlb.run(sdlConfig))
@@ -398,6 +398,64 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       )
       assert(resultActionsState == expectedActionsState)
     }
+  }
+
+  test("sdlb run incremental chain") {
+
+    // init sdlb
+    val appName = "sdlb-incremental"
+    val feedName = "test"
+
+    HdfsUtil.deleteFiles(new Path(statePath), false)
+    val sdlb = new DefaultSmartDataLakeBuilder()
+    implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
+    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+
+    // setup DataObjects
+    val src1DO = MockDataObject("src1").register
+    val src2DO = MockDataObject("src2").register
+    val tgt1DO = MockDataObject("tgt1").register
+    val tgt2DO = MockDataObject("tgt2").register
+    val tgt3DO = MockDataObject("tgt3").register
+    val tgt4DO = MockDataObject("tgt4").register
+
+    // prepare data
+    val dfSrc1 = Seq((1,"20180101", "person", "doe","john",5), (2,"20190101", "company", "olmo","-",10))
+      .toDF("id", "dt", "type", "lastname", "firstname", "rating")
+    src1DO.writeSparkDataFrame(dfSrc1, Seq())
+    val dfSrc2 = Seq((1,"abc"))
+      .toDF("id", "comment")
+    src2DO.writeSparkDataFrame(dfSrc2, Seq())
+
+    // start first dag run -> fail
+    // action1 has data
+    val action1 = CopyAction("a", src1DO.id, tgt1DO.id, metadata = Some(ActionMetadata(feed = Some(feedName)))
+    , executionMode = Some(DataFrameIncrementalMode("id"))
+    )
+    instanceRegistry.register(action1.copy())
+    // action2 is skipped in init phase as data is not yet there, but should execute in exec phase
+    val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id, metadata = Some(ActionMetadata(feed = Some(feedName)))
+      , executionMode = Some(DataFrameIncrementalMode("id"))
+    )
+    instanceRegistry.register(action2.copy())
+    // action3 is skipped in init phase as data is not yet there, but should execute in exec phase
+    val action3 = CopyAction("c", tgt2DO.id, tgt3DO.id, metadata = Some(ActionMetadata(feed = Some(feedName)))
+      , executionMode = Some(DataFrameIncrementalMode("id"))
+    )
+    instanceRegistry.register(action3.copy())
+    // action4 is skipped in init phase as data is not yet there, but should execute in exec phase
+    val action4 = CustomDataFrameAction("d", Seq(tgt3DO.id,src2DO.id), Seq(tgt4DO.id), metadata = Some(ActionMetadata(feed = Some(feedName)))
+      , executionMode = Some(DataFrameIncrementalMode("id"))
+      , transformers = Seq(SQLDfsTransformer(code = Map("tgt4" -> "select dt, type, lastname, firstname, udfAddX(rating) rating from tgt3")))
+    )
+    instanceRegistry.register(action4.copy())
+    val sdlConfig = SmartDataLakeBuilderConfig(feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
+
+    // start dag run
+    sdlb.run(sdlConfig)
+
+    // check results
+    assert(tgt4DO.getSparkDataFrame(Seq()).count == 2)
   }
 
   test("sdlb run with executionMode=PartitionDiffMode, increase runId on second run, state listener") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -805,7 +805,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(srcDO)
     val tgt1DO = JsonFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = JsonFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), jsonOptions = Some(Map("multiLine" -> "false")))
+    val tgt2DO = JsonFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), saveMode = SDLSaveMode.OverwriteOptimized, jsonOptions = Some(Map("multiLine" -> "false")))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
@@ -1199,7 +1199,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode=Some(PartitionDiffMode(failConditions = Seq(Condition(expression = "year(runStartTime) > 2000", Some("testing"))))))
     val dag1: ActionDAGRun = ActionDAGRun(Seq(action1))
     dag1.prepare
-    val ex1 = intercept[TaskFailedException](dag1.init)
+    dag1.init
+    val ex1 = intercept[TaskFailedException](dag1.exec(contextExec))
     assert(ex1.cause.isInstanceOf[ExecutionModeFailedException])
     assert(ex1.cause.getMessage.contains("testing"))
 
@@ -1277,7 +1278,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // second dag run - skip action execution because there are no new partitions to process
     dag.prepare
-    val results = dag.init
+    dag.init
+    val results = dag.exec(contextExec)
     assert(results.head.isSkipped)
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDataFrameActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDataFrameActionTest.scala
@@ -291,9 +291,9 @@ class CustomDataFrameActionTest extends FunSuite with BeforeAndAfter {
     val srcSubFeed1 = SparkSubFeed(None, "src1", Seq(), isSkipped = true)
     val srcSubFeed2 = SparkSubFeed(None, "src2", Seq(), isSkipped = true)
     val tgtSubFeed1 = SparkSubFeed(None, "tgt1", Seq(), isSkipped = true)
-    intercept[TaskSkippedDontStopWarning[_]](action1.preInit(Seq(srcSubFeed1,srcSubFeed2), Seq()))
-    intercept[TaskSkippedDontStopWarning[_]](action1.preExec(Seq(srcSubFeed1,srcSubFeed2)))
-    action1.postExec(Seq(srcSubFeed1,srcSubFeed2), Seq(tgtSubFeed1))
+    action1.preInit(Seq(srcSubFeed1,srcSubFeed2), Seq())
+    intercept[TaskSkippedDontStopWarning[_]](action1.preExec(Seq(srcSubFeed1,srcSubFeed2))(contextExec))
+    action1.postExec(Seq(srcSubFeed1,srcSubFeed2), Seq(tgtSubFeed1))(contextExec)
 
     // dont skip if one subfeed skipped
     val action2 = CustomDataFrameAction("ca", List(srcDO1.id, srcDO2.id), List(tgtDO1.id),


### PR DESCRIPTION
### What changes are included in the pull request? Why are the changes needed?
Up to know executionCondition and executionMode was applied in Init- and Exec-Phase. As applying executionMode might be performance intensive (listing partitions, finding highwatermark), the result was cached and recalculated for specific cases. The logic to check if recalculation was needed had a bug if there were multiple inputs. In any case the recalculation was needed very often.
Solution: dont apply executionCondition and executionMode in Init-Phase, but only in Exec-Phase. This simplifies a lot, without changing the main functionality. It has an also desired side effect - early validation is no longer skipped in Init-Phase if there is no data for an Action.
With the changes of PR, Init-Phase is responsible for validating the Datapipeline, Exec-Phase checks what data needs to be processed, executes the pipeline skipping unneeded Actions.
