### PR TITLE
Improve JDBC transaction handling

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
@@ -232,12 +232,12 @@ case class JdbcTableConnection(override val id: ConnectionId,
    * Class for handling database transactions. If all operations succeeded call [[commit]], otherwise [[rollback]].
    */
   class JdbcTransaction(connection: JdbcTableConnection) extends SmartDataLakeLogger {
-    logger.info(s"begin transaction [$id]")
+    logger.info(s"($id) begin transaction")
     private val jdbcConnection: SqlConnection = connection.pool.borrowObject()
 
     def execJdbcStatement(sql:String, logging: Boolean = true) : Boolean = {
       connection.execWithJdbcStatement(jdbcConnection, doCommit = false) { stmt =>
-        if (logging) logger.info(s"execJdbcStatement in transaction [$id]: $sql")
+        if (logging) logger.info(s"($id) execJdbcStatement in transaction: $sql")
         if (autoCommit) logger.warn("autoCommit is enabled, so statement will be committed immediately")
         stmt.execute(sql)
       }
@@ -245,7 +245,7 @@ case class JdbcTableConnection(override val id: ConnectionId,
 
     def commit(): Unit = {
       if (!connection.autoCommit) {
-        logger.info(s"commit transaction [$id]")
+        logger.info(s"($id) commit transaction")
         jdbcConnection.commit()
       };
       close()
@@ -254,7 +254,7 @@ case class JdbcTableConnection(override val id: ConnectionId,
     def rollback(): Unit = {
       try {
         if (!connection.autoCommit) {
-          logger.info(s"roll back transaction [$id]")
+          logger.info(s"($id) roll back transaction")
           jdbcConnection.rollback()
         };
       } finally {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
@@ -47,11 +47,11 @@ import java.time.Duration
  * @param driver class name of jdbc driver
  * @param authMode optional authentication information: for now BasicAuthMode is supported.
  * @param db jdbc database
- * @param maxParallelConnections number of parallel jdbc connections created by an instance of this connection
+ * @param maxParallelConnections max number of parallel jdbc connections created by an instance of this connection, default is 3
  *                               Note that Spark manages JDBC Connections on its own. This setting only applies to JDBC connection
  *                               used by SDL for validating metadata or pre/postSQL.
  * @param connectionPoolMaxIdleTimeSec timeout to close unused connections in the pool
- * @param connectionPoolMaxWaitTimeSec timeout when waiting for connection in pool to become available. Default is 60 seconds.
+ * @param connectionPoolMaxWaitTimeSec timeout when waiting for connection in pool to become available. Default is 600 seconds (10 minutes).
  * @param autoCommit flag to enable or disable the auto-commit behaviour. When autoCommit is enabled, each database request is executed in its own transaction.
  *                   Default is autoCommit = false. It is not recommended to enable autoCommit as it will deactivate any transactional behaviour.
  * @param connectionInitSql SQL statement to be executed every time a new connection is created, for example to set session parameters
@@ -61,9 +61,9 @@ case class JdbcTableConnection(override val id: ConnectionId,
                                driver: String,
                                authMode: Option[AuthMode] = None,
                                db: Option[String] = None,
-                               maxParallelConnections: Int = 1,
+                               maxParallelConnections: Int = 3,
                                connectionPoolMaxIdleTimeSec: Int = 3,
-                               connectionPoolMaxWaitTimeSec: Int = 60,
+                               connectionPoolMaxWaitTimeSec: Int = 600,
                                override val metadata: Option[ConnectionMetadata] = None,
                                @Deprecated @deprecated("Enabling autoCommit is no longer recommended.", "2.5.0") autoCommit: Boolean = false,
                                connectionInitSql: Option[String] = None
@@ -191,7 +191,6 @@ case class JdbcTableConnection(override val id: ConnectionId,
   // setup connection pool
   val pool = new GenericObjectPool[SqlConnection](new JdbcClientPoolFactory)
   pool.setMaxTotal(maxParallelConnections)
-  pool.setMaxIdle(1) // keep max one idle jdbc connection
   pool.setMinEvictableIdle(Duration.ofSeconds(connectionPoolMaxIdleTimeSec)) // timeout to close jdbc connection if not in use
   pool.setMaxWait(Duration.ofSeconds(connectionPoolMaxWaitTimeSec))
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -474,18 +474,17 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   }
 
   override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    deletePartitionsImpl(partitionValues)
+    if (partitionValues.nonEmpty) {
+      connection.execJdbcStatement(deletePartitionsQuery(partitionValues))
+    }
   }
 
   /**
    * Delete virtual partitions by "delete from" statement
    * @param partitionValues nonempty list of partition values
    */
-  def deletePartitionsImpl(partitionValues: Seq[PartitionValues], doCommit: Boolean = true)(implicit context: ActionPipelineContext): Unit = {
-    if (partitionValues.nonEmpty) {
-      val deletePartitionQuery = SQLUtil.createDeletePartitionStatement(table.fullName, partitionValues, quoteCaseSensitiveColumn(_))
-      connection.execJdbcStatement(deletePartitionQuery, doCommit)
-    }
+  private def deletePartitionsQuery(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): String = {
+    SQLUtil.createDeletePartitionStatement(table.fullName, partitionValues, quoteCaseSensitiveColumn(_))
   }
 
   // jdbc column metadata - exact column metadata needed to check schema with case-sensitive column names

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
@@ -46,6 +46,7 @@ class JdbcTableConnectionTest extends FunSuite {
     val transaction1 = jdbcConnection.beginTransaction()
     transaction1.commit()
     val transaction2 = jdbcConnection.beginTransaction()
+    transaction2.commit();
 
     // check
     // no exception
@@ -60,6 +61,7 @@ class JdbcTableConnectionTest extends FunSuite {
     val transaction1 = jdbcConnection.beginTransaction()
     transaction1.rollback()
     val transaction2 = jdbcConnection.beginTransaction()
+    transaction2.commit();
 
     // check
     // no exception
@@ -73,6 +75,8 @@ class JdbcTableConnectionTest extends FunSuite {
     // run
     val transaction1 = jdbcConnection.beginTransaction()
     val transaction2 = jdbcConnection.beginTransaction()
+    transaction1.commit();
+    transaction2.commit();
 
     // check
     // no exception

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
@@ -21,21 +21,86 @@ package io.smartdatalake.workflow.connection.jdbc
 
 import org.scalatest.FunSuite
 
+import java.sql.SQLException
+
 class JdbcTableConnectionTest extends FunSuite {
 
-  test("turn off autocommit with connectionInitSql") {
+  test("autocommit is disabled by default") {
+    // prepare
     val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
-      "org.hsqldb.jdbcDriver", connectionInitSql = Some("SET AUTOCOMMIT FALSE"))
+      "org.hsqldb.jdbcDriver")
 
+    // run
     val autoCommitEnabled = jdbcConnection.execWithJdbcConnection(_.getAutoCommit)
+
+    // check
     assert(!autoCommitEnabled)
   }
 
-  test("turn off autocommit with autoCommit flag") {
+  test("JdbcTransaction.commit returns connection back to pool") {
+    // prepare
     val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
-      "org.hsqldb.jdbcDriver", autoCommit = Some(false))
+      "org.hsqldb.jdbcDriver", maxParallelConnections = 1)
 
-    val autoCommitEnabled = jdbcConnection.execWithJdbcConnection(_.getAutoCommit)
-    assert(!autoCommitEnabled)
+    // run
+    val transaction1 = jdbcConnection.beginTransaction()
+    transaction1.commit()
+    val transaction2 = jdbcConnection.beginTransaction()
+
+    // check
+    // no exception
   }
+
+  test("JdbcTransaction.rollback returns connection back to pool") {
+    // prepare
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
+      "org.hsqldb.jdbcDriver", maxParallelConnections = 1)
+
+    // run
+    val transaction1 = jdbcConnection.beginTransaction()
+    transaction1.rollback()
+    val transaction2 = jdbcConnection.beginTransaction()
+
+    // check
+    // no exception
+  }
+
+  test("maxParallelConnections > 1 allows concurrent transactions") {
+    // prepare
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
+      "org.hsqldb.jdbcDriver", maxParallelConnections = 2)
+
+    // run
+    val transaction1 = jdbcConnection.beginTransaction()
+    val transaction2 = jdbcConnection.beginTransaction()
+
+    // check
+    // no exception
+  }
+
+  test("rollback after failed statement") {
+    // prepare
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
+      "org.hsqldb.jdbcDriver")
+
+    jdbcConnection.execJdbcStatement("drop table if exists test_rollback")
+    jdbcConnection.execJdbcStatement("create table test_rollback( id int )")
+
+    // run
+    val transaction = jdbcConnection.beginTransaction()
+    try {
+      transaction.execJdbcStatement("insert into test_rollback(id) values(1)")
+      transaction.execJdbcStatement("insert into test_rollback(id) values('bla')") // throws exception
+    } catch {
+      case _: SQLException => transaction.rollback()
+    }
+
+    // check
+    jdbcConnection.execJdbcQuery("select count(*) from test_rollback", rs => {
+      rs.next()
+      assert(rs.getInt(1) == 0)
+    })
+  }
+
+
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
@@ -27,7 +27,7 @@ class JdbcTableConnectionTest extends FunSuite {
 
   test("autocommit is disabled by default") {
     // prepare
-    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:JdbcTableConnectionTest",
       "org.hsqldb.jdbcDriver")
 
     // run
@@ -39,8 +39,8 @@ class JdbcTableConnectionTest extends FunSuite {
 
   test("JdbcTransaction.commit returns connection back to pool") {
     // prepare
-    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
-      "org.hsqldb.jdbcDriver", maxParallelConnections = 1)
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:JdbcTableConnectionTest",
+      "org.hsqldb.jdbcDriver", maxParallelConnections = 1, connectionPoolMaxWaitTimeSec = 10)
 
     // run
     val transaction1 = jdbcConnection.beginTransaction()
@@ -54,8 +54,8 @@ class JdbcTableConnectionTest extends FunSuite {
 
   test("JdbcTransaction.rollback returns connection back to pool") {
     // prepare
-    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
-      "org.hsqldb.jdbcDriver", maxParallelConnections = 1)
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:JdbcTableConnectionTest",
+      "org.hsqldb.jdbcDriver", maxParallelConnections = 1, connectionPoolMaxWaitTimeSec = 10)
 
     // run
     val transaction1 = jdbcConnection.beginTransaction()
@@ -69,8 +69,8 @@ class JdbcTableConnectionTest extends FunSuite {
 
   test("maxParallelConnections > 1 allows concurrent transactions") {
     // prepare
-    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
-      "org.hsqldb.jdbcDriver", maxParallelConnections = 2)
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:JdbcTableConnectionTest",
+      "org.hsqldb.jdbcDriver", maxParallelConnections = 2, connectionPoolMaxWaitTimeSec = 10)
 
     // run
     val transaction1 = jdbcConnection.beginTransaction()
@@ -84,7 +84,7 @@ class JdbcTableConnectionTest extends FunSuite {
 
   test("rollback after failed statement") {
     // prepare
-    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:file:target/JdbcTableDataObjectTest/hsqldb",
+    val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:JdbcTableConnectionTest",
       "org.hsqldb.jdbcDriver")
 
     jdbcConnection.execJdbcStatement("drop table if exists test_rollback")


### PR DESCRIPTION
See #635 

This PR includes several improvements for the JDBC transaction handling:

* A new class `JdbcTransaction` inside `JdbcConnection` which reserves a database connection for the active transaction and releases it on commit or rollback. This makes sure we always use the same connection even if the connection pool contains multiple ones and that no other part of the application interferes with the transaction.
* `JdbcConnection.execJdbcStatement` and `JdbcConnection.execJdbcStatement` always commit after the execution. Because Spark writes to the database using separate connections, it is hard to guarantee end-to-end transactional behaviour in `JdbcTableDataObject`. In particular, depending on the isolation level of the database, changes from Spark connections might not be visible inside the transaction if the transaction is started before the Spark job. Therefore, we commit all statements or queries immediately, except those managed by `JdbcTransaction`. This was also the default behaviour before when the JDBC driver was set to `autoCommit = true` per default.
* The property `JdbcConnection.autoCommit` is now `false` per default and it should not be necessary for a user to set it to `true`. I think it requires too much knowledge of how SDLB works for a user to set `autoCommit` and now that the transaction handling has been improved it is obsolete. Thus, it is now deprecated and should be removed in a future release.
* The property `JdbcConnection.enableCommit` has been removed. Its behaviour has been replaced by `!autoCommit`. Since `enableCommit` was only introduced in version 2.4.2 and most people probably use `autoCommit` instead, I feel it is ok to remove it although it is not backwards compatible.
