### PR TITLE
Multiple small improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
                             </manifest>
                         </archive>
                         <excludes>
-                            <exclude>log4j.properties</exclude> <!-- Logging configuration should be left to user. -->
+                            <exclude>log4j2.*</exclude> <!-- Logging configuration should be left to user. -->
                             <exclude>${project.artifactId}*.jar
                             </exclude> <!-- avoid "Error assembling JAR" because of already existing artifact jar -->
                         </excludes>
@@ -594,12 +594,6 @@
                             </goals>
                         </execution>
                     </executions>
-                    <configuration>
-                        <excludes>
-                            <exclude>log4j.properties
-                            </exclude> <!-- Logging configuration source should not be distributed. -->
-                        </excludes>
-                    </configuration>
                 </plugin>
 
                 <!-- Builds executable fat-jar that includes all dependencies -->

--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -58,6 +58,13 @@ import org.apache.spark.util.PrivateAccessor
  * @param synchronousStreamingTriggerIntervalSec Trigger interval for synchronous actions in streaming mode in seconds (default = 60 seconds)
  *                       The synchronous actions of the DAG will be executed with this interval if possile.
  *                       Note that for asynchronous actions there are separate settings, e.g. SparkStreamingMode.triggerInterval.
+ * @param allowAsRecursiveInput allow exception for specific DataObjects to the validation rules for Action.recursiveInputIds.
+ *                              The validation rules are
+ *                              1) that recursive input DataObjects must also be listed in output DataObjects of the same action
+ *                              2) the DataObject must implement TransactionalSparkTableDataObject interface
+ *                              This can be used for well thought exceptions, but should be avoided in general.
+ *                              Note that if 1) is true, also 2) must be fullfilled for Spark to work properly (because Spark can't read/write the same storage location in the same job),
+ *                              but there might be cases with recursions with different Actions involved, that dont need to fullfill 2).
  * @param environment    Override environment settings defined in Environment object by setting the corresponding key to the desired value (key in camelcase notation with the first letter in lowercase)
  */
 case class GlobalConfig(kryoClasses: Option[Seq[String]] = None
@@ -71,6 +78,7 @@ case class GlobalConfig(kryoClasses: Option[Seq[String]] = None
                         , pythonUDFs: Option[Map[String, PythonUDFCreatorConfig]] = None
                         , secretProviders: Option[Map[String, SecretProviderConfig]] = None
                         , allowOverwriteAllPartitionsWithoutPartitionValues: Seq[DataObjectId] = Seq()
+                        , allowAsRecursiveInput: Seq[DataObjectId] = Seq()
                         , synchronousStreamingTriggerIntervalSec: Int = 60
                         , environment: Map[String, String] = Map()
                        )

--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -58,11 +58,11 @@ import org.apache.spark.util.PrivateAccessor
  * @param synchronousStreamingTriggerIntervalSec Trigger interval for synchronous actions in streaming mode in seconds (default = 60 seconds)
  *                       The synchronous actions of the DAG will be executed with this interval if possile.
  *                       Note that for asynchronous actions there are separate settings, e.g. SparkStreamingMode.triggerInterval.
- * @param allowAsRecursiveInput allow exception for specific DataObjects to the validation rules for Action.recursiveInputIds.
+ * @param allowAsRecursiveInput List of DataObjects for which the validation rules for Action.recursiveInputIds are *not* checked.
  *                              The validation rules are
  *                              1) that recursive input DataObjects must also be listed in output DataObjects of the same action
  *                              2) the DataObject must implement TransactionalSparkTableDataObject interface
- *                              This can be used for well thought exceptions, but should be avoided in general.
+ *                              Listing a DataObject in allowAsRecursiveInput can be used for well thought exceptions, but should be avoided in general.
  *                              Note that if 1) is true, also 2) must be fullfilled for Spark to work properly (because Spark can't read/write the same storage location in the same job),
  *                              but there might be cases with recursions with different Actions involved, that dont need to fullfill 2).
  * @param environment    Override environment settings defined in Environment object by setting the corresponding key to the desired value (key in camelcase notation with the first letter in lowercase)

--- a/sdl-core/src/main/scala/io/smartdatalake/app/VersionInfoWriter.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/VersionInfoWriter.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.app
 
 import io.smartdatalake.app.BuildVersionInfo.buildVersionInfoFilename
 import io.smartdatalake.config.ConfigurationException
-import io.smartdatalake.util.misc.{SmartDataLakeLogger, TryWithRessource}
+import io.smartdatalake.util.misc.{SmartDataLakeLogger, WithResource}
 import scopt.OptionParser
 
 import java.nio.file.{Files, Paths, StandardOpenOption}
@@ -83,7 +83,7 @@ case class BuildVersionInfo(version: String, user: String, date: LocalDateTime) 
     props.setProperty("version", version)
     props.setProperty("user", user)
     props.setProperty("date", date.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
-    TryWithRessource.exec(Files.newOutputStream(Paths.get(versionInfoFile), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+    WithResource.exec(Files.newOutputStream(Paths.get(versionInfoFile), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
       os => props.store(os, "")
     }
   }
@@ -112,7 +112,7 @@ object BuildVersionInfo extends SmartDataLakeLogger {
       logger.warn(s"Could not find resource $buildVersionInfoFilename")
       None
     } else {
-      TryWithRessource.exec(resourceStream) {
+      WithResource.exec(resourceStream) {
         stream =>
           val props = new Properties()
           props.load(stream)

--- a/sdl-core/src/main/scala/io/smartdatalake/util/evolution/SchemaEvolution.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/evolution/SchemaEvolution.scala
@@ -30,7 +30,7 @@ import scala.util.Try
 /**
   * Functions for schema evolution
   */
-private[smartdatalake] object SchemaEvolution extends SmartDataLakeLogger {
+object SchemaEvolution extends SmartDataLakeLogger {
 
   /**
     * Converts column names to lowercase

--- a/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
@@ -22,7 +22,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, FileRefMapping}
 import io.smartdatalake.workflow.dataobject._
 import org.apache.spark.sql.SparkSession
 
-private[smartdatalake] trait FileTransfer {
+trait FileTransfer {
 
   protected val srcDO: FileRefDataObject
   protected val tgtDO: FileRefDataObject

--- a/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
@@ -22,6 +22,8 @@ import io.smartdatalake.workflow.{ActionPipelineContext, FileRefMapping}
 import io.smartdatalake.workflow.dataobject._
 import org.apache.spark.sql.SparkSession
 
+import scala.util.matching.Regex
+
 trait FileTransfer {
 
   protected val srcDO: FileRefDataObject
@@ -32,8 +34,8 @@ trait FileTransfer {
    * @param fileRefs files to be transferred
    * @return target files which will be created when file transfer is executed
    */
-  def getFileRefMapping(fileRefs: Seq[FileRef])(implicit context: ActionPipelineContext): Seq[FileRefMapping] = {
-    tgtDO.translateFileRefs(fileRefs)
+  def getFileRefMapping(fileRefs: Seq[FileRef], filenameExtractorRegex: Option[Regex] = None)(implicit context: ActionPipelineContext): Seq[FileRefMapping] = {
+    tgtDO.translateFileRefs(fileRefs, filenameExtractorRegex)
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/FileTransfer.scala
@@ -43,16 +43,3 @@ trait FileTransfer {
   def exec(fileRefPairs: Seq[FileRefMapping])(implicit context: ActionPipelineContext): Unit
 
 }
-
-/**
- * Factory for FileTransfer's.
- * For now we can do everything with the StreamFileTransfer.
- */
-private[smartdatalake] object FileTransfer {
-  def apply( srcDO: DataObject, tgtDO: DataObject, overwrite: Boolean): FileTransfer = {
-    (srcDO, tgtDO) match {
-      case (inputDO: FileRefDataObject with CanCreateInputStream, outputDO: FileRefDataObject with CanCreateOutputStream) => new StreamFileTransfer(inputDO, outputDO, overwrite)
-      case x => throw new IllegalStateException(s"Unmatched case $x")
-    }
-  }
-}

--- a/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/SshUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/SshUtil.scala
@@ -140,8 +140,8 @@ private[smartdatalake] object SshUtil extends SmartDataLakeLogger {
     }
   }
 
-  def getOutputStream(path: String, onCloseFunc: () => Unit)(implicit sftp: SFTPClient): OutputStream = {
-    val handle: RemoteFile = sftp.open(path, util.EnumSet.of(OpenMode.WRITE, OpenMode.CREAT))
+  def getOutputStream(path: String, overwrite: Boolean, onCloseFunc: () => Unit)(implicit sftp: SFTPClient): OutputStream = {
+    val handle: RemoteFile = sftp.open(path, util.EnumSet.of(OpenMode.WRITE, OpenMode.CREAT, if (overwrite) OpenMode.TRUNC else OpenMode.APPEND))
     new handle.RemoteFileOutputStream() {
       override def close(): Unit = try {
         super.close()

--- a/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/StreamFileTransfer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/filetransfer/StreamFileTransfer.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.util.filetransfer
 
 import java.io.{InputStream, OutputStream}
-import io.smartdatalake.util.misc.{SmartDataLakeLogger, TryWithRessource}
+import io.smartdatalake.util.misc.{SmartDataLakeLogger, WithResource}
 import io.smartdatalake.workflow.{ActionPipelineContext, FileRefMapping}
 import io.smartdatalake.workflow.dataobject.{CanCreateInputStream, CanCreateOutputStream, FileRef, FileRefDataObject}
 import org.apache.spark.sql.SparkSession
@@ -40,8 +40,8 @@ private[smartdatalake] class StreamFileTransfer(override val srcDO: FileRefDataO
     parallelize(fileRefPairs).foreach { m =>
       logger.info(s"Copy ${srcDO.id}:${m.src.toStringShort} -> ${tgtDO.id}:${m.tgt.toStringShort}")
       // get streams
-      TryWithRessource.exec(srcDO.createInputStream(m.src.fullPath)) { is =>
-        TryWithRessource.exec( tgtDO.createOutputStream(m.tgt.fullPath, overwrite)) { os =>
+      WithResource.exec(srcDO.createInputStream(m.src.fullPath)) { is =>
+        WithResource.exec( tgtDO.createOutputStream(m.tgt.fullPath, overwrite)) { os =>
           // transfer data
           Try(copyStream(is, os)) match {
             case Success(r) => r

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -171,7 +171,7 @@ object PartitionValues {
 /**
  * Helper methods to handle partition layout string
  */
-private[smartdatalake] object PartitionLayout {
+object PartitionLayout {
   private[hdfs] val delimiter = "%"
   private val tokenRegex = s"$delimiter([0-9a-zA-Z_]+)(:(.*?))?$delimiter".r.unanchored
 

--- a/sdl-core/src/main/scala/io/smartdatalake/util/historization/Historization.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/historization/Historization.scala
@@ -33,7 +33,7 @@ import java.time.LocalDateTime
 /**
  * Functions for historization
  */
-private[smartdatalake] object Historization extends SmartDataLakeLogger {
+object Historization extends SmartDataLakeLogger {
 
   private[smartdatalake] val historizeHashColName = "dl_hash" // incrementalHistorize adds hash col to target schema for comparing changes
   private[smartdatalake] val historizeOperationColName = "dl_operation" // incrementalHistorize needs operation col for merge statement. It is temporary and is not added to target schema.
@@ -365,7 +365,7 @@ private[smartdatalake] object Historization extends SmartDataLakeLogger {
   }
 }
 
-private[smartdatalake] object HistorizationRecordOperations {
+object HistorizationRecordOperations {
   val updateClose = "updateClose"
   val insertNew = "insertNew"
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/WithResource.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/WithResource.scala
@@ -24,14 +24,13 @@ import org.apache.commons.pool2.impl.GenericObjectPool
 
 import scala.io.Source
 
-private[smartdatalake] object TryWithRessource {
+private[smartdatalake] object WithResource {
   /**
    * tries executing some function and closes the resource afterward also on exceptions
    */
   def exec[A <: Closeable, B](resource: A)(func: A => B): B = {
     try {
       val result = func(resource)
-      resource.close()
       result
     } finally {
       resource.close()
@@ -44,7 +43,6 @@ private[smartdatalake] object TryWithRessource {
   def execSource[A <: Source, B](resource: A)(func: A => B): B = {
     try {
       val result = func(resource)
-      resource.close()
       result
     } finally {
       resource.close()
@@ -52,7 +50,7 @@ private[smartdatalake] object TryWithRessource {
   }
 }
 
-private[smartdatalake] object TryWithResourcePool {
+private[smartdatalake] object WithResourcePool {
   /**
    * tries executing some function and returns the ressource afterwards to the pool
    */

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/WithResourcePool.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/WithResourcePool.scala
@@ -1,7 +1,7 @@
 /*
  * Smart Data Lake - Build your data lake the smart way.
  *
- * Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,36 +16,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package io.smartdatalake.util.misc
 
-import java.io.Closeable
+package io.smartdatalake.util.misc
 
 import org.apache.commons.pool2.impl.GenericObjectPool
 
-import scala.io.Source
-
-object WithResource {
+object WithResourcePool {
   /**
-   * tries executing some function and closes the resource afterward also on exceptions
+   * tries executing some function and returns the resource afterwards to the pool
    */
-  def exec[A <: Closeable, B](resource: A)(func: A => B): B = {
+  def exec[A, B](pool: GenericObjectPool[A])(func: A => B): B = {
+    val resource = pool.borrowObject()
     try {
       val result = func(resource)
       result
     } finally {
-      resource.close()
-    }
-  }
-
-  /**
-   * tries executing some function and closes the resource afterward also on exceptions
-   */
-  def execSource[A <: Source, B](resource: A)(func: A => B): B = {
-    try {
-      val result = func(resource)
-      result
-    } finally {
-      resource.close()
+      pool.returnObject(resource)
     }
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/secrets/FileSecretProvider.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/secrets/FileSecretProvider.scala
@@ -20,7 +20,7 @@
 package io.smartdatalake.util.secrets
 
 import io.smartdatalake.config.ConfigurationException
-import io.smartdatalake.util.misc.TryWithRessource
+import io.smartdatalake.util.misc.WithResource
 
 /**
  * Read a secret from a property file, where the filename is provided directly in the configuration entry.
@@ -51,7 +51,7 @@ class FileSecretProvider(file: String) extends SecretProvider {
 }
 object FileSecretProvider {
   def getSecretFromFile(file: String, name: String): String = {
-    val props = TryWithRessource.execSource(scala.io.Source.fromFile(file))(_.getLines.toSeq)
+    val props = WithResource.execSource(scala.io.Source.fromFile(file))(_.getLines.toSeq)
     val namePrefix = name + "="
     props.find(_.startsWith(namePrefix))
       .map(_.stripPrefix(namePrefix))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -42,7 +42,7 @@ import scala.util.Try
  * An action defines a [[DAGNode]], that is, a transformation from input [[DataObject]]s to output [[DataObject]]s in
  * the DAG of actions.
  */
-private[smartdatalake] trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNode with SmartDataLakeLogger with AtlasExportable {
+trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNode with SmartDataLakeLogger with AtlasExportable {
 
   /**
    * A unique identifier for this instance.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -63,11 +63,11 @@ trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNod
    * Recursive Inputs are DataObjects that are used as Output and Input in the same or different action.
    * This is usually prohibited as it creates loops in the DAG.
    * In special cases this makes sense, i.e. when building a complex comparision/update logic.
-   * Recursive inputs are allowed in the same Action if the DataObject implement TransactionalSparkTableDataObject.
+   * Recursive inputs are allowed in the same Action if the DataObject implements TransactionalSparkTableDataObject.
    * For special cases this is to restrictive. To allow special DataObjects for recursive use within two different actions,
    * see also [[GlobalConfig.allowAsRecursiveInput]].
    *
-   * Usage: add DataObjects used as Output and Input as outputIds and recursiveInputIds, but not as inputIds.
+   * Usage: add DataObjects that are used both as Output and Input as outputIds and recursiveInputIds, but do not add them as inputIds.
    */
   def recursiveInputs: Seq[DataObject] = Seq()
 
@@ -118,7 +118,7 @@ trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNod
   def validateConfig(): Unit = {
     recursiveInputs.foreach { input =>
       if (outputs.exists(_.id == input.id)) {
-        assert(input.isInstanceOf[TransactionalSparkTableDataObject], s"($id) Recursive input ${input.id} is listed in outputIds but is not a TransactionalSparkTableDataObjects.")
+        assert(input.isInstanceOf[TransactionalSparkTableDataObject], s"($id) Recursive input ${input.id} is listed in outputIds but is not a TransactionalSparkTableDataObject.")
       } else if (Environment.globalConfig.allowAsRecursiveInput.contains(input.id)) {
         logger.info(s"($id) Using ${input.id} as recursive input even though it is not listed in outputIds of the same Action, but in globalConfig.allowAsRecursiveInput")
       } else {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -38,7 +38,7 @@ import scala.reflect.runtime.universe.Type
 /**
  * Collection of helper functions for Actions
  */
-private[smartdatalake] object ActionHelper extends SmartDataLakeLogger {
+object ActionHelper extends SmartDataLakeLogger {
 
   /**
    * Removes all columns from a [[DataFrame]] except those specified in whitelist.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -22,7 +22,7 @@ import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.Condition
-import io.smartdatalake.util.filetransfer.FileTransfer
+import io.smartdatalake.util.filetransfer.{FileTransfer, StreamFileTransfer}
 import io.smartdatalake.util.misc.{SmartDataLakeLogger, TryWithRessource}
 import io.smartdatalake.workflow.action.executionMode.ExecutionMode
 import io.smartdatalake.workflow.action.spark.customlogic.CustomFileTransformerConfig
@@ -120,7 +120,7 @@ case class CustomFileAction(override val id: ActionId,
           // exec only if output returned a sample file to create
           sampleFile.foreach {
             file =>
-              val sampleFileTransfer = FileTransfer(input, output, overwrite = true)
+              val sampleFileTransfer = new StreamFileTransfer(input, output, overwrite = true)
               val hadoopSrcPath = new Path(sampleFileRefMapping.src.fullPath)
               val hadoopTgtPath = new Path(file)
               val result = TryWithRessource.exec(input.filesystem.open(hadoopSrcPath)) { is =>

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.Condition
 import io.smartdatalake.util.filetransfer.{FileTransfer, StreamFileTransfer}
-import io.smartdatalake.util.misc.{SmartDataLakeLogger, TryWithRessource}
+import io.smartdatalake.util.misc.{SmartDataLakeLogger, WithResource}
 import io.smartdatalake.workflow.action.executionMode.ExecutionMode
 import io.smartdatalake.workflow.action.spark.customlogic.CustomFileTransformerConfig
 import io.smartdatalake.workflow.dataobject.HadoopFileDataObject
@@ -89,8 +89,8 @@ case class CustomFileAction(override val id: ActionId,
         .map { case (srcPath, tgtPath) =>
           val hadoopSrcPath = new Path(srcPath)
           val hadoopTgtPath = new Path(tgtPath)
-          val result = TryWithRessource.exec(srcDO.getFilesystem(hadoopSrcPath).open(hadoopSrcPath)) { is =>
-            TryWithRessource.exec(tgtDO.getFilesystem(hadoopTgtPath).create(hadoopTgtPath, true)) { os => // overwrite = true
+          val result = WithResource.exec(srcDO.getFilesystem(hadoopSrcPath).open(hadoopSrcPath)) { is =>
+            WithResource.exec(tgtDO.getFilesystem(hadoopTgtPath).create(hadoopTgtPath, true)) { os => // overwrite = true
               transformerVal.transform(is, os)
             }
           }
@@ -123,8 +123,8 @@ case class CustomFileAction(override val id: ActionId,
               val sampleFileTransfer = new StreamFileTransfer(input, output, overwrite = true)
               val hadoopSrcPath = new Path(sampleFileRefMapping.src.fullPath)
               val hadoopTgtPath = new Path(file)
-              val result = TryWithRessource.exec(input.filesystem.open(hadoopSrcPath)) { is =>
-                TryWithRessource.exec(output.filesystem.create(hadoopTgtPath, true)) { os => // overwrite = true
+              val result = WithResource.exec(input.filesystem.open(hadoopSrcPath)) { is =>
+                WithResource.exec(output.filesystem.create(hadoopTgtPath, true)) { os => // overwrite = true
                   transformer.transform(is, os)
                 }
               }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
@@ -43,7 +43,7 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * Implementation of logic needed for Spark Actions.
  * This is a generic implementation that supports many input and output SubFeeds.
  */
-private[smartdatalake] abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] {
+abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] {
 
   override def inputs: Seq[DataObject with CanCreateDataFrame]
   override def outputs: Seq[DataObject with CanWriteDataFrame]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
@@ -385,7 +385,7 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
     }
     // create output subfeeds from transformed dataframes
     outputSubFeeds.map { subFeed=>
-        val df = outputDfsMap.getOrElse(subFeed.dataObjectId.id, throw ConfigurationException(s"($id) No result found for output ${subFeed.dataObjectId}. Available tesults are ${outputDfsMap.keys.mkString(", ")}."))
+        val df = outputDfsMap.getOrElse(subFeed.dataObjectId.id, throw ConfigurationException(s"($id) No result found for output ${subFeed.dataObjectId}. Available results are ${outputDfsMap.keys.mkString(", ")}."))
         subFeed.withDataFrame(Some(df))
     }
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -74,6 +74,7 @@ case class FileTransferAction(override val id: ActionId,
   override def transform(inputSubFeed: FileSubFeed, outputSubFeed: FileSubFeed)(implicit context: ActionPipelineContext): FileSubFeed = {
     assert(inputSubFeed.fileRefs.nonEmpty, "inputSubFeed.fileRefs must be defined for FileTransferAction.doTransform")
     val inputFileRefs = inputSubFeed.fileRefs.get
+    logger.info(s"($id) got ${inputFileRefs.size} files to copy")
     outputSubFeed.copy(fileRefMapping = Some(fileTransfer.getFileRefMapping(inputFileRefs, filenameExtractorRegex.map(_.r))))
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/MetricsCheckFailed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/MetricsCheckFailed.scala
@@ -19,7 +19,7 @@
 
 package io.smartdatalake.workflow.action
 
-private[smartdatalake] case class MetricsCheckFailed(msg: String) extends Exception(msg)
+case class MetricsCheckFailed(msg: String) extends Exception(msg)
 
 case class Metric(dataObjectId: String, key: Option[String], value: Option[String]) {
   override def toString: String = s"Metric(dataObjectId=$dataObjectId key=$key value=$value)"

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/TimeOrderLogicException.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/TimeOrderLogicException.scala
@@ -24,4 +24,4 @@ package io.smartdatalake.workflow.action
  *
  * @param message Message of Exception
  */
-private[smartdatalake] class TimeOrderLogicException(message: String) extends RuntimeException(message) {}
+class TimeOrderLogicException(message: String) extends RuntimeException(message) {}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/Connection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/Connection.scala
@@ -22,7 +22,7 @@ import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{ParsableFromConfig, SdlConfigObject}
 import io.smartdatalake.workflow.AtlasExportable
 
-private[smartdatalake] trait Connection extends SdlConfigObject with ParsableFromConfig[Connection] with AtlasExportable {
+trait Connection extends SdlConfigObject with ParsableFromConfig[Connection] with AtlasExportable {
 
   /**
    * A unique identifier for this instance.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.{AuthMode, BasicAuthMode, PublicKeyAuthMode}
 import io.smartdatalake.util.filetransfer.SshUtil
-import io.smartdatalake.util.misc.TryWithResourcePool
+import io.smartdatalake.util.misc.WithResourcePool
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.sftp.SFTPClient
 import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool}
@@ -70,13 +70,13 @@ case class SFtpFileRefConnection(override val id: ConnectionId,
   }
 
   def execWithSFtpClient[A]( func: SFTPClient => A ): A = {
-    TryWithResourcePool.exec(pool){
+    WithResourcePool.exec(pool){
       sftp => func(sftp)
     }
   }
 
   def test(): Unit = {
-    TryWithResourcePool.exec(pool){ sftp => Unit } // no operation
+    WithResourcePool.exec(pool){ sftp => Unit } // no operation
   }
 
   // setup connection pool

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
@@ -43,7 +43,7 @@ import java.net.{InetSocketAddress, Proxy}
  * @param connectionPoolMaxIdleTimeSec timeout to close unused connections in the pool
  * @param metadata
  */
-case class SftpFileRefConnection(override val id: ConnectionId,
+case class SFtpFileRefConnection(override val id: ConnectionId,
                                  host: String,
                                  port: Int = 22,
                                  authMode: AuthMode,
@@ -70,11 +70,11 @@ case class SftpFileRefConnection(override val id: ConnectionId,
   }
 
   // setup connection pool
-  val pool = new GenericObjectPool[SFTPClient](new SftpClientPoolFactory)
+  val pool = new GenericObjectPool[SFTPClient](new SFtpClientPoolFactory)
   pool.setMaxTotal(maxParallelConnections)
   pool.setMaxIdle(1) // keep max one idle sftp connection
   pool.setMinEvictableIdleTimeMillis(connectionPoolMaxIdleTimeSec * 1000) // timeout to close sftp connection if not in use
-  private class SftpClientPoolFactory extends BasePooledObjectFactory[SFTPClient] {
+  private class SFtpClientPoolFactory extends BasePooledObjectFactory[SFTPClient] {
     override def create(): SFTPClient = {
       authMode match {
         case m: BasicAuthMode => SshUtil.connectWithUserPw(host, port,
@@ -88,12 +88,12 @@ case class SftpFileRefConnection(override val id: ConnectionId,
       p.getObject.close()
   }
 
-  override def factory: FromConfigFactory[Connection] = SftpFileRefConnection
+  override def factory: FromConfigFactory[Connection] = SFtpFileRefConnection
 }
 
-object SftpFileRefConnection extends FromConfigFactory[Connection] {
-  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): SftpFileRefConnection = {
-    extract[SftpFileRefConnection](config)
+object SFtpFileRefConnection extends FromConfigFactory[Connection] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): SFtpFileRefConnection = {
+    extract[SFtpFileRefConnection](config)
   }
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
@@ -61,7 +61,7 @@ case class SFtpFileRefConnection(override val id: ConnectionId,
   private val supportedAuths = Seq(classOf[BasicAuthMode], classOf[PublicKeyAuthMode])
   require(supportedAuths.contains(authMode.getClass), s"${authMode.getClass.getSimpleName} not supported by ${this.getClass.getSimpleName}. Supported auth modes are ${supportedAuths.map(_.getSimpleName).mkString(", ")}.")
 
-  private val createSshClient: SSHClient = {
+  private def createSshClient: SSHClient = {
     authMode match {
       case m: BasicAuthMode => SshUtil.connectWithUserPw(host, port, m.userSecret.resolve(), m.passwordSecret.resolve(), proxy.map(_.instance), ignoreHostKeyVerification)
       case m: PublicKeyAuthMode => SshUtil.connectWithPublicKey(host, port, m.userSecret.resolve(), proxy.map(_.instance), ignoreHostKeyVerification)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
@@ -53,7 +53,7 @@ case class SFtpFileRefConnection(override val id: ConnectionId,
                                  connectionPoolMaxIdleTimeSec: Int = 3,
                                  override val metadata: Option[ConnectionMetadata] = None
                                  ) extends Connection {
-
+  require(maxParallelConnections > 0, s"maxParallelConnections must be greater than 0, but is $maxParallelConnections")
 
   // Allow only supported authentication modes
   private val supportedAuths = Seq(classOf[BasicAuthMode], classOf[PublicKeyAuthMode])

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
@@ -82,14 +82,12 @@ case class SFtpFileRefConnection(override val id: ConnectionId,
   // setup connection pool
   val pool = new GenericObjectPool[SFTPClient](new SFtpClientPoolFactory)
   pool.setMaxTotal(maxParallelConnections)
-  pool.setMaxIdle(1) // keep max one idle sftp connection
   pool.setMinEvictableIdle(Duration.ofSeconds(connectionPoolMaxIdleTimeSec)) // timeout to close sftp connection if not in use
   private class SFtpClientPoolFactory extends BasePooledObjectFactory[SFTPClient] {
     override def create(): SFTPClient = createSshClient.newSFTPClient()
     override def wrap(sftp: SFTPClient): PooledObject[SFTPClient] = new DefaultPooledObject(sftp)
-    override def destroyObject(p: PooledObject[SFTPClient]): Unit =
-      p.getObject.close()
-  }
+    override def destroyObject(p: PooledObject[SFTPClient]): Unit = p.getObject.close()
+}
 
   override def factory: FromConfigFactory[Connection] = SFtpFileRefConnection
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SftpFileRefConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SftpFileRefConnection.scala
@@ -50,6 +50,9 @@ case class SftpFileRefConnection(override val id: ConnectionId,
                                  override val metadata: Option[ConnectionMetadata] = None
                                  ) extends Connection {
 
+  import java.net.Proxy
+  val proxy = new java.net.Proxy(Proxy.Type)
+
   // Allow only supported authentication modes
   private val supportedAuths = Seq(classOf[BasicAuthMode], classOf[PublicKeyAuthMode])
   require(supportedAuths.contains(authMode.getClass), s"${authMode.getClass.getSimpleName} not supported by ${this.getClass.getSimpleName}. Supported auth modes are ${supportedAuths.map(_.getSimpleName).mkString(", ")}.")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
@@ -22,7 +22,7 @@ import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.{AuthMode, BasicAuthMode}
-import io.smartdatalake.util.misc.{SQLUtil, SchemaUtil, SmartDataLakeLogger, TryWithResourcePool}
+import io.smartdatalake.util.misc.{SQLUtil, SchemaUtil, SmartDataLakeLogger, WithResourcePool}
 import io.smartdatalake.workflow.connection.{Connection, ConnectionMetadata}
 import io.smartdatalake.workflow.dataobject.JdbcTableDataObject
 import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool}
@@ -81,7 +81,7 @@ case class JdbcTableConnection(override val id: ConnectionId,
    * Get a connection from the pool and execute an arbitrary function
    */
   def execWithJdbcConnection[A]( func: SqlConnection => A ): A = {
-    TryWithResourcePool.exec(pool){
+    WithResourcePool.exec(pool){
       con => func(con)
     }
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanMergeDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanMergeDataFrame.scala
@@ -21,4 +21,4 @@ package io.smartdatalake.workflow.dataobject
 /**
  * Marker interface to let Actions know that a DataObject supports SDLSaveMode.Merge.
  */
-private[smartdatalake] trait CanMergeDataFrame
+trait CanMergeDataFrame

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanReceiveScriptNotification.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanReceiveScriptNotification.scala
@@ -22,7 +22,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.sql.SparkSession
 
-private[smartdatalake] trait CanReceiveScriptNotification {
+trait CanReceiveScriptNotification {
 
   def scriptNotification(parameters: Map[String,String], partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): Unit
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
 
 import scala.reflect.runtime.universe.Type
 
-private[smartdatalake] trait CanWriteDataFrame {
+trait CanWriteDataFrame {
 
   // additional streaming options which can be overridden by the DataObject, e.g. Kafka topic to write to
   def streamingOptions: Map[String, String] = Map()

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteSparkDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteSparkDataFrame.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
 
 import scala.reflect.runtime.universe.{Type, typeOf}
 
-private[smartdatalake] trait CanWriteSparkDataFrame extends CanWriteDataFrame { this: DataObject =>
+trait CanWriteSparkDataFrame extends CanWriteDataFrame { this: DataObject =>
 
   /**
    * Configured options for the Spark [[DataFrameReader]]/[[DataFrameWriter]].

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -167,7 +167,7 @@ trait FileRefDataObject extends FileDataObject {
 
   /**
    * Create directories if not existing.
-   * If no implementation is given, it is assumed that directories will be created on the file when writing a file.
+   * If no implementation is given, it is assumed that directories will be created on-the-fly when writing a file.
    */
   def mkDirs(path: String)(implicit context: ActionPipelineContext): Unit = Unit
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -25,7 +25,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, FileRefMapping}
 
 import java.nio.file.FileAlreadyExistsException
 
-private[smartdatalake] trait FileRefDataObject extends FileDataObject {
+trait FileRefDataObject extends FileDataObject {
 
   /**
    * Definition of partition layout

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileRefDataObject.scala
@@ -143,6 +143,13 @@ trait FileRefDataObject extends FileDataObject {
     }
   }
 
+  /**
+   * Define recommended number of files to be read or written in parallel for this DataObject.
+   * Actions using this DataObject are not forced to respect the parallelism given, but they can use the information to better control parallel operations.
+   * When set to None there is no special recommendation for parallelism.
+   * Note: this was implemented for FileTransferAction working with SFtpFileRefDataObject, to make use of SFtpFileRefConnection.maxParallelConnections.
+   */
+  def recommendedParallelism: Option[Int] = None
 
   /**
    * Delete all data. This is used to implement SaveMode.Overwrite.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -166,6 +166,8 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
     case ex: Throwable => throw ConnectionTestException(s"($id) Can not connect. Error: ${ex.getMessage}", ex)
   }
 
+  override def recommendedParallelism: Option[Int] = Some(connection.maxParallelConnections)
+
   override def factory: FromConfigFactory[DataObject] = SFtpFileRefDataObject
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -196,7 +196,7 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
   override def createOutputStream(path: String, overwrite: Boolean)(implicit context: ActionPipelineContext): OutputStream = {
     Try {
       implicit val sftp = connection.pool.borrowObject
-      SshUtil.getOutputStream(path, () => Try(connection.pool.returnObject(sftp)))
+      SshUtil.getOutputStream(path, overwrite, () => Try(connection.pool.returnObject(sftp)))
     } match {
       case Success(r) => r
       case Failure(e) => throw new RuntimeException(s"Can't create OutputStream for $id and $path: ${e.getClass.getSimpleName} - ${e.getMessage}", e)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -27,7 +27,7 @@ import io.smartdatalake.util.filetransfer.SshUtil
 import io.smartdatalake.util.hdfs.{PartitionLayout, PartitionValues}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.ActionPipelineContext
-import io.smartdatalake.workflow.connection.SftpFileRefConnection
+import io.smartdatalake.workflow.connection.SFtpFileRefConnection
 import net.schmizz.sshj.sftp.SFTPException
 
 import java.io.{InputStream, OutputStream}
@@ -66,7 +66,7 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
   /**
    * Connection defines host, port and credentials in central location
    */
-  private val connection = getConnection[SftpFileRefConnection](connectionId)
+  private val connection = getConnection[SFtpFileRefConnection](connectionId)
 
   override def getFileRefs(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Seq[FileRef] = {
     connection.execWithSFtpClient {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow.dataobject
 
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
-import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.util.filetransfer.SshUtil
@@ -28,10 +28,12 @@ import io.smartdatalake.util.hdfs.{PartitionLayout, PartitionValues}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.connection.SFtpFileRefConnection
-import net.schmizz.sshj.sftp.SFTPException
+import net.schmizz.sshj.sftp.{SFTPClient, SFTPException}
 
 import java.io.{InputStream, OutputStream}
 import java.nio.file.FileAlreadyExistsException
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -44,9 +46,12 @@ import scala.util.{Failure, Success, Try}
  *
  * @param partitionLayout partition layout defines how partition values can be extracted from the path.
  *                        Use "%<colname>%" as token to extract the value for a partition column.
+ *                        As partition layout extracts partition from the path of individual files, it can also be used to extract partitions from the file name.
  *                        With "%<colname:regex>%" a regex can be given to limit search. This is especially useful
  *                        if there is no char to delimit the last token from the rest of the path or also between
  *                        two tokens.
+ *                        Be careful that for directory based partition values extraction, the final path separator must be part
+ *                        of the partition layout to extract the last token correctly, e.g. "%year%/" for partitioning with yearly directories.
  * @param saveMode Overwrite or Append new data.
  * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
  *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
@@ -86,6 +91,55 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
     }
   }
 
+  override def deleteAll(implicit context: ActionPipelineContext): Unit = {
+    connection.execWithSFtpClient { sftp =>
+      def deleteDirectoryContent(path: String): Unit = {
+        val (dirs, files) = sftp.ls(getPath).asScala.partition(_.isDirectory)
+        files.foreach(f => sftp.rm(f.getPath))
+        dirs.foreach { d =>
+          deleteDirectoryContent(d.getPath)
+          sftp.rmdir(d.getPath)
+        }
+      }
+      deleteDirectoryContent(getPath)
+    }
+  }
+
+  /**
+   * Get parent directory of path
+   */
+  private def getParent(path: String) = {
+    path.reverse.dropWhile(_ == separator).dropWhile(_ != separator).dropWhile(_ == separator).reverse
+  }
+
+  def deletePartitionsContent(partitionValues: Seq[PartitionValues], sftp: SFTPClient)(implicit context: ActionPipelineContext): Seq[String] = {
+    val searchPaths = getSearchPaths(partitionValues).map(_._2)
+    searchPaths.map { p =>
+      val files = SshUtil.sftpListFiles(p)(sftp)
+      files.foreach(sftp.rm)
+      p
+    }
+  }
+
+  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    connection.execWithSFtpClient { sftp =>
+      @tailrec
+      def deleteEmptyParents(partitionPath: String): Unit = {
+        val parentPath = getParent(partitionPath)
+        // check that it is subdirectory of base path
+        if (parentPath.startsWith(getPath) && parentPath.length > getPath.length) {
+          if (sftp.ls(parentPath).isEmpty) {
+            sftp.rmdir(parentPath)
+            deleteEmptyParents(parentPath)
+          }
+        }
+      }
+      val searchPaths = deletePartitionsContent(partitionValues, sftp)
+      val parentDirectories = searchPaths.map(getParent).distinct
+      parentDirectories.foreach(deleteEmptyParents)
+    }
+  }
+
   override def deleteFile(file: String)(implicit context: ActionPipelineContext): Unit = {
     connection.execWithSFtpClient {
       sftp => sftp.rm(file)
@@ -102,6 +156,12 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
     }
   }
 
+  override def mkDirs(path: String)(implicit context: ActionPipelineContext): Unit = {
+    connection.execWithSFtpClient {
+      sftp => sftp.mkdirs(path)
+    }
+  }
+
   override def createInputStream(path: String)(implicit context: ActionPipelineContext): InputStream = {
     Try {
       implicit val sftp = connection.pool.borrowObject
@@ -113,10 +173,17 @@ case class SFtpFileRefDataObject(override val id: DataObjectId,
   }
 
   override def startWritingOutputStreams(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): Unit = {
+    // ensure base and partition directories are existing
+    mkDirs(path)
+    val searchPaths = getSearchPaths(partitionValues)
+    val partitionDirectories = searchPaths.map(p => getParent(p._2))
+    partitionDirectories.foreach(mkDirs)
+    // cleanup on overwrite
     if (saveMode == SDLSaveMode.Overwrite) {
       if (partitions.nonEmpty)
-        if (partitionValues.nonEmpty) deletePartitions(partitionValues)
-        else logger.warn(s"($id) Cannot delete data from partitioned data object as no partition values are given but saveMode=overwrite")
+        if (partitionValues.nonEmpty) connection.execWithSFtpClient { sftp =>
+          deletePartitionsContent(partitionValues, sftp)
+        } else logger.warn(s"($id) Cannot delete data from partitioned data object as no partition values are given but saveMode=overwrite")
       else deleteAll
     }
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SchemaValidation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SchemaValidation.scala
@@ -25,7 +25,7 @@ import io.smartdatalake.workflow.SchemaViolationException
 /**
  * A [[DataObject]] that allows for optional schema validation on read and on write.
  */
-private[smartdatalake] trait SchemaValidation { this: DataObject =>
+trait SchemaValidation { this: DataObject =>
 
   /**
    * An optional, minimal schema that a [[DataObject]] schema must have to pass schema validation.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types.StructType
 
 import scala.reflect.runtime.universe.Type
 
-private[smartdatalake] trait TableDataObject extends DataObject with CanCreateDataFrame with SchemaValidation {
+trait TableDataObject extends DataObject with CanCreateDataFrame with SchemaValidation {
 
   var table: Table
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableMissingException.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableMissingException.scala
@@ -21,4 +21,4 @@ package io.smartdatalake.workflow.dataobject
 /**
  * Exception if a table is missing
  */
-private[smartdatalake] class TableMissingException(message: String) extends RuntimeException(message) {}
+class TableMissingException(message: String) extends RuntimeException(message) {}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TransactionalSparkTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TransactionalSparkTableDataObject.scala
@@ -23,7 +23,7 @@ package io.smartdatalake.workflow.dataobject
  * and [[io.smartdatalake.workflow.action.DeduplicateAction]] which need any kind
  * of transactional util table
  */
-private[smartdatalake] trait TransactionalSparkTableDataObject extends TableDataObject with CanCreateSparkDataFrame with CanWriteSparkDataFrame {
+trait TransactionalSparkTableDataObject extends TableDataObject with CanCreateSparkDataFrame with CanWriteSparkDataFrame {
 
   override def options: Map[String, String] = Map() // override options because of conflicting definitions in CanCreateSparkDataFrame and CanWriteSparkDataFrame
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/UserDefinedSchema.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/UserDefinedSchema.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.workflow.dataframe.GenericSchema
 /**
  * A [[DataObject]] that allows optional user-defined schema definition.
  */
-private[smartdatalake] trait UserDefinedSchema {
+trait UserDefinedSchema {
 
   /**
    * An optional [[DataObject]] user-defined schema definition.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ZipCsvCodec.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ZipCsvCodec.scala
@@ -35,7 +35,7 @@ import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
  */
 class ZipCsvCodec extends ZipCodec("data.csv")
 
-private[smartdatalake] class ZipCodec(entryName: String) extends DefaultCodec {
+class ZipCodec(entryName: String) extends DefaultCodec {
   override def createInputStream(in: InputStream): CompressionInputStream = {
     val zipIs = new ZipInputStream(in)
     new ZipDecompressorStream(zipIs)
@@ -47,7 +47,7 @@ private[smartdatalake] class ZipCodec(entryName: String) extends DefaultCodec {
   override def getDefaultExtension: String = ".zip"
 }
 
-private[smartdatalake] class ZipDecompressorStream(in: ZipInputStream) extends CompressionInputStream(in) {
+class ZipDecompressorStream(in: ZipInputStream) extends CompressionInputStream(in) {
   in.getNextEntry
   private val oneByte = new Array[Byte](1)
   override def read(): Int = {
@@ -60,7 +60,7 @@ private[smartdatalake] class ZipDecompressorStream(in: ZipInputStream) extends C
   override def resetState(): Unit = {}
 }
 
-private[smartdatalake] class ZipCompressorStream(out: ZipOutputStream, entryName: String) extends CompressionOutputStream(out) {
+class ZipCompressorStream(out: ZipOutputStream, entryName: String) extends CompressionOutputStream(out) {
   out.putNextEntry(new ZipEntry(entryName))
   override def write(b: Int): Unit = out.write(b)
   override def write(data: Array[Byte], offset: Int, length: Int): Unit = {

--- a/sdl-core/src/test/scala/io/smartdatalake/util/json/SchemaConverterTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/json/SchemaConverterTest.scala
@@ -19,7 +19,7 @@
 
 package io.smartdatalake.util.json
 
-import io.smartdatalake.util.misc.TryWithRessource
+import io.smartdatalake.util.misc.WithResource
 import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 
@@ -461,7 +461,7 @@ class SchemaConverterTest extends FunSuite with Matchers with BeforeAndAfter {
 
   def getTestResourceContent(relativePath: String): String = {
     Option(getClass.getResource(relativePath)) match {
-      case Some(relPath) => TryWithRessource.exec(Source.fromURL(relPath))(_.mkString)
+      case Some(relPath) => WithResource.exec(Source.fromURL(relPath))(_.mkString)
       case None => throw new IllegalArgumentException(s"Path can not be reached: $relativePath")
     }
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.action
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.util.misc.TryWithRessource
+import io.smartdatalake.util.misc.WithResource
 import io.smartdatalake.workflow.action.executionMode.PartitionDiffMode
 import io.smartdatalake.workflow.action.spark.customlogic.{CustomFileTransformer, CustomFileTransformerConfig}
 import io.smartdatalake.workflow.dataobject.CsvFileDataObject
@@ -141,8 +141,8 @@ object CustomFileActionTest {
 class TestFileTransformer extends CustomFileTransformer {
   override def transform(options: Map[String,String], input: FSDataInputStream, output: FSDataOutputStream): Option[Exception] = {
     assert(options("test")=="true")
-    TryWithRessource.execSource(Source.fromInputStream(input)) { src =>
-      TryWithRessource.exec(new PrintWriter(output)) { os =>
+    WithResource.execSource(Source.fromInputStream(input)) { src =>
+      WithResource.exec(new PrintWriter(output)) { os =>
         src.getLines().foreach { l =>
           // reduce to 2 cols
           val transformedLine = l.split(CustomFileActionTest.delimiter).take(2).mkString(CustomFileActionTest.delimiter)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
@@ -25,7 +25,7 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.action.executionMode.FileIncrementalMoveMode
-import io.smartdatalake.workflow.connection.SftpFileRefConnection
+import io.smartdatalake.workflow.connection.SFtpFileRefConnection
 import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, FileSubFeed}
 import org.apache.commons.io.FileUtils
@@ -55,7 +55,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
 
   before {
     instanceRegistry.clear()
-    instanceRegistry.register(SftpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshUser))), ignoreHostKeyVerification = true))
+    instanceRegistry.register(SFtpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshUser))), ignoreHostKeyVerification = true))
   }
 
   test("copy file from sftp to hadoop without partitions") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
@@ -24,7 +24,7 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.ActionPipelineContext
-import io.smartdatalake.workflow.connection.SftpFileRefConnection
+import io.smartdatalake.workflow.connection.SFtpFileRefConnection
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.sshd.server.SshServer
@@ -55,7 +55,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
 
   override def beforeEach(): Unit = {
     registry.clear()
-    registry.register(SftpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshPwd))), ignoreHostKeyVerification = true))
+    registry.register(SFtpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshPwd))), ignoreHostKeyVerification = true))
     tempDir = Files.createTempDirectory("sftp-test")
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
@@ -236,7 +236,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     tgtDO.startWritingOutputStreams(fileRefPairs1.map(_.tgt.partitionValues))
     filetransfer1.exec(fileRefPairs1)
     val tgtFileRefs1 = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefs1.toSet == fileRefPairs1.map(_.tgt).toSet)
+    assert(tgtFileRefs1.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("AB_NYC_2019.csv1"))
 
     // src2 file transfer overwriting partition 2022
     val filetransfer2 = new StreamFileTransfer(srcDO2, tgtDO)
@@ -246,7 +246,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     tgtDO.startWritingOutputStreams(fileRefPairs2.map(_.tgt.partitionValues))
     filetransfer2.exec(fileRefPairs2)
     val tgtFileRefs2 = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefs2.toSet == fileRefPairs2.map(_.tgt).toSet)
+    assert(tgtFileRefs2.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("AB_NYC_2019.csv2"))
   }
 
   test("overwrite directory based partition") {
@@ -273,7 +273,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     tgtDO.startWritingOutputStreams(fileRefPairs1.map(_.tgt.partitionValues))
     filetransfer1.exec(fileRefPairs1)
     val tgtFileRefs1 = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefs1.toSet == fileRefPairs1.map(_.tgt).toSet)
+    assert(tgtFileRefs1.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("2022/AB_NYC_2019.csv1"))
 
     // src2 file transfer overwriting partition 2022
     val filetransfer2 = new StreamFileTransfer(srcDO2, tgtDO)
@@ -283,7 +283,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     tgtDO.startWritingOutputStreams(fileRefPairs2.map(_.tgt.partitionValues))
     filetransfer2.exec(fileRefPairs2)
     val tgtFileRefs2 = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefs2.toSet == fileRefPairs2.map(_.tgt).toSet)
+    assert(tgtFileRefs2.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("2022/AB_NYC_2019.csv2"))
   }
 
   test("overwrite directory and filename based partition") {
@@ -305,15 +305,15 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     // src1 file transfer
     val filetransfer1 = new StreamFileTransfer(srcDO1, tgtDO)
     val srcFileRefs1 = srcDO1.getFileRefs(Seq())
-    assert(srcFileRefs1.size==1)
+    assert(srcFileRefs1.map(f => srcDO1.relativizePath(f.fullPath)).toSet==Set("20220101/AB_NYC_2019.csv2"))
     val tgtFileRefs1 = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefs1.size==3)
+    assert(tgtFileRefs1.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_BN_2019.csv","20220101/AB_NYC_2019.csv1","20220201/AB_NYC_2019.csv"))
     val fileRefPairs1 = tgtDO.translateFileRefs(srcFileRefs1, Some("\\.csv.*".r)) // keep only filetype from source filename, the rest is handled as partition values...
     tgtDO.startWritingOutputStreams(fileRefPairs1.map(_.tgt.partitionValues))
     filetransfer1.exec(fileRefPairs1)
     val tgtFileRefs1after = tgtDO.getFileRefs(Seq(PartitionValues(Map("date"->"20220101","town"->"NYC","year"->"2019"))))
-    assert(tgtFileRefs1after.toSet == fileRefPairs1.map(_.tgt).toSet)
+    assert(tgtFileRefs1after.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_NYC_2019.csv2"))
     val tgtFileRefsFinal = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefsFinal.size == 3)
+    assert(tgtFileRefsFinal.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_BN_2019.csv","20220101/AB_NYC_2019.csv2","20220201/AB_NYC_2019.csv"))
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
@@ -21,6 +21,7 @@ package io.smartdatalake.workflow.dataobject
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions.BasicAuthMode
 import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.util.filetransfer.StreamFileTransfer
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -42,11 +43,13 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
   val sshPort = 8001
   val sshUser = "test"
   val sshPwd = "test"
+  var con: SFtpFileRefConnection = _
 
   var tempDir: Path = _
 
   override protected def beforeAll(): Unit = {
     sshd = TestUtil.setupSSHServer(sshPort, sshUser, sshPwd)
+    con = SFtpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshPwd))), ignoreHostKeyVerification = true, maxParallelConnections = 10)
   }
 
   override protected def afterAll(): Unit = {
@@ -55,7 +58,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
 
   override def beforeEach(): Unit = {
     registry.clear()
-    registry.register(SFtpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshPwd))), ignoreHostKeyVerification = true))
+    registry.register(con)
     tempDir = Files.createTempDirectory("sftp-test")
   }
 
@@ -115,14 +118,14 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
       , tempDir.resolve(ftpDir).toString.replace('\\','/')
       , connectionId = "con1"
       , partitions = Seq("town", "year")
-      , partitionLayout = Some("AB_%town%_%year%" ))
+      , partitionLayout = Some("AB_%town%_%year:[0-9]+%" ))
     val partitionValuesExpected = Seq(PartitionValues(Map("town" -> "NYC", "year" -> "2019")))
 
     // list all files and extract partitions
     val fileRefsAll = sftpDO.getFileRefs(Seq())
     assert(fileRefsAll.size == 1)
     assert(fileRefsAll.head.fileName == resourceFile)
-    assert(fileRefsAll.head.partitionValues.keys == Set("town","year"))
+    assert(fileRefsAll.head.partitionValues == partitionValuesExpected.head)
 
     // list with matched partition filter
     val fileRefsPartitionFilter = sftpDO.getFileRefs(partitionValuesExpected)
@@ -152,14 +155,14 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
       , tempDir.resolve(ftpDir).toString.replace('\\','/')
       , connectionId = "con1"
       , partitions = Seq("date", "town", "year")
-      , partitionLayout = Some("%date%/AB_%town%_%year%" ))
+      , partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%" ))
     val partitionValuesExpected = Seq(PartitionValues(Map("date" -> "20190101", "town" -> "NYC", "year" -> "2019")))
 
     // list all files and extract partitions
     val fileRefsAll = sftpDO.getFileRefs(Seq())
     assert(fileRefsAll.size == 1)
     assert(fileRefsAll.head.fileName == resourceFile)
-    assert(fileRefsAll.head.partitionValues.keys == Set("date","town","year"))
+    assert(fileRefsAll.head.partitionValues == partitionValuesExpected.head)
 
     // list with matched partition filter
     val fileRefsPartitionFilter = sftpDO.getFileRefs(partitionValuesExpected)
@@ -206,5 +209,111 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     )
     val fileRefs2 = sftpDO.getFileRefs(Seq())
     assert(fileRefs2.size == 2 && fileRefs2.map(_.fileName).forall(_.startsWith(resourceFile)))
+  }
+
+
+  test("overwrite target") {
+
+    val srcDir1 = "testSrc1"
+    val srcDir2 = "testSrc2"
+    val tgtDir = "testTgt"
+    val resourceFile = "AB_NYC_2019.csv"
+
+    // copy data file to ftp
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir1).resolve(resourceFile + "1").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir2).resolve(resourceFile + "2").toFile)
+
+    // setup DataObject
+    val srcDO1 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir1).toString.replace('\\', '/'), connectionId = "con1")
+    val srcDO2 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir2).toString.replace('\\', '/'), connectionId = "con1")
+    val tgtDO = SFtpFileRefDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), connectionId = "con1")
+
+    // src1 file transfer
+    val filetransfer1 = new StreamFileTransfer(srcDO1, tgtDO)
+    val srcFileRefs1 = srcDO1.getFileRefs(Seq())
+    assert(srcFileRefs1.nonEmpty)
+    val fileRefPairs1 = tgtDO.translateFileRefs(srcFileRefs1)
+    tgtDO.startWritingOutputStreams(fileRefPairs1.map(_.tgt.partitionValues))
+    filetransfer1.exec(fileRefPairs1)
+    val tgtFileRefs1 = tgtDO.getFileRefs(Seq())
+    assert(tgtFileRefs1.toSet == fileRefPairs1.map(_.tgt).toSet)
+
+    // src2 file transfer overwriting partition 2022
+    val filetransfer2 = new StreamFileTransfer(srcDO2, tgtDO)
+    val srcFileRefs2 = srcDO2.getFileRefs(Seq())
+    assert(srcFileRefs2.nonEmpty)
+    val fileRefPairs2 = tgtDO.translateFileRefs(srcFileRefs2)
+    tgtDO.startWritingOutputStreams(fileRefPairs2.map(_.tgt.partitionValues))
+    filetransfer2.exec(fileRefPairs2)
+    val tgtFileRefs2 = tgtDO.getFileRefs(Seq())
+    assert(tgtFileRefs2.toSet == fileRefPairs2.map(_.tgt).toSet)
+  }
+
+  test("overwrite directory based partition") {
+
+    val srcDir1 = "testSrc1"
+    val srcDir2 = "testSrc2"
+    val tgtDir = "testTgt"
+    val resourceFile = "AB_NYC_2019.csv"
+
+    // copy data file to ftp
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir1).resolve("2022").resolve(resourceFile+"1").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir2).resolve("2022").resolve(resourceFile+"2").toFile)
+
+    // setup DataObject
+    val srcDO1 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir1).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("year"), partitionLayout = Some("%year%/"))
+    val srcDO2 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir2).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("year"), partitionLayout = Some("%year%/"))
+    val tgtDO = SFtpFileRefDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("year"), partitionLayout = Some("%year%/"))
+
+    // src1 file transfer
+    val filetransfer1 = new StreamFileTransfer(srcDO1, tgtDO)
+    val srcFileRefs1 = srcDO1.getFileRefs(Seq())
+    assert(srcFileRefs1.nonEmpty)
+    val fileRefPairs1 = tgtDO.translateFileRefs(srcFileRefs1)
+    tgtDO.startWritingOutputStreams(fileRefPairs1.map(_.tgt.partitionValues))
+    filetransfer1.exec(fileRefPairs1)
+    val tgtFileRefs1 = tgtDO.getFileRefs(Seq())
+    assert(tgtFileRefs1.toSet == fileRefPairs1.map(_.tgt).toSet)
+
+    // src2 file transfer overwriting partition 2022
+    val filetransfer2 = new StreamFileTransfer(srcDO2, tgtDO)
+    val srcFileRefs2 = srcDO2.getFileRefs(Seq())
+    assert(srcFileRefs2.nonEmpty)
+    val fileRefPairs2 = tgtDO.translateFileRefs(srcFileRefs2)
+    tgtDO.startWritingOutputStreams(fileRefPairs2.map(_.tgt.partitionValues))
+    filetransfer2.exec(fileRefPairs2)
+    val tgtFileRefs2 = tgtDO.getFileRefs(Seq())
+    assert(tgtFileRefs2.toSet == fileRefPairs2.map(_.tgt).toSet)
+  }
+
+  test("overwrite directory and filename based partition") {
+
+    val srcDir1 = "testSrc1"
+    val tgtDir = "testTgt"
+    val resourceFile = "AB_NYC_2019.csv"
+
+    // copy data file to ftp
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir1).resolve("20220101").resolve(resourceFile + "2").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(tgtDir).resolve("20220101").resolve(resourceFile + "1").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(tgtDir).resolve("20220101").resolve("AB_BN_2019.csv").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(tgtDir).resolve("20220201").resolve(resourceFile).toFile)
+
+    // setup DataObject
+    val srcDO1 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir1).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("date","town","year"), partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%"))
+    val tgtDO = SFtpFileRefDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("date","town","year"), partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%"))
+
+    // src1 file transfer
+    val filetransfer1 = new StreamFileTransfer(srcDO1, tgtDO)
+    val srcFileRefs1 = srcDO1.getFileRefs(Seq())
+    assert(srcFileRefs1.size==1)
+    val tgtFileRefs1 = tgtDO.getFileRefs(Seq())
+    assert(tgtFileRefs1.size==3)
+    val fileRefPairs1 = tgtDO.translateFileRefs(srcFileRefs1, Some("\\.csv.*".r)) // keep only filetype from source filename, the rest is handled as partition values...
+    tgtDO.startWritingOutputStreams(fileRefPairs1.map(_.tgt.partitionValues))
+    filetransfer1.exec(fileRefPairs1)
+    val tgtFileRefs1after = tgtDO.getFileRefs(Seq(PartitionValues(Map("date"->"20220101","town"->"NYC","year"->"2019"))))
+    assert(tgtFileRefs1after.toSet == fileRefPairs1.map(_.tgt).toSet)
+    val tgtFileRefsFinal = tgtDO.getFileRefs(Seq())
+    assert(tgtFileRefsFinal.size == 3)
   }
 }

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -170,7 +170,10 @@ case class IcebergTableDataObject(override val id: DataObjectId,
       require(session.conf.getOption("spark.sql.extensions").toSeq.flatMap(_.split(',')).contains("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"),
         s"($id) Iceberg spark properties are missing. Please set spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions and org.apache.iceberg.spark.SparkSessionCatalog")
     }
-    require(isDbExisting, s"($id) DB ${table.db.get} doesn't exist (needs to be created manually).")
+    if(!isDbExisting) {
+      // DB (schema) is created automatically by iceberg when creatig tables. But we would like to keep the same behaviour as done by spark_catalog, where only default DB is existing, and others must be created manually.
+      require(table.db.contains("default"), s"($id) DB ${table.db.get} doesn't exist (needs to be created manually).")
+    }
     if (!isTableExisting) {
       require(path.isDefined, s"($id) If DeltaLake table does not exist yet, path must be set.")
       if (filesystem.exists(hadoopPath)) {

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -171,7 +171,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
         s"($id) Iceberg spark properties are missing. Please set spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions and org.apache.iceberg.spark.SparkSessionCatalog")
     }
     if(!isDbExisting) {
-      // DB (schema) is created automatically by iceberg when creatig tables. But we would like to keep the same behaviour as done by spark_catalog, where only default DB is existing, and others must be created manually.
+      // DB (schema) is created automatically by iceberg when creating tables. But we would like to keep the same behaviour as done by spark_catalog, where only default DB is existing, and others must be created manually.
       require(table.db.contains("default"), s"($id) DB ${table.db.get} doesn't exist (needs to be created manually).")
     }
     if (!isTableExisting) {

--- a/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
+++ b/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
@@ -58,6 +58,7 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter {
     val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable)
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
+    targetDO.prepare
 
     // prepare & start load
     val testAction = CopyAction(id = s"load", inputId = sourceDO.id, outputId = targetDO.id)

--- a/sdl-lang/src/test/scala/io/smartdatalake/lab/LabCatalogGeneratorTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/lab/LabCatalogGeneratorTest.scala
@@ -19,7 +19,7 @@
 
 package io.smartdatalake.lab
 
-import io.smartdatalake.util.misc.TryWithRessource
+import io.smartdatalake.util.misc.WithResource
 import org.scalatest.FunSuite
 
 import java.nio.file.{Files, Paths}
@@ -34,7 +34,7 @@ class LabCatalogGeneratorTest extends FunSuite {
     LabCatalogGenerator.generateDataObjectCatalog(config)
     val path = Paths.get(s"$srcDir/${packageName.split('.').mkString("/")}/$className.scala")
     assert(Files.exists(path))
-    assert(TryWithRessource.execSource(Source.fromFile(path.toFile)) {
+    assert(WithResource.execSource(Source.fromFile(path.toFile)) {
       x => x.getLines.exists(_.contains("dataObjectParquet12"))
     })
   }


### PR DESCRIPTION
### What changes are included in the pull request?
Many smaller improvements:
- make more APIs public to simplify extending SDLB and debugging in notebooks easier
- implement proxy support for SftpFileRefConnection
- rename SftpFileRefConnection -> SFtpFileRefConnection (this is not backward compatible, but also not widely used)
- FileTransferAction: implement transfer of multiple files in parallel 
- improve SFtp write support: parallelization, partition layout including file names
- fix duplicate close in WithResource, cleanup naming TryWithRessource … 
- implement GlobalConfig.allowAsRecursiveInput (#638)
- FtpFileRefConnection: fix createSshClient lazy
- SFtpFileRefConnection: fix keeping idle connections in pool
- FileTransferAction: improve logging
- fix SFtpFileRefDataObject.createOutputStream overwrite
- Let Iceberg create default catalog automatically 