### PR TITLE
Feature/571 stringorsecret fixes

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/GlobalConfig.scala
@@ -26,7 +26,7 @@ import io.smartdatalake.config.ConfigImplicits
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.misc.{LogUtil, MemoryUtils, SmartDataLakeLogger}
-import io.smartdatalake.util.secrets.{SecretProviderConfig, SecretsUtil}
+import io.smartdatalake.util.secrets.{SecretProviderConfig, SecretsUtil, StringOrSecret}
 import io.smartdatalake.workflow.action.spark.customlogic.{PythonUDFCreatorConfig, SparkUDFCreatorConfig}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.SparkSession
@@ -68,7 +68,7 @@ import org.apache.spark.util.PrivateAccessor
  * @param environment    Override environment settings defined in Environment object by setting the corresponding key to the desired value (key in camelcase notation with the first letter in lowercase)
  */
 case class GlobalConfig(kryoClasses: Option[Seq[String]] = None
-                        , sparkOptions: Option[Map[String, String]] = None
+                        , sparkOptions: Option[Map[String, StringOrSecret]] = None
                         , statusInfo: Option[StatusInfoConfig] = None
                         , enableHive: Boolean = true
                         , memoryLogTimer: Option[MemoryLogTimerConfig] = None
@@ -98,12 +98,14 @@ extends SmartDataLakeLogger {
     SecretsUtil.registerProvider(id, providerConfig.provider)
   }
 
+  val resolvedSparkOptions: Option[Map[String, String]] = sparkOptions.map(_.mapValues(_.resolve()))
+
   /**
    * Get Hadoop configuration as Spark would see it.
    * This is using potential hadoop properties defined in sparkOptions.
    */
   def getHadoopConfiguration: Configuration = {
-    PrivateAccessor.getHadoopConfiguration(sparkOptions.getOrElse(Map()))
+    PrivateAccessor.getHadoopConfiguration(resolvedSparkOptions.getOrElse(Map()))
   }
 
   /**
@@ -112,14 +114,14 @@ extends SmartDataLakeLogger {
   private def createSparkSession(appName: String, master: Option[String], deployMode: Option[String] = None): SparkSession = {
     // prepare additional spark options
     // enable MemoryLoggerExecutorPlugin if memoryLogTimer is enabled
-    val executorPlugins = sparkOptions.flatMap(_.get("spark.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq())
+    val executorPlugins = resolvedSparkOptions.flatMap(_.get("spark.plugins")).toSeq ++ (if (memoryLogTimer.isDefined) Seq(classOf[MemoryLoggerExecutorPlugin].getName) else Seq())
     val executorPluginOptions = if (executorPlugins.nonEmpty) Map("spark.executor.plugins" -> executorPlugins.mkString(",")) else Map[String, String]()
     // config for MemoryLoggerExecutorPlugin can only be transferred to Executor by spark-options
     val memoryLogOptions = memoryLogTimer.map(_.getAsMap).getOrElse(Map())
     // get additional options from modules
     val moduleOptions = ModulePlugin.modules.map(_.additionalSparkProperties()).reduceOption(mergeSparkOptions).getOrElse(Map())
     // combine all options: custom options will override framework options
-    val sparkOptionsExtended = Seq(moduleOptions, memoryLogOptions, executorPluginOptions).reduceOption(mergeSparkOptions).getOrElse(Map()) ++ sparkOptions.getOrElse(Map())
+    val sparkOptionsExtended = Seq(moduleOptions, memoryLogOptions, executorPluginOptions).reduceOption(mergeSparkOptions).getOrElse(Map()) ++ resolvedSparkOptions.getOrElse(Map())
     val sparkSession = AppUtil.createSparkSession(appName, master, deployMode, kryoClasses, sparkOptionsExtended, enableHive)
     registerUdf(sparkSession)
     // adjust log level
@@ -152,7 +154,7 @@ extends SmartDataLakeLogger {
   def hasSparkSession: Boolean = _sparkSession.isDefined
 
   private[smartdatalake] def setSparkOptions(session:SparkSession): Unit = {
-    sparkOptions.getOrElse(Map()).foreach{ case (k,v) => session.conf.set(k,v)}
+    resolvedSparkOptions.getOrElse(Map()).foreach{ case (k,v) => session.conf.set(k,v)}
   }
 
   private[smartdatalake] def registerUdf(session: SparkSession): Unit = {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/secrets/StringOrSecret.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/secrets/StringOrSecret.scala
@@ -31,7 +31,10 @@ case class StringOrSecret(private val secret: String) {
   /**
    * Resolves the secret, if necessary by retrieving it from a secret provider.
    */
-  def resolve(): String = {
-    SecretsUtil.resolveSecret(secret)
-  }
+  def resolve(): String = SecretsUtil.resolveSecret(secret)
+
+  /**
+   * Representation of the secret. Secrets from providers are not resolved.
+   */
+  override def toString: String = secret
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/app/GlobalConfigTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/GlobalConfigTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.app
+
+import io.smartdatalake.util.secrets.{SecretProvider, SecretProviderConfig, StringOrSecret}
+import org.scalatest.FunSuite
+
+class GlobalConfigTest extends FunSuite {
+  test("sparkOptions secrets are resolved") {
+    // prepare
+    val providerConfig = SecretProviderConfig(classOf[TestSecretProvider].getName, Some(Map()))
+
+    // execute
+    val globalConfig = GlobalConfig(sparkOptions = Some(Map("option" -> StringOrSecret("###TESTPROVIDER#secret###"))),
+      secretProviders = Some(Map("TESTPROVIDER" -> providerConfig)))
+
+    // check
+    assert(globalConfig.resolvedSparkOptions.get("option") == "resolvedSecret")
+  }
+}
+
+class TestSecretProvider(options: Map[String, String]) extends SecretProvider {
+  override def getSecret(name: String): String = {
+    name match {
+      case "secret" => "resolvedSecret"
+      case _ => throw new IllegalArgumentException("Secret cannot be resolved")
+    }
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -32,6 +32,7 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.spark.DataFrameUtil.{DfSDL, defaultPersistDf}
 import io.smartdatalake.util.misc.{SerializableHadoopConfiguration, SmartDataLakeLogger}
+import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.action.SDLExecutionId
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
@@ -57,10 +58,10 @@ import scala.util.Try
  */
 object TestUtil extends SmartDataLakeLogger {
 
-  def sparkSessionBuilder(withHive : Boolean = false, additionalSparkProperties: Map[String,String] = Map()) : SparkSession.Builder = {
+  def sparkSessionBuilder(withHive : Boolean = false, additionalSparkProperties: Map[String,StringOrSecret] = Map()) : SparkSession.Builder = {
     // create builder
     val builder = additionalSparkProperties.foldLeft(SparkSession.builder()) {
-      case (builder, config) => builder.config(config._1, config._2)
+      case (builder, config) => builder.config(config._1, config._2.resolve())
     }
       .config("hive.exec.dynamic.partition", "true")
       .config("hive.exec.dynamic.partition.mode", "nonstrict")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -96,7 +96,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
 
     val globalConfig = GlobalConfig.from(config)
     implicit val instanceRegistry: InstanceRegistry = ConfigParser.parse(config)
-    implicit val session: SparkSession = sparkSessionBuilder(withHive = true, globalConfig.resolvedSparkOptions.getOrElse(Map())).getOrCreate()
+    implicit val session: SparkSession = sparkSessionBuilder(withHive = true, globalConfig.sparkOptions.getOrElse(Map())).getOrCreate()
     import session.implicits._
 
     implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -96,7 +96,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
 
     val globalConfig = GlobalConfig.from(config)
     implicit val instanceRegistry: InstanceRegistry = ConfigParser.parse(config)
-    implicit val session: SparkSession = sparkSessionBuilder(withHive = true, globalConfig.sparkOptions.getOrElse(Map())).getOrCreate()
+    implicit val session: SparkSession = sparkSessionBuilder(withHive = true, globalConfig.resolvedSparkOptions.getOrElse(Map())).getOrCreate()
     import session.implicits._
 
     implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
@@ -172,7 +172,7 @@ private[smartdatalake] object JsonSchemaUtil extends SmartDataLakeLogger {
               val subTypeCls = t.typeArgs.head.typeSymbol.asClass
               JsonArrayDef(convertToJsonType(subTypeCls.toType), description, deprecated = isDeprecated)
             // map with key=String and value=StringOrSecret
-            case 2 if t.typeArgs.head.typeSymbol.asType.toType =:= typeOf[String] || t.typeArgs.last.typeSymbol.asType.toType =:= typeOf[StringOrSecret] =>
+            case 2 if t.typeArgs.head.typeSymbol.asType.toType =:= typeOf[String] && t.typeArgs.last.typeSymbol.asType.toType =:= typeOf[StringOrSecret] =>
               JsonMapDef(additionalProperties = convertToJsonType(typeOf[StringOrSecret]), description = Some(addSecretScaladocToDescription(description)), deprecated = isDeprecated)
             // map with key=String
             case 2 if t.typeArgs.head.typeSymbol.asType.toType =:= typeOf[String] || t.typeArgs.head.typeSymbol.asType.toType <:< typeOf[ConfigObjectId] =>

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
@@ -167,7 +167,17 @@ class JsonTypeConverterTest extends FunSuite {
     assert(jsonTypeDef.properties("options").isInstanceOf[JsonMapDef])
     assert(jsonTypeDef.properties("options").asInstanceOf[JsonMapDef].description.get.contains("```###<PROVIDERID>#<SECRETNAME>###```"))
   }
-  
+
+  case class TestClassWithoutSecretsInOptions(options: Map[String, String])
+  test("Map without StringOrSecret values has no additional description") {
+    val typeDef = getGenericTypeDef(typeOf[TestClassWithoutSecretsInOptions])
+
+    val jsonTypeDef = jsonTypeConverter.fromGenericTypeDef(typeDef)
+
+    assert(jsonTypeDef.properties("options").isInstanceOf[JsonMapDef])
+    assert(jsonTypeDef.properties("options").asInstanceOf[JsonMapDef].description.isEmpty)
+  }
+
   private def getGenericTypeDef(tpe: Type, baseType: Option[Type] = None): GenericTypeDef = {
     val attributes = attributesForCaseClass(tpe, Map())
     GenericTypeDef("testTypeDef", baseType, tpe, None, true, Set(), attributes)

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
@@ -21,7 +21,6 @@ package io.smartdatalake.meta.jsonschema
 
 import io.smartdatalake.config.{FromConfigFactory, SdlConfigObject}
 import io.smartdatalake.config.SdlConfigObject.{ActionId, ConfigObjectId, ConnectionId, DataObjectId}
-import io.smartdatalake.definitions.BasicAuthMode
 import io.smartdatalake.meta.GenericTypeDef
 import io.smartdatalake.meta.GenericTypeUtil.attributesForCaseClass
 import io.smartdatalake.util.secrets.StringOrSecret


### PR DESCRIPTION
Some fixes/improvements for `StringOrSecret`

1. Maps which do not contain `StringOrSecret` are no longer marked as containing secretes in the JSON schema
2. sparkOptions can now also contain secrets
