### PR TITLE
Resolve secrets in KafkaConnection (#571)

### DIFF
--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
@@ -50,8 +50,8 @@ case class KafkaConnection(override val id: ConnectionId,
 
   @transient private lazy val adminClient = {
     val props = new Properties()
-    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
-    authProps.asScala.foreach { case (k, v) => props.put(k, v) }
+    props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+    authProps.asScala.foreach { case (k, v) => props.setProperty(k, v) }
     AdminClient.create(props)
   }
 
@@ -65,22 +65,22 @@ case class KafkaConnection(override val id: ConnectionId,
     val props = new Properties()
     authMode match {
       case Some(m: SSLCertsAuthMode) => {
-        props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, KafkaSSLSecurityProtocol)
-        props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, m.keystorePath)
-        props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, m.keystorePassSecret)
-        props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, m.keystoreType.getOrElse(SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE))
-        props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, m.truststorePath)
-        props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, m.truststorePassSecret)
-        props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, m.truststoreType.getOrElse(SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE))
+        props.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, KafkaSSLSecurityProtocol)
+        props.setProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, m.keystorePath)
+        props.setProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, m.keystorePassSecret.resolve())
+        props.setProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, m.keystoreType.getOrElse(SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE))
+        props.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, m.truststorePath)
+        props.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, m.truststorePassSecret.resolve())
+        props.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, m.truststoreType.getOrElse(SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE))
       }
      case Some(m: SASLSCRAMAuthMode) => {
-        props.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, KafkaSASLSSLSecurityProtocol)
-        props.put("sasl.mechanism", m.sslMechanism)
-        props.put("sasl.jaas.config", "org.apache.kafka.common.security.scram.ScramLoginModule required username=\""
+        props.setProperty(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, KafkaSASLSSLSecurityProtocol)
+        props.setProperty("sasl.mechanism", m.sslMechanism)
+        props.setProperty("sasl.jaas.config", "org.apache.kafka.common.security.scram.ScramLoginModule required username=\""
           + m.username + "\" password=\"" + m.passwordSecret + "\";")
-        props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, m.truststorePath)
-        props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, m.truststorePassSecret)
-        props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, m.truststoreType.getOrElse(SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE))
+        props.setProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, m.truststorePath)
+        props.setProperty(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, m.truststorePassSecret.resolve())
+        props.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, m.truststoreType.getOrElse(SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE))
       }
       case Some(m) => throw ConfigurationException(s"${m.getClass.getSimpleName} is not supported for ${getClass.getSimpleName}")
       case None => Unit


### PR DESCRIPTION
* StringOrSecret variables are now correctly resolved in KafkaConnection
* Use `Properties.setProperty` instead of `Properties.put` in KafkaConnection because `Properties.put` is not typesafe
