### PR TITLE
Bugfix/648 update getting started docu

### DIFF
--- a/docs/getting-started/part-1/get-departures.md
+++ b/docs/getting-started/part-1/get-departures.md
@@ -67,7 +67,7 @@ This data object acts as a target for our first action, so where and how to down
 We set type to JsonFileDataObject because we know from before that the webservice will return a json file.
 Path defines where the file will be stored. You could choose any name you want, but most of the time, the name of your DataObject is a good fit.
 Instead of writing *stg-departures* again,
-we used the placeholder *{~id}* which gets replaced by the DataObject-ID. Don't forget to surround that placeholder
+we used the placeholder *~{id}* which gets replaced by the DataObject-ID. Don't forget to surround that placeholder
 with double quotes so that it is interpreted as a string.
 We defined a relative path - it is relative to the working directory SDL is started in. 
 The working directory has been set to the *data* directory in the Dockerfile by setting the JVM Property 

--- a/docs/getting-started/part-2/historical-data.md
+++ b/docs/getting-started/part-2/historical-data.md
@@ -98,7 +98,7 @@ It has millisecond precision, but the timestamp value is set to the current time
 The two attributes show the time period in which an object with this combination of attribute values has existed in our data source. 
 The sampling rate is given by the frequency that our data pipeline is scheduled.
 
-    dataIntAirports.getDataFrame().printSchema
+    dataIntAirports.getSparkDataFrame().printSchema
 
     root
     |-- ident: string (nullable = true)
@@ -110,7 +110,7 @@ The sampling rate is given by the frequency that our data pipeline is scheduled.
 
 If you look at the data, there should be only one record per object for now, as we didn't run our data pipeline with historical data yet.
 
-    dataIntAirports.getDataFrame().orderBy($"ident",$"dl_ts_captured").show
+    dataIntAirports.getSparkDataFrame().orderBy($"ident",$"dl_ts_captured").show
 
     +-----+--------------------+------------------+-------------------+--------------------+-------------------+
     |ident|                name|      latitude_deg|      longitude_deg|      dl_ts_captured|    dl_ts_delimited|
@@ -132,7 +132,7 @@ Afterwards, start actions `download-airports` and `historize-airports` by using 
 
 Now check in Polynote again and you'll find several airports that have changed between the intitial and the current state:
 
-    dataIntAirports.getDataFrame()
+    dataIntAirports.getSparkDataFrame()
     .groupBy($"ident").count
     .orderBy($"count".desc)
     .show
@@ -149,7 +149,7 @@ Now check in Polynote again and you'll find several airports that have changed b
 
 When checking the details it seems that for many airports the number of significant digits was reduced for the position:
 
-    dataIntAirports.getDataFrame()
+    dataIntAirports.getSparkDataFrame()
     .where($"ident"==="CDV3")
     .show(false)
     
@@ -238,7 +238,7 @@ podman run --rm --hostname=localhost -v ${PWD}/data:/mnt/data -v ${PWD}/target:/
 After successful execution you can check the schema and data of our table in Polynote. 
 The new column `dl_ts_captured` shows the current time of the data pipeline run when this object first occurred in the input data. 
 
-    dataIntDepartures.getDataFrame().printSchema
+    dataIntDepartures.getSparkDataFrame().printSchema
 
     root
     |-- arrivalairportcandidatescount: long (nullable = true)
@@ -258,7 +258,7 @@ The new column `dl_ts_captured` shows the current time of the data pipeline run 
 
 We can check the work of DeduplicateAction by the following query in Polynote: 
 
-    dataIntDepartures.getDataFrame()
+    dataIntDepartures.getSparkDataFrame()
     .groupBy($"icao24", $"estdepartureairport", $"dt")
     .count
     .orderBy($"count".desc)

--- a/docs/getting-started/part-3/custom-webservice.md
+++ b/docs/getting-started/part-3/custom-webservice.md
@@ -152,9 +152,9 @@ Having a look at the log, something similar should appear on your screen.
 ```
 
 It is important to notice that the two requests for each airport to the API were not send only once, but twice. 
-This stems from the fact that the method `getDataFrame` of the Data Object is called twice in the DAG execution of the Smart Data Lake Builder: 
+This stems from the fact that the method `getSparkDataFrame` of the Data Object is called twice in the DAG execution of the Smart Data Lake Builder: 
 Once during the Init Phase and once again during the Exec Phase. See [this page](/docs/reference/executionPhases) for more information on that. 
-Before we address and mitigate this behaviour in the next section, let's have a look at the `getDataFrame` method and the currently implemented logic:
+Before we address and mitigate this behaviour in the next section, let's have a look at the `getSparkDataFrame` method and the currently implemented logic:
 
 ```Scala
 // use the queryParameters from the config
@@ -187,7 +187,7 @@ We used such a column based function *from_json* to parse the response string wi
 At the end we return the freshly created data frame `departuresDf`.
 
 :::tip
-The return type of the response is `Array[Byte]`. To convert that to `Array[String]` a *User Defined Function* (also called *UDF*) `byte2String` has been used, which is declared inside the getDataFrame method.
+The return type of the response is `Array[Byte]`. To convert that to `Array[String]` a *User Defined Function* (also called *UDF*) `byte2String` has been used, which is declared inside the getSparkDataFrame method.
 This function is a nice example of how to write your own *UDF*.
 :::
 


### PR DESCRIPTION
See: https://github.com/smart-data-lake/smart-data-lake/issues/648

The following changes have been done:
 - Placeholder id replaced in text with ~{id}
 - In the Getting Started Documentation the DeltaLakeTableDataObject function getSparkDataFrame() is used instead of the old                                       function getDataFrame()

