### PR TITLE
Added - check if all files provided as part of the config actually exist

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -97,12 +97,10 @@ object ConfigLoader extends SmartDataLakeLogger {
         else
           try {
             var fs = location.getFileSystem(hadoopConf)
-            if(fs.getFileStatus(location).isDirectory) {
-              if(!RemoteIteratorWrapper(fs.listFiles(location, true)).exists(path =>
+            if(fs.getFileStatus(location).isDirectory & !RemoteIteratorWrapper(fs.listFiles(location, true)).exists(path =>
                 configFileExtensions.contains(path.getPath.toUri.toString.split("\\.").last)
               ))
                 throw ConfigurationException(s"The provided directory path ${location.toUri.getPath} does not contain any valid config files")
-            }
             getFilesInBfsOrder(location)(location.getFileSystem(hadoopConf))
           } catch {
             case exception: FileNotFoundException => throw ConfigurationException(s"The provided config file does not exist or the provided directory is empty:  ${location.toUri.getPath}", None, exception)

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -100,7 +100,7 @@ object ConfigLoader extends SmartDataLakeLogger {
             if (files.isEmpty){
               throw ConfigurationException(s"The provided directory path ${location.toUri.getPath} does not contain any valid config files")
             }
-            getFilesInBfsOrder(location)(location.getFileSystem(hadoopConf))
+            files
           } catch {
             case exception: FileNotFoundException => throw ConfigurationException(s"The provided config file does not exist or the provided directory is empty:  ${location.toUri.getPath}", None, exception)
          }

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -96,12 +96,11 @@ object ConfigLoader extends SmartDataLakeLogger {
           Seq(ClasspathConfigFile(location))
         else
           try {
-            var fs = location.getFileSystem(hadoopConf)
-            if(fs.getFileStatus(location).isDirectory & !RemoteIteratorWrapper(fs.listFiles(location, true)).exists(path =>
-                configFileExtensions.contains(path.getPath.toUri.toString.split("\\.").last)
-              ))
-                throw ConfigurationException(s"The provided directory path ${location.toUri.getPath} does not contain any valid config files")
-            getFilesInBfsOrder(location)(location.getFileSystem(hadoopConf))
+            val files = getFilesInBfsOrder(location)(location.getFileSystem(hadoopConf))
+            if (files.isEmpty){
+              throw ConfigurationException(s"The provided directory path ${location.toUri.getPath} does not contain any valid config files")
+            }
+            files
           } catch {
             case exception: FileNotFoundException => throw ConfigurationException(s"The provided config file does not exist or the provided directory is empty:  ${location.toUri.getPath}", None, exception)
          }

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigLoader.scala
@@ -100,7 +100,7 @@ object ConfigLoader extends SmartDataLakeLogger {
             if (files.isEmpty){
               throw ConfigurationException(s"The provided directory path ${location.toUri.getPath} does not contain any valid config files")
             }
-            files
+            getFilesInBfsOrder(location)(location.getFileSystem(hadoopConf))
           } catch {
             case exception: FileNotFoundException => throw ConfigurationException(s"The provided config file does not exist or the provided directory is empty:  ${location.toUri.getPath}", None, exception)
          }

--- a/sdl-core/src/test/resources/config/empty/file.txt
+++ b/sdl-core/src/test/resources/config/empty/file.txt
@@ -1,0 +1,20 @@
+====
+    Smart Data Lake - Build your data lake the smart way.
+
+    Copyright © 2019-2020 ELCA Informatique SA (<https://www.elca.ch>)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+====
+
+noconfig = file

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -62,8 +62,12 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
     an [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("foo/bar"), defaultHadoopConf)
   }
 
+  it must "fail if provided directory is empty" in {
+    an[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config").toURI.toString + "/emptydirectory"), defaultHadoopConf)
+  }
+
   it must "fail if no configuration files are found for any location provided location in the Sequence" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/error.conf"), defaultHadoopConf)
+    //a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/error.conf"), defaultHadoopConf)
     a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/empty"), defaultHadoopConf)
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -62,6 +62,10 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
     an [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("foo/bar"), defaultHadoopConf)
   }
 
+  it must "fail if no configuration files are found for any location provided location in the Sequence" in {
+    an[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, "file:/config/error.conf"), defaultHadoopConf)
+  }
+
   it must "fail parsing a non-existing classpath entry" in {
     a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar.conf"), defaultHadoopConf)
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -67,7 +67,7 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
   }
 
   it must "fail if no configuration files are found for any location provided location in the Sequence" in {
-    //a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/error.conf"), defaultHadoopConf)
+    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/error.conf"), defaultHadoopConf)
     a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/empty"), defaultHadoopConf)
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -63,7 +63,8 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
   }
 
   it must "fail if no configuration files are found for any location provided location in the Sequence" in {
-    an[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, "file:/config/error.conf"), defaultHadoopConf)
+    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/error.conf"), defaultHadoopConf)
+    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/empty"), defaultHadoopConf)
   }
 
   it must "fail parsing a non-existing classpath entry" in {


### PR DESCRIPTION
This contribution is linked to the following issue: https://github.com/smart-data-lake/smart-data-lake/issues/653

### What changes are included in the pull request?
- This pull requests includes updated to the ConfigLoader class. As part of this change it is checked if all config files included in a sequence exist. If not a ConfigurationException is thrown.
- A test is added to validate the expected behaviour.

### Why are the changes needed?
- Until now no error has been shown if in a sequence of config files a invalid config files has been provided. 
