### PR TITLE
Trim enum name when creating json schema

### DIFF
--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
@@ -184,7 +184,7 @@ private[smartdatalake] object JsonSchemaUtil extends SmartDataLakeLogger {
         case t: TypeRef if t.pre <:< typeOf[Enumeration] =>
           val enumValues = t.pre.members.filter(m => !m.isMethod && !m.isType  && m.typeSignature.typeSymbol.name.toString == "Value")
           assert(enumValues.nonEmpty, s"Enumeration values for ${t.typeSymbol.fullName} not found")
-          JsonStringDef(description, enum = Some(enumValues.map(_.name.toString).toSeq), deprecated = isDeprecated)
+          JsonStringDef(description, enum = Some(enumValues.map(_.name.toString.trim).toSeq), deprecated = isDeprecated)
         case t if t.typeSymbol.asClass.isJavaEnum =>
           // we assume that if a java enum is an inner class, it's parent starts with capital letter. In that case it has to be separated by '$' instead of '.' to be found by Java classloader.
           val classNamePartsIterator = t.typeSymbol.fullName.split("\\.")

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
@@ -23,6 +23,7 @@ import io.smartdatalake.config.{FromConfigFactory, SdlConfigObject}
 import io.smartdatalake.config.SdlConfigObject.{ActionId, ConfigObjectId, ConnectionId, DataObjectId}
 import io.smartdatalake.meta.GenericTypeDef
 import io.smartdatalake.meta.GenericTypeUtil.attributesForCaseClass
+import io.smartdatalake.meta.jsonschema.TestEnum.TestEnum
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.connection.{Connection, ConnectionMetadata}
 import io.smartdatalake.workflow.dataobject.{DataObject, DataObjectMetadata}
@@ -181,4 +182,21 @@ class JsonTypeConverterTest extends FunSuite {
     val attributes = attributesForCaseClass(tpe, Map())
     GenericTypeDef("testTypeDef", baseType, tpe, None, true, Set(), attributes)
   }
+
+  case class TestClassWithEnum(testEnum: TestEnum)
+  test("convert scala enum to json enum") {
+    val typeDef = getGenericTypeDef(typeOf[TestClassWithEnum])
+
+    val jsonTypeDef = jsonTypeConverter.fromGenericTypeDef(typeDef)
+
+    assert(jsonTypeDef.properties("testEnum").isInstanceOf[JsonStringDef])
+    val jsonEnum = jsonTypeDef.properties("testEnum").asInstanceOf[JsonStringDef]
+    assert(jsonEnum.enum.get.toSet == Set("firstValue", "secondValue"))
+   }
+}
+
+object TestEnum extends Enumeration {
+  type TestEnum = Value
+  val firstValue = Value("firstValue")
+  val secondValue = Value("secondValue")
 }


### PR DESCRIPTION
Somehow, the enum values we get by calling `name` on the respective type have a trailing whitespace. This affects the generated JSON schema, for example: 

```
          "saveMode": {
            "type": "string",
            "description": "Overwrite or Append new data.\nWhen writing partitioned data, this applies only to partitions concerned.",
            "enum": [
              "Merge ",
              "OverwriteOptimized ",
              "OverwritePreserveDirectories ",
              "Ignore ",
              "ErrorIfExists ",
              "Append ",
              "Overwrite "
            ]
          },
```
