### PR TITLE
Feature/transformer not deprecated

### DIFF
--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/GenericTypeUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/GenericTypeUtil.scala
@@ -6,6 +6,7 @@ import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.action.executionMode.ExecutionMode
 import io.smartdatalake.workflow.action.generic.transformer.{GenericDfTransformer, GenericDfsTransformer, ValidationRule}
 import io.smartdatalake.workflow.action.script.ParsableScriptDef
+import io.smartdatalake.workflow.action.spark.customlogic.CustomDfTransformerConfig
 import io.smartdatalake.workflow.action.{Action, ActionMetadata}
 import io.smartdatalake.workflow.connection.{Connection, ConnectionMetadata}
 import io.smartdatalake.workflow.dataobject.{DataObject, DataObjectMetadata, HousekeepingMode, Table}
@@ -40,7 +41,8 @@ private[smartdatalake] object GenericTypeUtil extends SmartDataLakeLogger {
     typeOf[HousekeepingMode],
     typeOf[AuthMode],
     typeOf[ValidationRule],
-    typeOf[SaveModeOptions]
+    typeOf[SaveModeOptions],
+    typeOf[CustomDfTransformerConfig]
   )
 
   def getReflections = new Reflections("io.smartdatalake")

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
@@ -153,7 +153,7 @@ private[smartdatalake] object JsonSchemaUtil extends SmartDataLakeLogger {
           if (refDefs.size > 1) JsonOneOfDef(refDefs, description, deprecated = isDeprecated)
           else refDefs.head
         }
-        case t if registry.typeExists(t) => registry.getJsonRefDef(t)
+        case t if registry.typeExists(t) => registry.getJsonRefDef(t, isDeprecated)
         case t if t <:< typeOf[Product] => fromCaseClass(t.typeSymbol.asClass)
         case t if t <:< typeOf[ParsableFromConfig[_]] =>
           val baseCls = getClass.getClassLoader.loadClass(t.typeSymbol.fullName)
@@ -232,10 +232,10 @@ private[smartdatalake] class DefinitionRegistry() {
   def getJsonRefDef(baseType: Option[Type], tpe: Type): JsonRefDef = {
     JsonRefDef(s"#/definitions/${getDefinitionName(baseType, tpe.typeSymbol.name.toString)}")
   }
-  def getJsonRefDef(tpe: Type): JsonRefDef = {
+  def getJsonRefDef(tpe: Type, isDeprecated: Option[Boolean]): JsonRefDef = {
     val baseType = entries.flatMap { case (baseType, typeDefs) => typeDefs.keys.map( typeDef => (typeDef, baseType))}
       .find(_._1 == tpe).get._2
-    JsonRefDef(s"#/definitions/${getDefinitionName(baseType, tpe.typeSymbol.name.toString)}")
+    JsonRefDef(s"#/definitions/${getDefinitionName(baseType, tpe.typeSymbol.name.toString)}", deprecated = isDeprecated)
   }
   def getDefinitionMap: Map[String, ListMap[String, JsonTypeDef]] = {
     entries.map {

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
@@ -184,7 +184,7 @@ private[smartdatalake] object JsonSchemaUtil extends SmartDataLakeLogger {
         case t: TypeRef if t.pre <:< typeOf[Enumeration] =>
           val enumValues = t.pre.members.filter(m => !m.isMethod && !m.isType  && m.typeSignature.typeSymbol.name.toString == "Value")
           assert(enumValues.nonEmpty, s"Enumeration values for ${t.typeSymbol.fullName} not found")
-          JsonStringDef(description, enum = Some(enumValues.map(_.name.toString).toSeq), deprecated = isDeprecated)
+          JsonStringDef(description, enum = Some(enumValues.map(_.name.toString.trim).toSeq), deprecated = isDeprecated)
         case t if t.typeSymbol.asClass.isJavaEnum =>
           // we assume that if a java enum is an inner class, it's parent starts with capital letter. In that case it has to be separated by '$' instead of '.' to be found by Java classloader.
           val classNamePartsIterator = t.typeSymbol.fullName.split("\\.")

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
@@ -23,6 +23,7 @@ import io.smartdatalake.config.{FromConfigFactory, SdlConfigObject}
 import io.smartdatalake.config.SdlConfigObject.{ActionId, ConfigObjectId, ConnectionId, DataObjectId}
 import io.smartdatalake.meta.GenericTypeDef
 import io.smartdatalake.meta.GenericTypeUtil.attributesForCaseClass
+import io.smartdatalake.meta.jsonschema.TestEnum.TestEnum
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.connection.{Connection, ConnectionMetadata}
 import io.smartdatalake.workflow.dataobject.{DataObject, DataObjectMetadata}
@@ -181,4 +182,21 @@ class JsonTypeConverterTest extends FunSuite {
     val attributes = attributesForCaseClass(tpe, Map())
     GenericTypeDef("testTypeDef", baseType, tpe, None, true, Set(), attributes)
   }
+
+  case class TestClassWithEnum(testEnum: TestEnum)
+  test("convert scala enum to json enum") {
+    val typeDef = getGenericTypeDef(typeOf[TestClassWithEnum])
+
+    val jsonTypeDef = jsonTypeConverter.fromGenericTypeDef(typeDef)
+
+    assert(jsonTypeDef.properties("testEnum").isInstanceOf[JsonStringDef])
+    val jsonEnum = jsonTypeDef.properties("testEnum").asInstanceOf[JsonStringDef]
+    assert(jsonEnum.enum.get.toSet == Set("firstValue", "secondValue"))
+   }
+}
+
+object TestEnum extends Enumeration {
+  type TestEnum = Value
+  val firstValue = Value("firstValue")
+  val secondValue = Value("secondValue")
 }


### PR DESCRIPTION
The field `transformer` in `CopyAction` is not marked as deprecated in the JSON schema. With this change, the corresponding class `CustomDfTransformerConfig` is moved to the definitions section and referred to in a ref, where it is now possible to pass the `deprecated` flag.