### PR TITLE
Upgrade sdlb-schema-viewer to version 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "sdlb-schema-viewer": "^1.1.1"
+    "sdlb-schema-viewer": "^1.1.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Version 1.1.2 of schema viewer supports having other fields alongside `$ref` in the JSON schema. This is needed to mark properties with `$ref` as deprecated in the JSON schema, which we use for part 2 of #693.