### PR TITLE
Feature/minor improvements

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
@@ -250,7 +250,7 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
   def prefixHadoopPath(path: String, prefix: Option[String]): Path = {
     val hadoopPath = new Path(path)
     if (hadoopPath.isAbsoluteAndSchemeAuthorityNull || !hadoopPath.isAbsolute) {
-      val hadoopPathPrefixed = prefix.map( p => new Path(p + HdfsUtil.addLeadingSeparator(path)))
+      val hadoopPathPrefixed = prefix.map( p => new Path(p, path))
         .getOrElse(hadoopPath)
       HdfsUtil.addHadoopDefaultSchemaAuthority( hadoopPathPrefixed )
     }
@@ -287,10 +287,6 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
    */
   def getHadoopFsWithConf(path: Path)(implicit hadoopConf: Configuration): FileSystem = {
     Environment.fileSystemFactory.getFileSystem(path, hadoopConf)
-  }
-
-  def addLeadingSeparator(path: String): String = {
-    if (path.startsWith(Path.SEPARATOR)) path else Path.SEPARATOR + path
   }
 
   def getHadoopPartitionLayout(partitionCols: Seq[String]): String = {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -166,6 +166,11 @@ object PartitionValues {
   }
 
   def oneToOneMapping(partitionValues: Seq[PartitionValues]): Map[PartitionValues,PartitionValues] = partitionValues.map(x => (x,x)).toMap
+
+  def sort(partitionCols: Seq[String], partitionValues: Seq[PartitionValues]): Seq[PartitionValues] = {
+    val ordering = getOrdering(partitionCols)
+    partitionValues.sorted(ordering)
+  }
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionSubFeedsImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionSubFeedsImpl.scala
@@ -217,8 +217,12 @@ abstract class ActionSubFeedsImpl[S <: SubFeed : TypeTag] extends Action {
   }
 
   protected def logWritingStarted(subFeed: S)(implicit context: ActionPipelineContext): Unit = {
-    val msg = s"writing to ${subFeed.dataObjectId}" + (if (subFeed.partitionValues.nonEmpty) s", partitionValues ${subFeed.partitionValues.mkString(" ")}" else "")
-    logger.info(s"($id) start " + msg)
+    // sort partition values for logging
+    val sortedPartitionValues = mainOutput match {
+      case output: CanHandlePartitions => PartitionValues.sort(output.partitions, subFeed.partitionValues)
+      case _ => subFeed.partitionValues
+    }
+    logger.info(s"($id) start writing to ${subFeed.dataObjectId}" + (if (subFeed.partitionValues.nonEmpty) s", partitionValues ${sortedPartitionValues.mkString(" ")}" else ""))
   }
 
   protected def logWritingFinished(subFeed: S, metrics: Map[String,Any], duration: Duration)(implicit context: ActionPipelineContext): Unit = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
@@ -36,16 +36,16 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Configuration of a custom GenericDataFrame transformation between one input and one output (1:1) as SQL code.
  * The input data is available as temporary view in SQL. The inputs name is either the name of the DataObject,
  * or the name of the previous transformation, if this is not the first transformation of the chain. Also note that to create
- * the name of temporary view, special characters are replaced by underscores and a postfix "_sdltemp" is added.
- * It is therefore recommended to use special token %{inputViewName} or ${inputViewName_<input name>} that will be
+ * the name of temporary view, special characters are replaced by underscores and a postfix `_sdltemp` is added.
+ * It is therefore recommended to use special token `%{inputViewName}` or `%{inputViewName_<input name>}` that will be
  * replaced with the name of the temporary view at runtime.
  *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param code           SQL code for transformation.
- *                       Use tokens %{<key>} to replace with runtimeOptions in SQL code.
- *                       Example: "select * from test where run = %{runId}"
- *                       The special token %{inputViewName} or ${inputViewName_<input_name>} can be used to insert the temporary view name.
+ *                       Use tokens `%{<key>}` to replace with runtimeOptions in SQL code.
+ *                       Example: `select * from test where run = %{runId}`
+ *                       The special token `%{inputViewName}` or `%{inputViewName_<input_name>}` can be used to insert the temporary view name.
  *                       The input name is either the name of the DataObject, or the name of the previous transformation
  *                       if this is not the first transformation of the chain. Make sure to change the standard name of
  *                       the previous transformation in that case.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
@@ -37,8 +37,8 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * (special characters are replaces by underscores).
  * The input data is available as temporary view in SQL. The input name is either an id of the input DataObject,
  * or the name of an output of the previous transformation if this is not the first transformation of the chain.
- * Also note that to create the name of temporary view, special characters are replaced by underscores and a postfix "_sdltemp" is added.
- * It is therefore recommended to use the special token ${inputViewName_<input name>}, that will be replaced with the name
+ * Also note that to create the name of temporary view, special characters are replaced by underscores and a postfix `_sdltemp` is added.
+ * It is therefore recommended to use the special token `%{inputViewName_<input name>}`, that will be replaced with the name
  * of the temporary view at runtime.
  *
  * Note that you can access arbitrary tables from the metastore in the SQL code, but this is against the principle of SDLB
@@ -49,9 +49,9 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * @param code           Map of output names and corresponding SQL code for transformation.
  *                       If this is the last transformation in the chain, the output name has to match an output DataObject id,
  *                       otherwise it can be any name which will then be available in the next transformation.
- *                       Use tokens %{<key>} to replace with runtimeOptions in SQL code.
- *                       Example: "select * from test where run = %{runId}"
- *                       The special token ${inputViewName_<input_name>} can be used to insert the name of temporary views.
+ *                       Use tokens `%{<key>}` to replace with runtimeOptions in SQL code.
+ *                       Example: `select * from test where run = %{runId}`
+ *                       The special token `%{inputViewName_<input_name>}` can be used to insert the name of temporary views.
  *                       The input name is either the id of an input DataObject, or the name of an output of the previous transformation
  *                       if this is not the first transformation of the chain.
  * @param options        Options to pass to the transformation

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -187,11 +187,11 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
    * List partitions on data object's root path
    */
   override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
-    getPartitionPathStatis
+    getPartitionPathsStatus
       .map(path => extractPartitionValuesFromDirPath(path.getPath.toString))
   }
 
-  def getPartitionPathStatis(implicit context: ActionPipelineContext): Seq[FileStatus] = {
+  def getPartitionPathsStatus(implicit context: ActionPipelineContext): Seq[FileStatus] = {
     partitionLayout().map {
       partitionLayout =>
         // get search pattern for root directory

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
@@ -22,9 +22,12 @@ package io.smartdatalake.lab
 import io.smartdatalake.config.SdlConfigObject.ConfigObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
-import io.smartdatalake.workflow.dataobject.{CanCreateSparkDataFrame, CanHandlePartitions, CanWriteSparkDataFrame, DataObject}
+import io.smartdatalake.workflow.dataobject.{CanCreateSparkDataFrame, CanHandlePartitions, CanWriteSparkDataFrame, DataObject, FileRefDataObject, HadoopFileDataObject, HasHadoopStandardFilestore, HiveTableDataObject, TableDataObject}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.StructType
+
+import java.time.{Instant, LocalDateTime, ZoneId}
+import java.util.TimeZone
 
 /**
  * A wrapper around a Spark DataObject simplifying the interface for interactive use.
@@ -54,6 +57,19 @@ case class LabSparkDataObjectWrapper[T <: DataObject with CanCreateSparkDataFram
       case _ => throw NotSupportedException(dataObject.id, "can not write Spark DataFrames")
     }
   }
+
+  def dropPartitions(partitions: Seq[Map[String,String]]): Unit = dataObject match {
+    case o: CanHandlePartitions => o.deletePartitions(partitions.map(pv => PartitionValues(pv)))(context)
+    case _ => throw NotSupportedException(dataObject.id, "is not partitioned")
+  }
+
+  def infos: Map[String,String] = {
+    Seq(
+      Some(dataObject).collect{case o: TableDataObject => ("table", o.table.fullName)},
+      Some(dataObject).collect{case o: FileRefDataObject => ("path", o.getPath(context))}
+    ).flatten.toMap
+  }
+
   def partitionColumns: Seq[String] = dataObject match {
     case o: CanHandlePartitions => o.partitions
     case _ => Seq()
@@ -63,6 +79,16 @@ case class LabSparkDataObjectWrapper[T <: DataObject with CanCreateSparkDataFram
     case _ => throw NotSupportedException(dataObject.id, "is not partitioned")
   }
   def topLevelPartitions: Seq[String] = partitions.map(_(partitionColumns.head))
+
+  /**
+   * lists modification date of partition folders
+   */
+  def partitionModDates(timezoneId: ZoneId = TimeZone.getDefault.toZoneId): Seq[(PartitionValues,LocalDateTime)] = dataObject match {
+    case o: HadoopFileDataObject with CanHandlePartitions =>
+      o.getPartitionPathStatis(context)
+        .map( s => (o.extractPartitionValuesFromDirPath(s.getPath.toString)(context), LocalDateTime.ofInstant(Instant.ofEpochMilli(s.getModificationTime), timezoneId)))
+    case _ => throw NotSupportedException(dataObject.id, "is not partitioned or has no hadoop directory layout")
+  }
   def schema: StructType = dataObject.getSparkDataFrame()(context).schema
   def printSchema(): Unit = dataObject.getSparkDataFrame()(context).printSchema()
 }

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
@@ -85,7 +85,7 @@ case class LabSparkDataObjectWrapper[T <: DataObject with CanCreateSparkDataFram
    */
   def partitionModDates(timezoneId: ZoneId = TimeZone.getDefault.toZoneId): Seq[(PartitionValues,LocalDateTime)] = dataObject match {
     case o: HadoopFileDataObject with CanHandlePartitions =>
-      o.getPartitionPathStatis(context)
+      o.getPartitionPathsStatus(context)
         .map( s => (o.extractPartitionValuesFromDirPath(s.getPath.toString)(context), LocalDateTime.ofInstant(Instant.ofEpochMilli(s.getModificationTime), timezoneId)))
     case _ => throw NotSupportedException(dataObject.id, "is not partitioned or has no hadoop directory layout")
   }


### PR DESCRIPTION
Small improvements and fixes:
- sort partition values in log output when writing to DataObject
- fix and improve SQLDf(s)Transformer description
- PartitionDiffMode: apply selectExpression before nbOfPartitionValuesPerRun
- LabSparkDataObjectWrapper: add dropPartitions, infos and partitionModDates methods
- HiveTableDataObject: avoid wrong warning about different path of existing table by using getAbsolutePath
. This fix uses the same logic as already present in DeltaLakeTableDataObject.