### PR TITLE
update docs after removal of podman-compose

### DIFF
--- a/blog/2022-03-18-SDL-airbyte/2022-03-18-SDL-airbyte.md
+++ b/blog/2022-03-18-SDL-airbyte/2022-03-18-SDL-airbyte.md
@@ -34,7 +34,7 @@ The [github connector](https://docs.airbyte.com/integrations/sources/github) is 
 ## Prerequisites
 After downloading and installing all necessary packages, the connector is briefly tested:
 * Python
-* [Podman including `podman-compose`](../../docs/getting-started/troubleshooting/docker-on-windows) or [Docker](https://www.docker.com/get-started)
+* [Podman](../../docs/getting-started/troubleshooting/docker-on-windows) or [Docker](https://www.docker.com/get-started)
 * [SDL example](https://github.com/smart-data-lake/getting-started/archive/refs/heads/master.zip), download and unpack: 
   ```Bash
   git clone https://github.com/smart-data-lake/getting-started.git SDL_airbyte
@@ -134,7 +134,7 @@ Now we are ready to go. My full [SDLB config file](application.conf) additionall
 ## Run and inspect results
 Since the data will be streamed into a `DeltaLakeTableDataObject`, the metastore container is necessary. Further, we aim to inspect the data using the Polynote notebook. Thus, first these containers are launched using (in the SDL example base directory):
 ```Bash
-podman-compose up
+./part2/podman-compose.sh #use the script from the getting-started guide
 podman pod ls
 ```
 With the second command we can verify the pod name and both running containers in it (should be three including the infra container).

--- a/blog/2022-05-11-SDL-historization/2022-05-11-historization.md
+++ b/blog/2022-05-11-SDL-historization/2022-05-11-historization.md
@@ -76,7 +76,7 @@ It should be noted that there are a duplicates in the dataset. In the first case
 * start the pod with the metastore and polynote: 
   ```Bash
   mkdir -p data/_metastore
-  podman-compose up
+  ./part2/podman-compose.sh #use the script from the getting-started guide
   ```
 * start the MS SQL server: 
   ```Bash

--- a/blog/2022-05-11-SDL-historization/restart_databases.sh
+++ b/blog/2022-05-11-SDL-historization/restart_databases.sh
@@ -1,13 +1,12 @@
 
 # shutdown, cleanup
 podman stop mssql
-podman-compose down ### This also deletes the mssql container
 rm -r data/_metastore data/int-* data/spark-warehouse data/state
 mkdir -p data/_metastore
 
 # startup
 set -e # exit on errors
-podman-compose up -d
+./part2/podman-compose.sh #use the script from the getting-started guide
 podman run -d --pod sdl_sql --hostname mssqlserver --add-host mssqlserver:127.0.0.1 --name mssql -v ${PWD}/data:/data  -v ${PWD}/config:/config -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=%abcd1234%" mcr.microsoft.com/mssql/server:2017-latest
 sleep 10  ### wait until the MSSQL server is ready (maybe a very conservative time)
 podman exec -it mssql /opt/mssql/bin/mssql-conf set sqlagent.enabled true

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -207,15 +207,11 @@ docker run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/
 <TabItem value="podman">
 
 ```jsx
-podman run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel '.*'
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --pod getting-started sdl-spark:latest -c /mnt/config --feed-sel '.*'
 ```
 
 </TabItem>
 </Tabs>
-
-:::info Podman Hostname Specification
-Without specifying the hostname, the containter name (by default the docker/podman container ID) can not be resolved to localhost. If you need to name your container differently, the following arguments can be used alternatively: `--hostname myhost --add-host myhost:127.0.0.1 -rm ...`
-:::
 
 After you run your data pipeline again, you should now be able to see our DataObjects data in Polynote.
 No need to restart Polynote, just open it again and run all cells.

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -138,7 +138,8 @@ But state-of-the-art is to use notebooks like Jupyter for this.
 One of the most advanced notebooks for Scala code we found is Polynote, see [polynote.org](https://polynote.org/).
 
 We will now start Polynote in a docker container, and an external Metastore (Derby database) in another container to share the catalog between our experiments and the notebook.
-To do so you need to add additional files to the project. Change to the projects root directory and `unzip part2.additional-files.zip` into the project's root directoy, then run the following commands in the projects root directory:
+To do so, we will use the additional files in the subfolder `part2`. 
+Execute these commands:
 
 <Tabs groupId = "docker-podman-switch"
 defaultValue="docker"
@@ -149,9 +150,9 @@ values={[
 <TabItem value="docker">
 
 ```jsx
-docker-compose build
+docker-compose build -f part2/docker-compose.yml
 mkdir -p data/_metastore
-docker-compose up
+docker-compose up -f part2/docker-compose.yml
 ```
 
 </TabItem>
@@ -170,6 +171,9 @@ You should now be able to access Polynote at `localhost:8192`.
 
 :::info Docker on Windows
 If you use Windows, please read our note on [Docker for Windows](../troubleshooting/docker-on-windows).
+You might notice that the commands for docker and podman differ at this point. 
+The latest version of podman-compose changed the behavior of creating pods, 
+which is why we have implemented a script `podman-compose.sh` to emulate podman-compose.
 :::
 
 But when you walk through the prepared notebook "SelectingData", you won't see any tables and data yet. 

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -88,7 +88,7 @@ Finally, adapt the action definition for `join-departures-airports`:
 - Adapted the existing action `join-departures-airports` to use the new table `int-departures`
 :::
 
-To run our data pipeline, first delete the data directory - otherwise DeltaLakeTableDataObject will fail because of existing files in different format.
+To run our data pipeline, first make sure data directory is empty - otherwise DeltaLakeTableDataObject will fail because of existing files in different format.
 Then you can execute the usual *docker run* command for all feeds:
 
 <Tabs groupId = "docker-podman-switch"
@@ -158,9 +158,8 @@ docker-compose up
 <TabItem value="podman">
 
 ```jsx
-podman-compose build
 mkdir -p data/_metastore
-podman-compose up
+./part2/podman-compose.sh 
 ```
 
 </TabItem>

--- a/docs/getting-started/part-2/delta-lake-format.md
+++ b/docs/getting-started/part-2/delta-lake-format.md
@@ -150,9 +150,9 @@ values={[
 <TabItem value="docker">
 
 ```jsx
-docker-compose build -f part2/docker-compose.yml
+docker-compose -f part2/docker-compose.yml build
 mkdir -p data/_metastore
-docker-compose up -f part2/docker-compose.yml
+docker-compose -f part2/docker-compose.yml up
 ```
 
 </TabItem>
@@ -204,7 +204,7 @@ values={[
 <TabItem value="docker">
 
 ```jsx
-docker run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network getting-started_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
+docker run --hostname localhost --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config --network part2_default sdl-spark:latest -c /mnt/config --feed-sel '.*'
 ```
 
 </TabItem>

--- a/docs/getting-started/part-3/custom-webservice.md
+++ b/docs/getting-started/part-3/custom-webservice.md
@@ -74,9 +74,10 @@ Hence, our `CustomWebserviceDataObject` will enforce the rule that if the chosen
 
 Note that we changed the type to `CustomWebserviceDataObject`.
 This is a custom DataObject type, not included in standard Smart Data Lake Builder. 
-To make it work please go to the project's root directory and `unzip part3.additional-files.zip` into the project's root folder.
-It includes the following file for you:
+To make it work, please go to the project's root directory and copy the Scala class with 
+`cp part3/src/ ./ -r`:
 
+This copied the following file:
   - ./src/scala/io/smartdatalake/workflow/dataobject/CustomWebserviceDataObject.scala
   
 In this part we will work exclusively on the `CustomWebserviceDataObject.scala` file.
@@ -96,7 +97,7 @@ download-departures {
 The type is no longer `FileTransferAction` but a `CopyAction` instead, as our new `CustomWebserviceDataObject` converts the Json-Output of the Webservice into a Spark DataFrame.
 
 :::info
-`FileTransferAction`s are used, when your DataObjects reads an InputStream or writes an OutputStream like `WebserviceFileDataObject` or `SFtpFileRefDataObject`. 
+`FileTransferAction`s are used, when your DataObject reads an InputStream or writes an OutputStream like `WebserviceFileDataObject` or `SFtpFileRefDataObject`. 
 These transfer files one-to-one from input to output.  
 More often you work with one of the many provided `SparkAction`s like the `CopyAction` shown here. 
 They work by using Spark Data Frames under the hood. 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -35,7 +35,7 @@ docker build -t sdl-spark .
 <TabItem value="podman">
 
 ```jsx
-podman build -t sdl-spark .
+podman build -v ${PWD}/.mvnrepo:/mnt/.mvnrepo -t sdl-spark .
 ```
 
 </TabItem>

--- a/docs/getting-started/troubleshooting/common-problems.md
+++ b/docs/getting-started/troubleshooting/common-problems.md
@@ -51,3 +51,8 @@ Use the container id to stop the container by typing:
 
     docker containter stop <container id>
 
+## ERROR 08001: java.net.ConnectException : Error connecting to server localhost on port 1527
+
+This likely happens during or after part 2 if you forget to add `--pod getting-started` to your podman command.
+Remember that SDL now needs to communicate with the Metastore that we are starting. 
+To allow this communication, you need to make sure that SDL and the metastore are running in the same pod.

--- a/docs/getting-started/troubleshooting/docker-on-windows.md
+++ b/docs/getting-started/troubleshooting/docker-on-windows.md
@@ -23,20 +23,13 @@ Install podman on WSL2 Ubuntu:
 Throughout this tutorial, we often refer to the commands `docker build` and `docker run`.
 Podman has identically named commands, which, for the purpose of this tutorial, do exactly the same thing.
 So with podman you can just type `podman build` and `podman run` instead.
+The podman commands that we provide in our tutorials all assume that they are executed either from a unix environment or from the WSL.
 
-## Using podman compose
-For [part 2 of this guide](../part-2/delta-lake-format.md), you need docker compose.
-For Windows, you can use the alternative podman compose.
-Install podman-compose for podman in WSL2:
+## Equivalent of docker-compose
+For [part 2 of this guide](../part-2/delta-lake-format.md), you need docker-compose.
+For composing multiple podman containers, you can just execute our custom script podman-compose.sh from the getting-started base directory.
 
-    sudo apt install python3-pip
-    sudo pip3 install podman-compose==0.1.11
-
-:::info podman version
-`podman-compose` with major 1 (tested up to 1.0.3) do not create pods automatically. Therewith, the used commands results in networking issues between the containers. Thus, we recommend to use the latest version with automatic pod creation, version 0.1.11. The behaviour may change in future versions. 
-:::
-
-After starting `podman-compose up` in the getting-started folder you should now be able to open Polynote on port localhost:8192, as WSL2 automatically publishes all ports on Windows.
+After running the script in the getting-started folder you should now be able to open Polynote on port localhost:8192, as WSL2 automatically publishes all ports on Windows.
 If the port is not accessible, you can use `wsl hostname -I` on Windows command line to get the IP adress of WSL, and then access Polynote over {ip-address}:8192.
 
 ## Known Issue with podman on WSL2 on Windows

--- a/docs/reference/commandLine.md
+++ b/docs/reference/commandLine.md
@@ -108,7 +108,7 @@ podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/con
 
 
 ## Pods with Podman
-When interacting between multiple containers, e.g. SDL container and a metastore container, pods are utilized to manage the container and especially the network. A set of containers is launched using podman-compose and a `docker-compose.yaml`. Podman-compose < 1.0.0 creates the pods automatically. This seems to be broken in later versions. That is why we suggest to install podman-compose 0.1.11.
+When interacting between multiple containers, e.g. SDL container and a metastore container, pods are utilized to manage the container and especially the network. A set of containers is launched using podman-compose.sh.
 
 Assuming an existing pod `mypod` is running, another container can be started within this pod using the additional podman arguments `--pod mypod --hostname myhost --add-host myhost:127.0.0.1`. 
 The hostname specification fixes an issue in resolving the own localhost.


### PR DESCRIPTION
### What changes are included in the pull request?
Changes from this PR need to be documented:
https://github.com/smart-data-lake/getting-started/pull/16

### Why are the changes needed?
We updated the getting-started to
- use the latest SDL version (2.5.0) incl. a few version upgrades (Spark. Polynote, etc.)
- Get rid of part2 and part3 zip files. Files are now provided in a subfolder that changes can be tracked.
- Get rid of podman-compose as it didn't work for us in the latest version