### PR TITLE
Docs - move warning about quotation mark from compute-distances.md to…

### DIFF
--- a/docs/getting-started/part-1/compute-distances.md
+++ b/docs/getting-started/part-1/compute-distances.md
@@ -180,22 +180,18 @@ values={[
 <TabItem value="docker">
 
 ```jsx
-docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ".*"
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel '.*'
 ```
 
 </TabItem>
 <TabItem value="podman">
 
 ```jsx
-podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel ".*"
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel '.*'
 ```
 
 </TabItem>
 </Tabs>        
-
-:::warning
-  Note the regex feed selection .* need to be specified in quotation marks (`'.*'` or `".*"`), otherwise our system would substitute the asterics.
-:::
 
 The successful execution DAG looks like this
 

--- a/docs/getting-started/part-1/select-columns.md
+++ b/docs/getting-started/part-1/select-columns.md
@@ -221,19 +221,22 @@ values={[
 <TabItem value="docker">
 
 ```jsx
-docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+docker run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel '.*'
 ```
 
 </TabItem>
 <TabItem value="podman">
 
 ```jsx
-podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel .*
+podman run --rm -v ${PWD}/data:/mnt/data -v ${PWD}/target:/mnt/lib -v ${PWD}/config:/mnt/config sdl-spark:latest --config /mnt/config --feed-sel '.*'
 ```
 
 </TabItem>
 </Tabs>
 
+:::warning
+Note the regex feed selection .* need to be specified in quotation marks (`'.*'` or `".*"`), otherwise our system would substitute the asterisk.
+:::
 
 
 ## Example of Common Mistake


### PR DESCRIPTION
### What changes are included in the pull request?
Move warning about regex from compute-distances to select-columns as this page appears first in the documentation.