### PR TITLE
add option to replace nonstandardSQL with _ in col names

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
@@ -371,14 +371,14 @@ private[smartdatalake] object DataFrameUtil {
   /**
    * Remove all hyphen and blanks from a string with underscores
    */
-  def replaceHyphenAndBlanksWithUnderscores(x: String): String = {
-    x.replaceAll("[\\- ]", "_")
+  def replaceNonSqlWithUnderscores(x: String): String = {
+    x.replaceAll("[^a-zA-Z0-9_]+", "_")
   }
   /**
    * Remove all chars from a string which dont belong to lowercase SQL standard naming characters
    */
   def removeNonStandardSQLNameChars(x: String): String = {
-    x.toLowerCase.replaceAll("[^a-z0-9_]", "")
+    x.toLowerCase.replaceAll("[^a-zA-Z0-9_]", "")
   }
 
   def getEmptyDataFrame(schema: StructType)(implicit session: SparkSession): DataFrame = {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
@@ -369,9 +369,9 @@ private[smartdatalake] object DataFrameUtil {
   }
 
   /**
-   * Remove all hyphen and bancs from a string with underscores
+   * Remove all hyphen and blanks from a string with underscores
    */
-  def replaceHyphenAndBlancsWithUnderscores(x: String): String = {
+  def replaceHyphenAndBlanksWithUnderscores(x: String): String = {
     x.replaceAll("[\\- ]", "_")
   }
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
@@ -372,7 +372,7 @@ private[smartdatalake] object DataFrameUtil {
    * Remove all chars from a string which dont belong to lowercase SQL standard naming characters
    */
   def removeNonStandardSQLNameChars(x: String): String = {
-    x.toLowerCase.replaceAll("[^a-z0-9_]", "")
+    x.toLowerCase.replaceAll("[\\- ]", "_").replaceAll("[^a-z0-9_]", "")
   }
 
   def getEmptyDataFrame(schema: StructType)(implicit session: SparkSession): DataFrame = {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/DataFrameUtil.scala
@@ -369,10 +369,16 @@ private[smartdatalake] object DataFrameUtil {
   }
 
   /**
+   * Remove all hyphen and bancs from a string with underscores
+   */
+  def replaceHyphenAndBlancsWithUnderscores(x: String): String = {
+    x.replaceAll("[\\- ]", "_")
+  }
+  /**
    * Remove all chars from a string which dont belong to lowercase SQL standard naming characters
    */
   def removeNonStandardSQLNameChars(x: String): String = {
-    x.toLowerCase.replaceAll("[\\- ]", "_").replaceAll("[^a-z0-9_]", "")
+    x.toLowerCase.replaceAll("[^a-z0-9_]", "")
   }
 
   def getEmptyDataFrame(schema: StructType)(implicit session: SparkSession): DataFrame = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
@@ -36,7 +36,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  *                         Otherwise converts just to lower case.
  * @param normalizeToAscii If selected, converts UTF-8 special characters (e.g. diacritics, umlauts) to ASCII chars (best effort), i.e. Öffi_émily -> Oeffi_emily
  * @param removeNonStandardSQLNameChars Remove all chars from a string which don't belong to lowercase SQL standard naming characters, i.e abc$!-& -> abc
- * @param replaceNonStandardSQLNameCharsWithUnderscores If selected, replaces all chars from a string which don't belong to lowercase SQL standard naming characters with underscores (_), i.e. "value of property!in$$" -> "value_of_property_in_"
+ * @param replaceNonStandardSQLNameCharsWithUnderscores If selected, replaces all chars from a string which don't belong to lowercase SQL standard naming characters with underscores (_), i.e. "value of property!in$$" -> "value_of_property_in_". Note: removeNonStandardSQLNameChars needs to be disabled
  */
 case class StandardizeColNamesTransformer(override val name: String = "colNamesLowercase",
                                           override val description: Option[String] = None,
@@ -47,6 +47,8 @@ case class StandardizeColNamesTransformer(override val name: String = "colNamesL
   extends GenericDfTransformer {
   override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String], executionModeResultOptions: Map[String,String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
+    assert(!(removeNonStandardSQLNameChars && replaceNonStandardSQLNameCharsWithUnderscores),
+      s"ERROR: cannot use removeNonStandardSQLNameChars and replaceNonStandardSQLNameCharsWithUnderscores at the same time in ${this.getClass.getSimpleName}")
     df.standardizeColNames(camelCaseToLower, normalizeToAscii,
       removeNonStandardSQLNameChars, replaceNonStandardSQLNameCharsWithUnderscores)
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
@@ -32,22 +32,23 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Parameters below can be used to disable specific rules if needed.
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
- * @param replaceHyphenBlanksWithUnderscores If selected, replaces hyphen (-) and blanks ( ) with underscores (_), i.e. "value of property" -> "value_of_property"
  * @param camelCaseToLower If selected, converts Camel case names to lower case  with underscores, i.e. TestString -> test_string, testABCtest -> test_ABCtest
  *                         Otherwise converts just to lower case.
  * @param normalizeToAscii If selected, converts UTF-8 special characters (e.g. diacritics, umlauts) to ASCII chars (best effort), i.e. Öffi_émily -> Oeffi_emily
- * @param removeNonStandardSQLNameChars Remove all chars from a string which dont belong to lowercase SQL standard naming characters, i.e abc$!-& -> abc
+ * @param removeNonStandardSQLNameChars Remove all chars from a string which don't belong to lowercase SQL standard naming characters, i.e abc$!-& -> abc
+ * @param replaceNonStandardSQLNameCharsWithUnderscores If selected, replaces all chars from a string which don't belong to lowercase SQL standard naming characters with underscores (_), i.e. "value of property!in$$" -> "value_of_property_in_"
  */
 case class StandardizeColNamesTransformer(override val name: String = "colNamesLowercase",
                                           override val description: Option[String] = None,
-                                          camelCaseToLower: Boolean=true, normalizeToAscii: Boolean=true,
+                                          camelCaseToLower: Boolean=true,
+                                          normalizeToAscii: Boolean=true,
                                           removeNonStandardSQLNameChars: Boolean=true,
-                                          replaceHyphenBlanksWithUnderscores: Boolean=false)
+                                          replaceNonStandardSQLNameCharsWithUnderscores: Boolean=false)
   extends GenericDfTransformer {
   override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String], executionModeResultOptions: Map[String,String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
     df.standardizeColNames(camelCaseToLower, normalizeToAscii,
-      removeNonStandardSQLNameChars, replaceHyphenBlanksWithUnderscores)
+      removeNonStandardSQLNameChars, replaceNonStandardSQLNameCharsWithUnderscores)
   }
   override def factory: FromConfigFactory[GenericDfTransformer] = StandardizeColNamesTransformer
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
@@ -32,15 +32,22 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Parameters below can be used to disable specific rules if needed.
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
+ * @param replaceHyphenBlancsWithUnderscores If selected, replaces hyphen (-) and blancs ( ) with underscores (_), i.e. "value of property" -> "value_of_property"
  * @param camelCaseToLower If selected, converts Camel case names to lower case  with underscores, i.e. TestString -> test_string, testABCtest -> test_ABCtest
  *                         Otherwise converts just to lower case.
  * @param normalizeToAscii If selected, converts UTF-8 special characters (e.g. diacritics, umlauts) to ASCII chars (best effort), i.e. Öffi_émily -> Oeffi_emily
  * @param removeNonStandardSQLNameChars Remove all chars from a string which dont belong to lowercase SQL standard naming characters, i.e abc$!-& -> abc
  */
-case class StandardizeColNamesTransformer(override val name: String = "colNamesLowercase", override val description: Option[String] = None, camelCaseToLower: Boolean=true, normalizeToAscii: Boolean=true, removeNonStandardSQLNameChars: Boolean=true) extends GenericDfTransformer {
+case class StandardizeColNamesTransformer(override val name: String = "colNamesLowercase",
+                                          override val description: Option[String] = None,
+                                          camelCaseToLower: Boolean=true, normalizeToAscii: Boolean=true,
+                                          removeNonStandardSQLNameChars: Boolean=true,
+                                          replaceHyphenBlancsWithUnderscores: Boolean=false)
+  extends GenericDfTransformer {
   override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String], executionModeResultOptions: Map[String,String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
-    df.standardizeColNames(camelCaseToLower, normalizeToAscii, removeNonStandardSQLNameChars)
+    df.standardizeColNames(camelCaseToLower, normalizeToAscii,
+      removeNonStandardSQLNameChars, replaceHyphenBlancsWithUnderscores)
   }
   override def factory: FromConfigFactory[GenericDfTransformer] = StandardizeColNamesTransformer
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
@@ -32,7 +32,7 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Parameters below can be used to disable specific rules if needed.
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
- * @param replaceHyphenBlancsWithUnderscores If selected, replaces hyphen (-) and blancs ( ) with underscores (_), i.e. "value of property" -> "value_of_property"
+ * @param replaceHyphenBlanksWithUnderscores If selected, replaces hyphen (-) and blanks ( ) with underscores (_), i.e. "value of property" -> "value_of_property"
  * @param camelCaseToLower If selected, converts Camel case names to lower case  with underscores, i.e. TestString -> test_string, testABCtest -> test_ABCtest
  *                         Otherwise converts just to lower case.
  * @param normalizeToAscii If selected, converts UTF-8 special characters (e.g. diacritics, umlauts) to ASCII chars (best effort), i.e. Öffi_émily -> Oeffi_emily
@@ -42,12 +42,12 @@ case class StandardizeColNamesTransformer(override val name: String = "colNamesL
                                           override val description: Option[String] = None,
                                           camelCaseToLower: Boolean=true, normalizeToAscii: Boolean=true,
                                           removeNonStandardSQLNameChars: Boolean=true,
-                                          replaceHyphenBlancsWithUnderscores: Boolean=false)
+                                          replaceHyphenBlanksWithUnderscores: Boolean=false)
   extends GenericDfTransformer {
   override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String], executionModeResultOptions: Map[String,String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
     df.standardizeColNames(camelCaseToLower, normalizeToAscii,
-      removeNonStandardSQLNameChars, replaceHyphenBlancsWithUnderscores)
+      removeNonStandardSQLNameChars, replaceHyphenBlanksWithUnderscores)
   }
   override def factory: FromConfigFactory[GenericDfTransformer] = StandardizeColNamesTransformer
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -151,9 +151,13 @@ trait GenericDataFrame extends GenericTypedObject {
   /**
    * Standardize column names according to enabled rules.
    */
-  def standardizeColNames(camelCaseToLower: Boolean = true, normalizeToAscii: Boolean = true, removeNonStandardSQLNameChars: Boolean = true)( implicit function: DataFrameFunctions): GenericDataFrame = {
+  def standardizeColNames(camelCaseToLower: Boolean = true,
+                          normalizeToAscii: Boolean = true,
+                          removeNonStandardSQLNameChars: Boolean = true,
+                          replaceHyphenBlancsWithUnderscores: Boolean = false)( implicit function: DataFrameFunctions): GenericDataFrame = {
     def standardizeColName(name: String): String = {
       var standardName = name
+      standardName = if (replaceHyphenBlancsWithUnderscores) DataFrameUtil.replaceHyphenAndBlancsWithUnderscores(standardName) else standardName
       standardName = if (normalizeToAscii) DataFrameUtil.normalizeToAscii(standardName) else standardName
       standardName = if (camelCaseToLower) DataFrameUtil.strCamelCase2LowerCaseWithUnderscores(standardName) else standardName.toLowerCase
       standardName = if (removeNonStandardSQLNameChars) DataFrameUtil.removeNonStandardSQLNameChars(standardName) else standardName

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -154,13 +154,14 @@ trait GenericDataFrame extends GenericTypedObject {
   def standardizeColNames(camelCaseToLower: Boolean = true,
                           normalizeToAscii: Boolean = true,
                           removeNonStandardSQLNameChars: Boolean = true,
-                          replaceHyphenBlanksWithUnderscores: Boolean = false)( implicit function: DataFrameFunctions): GenericDataFrame = {
+                          replaceNonStandardSQLNameCharsWithUnderscores: Boolean = false)( implicit function: DataFrameFunctions): GenericDataFrame = {
     def standardizeColName(name: String): String = {
+      assert(!(removeNonStandardSQLNameChars && replaceNonStandardSQLNameCharsWithUnderscores))
       var standardName = name
-      standardName = if (replaceHyphenBlanksWithUnderscores) DataFrameUtil.replaceHyphenAndBlanksWithUnderscores(standardName) else standardName
       standardName = if (normalizeToAscii) DataFrameUtil.normalizeToAscii(standardName) else standardName
       standardName = if (camelCaseToLower) DataFrameUtil.strCamelCase2LowerCaseWithUnderscores(standardName) else standardName.toLowerCase
       standardName = if (removeNonStandardSQLNameChars) DataFrameUtil.removeNonStandardSQLNameChars(standardName) else standardName
+      standardName = if (replaceNonStandardSQLNameCharsWithUnderscores) DataFrameUtil.replaceNonSqlWithUnderscores(standardName) else standardName
       // return
       standardName
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -154,9 +154,11 @@ trait GenericDataFrame extends GenericTypedObject {
   def standardizeColNames(camelCaseToLower: Boolean = true,
                           normalizeToAscii: Boolean = true,
                           removeNonStandardSQLNameChars: Boolean = true,
-                          replaceNonStandardSQLNameCharsWithUnderscores: Boolean = false)( implicit function: DataFrameFunctions): GenericDataFrame = {
+                          replaceNonStandardSQLNameCharsWithUnderscores: Boolean = false)
+                         ( implicit function: DataFrameFunctions): GenericDataFrame = {
     def standardizeColName(name: String): String = {
-      assert(!(removeNonStandardSQLNameChars && replaceNonStandardSQLNameCharsWithUnderscores))
+      assert(!(removeNonStandardSQLNameChars && replaceNonStandardSQLNameCharsWithUnderscores),
+        "ERROR: cannot use removeNonStandardSQLNameChars and replaceNonStandardSQLNameCharsWithUnderscores at the same time")
       var standardName = name
       standardName = if (normalizeToAscii) DataFrameUtil.normalizeToAscii(standardName) else standardName
       standardName = if (camelCaseToLower) DataFrameUtil.strCamelCase2LowerCaseWithUnderscores(standardName) else standardName.toLowerCase

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -154,10 +154,10 @@ trait GenericDataFrame extends GenericTypedObject {
   def standardizeColNames(camelCaseToLower: Boolean = true,
                           normalizeToAscii: Boolean = true,
                           removeNonStandardSQLNameChars: Boolean = true,
-                          replaceHyphenBlancsWithUnderscores: Boolean = false)( implicit function: DataFrameFunctions): GenericDataFrame = {
+                          replaceHyphenBlanksWithUnderscores: Boolean = false)( implicit function: DataFrameFunctions): GenericDataFrame = {
     def standardizeColName(name: String): String = {
       var standardName = name
-      standardName = if (replaceHyphenBlancsWithUnderscores) DataFrameUtil.replaceHyphenAndBlancsWithUnderscores(standardName) else standardName
+      standardName = if (replaceHyphenBlanksWithUnderscores) DataFrameUtil.replaceHyphenAndBlanksWithUnderscores(standardName) else standardName
       standardName = if (normalizeToAscii) DataFrameUtil.normalizeToAscii(standardName) else standardName
       standardName = if (camelCaseToLower) DataFrameUtil.strCamelCase2LowerCaseWithUnderscores(standardName) else standardName.toLowerCase
       standardName = if (removeNonStandardSQLNameChars) DataFrameUtil.removeNonStandardSQLNameChars(standardName) else standardName

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
@@ -45,8 +45,8 @@ class StandardizeColNamesTransformerTest extends FunSuite {
   }
 
   test("blanks in column names are replaces") {
-    val colNamesTransformer = StandardizeColNamesTransformer(replaceNonStandardSQLNameCharsWithUnderscores = true)
-    val df = SparkDataFrame(Seq((1, 1), (2, 2)).toDF("one dot", "two-do-ts", "value of property!in$$"))
+    val colNamesTransformer = StandardizeColNamesTransformer(removeNonStandardSQLNameChars=false, replaceNonStandardSQLNameCharsWithUnderscores = true)
+    val df = SparkDataFrame(Seq((1, 1, 1), (2, 2,2)).toDF("one dot", "two-do-ts", "value of property!in$$"))
 
     val transformed = colNamesTransformer.transform("id", Seq(), df, DataObjectId("dataObjectId"), None, Map())
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
@@ -35,14 +35,22 @@ class StandardizeColNamesTransformerTest extends FunSuite {
   implicit val instanceRegistry = new InstanceRegistry()
   implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
-  val colNamesTransformer = StandardizeColNamesTransformer()
-
   test("dots in column names are removed") {
+    val colNamesTransformer = StandardizeColNamesTransformer()
     val df = SparkDataFrame(Seq((1, 1), (2, 2)).toDF("one.dot", "two.do.ts"))
 
     val transformed = colNamesTransformer.transform("id", Seq(), df, DataObjectId("dataObjectId"), None, Map())
 
     assert(transformed.schema.columns == Seq("onedot", "twodots"))
+  }
+
+  test("blancs in column names are replaces") {
+    val colNamesTransformer = StandardizeColNamesTransformer(replaceHyphenBlancsWithUnderscores = true)
+    val df = SparkDataFrame(Seq((1, 1), (2, 2)).toDF("one dot", "two-do-ts"))
+
+    val transformed = colNamesTransformer.transform("id", Seq(), df, DataObjectId("dataObjectId"), None, Map())
+
+    assert(transformed.schema.columns == Seq("one_dot", "two_do_ts"))
   }
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
@@ -45,12 +45,12 @@ class StandardizeColNamesTransformerTest extends FunSuite {
   }
 
   test("blanks in column names are replaces") {
-    val colNamesTransformer = StandardizeColNamesTransformer(replaceHyphenBlanksWithUnderscores = true)
-    val df = SparkDataFrame(Seq((1, 1), (2, 2)).toDF("one dot", "two-do-ts"))
+    val colNamesTransformer = StandardizeColNamesTransformer(replaceNonStandardSQLNameCharsWithUnderscores = true)
+    val df = SparkDataFrame(Seq((1, 1), (2, 2)).toDF("one dot", "two-do-ts", "value of property!in$$"))
 
     val transformed = colNamesTransformer.transform("id", Seq(), df, DataObjectId("dataObjectId"), None, Map())
 
-    assert(transformed.schema.columns == Seq("one_dot", "two_do_ts"))
+    assert(transformed.schema.columns == Seq("one_dot", "two_do_ts", "value_of_property_in_"))
   }
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
@@ -44,8 +44,8 @@ class StandardizeColNamesTransformerTest extends FunSuite {
     assert(transformed.schema.columns == Seq("onedot", "twodots"))
   }
 
-  test("blancs in column names are replaces") {
-    val colNamesTransformer = StandardizeColNamesTransformer(replaceHyphenBlancsWithUnderscores = true)
+  test("blanks in column names are replaces") {
+    val colNamesTransformer = StandardizeColNamesTransformer(replaceHyphenBlanksWithUnderscores = true)
     val df = SparkDataFrame(Seq((1, 1), (2, 2)).toDF("one dot", "two-do-ts"))
 
     val transformed = colNamesTransformer.transform("id", Seq(), df, DataObjectId("dataObjectId"), None, Map())


### PR DESCRIPTION
When using removeNonStandardSQLNameChars so far chars are just removed. Thus a column name "sum of values" will be "sumofvalues". I suggest to change it to replace all non SQL standard characters with "_" thus we get "sum_of_values".

### What changes are included in the pull request?
A new option replaceNonStandardSQLNameCharsWithUnderscores is introduced for the StandardizeColNamesTransformer which first (in function order) replace everything which is not a-zA-Z0-9_ with "_". Multiple consecutive instances are replaced by single "_"

### Why are the changes needed?
I as a user want readable column names.