### PR TITLE
update timestamps of webservice to be newer, preventing timeouts

### DIFF
--- a/docs/getting-started/config-examples/application-part1-compute-cols.conf
+++ b/docs/getting-started/config-examples/application-part1-compute-cols.conf
@@ -7,7 +7,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part1-compute-dep-arr.conf
+++ b/docs/getting-started/config-examples/application-part1-compute-dep-arr.conf
@@ -7,7 +7,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part1-compute-final.conf
+++ b/docs/getting-started/config-examples/application-part1-compute-final.conf
@@ -7,7 +7,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part1-compute-join.conf
+++ b/docs/getting-started/config-examples/application-part1-compute-join.conf
@@ -7,7 +7,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part1-download-errors.conf
+++ b/docs/getting-started/config-examples/application-part1-download-errors.conf
@@ -7,7 +7,7 @@ global {
 dataObjects {
   NOPEext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part1-download.conf
+++ b/docs/getting-started/config-examples/application-part1-download.conf
@@ -7,7 +7,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part2-deltalake.conf
+++ b/docs/getting-started/config-examples/application-part2-deltalake.conf
@@ -12,7 +12,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part2-historical.conf
+++ b/docs/getting-started/config-examples/application-part2-historical.conf
@@ -12,7 +12,7 @@ global {
 dataObjects {
   ext-departures {
     type = WebserviceFileDataObject
-    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+    url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
     readTimeoutMs=200000
   }
   stg-departures {

--- a/docs/getting-started/config-examples/application-part3-download-custom-webservice.conf
+++ b/docs/getting-started/config-examples/application-part3-download-custom-webservice.conf
@@ -17,12 +17,12 @@ dataObjects {
     nRetry = 5
     queryParameters = [{
       airport = "LSZB"
-      begin = 1630200800
-      end = 1630310979
+      begin = 1673760980
+      end = 1673933780
     },{
       airport = "EDDF"
-      begin = 1630200800
-      end = 1630310979
+      begin = 1673760980
+      end = 1673933780
     }]
     timeouts {
       connectionTimeoutMs = 200000

--- a/docs/getting-started/config-examples/application-part3-download-incremental-mode.conf
+++ b/docs/getting-started/config-examples/application-part3-download-incremental-mode.conf
@@ -17,12 +17,12 @@ dataObjects {
     nRetry = 5
     queryParameters = [{
       airport = "LSZB"
-      begin = 1630200800
-      end = 1630310979
+      begin = 1673760980
+      end = 1673933780
     },{
       airport = "EDDF"
-      begin = 1630200800
-      end = 1630310979
+      begin = 1673760980
+      end = 1673933780
     }]
     timeouts {
       connectionTimeoutMs = 200000

--- a/docs/getting-started/get-input-data.md
+++ b/docs/getting-started/get-input-data.md
@@ -26,7 +26,7 @@ You know that Tom lives near Bern, Switzerland. A quick web search shows you tha
 *LSZB*. Let's focus on some specific time period for now to have reproducible results.
 You end up with the following REST-URL:
 
-    https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979
+    https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780
 
 When you run this in your web-browser, you will get a response in the JSON Format.
 For each record, it contains the ICAO identifier of the airport where the plane is flying to in the field

--- a/docs/getting-started/part-1/get-departures.md
+++ b/docs/getting-started/part-1/get-departures.md
@@ -36,7 +36,7 @@ Add the following lines to your configuration file:
     dataObjects {
       ext-departures {
         type = WebserviceFileDataObject
-        url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979"
+        url = "https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780"
         readTimeoutMs=200000
       }
       stg-departures {

--- a/docs/getting-started/part-3/custom-webservice.md
+++ b/docs/getting-started/part-3/custom-webservice.md
@@ -143,13 +143,13 @@ Having a look at the log, something similar should appear on your screen.
 2021-11-10 14:00:32 INFO  ActionDAGRun$ActionEventListener:228 - Action~download-departures[CopyAction]: Prepare started
 2021-11-10 14:00:32 INFO  ActionDAGRun$ActionEventListener:237 - Action~download-departures[CopyAction]: Prepare succeeded
 2021-11-10 14:00:32 INFO  ActionDAGRun$ActionEventListener:228 - Action~download-departures[CopyAction]: Init started
-2021-11-10 14:00:33 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979
-2021-11-10 14:00:33 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=EDDF&begin=1630200800&end=1630310979
+2021-11-10 14:00:33 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780
+2021-11-10 14:00:33 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=EDDF&begin=1673760980&end=1673933780
 2021-11-10 14:00:35 INFO  ActionDAGRun$ActionEventListener:237 - Action~download-departures[CopyAction]: Init succeeded
 2021-11-10 14:00:35 INFO  ActionDAGRun$ActionEventListener:228 - Action~download-departures[CopyAction]: Exec started
 2021-11-10 14:00:35 INFO  CopyAction:158 - (Action~download-departures) getting DataFrame for DataObject~ext-departures
-2021-11-10 14:00:36 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630200800&end=1630310979
-2021-11-10 14:00:37 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=EDDF&begin=1630200800&end=1630310979
+2021-11-10 14:00:36 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1673760980&end=1673933780
+2021-11-10 14:00:37 INFO  CustomWebserviceDataObject:69 - Success for request https://opensky-network.org/api/flights/departure?airport=EDDF&begin=1673760980&end=1673933780
 ```
 
 It is important to notice that the two requests for each airport to the API were not send only once, but twice. 


### PR DESCRIPTION
<!--
Thanks for creating a pull request. A few reminders:
Please follow the contributor guidelines: https://github.com/smart-data-lake/smart-data-lake/blob/develop/CONTRIBUTING.md
If your contribution is based on an issue, please link the issue (bug / feature) so the connection is clear.
If you added new functionality, please make sure you added adequate tests for it.
Enter a concise title and description for your PR to reflect the changes.
--> 

### What changes are included in the pull request?
Every now and then the default timestamps that we use for querying the web api become too old, resulting in timeouts.
The previous timestamps resulted in this url https://opensky-network.org/api/flights/departure?airport=LSZB&begin=1630310979&end=1630656579 when trying to run with state files, which results in a timeout on the server side.
Solution: use newer timstamps

### Why are the changes needed?
