### PR TITLE
implement custom metrics per DataObject (#529)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <scala.version>${scala.minor.version}.15</scala.version>
 
         <spark.version>3.4.1</spark.version>
-        <spark-extensions.version>3.4.0</spark-extensions.version> <!-- this sdl-specific extensions should match the minor version of property spark.version -->
+        <spark-extensions.version>3.4.1</spark-extensions.version> <!-- this sdl-specific extensions should match the minor version of property spark.version -->
         <spark.minor.version>3.4</spark.minor.version> <!-- this is used in sdl-snowflake -->
 
         <spark.version331>3.3.1</spark.version331> <!-- some libraries are still only available for spark 3.3, e.g. spark-excel -->

--- a/sdl-azure/src/main/scala/io/smartdatalake/util/azure/StateChangeLogger.scala
+++ b/sdl-azure/src/main/scala/io/smartdatalake/util/azure/StateChangeLogger.scala
@@ -94,12 +94,12 @@ class StateChangeLogger(options: Map[String, StringOrSecret]) extends StateListe
   def extractLogEvents(actionId: ActionId, runtimeInfo: RuntimeInfo, logContext: StateLogEventContext, instanceRegistry: InstanceRegistry): Seq[StateLogEvent] = {
     val results = runtimeInfo.results.map {
       result =>
-        val metadata = instanceRegistry.get[DataObject](result.subFeed.dataObjectId).metadata
+        val metadata = instanceRegistry.get[DataObject](result.dataObjectId).metadata
         val metadataMap: Map[String, String] = if (includeMetadata) attributesWithValuesForCaseClass(metadata).toMap.filterKeys(_ != "description").mapValues(_.toString)
         else Map()
-        val dataObjectsState = runtimeInfo.dataObjectsState.find(_.dataObjectId == result.subFeed.dataObjectId).map(_.state)
+        val dataObjectsState = runtimeInfo.dataObjectsState.find(_.dataObjectId == result.dataObjectId).map(_.state)
         StateLogEvent(logContext, actionId.id, runtimeInfo.state.toString, runtimeInfo.msg,
-          Some(result.subFeed.dataObjectId.id), optionalizeMap(metadataMap), optionalizeMap(result.mainMetrics), optionalizeSeq(result.subFeed.partitionValues.map(_.toString)), dataObjectsState)
+          Some(result.dataObjectId.id), optionalizeMap(metadataMap), result.metrics, optionalizeSeq(result.partitionValues.map(_.toString)), dataObjectsState)
     }
     // generate at least one log entry per Action if no results
     if (results.nonEmpty) results

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -384,7 +384,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
     // skip all succeeded actions
     val actionsToSkip = runState.actionsState
       .filter { case (id, info) => info.hasCompleted }
-    val initialSubFeeds = actionsToSkip.flatMap(_._2.results.map(_.subFeed)).toSeq
+    val initialSubFeeds = actionsToSkip.flatMap(_._2.results).toSeq
     // get latest DataObject state and overwrite with current DataObject state
     val lastStateId = stateStore.getLatestStateId(Some(runState.runId - 1))
     val lastRunState = lastStateId.map(stateStore.recoverRunState)

--- a/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStageMetrics.scala
@@ -19,6 +19,8 @@
 
 package io.smartdatalake.metrics
 
+import io.smartdatalake.config.SdlConfigObject
+
 import java.time.format.DateTimeFormatter
 import java.time.{Duration, Instant, ZoneId}
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
@@ -73,7 +75,7 @@ private[smartdatalake] case class SparkStageMetrics(jobInfo: JobInfo, stageId: I
   /**
    * @return A printable string reporting all metrics.
    */
-  def getAsText: String = {
+  override def getAsText: String = {
     val valueSeparator: String = "="
     val durationStringWithSeparator = durationString(valueSeparator)(_, _)
     val keyValueStringWithSeparator = keyValueString(valueSeparator)(_, _)
@@ -120,4 +122,10 @@ private[smartdatalake] case class SparkStageMetrics(jobInfo: JobInfo, stageId: I
       (if (recordsWritten == 0) Map("no_data" -> true) else Map())
   }
 }
-private[smartdatalake] case class JobInfo(id: Int, group: String, description: String, executionId: Option[SDLExecutionId])
+private[smartdatalake] case class JobInfo(id: Int, group: String, description: String, executionId: Option[SDLExecutionId]) {
+  val dataObjectIdRegex = (s"DataObject~(${SdlConfigObject.idRegexStr})").r.unanchored
+  val dataObjectId = description match {
+    case dataObjectIdRegex(id) => Some(DataObjectId(id))
+    case _ => None // there are some stages which are created by Spark DataFrame operations which dont manipulate Actions target DataObject's, e.g. pivot operator
+  }
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStageMetricsListener.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStageMetricsListener.scala
@@ -19,20 +19,26 @@
 
 package io.smartdatalake.metrics
 
-import io.smartdatalake.config.SdlConfigObject
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.workflow.action.{Action, SDLExecutionId}
-import io.smartdatalake.workflow.{ActionMetrics, ActionPipelineContext}
-import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart, SparkListenerStageCompleted}
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
+import io.smartdatalake.workflow.action.SDLExecutionId
+import org.apache.spark.scheduler.{SparkListener, SparkListenerJobEnd, SparkListenerJobStart, SparkListenerStageCompleted}
 
 import scala.collection.mutable
 import scala.util.matching.Regex
 
 /**
- * Collects spark metrics for spark stages.
+ * Collects spark metrics for spark stages filtered by ActionId and an optional DataObjectId
  */
-private[smartdatalake] class SparkStageMetricsListener(action: Action)(implicit context: ActionPipelineContext) extends SparkListener with SmartDataLakeLogger {
+private[smartdatalake] class SparkStageMetricsListener(actionId: ActionId, dataObjectId: Option[DataObjectId] = None)(implicit context: ActionPipelineContext) extends SparkListener with SmartDataLakeLogger {
+
+  /**
+   * Keeps track of running jobs, e.g. jobs that started but did not yet end.
+   * Map key is jobId.
+   */
+  val runningJobs: mutable.Map[Int, JobInfo] = mutable.Map.empty
 
   /**
    * Stores jobID and jobDescription indexed by stage ids.
@@ -40,9 +46,11 @@ private[smartdatalake] class SparkStageMetricsListener(action: Action)(implicit 
   val jobInfoLookupTable: mutable.Map[Int, JobInfo] = mutable.Map.empty
 
   // parses job group
-  private val jobGroupRegex = (s"${Regex.quote(context.appConfig.appName)} ${action.id} runId=([0-9]+) attemptId=([0-9]+)").r.unanchored
+  private val jobGroupRegex = (s"${Regex.quote(context.appConfig.appName)} $actionId runId=([0-9]+) attemptId=([0-9]+)").r.unanchored
   // for spark streaming jobs we cant set the jobGroup, but only the description. They also have no executionId.
-  private val jobDescriptionRegex = (s"${Regex.quote(context.appConfig.appName)} ${action.id}").r.unanchored
+  private val jobDescriptionRegex = (s"${Regex.quote(context.appConfig.appName)} $actionId").r.unanchored
+  // store collected metrics
+  private val metrics: mutable.Buffer[SparkStageMetrics] = mutable.Buffer.empty
 
   /**
    * On job start, register the job ids and stage ids.
@@ -51,11 +59,23 @@ private[smartdatalake] class SparkStageMetricsListener(action: Action)(implicit 
     val jobGroup = jobStart.properties.getProperty("spark.jobGroup.id")
     val jobDescription = jobStart.properties.getProperty("spark.job.description")
     val jobInfo = (jobGroup, jobDescription) match {
-      case (jobGroupRegex(runId,attemptId), _) => Some(JobInfo(jobStart.jobId, jobGroup, jobDescription, Some(SDLExecutionId(runId.toInt, attemptId.toInt))))
+      case (jobGroupRegex(runId, attemptId), _) => Some(JobInfo(jobStart.jobId, jobGroup, jobDescription, Some(SDLExecutionId(runId.toInt, attemptId.toInt))))
       case (_, jobDescriptionRegex()) => Some(JobInfo(jobStart.jobId, jobGroup, jobDescription, None)) // spark streaming job info is read from description, has no executionId information.
       case _ => None
     }
-    jobInfo.foreach(i => jobStart.stageIds.foreach(stageId => jobInfoLookupTable(stageId) = i))
+    jobInfo.foreach { i =>
+      if (dataObjectId.isEmpty || i.dataObjectId.contains(dataObjectId.get)) {
+        runningJobs(i.id) = i
+        jobStart.stageIds.foreach(stageId => jobInfoLookupTable(stageId) = i)
+      }
+    }
+  }
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+    if (runningJobs.isDefinedAt(jobEnd.jobId)) synchronized {
+      runningJobs.remove(jobEnd.jobId)
+      notifyAll() // wakeup waitFor method
+    }
   }
 
   /**
@@ -84,13 +104,56 @@ private[smartdatalake] class SparkStageMetricsListener(action: Action)(implicit 
         taskMetrics.shuffleWriteMetrics.writeTime, taskMetrics.shuffleWriteMetrics.bytesWritten, taskMetrics.shuffleWriteMetrics.recordsWritten,
         stageCompleted.stageInfo.accumulables.values.toSeq
       )
-      val dataObjectIdRegex = (s"DataObject~(${SdlConfigObject.idRegexStr})").r.unanchored
-      val dataObjectId = jobInfo.description match {
-        case dataObjectIdRegex(id) => Some(DataObjectId(id))
-        case _ => None // there are some stages which are created by Spark DataFrame operations which dont manipulate Actions target DataObject's, e.g. pivot operator
-      }
-      // note that executionId might be empty for asynchronous actions
-      action.addRuntimeMetrics(jobInfo.executionId, dataObjectId, sparkStageMetrics)
+      metrics.append(sparkStageMetrics)
     }
   }
+
+  def register: SparkStageMetricsListener = {
+    context.sparkSession.sparkContext.addSparkListener(this)
+    this
+  }
+
+  /**
+   * Waits until all jobs are ended, and returns relevant metrics.
+   * Note that this should be called when Spark Jobs are finished, but through the asynchronous nature of Spark listeners this might be a little bit late.
+   */
+  def waitForSparkMetrics(timeoutSec: Int = 10): Seq[SparkStageMetrics] = try {
+    synchronized {
+      // we need to loop as wait might return without us calling notify
+      // https://en.wikipedia.org/w/index.php?title=Spurious_wakeup&oldid=992601610
+      val ts = System.currentTimeMillis()
+      while (runningJobs.nonEmpty) {
+        logger.debug(s"waiting for jobIds=${runningJobs.keys.mkString(",")}")
+        wait(timeoutSec * 1000L)
+        if (ts + timeoutSec * 1000L <= System.currentTimeMillis) throw SparkJobNotEndedException(s"SparkStageMetricsListener didn't get onJobEnd notification for jobIds=${runningJobs.keys.mkString(",")} within timeout of $timeoutSec seconds.")
+      }
+    }
+    metrics
+  } finally {
+    context.sparkSession.sparkContext.removeSparkListener(this)
+  }
+
+  /**
+   * Wait for Spark metrics and return main metrics from latest job.
+   */
+  def waitForMetrics(timeoutSec: Int = 10): MetricsMap = {
+    waitForSparkMetrics(timeoutSec).sortBy(_.jobInfo.id).lastOption.map(_.getMainInfos).getOrElse(Map())
+  }
 }
+
+object SparkStageMetricsListener {
+
+  /**
+   * Executes a Spark statement and return metrics collected through listener
+   */
+  def execWithMetrics(dataObjectId: DataObjectId, sparkCode: => Unit)(implicit context: ActionPipelineContext): MetricsMap = {
+    // setup listener
+    val stageMetricsListener = context.currentAction.map(action => new SparkStageMetricsListener(action.id, Some(dataObjectId)).register)
+    // exec spark code
+    sparkCode
+    // return metrics
+    stageMetricsListener.map(_.waitForMetrics()).getOrElse(Map())
+  }
+}
+
+case class SparkJobNotEndedException(msg: String) extends Exception(msg)

--- a/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStreamingQueryListener.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/metrics/SparkStreamingQueryListener.scala
@@ -23,13 +23,14 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.action.{DataFrameActionImpl, RuntimeEventState, SparkStreamingExecutionId}
-import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, GenericMetrics, InitSubFeed}
-import org.apache.spark.sql.streaming.StreamingQueryListener
+import io.smartdatalake.workflow.{ActionMetrics, ActionPipelineContext, ExecutionPhase, InitSubFeed}
+import org.apache.spark.sql.streaming.{StreamingQueryListener, StreamingQueryProgress}
 
 import java.time.temporal.ChronoUnit
 import java.time.{Duration, Instant, LocalDateTime, ZoneId}
 import java.util.UUID
 import java.util.concurrent.Semaphore
+import scala.collection.mutable
 
 /**
  * Collect metrics for Spark streaming queries
@@ -47,18 +48,14 @@ class SparkStreamingQueryListener(action: DataFrameActionImpl, dataObjectId: Dat
   }
   override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
     if (event.progress.id == id) {
-      val noData = event.progress.durationMs.size == 2 // if only 2 phases have run, there was no data...
-      logger.info(s"(${event.progress.name}) streaming query ${if (noData) "had no data" else "made progress"}: batchId=${event.progress.batchId} duration=${Duration.ofMillis(event.progress.batchDuration)}")
       val executionId = SparkStreamingExecutionId(event.progress.batchId)
       val endTstmp = LocalDateTime.ofInstant(Instant.parse(event.progress.timestamp), ZoneId.systemDefault) // String is in UTC. It must be converted to local timezone.
       val startTstmp = endTstmp.minus(event.progress.batchDuration, ChronoUnit.MILLIS) // start time is not stored in event...
       action.addRuntimeEvent(executionId, ExecutionPhase.Exec, RuntimeEventState.STARTED, tstmp = startTstmp)
-      if (!noData) {
-        if (event.progress.sink.numOutputRows >= 0) { // -1 if reporting metrics is not supported by sink
-          // if there are streaming metrics, they have highest prio (9999)
-          val metrics = GenericMetrics(s"streaming-${event.progress.batchId}", 9999, Map("batchDuration" -> event.progress.batchDuration / 1000, "records_written" -> event.progress.sink.numOutputRows))
-          action.addRuntimeMetrics(Some(SparkStreamingExecutionId(event.progress.batchId)), Some(dataObjectId), metrics)
-        }
+      val streamingMetrics = SparkStreamingMetrics(event.progress)
+      logger.info(s"(${event.progress.name}) streaming query ${if (streamingMetrics.noData) "had no data" else "made progress"}: batchId=${event.progress.batchId} ${streamingMetrics.getAsText}")
+      if (!streamingMetrics.noData) {
+        action.addAsyncMetrics(Some(SparkStreamingExecutionId(event.progress.batchId)), Some(dataObjectId), streamingMetrics)
         action.addRuntimeEvent(executionId, ExecutionPhase.Exec, RuntimeEventState.SUCCEEDED, tstmp = endTstmp, results = Seq(InitSubFeed(dataObjectId, partitionValues = Seq()))) // dummy results provided for runtime info
       }
       releaseFirstProgressWaitLock()
@@ -66,9 +63,9 @@ class SparkStreamingQueryListener(action: DataFrameActionImpl, dataObjectId: Dat
   }
   override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
     if (event.id == id) {
-      logger.info(s"($queryName) streaming query terminated ${event.exception.map(e => s" exception=$e").getOrElse(" normally")}")
+      logger.info(s"($queryName) streaming query terminated ${event.exception.map(e => s"exception=$e").getOrElse("normally")}")
       context.sparkSession.streams.removeListener(this) // self-unregister
-      action.notifyStreamingQueryTerminated
+      action.notifySparkStreamingQueryTerminated
       releaseFirstProgressWaitLock()
     }
     Environment.stopStreamingGracefully = true // stop synchronous actions
@@ -78,5 +75,22 @@ class SparkStreamingQueryListener(action: DataFrameActionImpl, dataObjectId: Dat
       firstProgressWaitLock.foreach(_.release())
       isFirstProgress = false
     }
+  }
+}
+
+case class SparkStreamingMetrics(progress: StreamingQueryProgress) extends ActionMetrics {
+
+  val noData: Boolean = (progress.durationMs.size <= 2) // if only 2 phases have run, there was no data...
+
+  override val getId: String = s"streaming-${progress.batchId}"
+
+  override val getOrder: Long = Instant.parse(progress.timestamp).getEpochSecond
+
+  override def getMainInfos: Map[String, Any] = {
+    val metrics = mutable.Map[String, Any]("batch_duration" -> progress.batchDuration, "no_data" -> noData)
+    if (progress.sink.numOutputRows >= 0) { // -1 if reporting metrics is not supported by sink
+      metrics += ("records_written" -> progress.sink.numOutputRows)
+    }
+    metrics.toMap
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/FinalMetricsLogWriter.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/FinalMetricsLogWriter.scala
@@ -131,11 +131,12 @@ object LogExtractor extends SmartDataLakeLogger {
   def getActionLog(actionId: ActionId, info: RuntimeInfo, executionId: SDLExecutionId, finalState: RuntimeEventState, context: ActionPipelineContext): ActionLog = {
     val duration = info.duration.map(_.getSeconds)
     val dataObjectLogs = info.results.map { result =>
-      val numTasks = result.mainMetrics.get("num_tasks").map(castToLong)
-      val filesWritten = result.mainMetrics.get("files_written").map(castToLong)
-      val recordsWritten = result.mainMetrics.get("records_written").map(castToLong)
-      val metrics = result.mainMetrics.filterKeys(!Set("num_tasks", "files_written", "records_written").contains(_))
-      MetricsLog(result.subFeed.dataObjectId.id, Timestamp.valueOf(info.startTstmp.get), numTasks, filesWritten, recordsWritten, metrics.mapValues(_.toString), result.subFeed.partitionValues.map(_.getMapString))
+      val metrics = result.metrics.getOrElse(Map())
+      val numTasks = metrics.get ("num_tasks").map (castToLong)
+      val filesWritten = metrics.get ("files_written").map (castToLong)
+      val recordsWritten = metrics.get ("records_written").map (castToLong)
+      val filteredMetrics = metrics.filterKeys (! Set ("num_tasks", "files_written", "records_written").contains (_) )
+      MetricsLog (result.dataObjectId.id, Timestamp.valueOf (info.startTstmp.get), numTasks, filesWritten, recordsWritten, filteredMetrics.mapValues (_.toString), result.partitionValues.map (_.getMapString) )
     }
     ActionLog(executionId.runId, Timestamp.valueOf(context.runStartTime), actionId.id
       , executionId.attemptId, Timestamp.valueOf(context.attemptStartTime), finalState

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRun.scala
@@ -54,7 +54,7 @@ private[smartdatalake] trait ActionMetrics {
 
   def getMainInfos: Map[String, Any]
 
-  def getAsText: String
+  def getAsText: String = getMainInfos.map { case (k, v) => s"$k=$v" }.mkString(" ")
 }
 
 private[smartdatalake] case class GenericMetrics(id: String, order: Long, mainInfos: Map[String, Any]) extends ActionMetrics {
@@ -63,10 +63,6 @@ private[smartdatalake] case class GenericMetrics(id: String, order: Long, mainIn
   def getOrder: Long = order
 
   def getMainInfos: Map[String, Any] = mainInfos
-
-  def getAsText: String = {
-    mainInfos.map { case (k, v) => s"$k=$v" }.mkString(" ")
-  }
 }
 
 private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], executionId: SDLExecutionId, partitionValues: Seq[PartitionValues], parallelism: Int, initialSubFeeds: Seq[SubFeed], initialDataObjectsState: Seq[DataObjectState], stateStore: Option[ActionDAGRunStateStore[_]], stateListeners: Seq[StateListener], actionsSkipped: Map[ActionId, RuntimeInfo]) extends SmartDataLakeLogger {
@@ -112,34 +108,36 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], executionId: SD
     result.filter(_.isSuccess).map(_.get)
   }
 
-  def prepare(implicit context: ActionPipelineContext): Unit = {
-    context.phase = ExecutionPhase.Prepare
+  def prepare(context: ActionPipelineContext): Unit = {
+    implicit val phaseContext: ActionPipelineContext = context.copy(phase = ExecutionPhase.Prepare)
     // run prepare for every node
-    run[DummyDAGResult](context.phase) {
+    run[DummyDAGResult](phaseContext.phase) {
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => DummyDAGResult(dataObjectId))
       case (node: Action, _) =>
-        node.prepare
+        val actionContext = phaseContext.copy(currentAction = Some(node))
+        node.prepare(actionContext)
         node.outputs.map(outputDO => DummyDAGResult(outputDO.id.id))
       case x => throw new IllegalStateException(s"Unmatched case $x")
     }
   }
 
-  def init(implicit context: ActionPipelineContext): Seq[SubFeed] = {
-    context.phase = ExecutionPhase.Init
+  def init(context: ActionPipelineContext): Seq[SubFeed] = {
+    implicit val phaseContext: ActionPipelineContext = context.copy(phase = ExecutionPhase.Init)
     // initialize state listeners
-    stateListeners.foreach(_.init(context))
+    stateListeners.foreach(_.init(phaseContext))
     // run init for every node
-    val t = run[SubFeed](context.phase) {
+    val t = run[SubFeed](phaseContext.phase) {
       case (node: InitDAGNode, _) =>
         node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
       case (node: Action, subFeeds) =>
         val deduplicatedSubFeeds = unionDuplicateSubFeeds(subFeeds ++ getRecursiveSubFeeds(node), node.id)
         val previousThreadName = setThreadName(getActionThreadName(node.id))
         val resultSubFeeds = try {
+          val actionContext = phaseContext.copy(currentAction = Some(node))
           val inputIds = node.inputs.map(_.id)
-          node.preInit(deduplicatedSubFeeds, initialDataObjectsState.filter(state => inputIds.contains(state.dataObjectId)))
-          node.init(deduplicatedSubFeeds)
+          node.preInit(deduplicatedSubFeeds, initialDataObjectsState.filter(state => inputIds.contains(state.dataObjectId)))(actionContext)
+          node.init(deduplicatedSubFeeds)(actionContext)
         } finally {
           setThreadName(previousThreadName)
         }
@@ -161,20 +159,21 @@ private[smartdatalake] case class ActionDAGRun(dag: DAG[Action], executionId: SD
     }.values.toSeq
   }
 
-  def exec(implicit context: ActionPipelineContext): Seq[SubFeed] = {
+  def exec(context: ActionPipelineContext): Seq[SubFeed] = {
     // run exec for every node
     val result = {
-      context.phase = ExecutionPhase.Exec
-      run[SubFeed](context.phase, parallelism) {
+      implicit val phaseContext: ActionPipelineContext = context.copy(phase = ExecutionPhase.Exec)
+      run[SubFeed](phaseContext.phase, parallelism) {
         case (node: InitDAGNode, _) =>
           node.edges.map(dataObjectId => getInitialSubFeed(dataObjectId))
         case (node: Action, subFeeds) =>
           val deduplicatedSubFeeds = unionDuplicateSubFeeds(subFeeds ++ getRecursiveSubFeeds(node), node.id)
           val previousThreadName = setThreadName(getActionThreadName(node.id))
           val resultSubFeeds = try {
-            node.preExec(deduplicatedSubFeeds)
-            val resultSubFeeds = node.exec(deduplicatedSubFeeds)
-            node.postExec(deduplicatedSubFeeds, resultSubFeeds)
+            val actionContext = phaseContext.copy(currentAction = Some(node))
+            node.preExec(deduplicatedSubFeeds)(actionContext)
+            val resultSubFeeds = node.exec(deduplicatedSubFeeds)(actionContext)
+            node.postExec(deduplicatedSubFeeds, resultSubFeeds)(actionContext)
             resultSubFeeds
           } catch {
             case ex: Exception =>

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -76,7 +76,7 @@ case class DataObjectState(dataObjectId: DataObjectId, state: String) {
 
 private[smartdatalake] object ActionDAGRunState {
 
-  val runStateFormatVersion: Int = 3
+  val runStateFormatVersion: Int = 4
 
   private val durationSerializer = Json4sCompat.getCustomSerializer[Duration](formats => (
     {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -24,7 +24,7 @@ import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{SerializableHadoopConfiguration, SmartDataLakeLogger}
 import io.smartdatalake.workflow.ExecutionPhase.ExecutionPhase
-import io.smartdatalake.workflow.action.SDLExecutionId
+import io.smartdatalake.workflow.action.{Action, SDLExecutionId}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.SparkSession
@@ -61,13 +61,14 @@ case class ActionPipelineContext (
                                    runStartTime: LocalDateTime = LocalDateTime.now(),
                                    attemptStartTime: LocalDateTime = LocalDateTime.now(),
                                    simulation: Boolean = false,
-                                   var phase: ExecutionPhase = ExecutionPhase.Prepare,
+                                   phase: ExecutionPhase = ExecutionPhase.Prepare,
                                    dataFrameReuseStatistics: mutable.Map[(DataObjectId, Seq[PartitionValues]), Seq[ActionId]] = mutable.Map(),
                                    actionsSelected: Seq[ActionId] = Seq(),
                                    actionsSkipped: Seq[ActionId] = Seq(),
                                    @transient // Prevent polluting output with contents of classLoader field
                                    serializableHadoopConf: SerializableHadoopConfiguration,
-                                   globalConfig: GlobalConfig
+                                   globalConfig: GlobalConfig,
+                                   currentAction: Option[Action] = None
                                  ) extends SmartDataLakeLogger {
   private[smartdatalake] def getReferenceTimestampOrNow: LocalDateTime = referenceTimestamp.getOrElse(LocalDateTime.now)
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/DataFrameSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/DataFrameSubFeed.scala
@@ -22,6 +22,7 @@ package io.smartdatalake.workflow
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.ScalaUtil
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.dataframe._
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, DataObject, SchemaValidation, UserDefinedSchema}
 
@@ -31,7 +32,7 @@ import scala.reflect.runtime.universe.Type
 /**
  * A SubFeed that holds a DataFrame
  */
-trait DataFrameSubFeed extends SubFeed  {
+trait DataFrameSubFeed extends SubFeed {
   @transient
   def tpe: Type // concrete type of this DataFrameSubFeed
   implicit lazy val companion: DataFrameSubFeedCompanion = DataFrameSubFeed.getCompanion(tpe)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/FileSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/FileSubFeed.scala
@@ -21,6 +21,7 @@ package io.smartdatalake.workflow
 
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 import io.smartdatalake.workflow.dataobject.FileRef
 
@@ -39,8 +40,9 @@ case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
                        override val partitionValues: Seq[PartitionValues],
                        override val isDAGStart: Boolean = false,
                        override val isSkipped: Boolean = false,
-                       fileRefMapping: Option[Seq[FileRefMapping]] = None
-                      )
+                       fileRefMapping: Option[Seq[FileRefMapping]] = None,
+                       override val metrics: Option[MetricsMap] = None
+)
   extends SubFeed {
 
   override def breakLineage(implicit context: ActionPipelineContext): FileSubFeed = {
@@ -95,6 +97,13 @@ case class FileSubFeed(fileRefs: Option[Seq[FileRef]],
   override def applyExecutionModeResultForOutput(result: ExecutionModeResult)(implicit context: ActionPipelineContext): FileSubFeed = {
     this.copy(partitionValues = result.inputPartitionValues, isSkipped = false, fileRefs = None, fileRefMapping = None)
   }
+
+  override def withMetrics(metrics: MetricsMap): FileSubFeed = {
+    this.copy(metrics = Some(metrics))
+  }
+
+  def appendMetrics(metrics: MetricsMap): FileSubFeed = withMetrics(this.metrics.getOrElse(Map()) ++ metrics)
+
 }
 object FileSubFeed extends SubFeedConverter[FileSubFeed] {
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/InitSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/InitSubFeed.scala
@@ -21,6 +21,7 @@ package io.smartdatalake.workflow
 
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
@@ -33,7 +34,8 @@ import sun.reflect.generics.reflectiveObjects.NotImplementedException
  */
 case class InitSubFeed(override val dataObjectId: DataObjectId,
                        override val partitionValues: Seq[PartitionValues],
-                       override val isSkipped: Boolean = false
+                       override val isSkipped: Boolean = false,
+                       override val metrics: Option[MetricsMap] = None
                       )
   extends SubFeed {
   override def isDAGStart: Boolean = true
@@ -63,4 +65,8 @@ case class InitSubFeed(override val dataObjectId: DataObjectId,
   def applyExecutionModeResultForOutput(result: ExecutionModeResult)(implicit context: ActionPipelineContext): SubFeed = {
     this.copy(partitionValues = result.inputPartitionValues, isSkipped = false)
   }
+  override def withMetrics(metrics: MetricsMap): InitSubFeed = {
+    this.copy(metrics = Some(metrics))
+  }
+  def appendMetrics(metrics: MetricsMap): InitSubFeed = withMetrics(this.metrics.getOrElse(Map()) ++ metrics)
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ScriptSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ScriptSubFeed.scala
@@ -22,6 +22,7 @@ package io.smartdatalake.workflow
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.ScalaUtil.optionalizeMap
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 
 /**
@@ -38,7 +39,8 @@ case class ScriptSubFeed(parameters: Option[Map[String,String]] = None,
                          override val dataObjectId: DataObjectId,
                          override val partitionValues: Seq[PartitionValues],
                          override val isDAGStart: Boolean = false,
-                         override val isSkipped: Boolean = false
+                         override val isSkipped: Boolean = false,
+                         override val metrics: Option[MetricsMap] = None
                         )
   extends SubFeed {
   override def breakLineage(implicit context: ActionPipelineContext): ScriptSubFeed = this
@@ -72,6 +74,10 @@ case class ScriptSubFeed(parameters: Option[Map[String,String]] = None,
   override def applyExecutionModeResultForOutput(result: ExecutionModeResult)(implicit context: ActionPipelineContext): ScriptSubFeed = {
     this.copy(partitionValues = result.inputPartitionValues, isSkipped = false, parameters = None)
   }
+
+  def withMetrics(metrics: MetricsMap): ScriptSubFeed = this.copy(metrics = Some(metrics))
+  def appendMetrics(metrics: MetricsMap): ScriptSubFeed = withMetrics(this.metrics.getOrElse(Map()) ++ metrics)
+
 }
 object ScriptSubFeed extends SubFeedConverter[ScriptSubFeed] {
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/SubFeed.scala
@@ -22,6 +22,7 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.dag.DAGResult
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 
 /**
@@ -33,6 +34,7 @@ trait SubFeed extends DAGResult with SmartDataLakeLogger {
   def partitionValues: Seq[PartitionValues]
   def isDAGStart: Boolean
   def isSkipped: Boolean
+  def metrics: Option[MetricsMap]
 
   /**
    * Break lineage.
@@ -64,6 +66,11 @@ trait SubFeed extends DAGResult with SmartDataLakeLogger {
 
   def applyExecutionModeResultForInput(result: ExecutionModeResult, mainInputId: DataObjectId)(implicit context: ActionPipelineContext): SubFeed
   def applyExecutionModeResultForOutput(result: ExecutionModeResult)(implicit context: ActionPipelineContext): SubFeed
+
+  def withMetrics(metrics: MetricsMap): SubFeed
+
+  def appendMetrics(metrics: MetricsMap): SubFeed
+
 }
 object SubFeed {
   def filterPartitionValues(partitionValues: Seq[PartitionValues], partitions: Seq[String]): Seq[PartitionValues] = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/Action.scala
@@ -232,7 +232,7 @@ trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNod
   def postExec(inputSubFeeds: Seq[SubFeed], outputSubFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
     if (isAsynchronousProcessStarted) return
     // evaluate metrics fail condition if defined
-    metricsFailCondition.foreach( c => evaluateMetricsFailCondition(c))
+    metricsFailCondition.foreach( c => evaluateMetricsFailCondition(c, outputSubFeeds))
     // process postRead/Write hooks
     inputs.foreach( input => input.postRead(findSubFeedPartitionValues(input.id, inputSubFeeds)))
     outputs.foreach( output => output.postWrite(findSubFeedPartitionValues(output.id, outputSubFeeds)))
@@ -259,13 +259,11 @@ trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNod
   /**
    * Evaluates a condition against latest metrics and throws an MetricsCheckFailed if there is a match.
    */
-  private def evaluateMetricsFailCondition(condition: String)(implicit context: ActionPipelineContext): Unit = {
+  private def evaluateMetricsFailCondition(condition: String, subFeeds: Seq[SubFeed])(implicit context: ActionPipelineContext): Unit = {
     val conditionEvaluator = new ExpressionEvaluator[Metric,Boolean](expr(condition))
-    val metrics = {
-      getRuntimeMetrics().flatMap{
-        case (dataObjectId, Some(metrics)) => metrics.getMainInfos.map{ case (k,v) => Metric(dataObjectId.id, Some(k), Some(v.toString))}.toSeq
-        case (dataObjectId, _) => Seq(Metric(dataObjectId.id, None, None))
-      }.toSeq
+    val metrics = subFeeds.map(subFeed => (subFeed.dataObjectId, subFeed.metrics)).flatMap {
+      case (dataObjectId, Some(metrics)) => metrics.map{ case (k,v) => Metric(dataObjectId.id, Some(k), Some(v.toString))}.toSeq
+      case (dataObjectId, _) => Seq(Metric(dataObjectId.id, None, None))
     }
     metrics.filter( metric => Option(conditionEvaluator(metric)).getOrElse(false))
       .foreach( failedMetric => throw MetricsCheckFailed(s"""($id) metrics check failed: $failedMetric matched expression "$condition""""))
@@ -341,25 +339,16 @@ trait Action extends SdlConfigObject with ParsableFromConfig[Action] with DAGNod
   /**
    * Adds a runtime metric for this Action
    */
-  def addRuntimeMetrics(executionId: Option[ExecutionId], dataObjectId: Option[DataObjectId], metric: ActionMetrics): Unit = {
+  def addAsyncMetrics(executionId: Option[ExecutionId], dataObjectId: Option[DataObjectId], metric: ActionMetrics): Unit = {
     if (dataObjectId.isDefined) {
       if (outputs.exists(_.id == dataObjectId.get)) try {
         runtimeData.addMetric(executionId, dataObjectId.get, metric)
       } catch {
-        case e: LateArrivingMetricException => logger.error(s"($id) ${e.msg}")
         case e: AssertionError => logger.error(s"($id) ${e.getMessage}")
       }
       else logger.warn(s"($id) Metrics received for ${dataObjectId.get} which doesn't belong to outputs ($metric")
     } else logger.debug(s"($id) Metrics received for unspecified DataObject (${metric.getId})")
     if (logger.isDebugEnabled) logger.debug(s"($id) Metrics received:\n" + metric.getAsText)
-  }
-
-  /**
-   * Get the latest metrics for all DataObjects and a given SDLExecutionId.
-   * @param executionId ExecutionId to get metrics for. If empty metrics for last ExecutionId are returned.
-   */
-  def getRuntimeMetrics(executionId: Option[ExecutionId] = None): Map[DataObjectId, Option[ActionMetrics]] = {
-    outputs.map(dataObject => (dataObject.id, runtimeData.getMetrics(dataObject.id, executionId))).toMap
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -72,7 +72,7 @@ case class CustomFileAction(override val id: ActionId,
     outputSubFeed.copy(fileRefMapping = Some(output.translateFileRefs(inputFileRefs)))
   }
 
-  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult[FileSubFeed] = {
+  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): FileSubFeed = {
     val fileRefMapping = subFeed.fileRefMapping.getOrElse(throw new IllegalStateException(s"($id) file mapping is not defined"))
     output.startWritingOutputStreams(subFeed.partitionValues)
     if (fileRefMapping.nonEmpty) {
@@ -110,7 +110,7 @@ case class CustomFileAction(override val id: ActionId,
     // return metric to action
     val filesWritten = fileRefMapping.size.toLong
     val metrics = Map("files_written"->fileRefMapping.size.toLong) ++ (if (filesWritten == 0) Map ("no_data" -> true) else Map())
-    WriteSubFeedResult(subFeed, Some(fileRefMapping.isEmpty), Some(metrics))
+    subFeed.withMetrics(metrics)
   }
 
   override def postprocessOutputSubFeedCustomized(subFeed: FileSubFeed)(implicit context: ActionPipelineContext): FileSubFeed = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -78,7 +78,7 @@ case class FileTransferAction(override val id: ActionId,
     outputSubFeed.copy(fileRefMapping = Some(fileTransfer.getFileRefMapping(inputFileRefs, filenameExtractorRegex.map(_.r))))
   }
 
-  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult[FileSubFeed] = {
+  override def writeSubFeed(subFeed: FileSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): FileSubFeed = {
     val fileRefMapping = subFeed.fileRefMapping.getOrElse(throw new IllegalStateException(s"($id) file mapping is not defined"))
     output.startWritingOutputStreams(subFeed.partitionValues)
     if (fileRefMapping.nonEmpty) fileTransfer.exec(fileRefMapping)
@@ -86,7 +86,7 @@ case class FileTransferAction(override val id: ActionId,
     // return metric to action
     val filesWritten = fileRefMapping.size.toLong
     val metrics = Map("files_written"->filesWritten) ++ (if (filesWritten == 0) Map ("no_data" -> true) else Map())
-    WriteSubFeedResult(subFeed, Some(fileRefMapping.isEmpty), Some(metrics))
+    subFeed.withMetrics(metrics)
   }
 
   override def postprocessOutputSubFeedCustomized(subFeed: FileSubFeed)(implicit context: ActionPipelineContext): FileSubFeed = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ScriptActionImpl.scala
@@ -48,9 +48,9 @@ abstract class ScriptActionImpl extends ActionSubFeedsImpl[ScriptSubFeed] {
     } else outputSubFeeds
   }
 
-  override def writeSubFeed(subFeed: ScriptSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): WriteSubFeedResult[ScriptSubFeed] = {
+  override def writeSubFeed(subFeed: ScriptSubFeed, isRecursive: Boolean)(implicit context: ActionPipelineContext): ScriptSubFeed = {
     val output = outputs.find(_.id == subFeed.dataObjectId).getOrElse(throw new IllegalStateException(s"($id) output for subFeed ${subFeed.dataObjectId} not found"))
     output.scriptNotification(subFeed.parameters.getOrElse(Map()))
-    WriteSubFeedResult(subFeed, noData = None) // unknown if there is data
+    subFeed
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
@@ -98,12 +98,24 @@ case class JdbcTableConnection(override val id: ConnectionId,
   }
 
   /**
-   * Get a JDBC connection from the pool, create a JDBC statement and execute an arbitrary function
+   * Get a JDBC connection from the pool, create a JDBC statement and execute an arbitrary sql statement
+   * @return true if the first result is a ResultSet object; false if it is an update count or there are no results (see also Jdbc.Statement.execute())
    */
   def execJdbcStatement(sql:String, logging: Boolean = true) : Boolean = {
     execWithJdbcConnection(execWithJdbcStatement(_, doCommit = true) { stmt =>
       if (logging) logger.info(s"execJdbcStatement: $sql")
       stmt.execute(sql)
+    })
+  }
+
+  /**
+   * Get a JDBC connection from the pool, create a JDBC statement and execute an arbitrary function
+   * @return row count for SQL Data Manipulation Language (DML) statements (see also Jdbc.Statement.execute())
+   */
+  def execJdbcDmlStatement(sql: String, logging: Boolean = true): Int = {
+    execWithJdbcConnection(execWithJdbcStatement(_, doCommit = true) { stmt =>
+      if (logging) logger.info(s"execJdbcDmlStatement: $sql")
+      stmt.executeUpdate(sql)
     })
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -231,7 +231,7 @@ trait GenericSchema extends GenericTypedObject {
     SchemaConverter.convert(this, toSubFeedType)
   }
   def equalsSchema(schema: GenericSchema): Boolean = {
-    diffSchema(schema).nonEmpty || schema.diffSchema(this).nonEmpty
+    diffSchema(schema).isEmpty && schema.diffSchema(this).isEmpty
   }
   def diffSchema(schema: GenericSchema): Option[GenericSchema]
   def columns: Seq[String]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
@@ -23,6 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.spark.{DataFrameUtil, DummyStreamProvider}
 import io.smartdatalake.workflow._
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 import io.smartdatalake.workflow.dataframe._
 import org.apache.spark.sql.types.{ArrayType, StringType, StructField, StructType}
@@ -49,7 +50,8 @@ case class SparkSubFeed(@transient override val dataFrame: Option[SparkDataFrame
                         override val isSkipped: Boolean = false,
                         override val isDummy: Boolean = false,
                         override val filter: Option[String] = None,
-                        @transient override val observation: Option[DataFrameObservation] = None
+                        @transient override val observation: Option[DataFrameObservation] = None,
+                        override val metrics: Option[MetricsMap] = None
                        )
   extends DataFrameSubFeed {
   @transient
@@ -146,6 +148,9 @@ case class SparkSubFeed(@transient override val dataFrame: Option[SparkDataFrame
     this.copy(partitionValues = partitionValues, filter = filter)
       .applyFilter
   }
+  override def withMetrics(metrics: MetricsMap): SparkSubFeed = this.copy(metrics = Some(metrics))
+  def appendMetrics(metrics: MetricsMap): SparkSubFeed = withMetrics(this.metrics.getOrElse(Map()) ++ metrics)
+
 }
 
 object SparkSubFeed extends DataFrameSubFeedCompanion {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanWriteDataFrame.scala
@@ -22,6 +22,7 @@ import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.definitions.SaveModeOptions
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
@@ -41,14 +42,9 @@ trait CanWriteDataFrame {
 
   /**
    * Write a DataFrame to the DataObject
+   * @return collected metrics
    */
-  def writeDataFrame(df: GenericDataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)(implicit context: ActionPipelineContext): Unit
-
-  /**
-   * Write a GenericDataFrameSubFeed to the DataObject.
-   * See writeSubFeedSupportedTypes for supported languages of the GenericDataFrameSubFeed.
-   */
-  private[smartdatalake] def writeSubFeed(subFeed: DataFrameSubFeed, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)(implicit context: ActionPipelineContext): Unit
+  def writeDataFrame(df: GenericDataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)(implicit context: ActionPipelineContext): MetricsMap
 
   /**
    * Declare supported Language for writing DataFrame.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -324,7 +324,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   private def overwriteTableWithDataframe(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): MetricsMap = {
     try {
       // create & write to temp-table
-      val tableSchema = connection.catalog.getSchemaFromTable(table.fullName)
+      val tableSchema = getExistingSchema.get
       val metrics = writeToTempTable(df, tableSchema)
       overwriteTableWithTempTableInTransaction(partitionValues)
       // return

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -23,15 +23,16 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.definitions.{Environment, SDLSaveMode, SaveModeMergeOptions, SaveModeOptions}
+import io.smartdatalake.metrics.SparkStageMetricsListener
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{ProductUtil, SQLUtil, SchemaUtil}
-import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
 import io.smartdatalake.util.spark.{DefaultExpressionData, SparkExpressionUtil}
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.connection.jdbc.JdbcTableConnection
 import io.smartdatalake.workflow.dataframe.GenericSchema
 import io.smartdatalake.workflow.dataframe.spark.{SparkField, SparkSchema}
-import io.smartdatalake.workflow.ActionPipelineContext
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.custom.ExpressionEvaluator
 import org.apache.spark.sql.functions._
@@ -291,7 +292,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   }
 
   override def writeSparkDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit context: ActionPipelineContext): Unit = {
+                             (implicit context: ActionPipelineContext): MetricsMap = {
     implicit val session: SparkSession = context.sparkSession
     require(table.query.isEmpty, s"($id) Cannot write to jdbc DataObject defined by a query.")
     validateSchemaMin(SparkSchema(df.schema), "write")
@@ -306,7 +307,8 @@ case class JdbcTableDataObject(override val id: DataObjectId,
     finalSaveMode match {
 
       case SDLSaveMode.Overwrite =>
-        overwriteTableWithDataframe(df, partitionValues)
+        val metrics = overwriteTableWithDataframe(df, partitionValues)
+        metrics ++ metrics.get("records_written").map("rows_inserted" -> _) // standardize inserted metric
 
       case SDLSaveMode.Merge =>
         // write to tmp-table and merge by primary key
@@ -314,16 +316,19 @@ case class JdbcTableDataObject(override val id: DataObjectId,
 
       case SDLSaveMode.Append =>
         // write target table with SaveMode.Append
-        writeDataFrameInternalWithAppend(df, table.fullName)
+        val metrics = writeDataFrameInternalWithAppend(df, table.fullName)
+        metrics ++ metrics.get("records_written").map("rows_inserted" -> _) // standardize inserted metric
     }
   }
 
-  private def overwriteTableWithDataframe(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+  private def overwriteTableWithDataframe(df: DataFrame, partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): MetricsMap = {
     try {
       // create & write to temp-table
       val tableSchema = connection.catalog.getSchemaFromTable(table.fullName)
-      writeToTempTable(df, tableSchema)
+      val metrics = writeToTempTable(df, tableSchema)
       overwriteTableWithTempTableInTransaction(partitionValues)
+      // return
+      metrics
     } finally {
       // cleanup temp table
       connection.dropTable(tmpTable.fullName)
@@ -346,7 +351,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
     }
   }
 
-  private def writeToTempTable(df: DataFrame, tempTableSchema: StructType)(implicit context: ActionPipelineContext): Unit = {
+  private def writeToTempTable(df: DataFrame, tempTableSchema: StructType)(implicit context: ActionPipelineContext): MetricsMap = {
     implicit val session: SparkSession = context.sparkSession
     // cleanup temp table if existing
     if(connection.catalog.isTableExisting(tmpTable.fullName)) {
@@ -363,32 +368,35 @@ case class JdbcTableDataObject(override val id: DataObjectId,
    * Table.primaryKey is used as condition to check if a record is matched or not. If it is matched it gets updated (or deleted), otherwise it is inserted.
    * This all is done in one transaction.
    */
-  def mergeDataFrameByPrimaryKey(df: DataFrame, saveModeOptions: SaveModeMergeOptions)(implicit context: ActionPipelineContext): Unit = {
+  def mergeDataFrameByPrimaryKey(df: DataFrame, saveModeOptions: SaveModeMergeOptions)(implicit context: ActionPipelineContext): MetricsMap = {
     implicit val session: SparkSession = context.sparkSession
     assert(table.primaryKey.exists(_.nonEmpty), s"($id) table.primaryKey must be defined to use mergeDataFrameByPrimaryKey")
 
     try {
       // write data to temp table
-      writeToTempTable(df, df.schema)
+      val metrics = writeToTempTable(df, df.schema)
       // prepare SQL merge statement
       val mergeStmt = SQLUtil.createMergeStatement(table, df.columns.toSeq, tmpTable.fullName, saveModeOptions, quoteCaseSensitiveColumn(_))
       // execute
       logger.info(s"($id) executing merge statement with options: ${ProductUtil.attributesWithValuesForCaseClass(saveModeOptions).map(e => e._1+"="+e._2).mkString(" ")}")
       logger.debug(s"($id) merge statement: $mergeStmt")
-      connection.execJdbcStatement(mergeStmt)
+      val rowAffected = connection.execJdbcDmlStatement(mergeStmt)
+      metrics + ("rows_affected" -> rowAffected)
     } finally {
       // cleanup temp table
       connection.dropTable(tmpTable.fullName)
     }
   }
 
-  private def writeDataFrameInternalWithAppend(df: DataFrame, tableName: String): Unit = {
+  private def writeDataFrameInternalWithAppend(df: DataFrame, tableName: String)(implicit context: ActionPipelineContext): MetricsMap = {
     // No need to define any partitions as parallelization will be defined according to the data frame's partitions
-    df.write.mode(SaveMode.Append).format("jdbc")
-      .options(options)
-      .options(connection.getAuthModeSparkOptions)
-      .option("dbtable", tableName)
-      .save
+    SparkStageMetricsListener.execWithMetrics(this.id,
+      df.write.mode(SaveMode.Append).format("jdbc")
+        .options(options)
+        .options(connection.getAuthModeSparkOptions)
+        .option("dbtable", tableName)
+        .save
+    )
   }
 
   override def preRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -156,7 +156,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val resultActionsState = runState.actionsState.mapValues(x=>(x.state, x.executionId))
       val expectedActionsState = Map(action1.id -> (RuntimeEventState.SUCCEEDED,SDLExecutionId(1,1)), action2success.id -> (RuntimeEventState.SUCCEEDED,SDLExecutionId(1,2)))
       assert(resultActionsState == expectedActionsState)
-      assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == selectedPartitions)
+      assert(runState.actionsState.head._2.results.head.partitionValues == selectedPartitions)
       assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty)
     }
 
@@ -512,7 +512,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val resultActionsState = runState.actionsState.mapValues(_.state)
       val expectedActionsState = Map((action1.id, RuntimeEventState.SUCCEEDED))
       assert(resultActionsState == expectedActionsState)
-      assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt" -> "20180101"))))
+      assert(runState.actionsState.head._2.results.head.partitionValues == Seq(PartitionValues(Map("dt" -> "20180101"))))
     }
 
     // now fill src table with second partitions
@@ -542,7 +542,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val resultActionsState = runState.actionsState.mapValues(_.state)
       val expectedActionsState = Map((action1.id, RuntimeEventState.SUCCEEDED))
       assert(resultActionsState == expectedActionsState)
-      assert(runState.actionsState.head._2.results.head.subFeed.partitionValues == Seq(PartitionValues(Map("dt" -> "20190101"))))
+      assert(runState.actionsState.head._2.results.head.partitionValues == Seq(PartitionValues(Map("dt" -> "20190101"))))
       assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty)
     }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
@@ -25,6 +25,7 @@ import io.smartdatalake.workflow.dataframe.GenericSchema
 import io.smartdatalake.definitions.SaveModeOptions
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.dataobject._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -50,7 +51,7 @@ case class TestDataObject( id: DataObjectId,
   override def getSparkDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = null
 
   override def writeSparkDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit context: ActionPipelineContext): Unit = {}
+                             (implicit context: ActionPipelineContext): MetricsMap = Map()
 
   override var table: Table = Table(db=Some("testdb"), name="testtable")
 

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -23,10 +23,12 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import io.smartdatalake.app.{GlobalConfig, SmartDataLakeBuilderConfig}
 import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.misc.{SerializableHadoopConfiguration, SmartDataLakeLogger}
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
-import io.smartdatalake.workflow.action.SDLExecutionId
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
+import io.smartdatalake.workflow.action.{RuntimeInfo, SDLExecutionId}
 import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
@@ -49,7 +51,6 @@ import java.nio.file.Files
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDateTime}
 import scala.collection.JavaConverters._
-import scala.util.Try
 
 /**
  * Utility methods for testing.
@@ -394,6 +395,10 @@ object TestUtil extends SmartDataLakeLogger {
     }
     val rows = (1 to nbRecords).map( x => arbitraryRow(schema.fields)).asJava
     session.createDataFrame(rows, schema)
+  }
+
+  def getMetrics(runtimeInfo: RuntimeInfo, dataObjectId: DataObjectId): MetricsMap = {
+    runtimeInfo.results.find(_.dataObjectId == dataObjectId).get.metrics.getOrElse(Map())
   }
 }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/RuntimeDataTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/RuntimeDataTest.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
-import io.smartdatalake.workflow.{ExecutionPhase, GenericMetrics}
+import io.smartdatalake.workflow.{ExecutionPhase, GenericMetrics, SubFeed}
 import org.scalatest.FunSuite
 
 import java.time.LocalDateTime
@@ -61,30 +61,12 @@ class RuntimeDataTest extends FunSuite {
     assert(runtimeData.getEvents(Some(SparkStreamingExecutionId(1))).size==3)
     assert(runtimeData.getLatestEventState.contains(RuntimeEventState.FAILED))
   }
-  
-  test("store and get synchronous metrics") {
-    val runtimeData = SynchronousRuntimeData(10)
-    val dataObjectId = DataObjectId("test")
-    runtimeData.addEvent(SDLExecutionId(1), RuntimeEvent(LocalDateTime.now(), ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq()))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId, GenericMetrics("test-metric1", 1, Map("metric1" -> 1)))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId, GenericMetrics("test-metric2", 2, Map("metric2" -> 2)))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId+"dummy", GenericMetrics("test-metric99", 2, Map()))
-    assert(runtimeData.getMetrics(dataObjectId, Some(SDLExecutionId(1))).exists(_.getMainInfos.isDefinedAt("metric2")))
-    assert(runtimeData.getMetrics(dataObjectId).exists(_.getMainInfos.isDefinedAt("metric2")))
-    intercept[AssertionError](runtimeData.addMetric(Some(SDLExecutionId(2)), dataObjectId, GenericMetrics("test2-metric1", 1, Map())))
-    runtimeData.addEvent(SDLExecutionId(2), RuntimeEvent(LocalDateTime.now(), ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq()))
-    runtimeData.addMetric(Some(SDLExecutionId(2)), dataObjectId, GenericMetrics("test2-metric1", 1, Map("metric1" -> 1)))
-    runtimeData.addMetric(Some(SDLExecutionId(2)), dataObjectId, GenericMetrics("test2-metric2", 2, Map("metric2" -> 2)))
-    assert(runtimeData.getMetrics(dataObjectId, Some(SDLExecutionId(2))).exists(_.getMainInfos.isDefinedAt("metric2")))
-    assert(runtimeData.getMetrics(dataObjectId).exists(_.getMainInfos.isDefinedAt("metric2")))
-  }
 
   test("store and get asynchronous metrics") {
     val runtimeData = AsynchronousRuntimeData(10)
     val dataObjectId = DataObjectId("test")
     // synchronous execution first
     runtimeData.addEvent(SDLExecutionId(1), RuntimeEvent(LocalDateTime.now(), ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq()))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId, GenericMetrics("spark-metric1", 1, Map()))
     runtimeData.addMetric(None, dataObjectId, GenericMetrics("spark-metric1", 1, Map()))
     // asynchronous execution 1
     runtimeData.addEvent(SparkStreamingExecutionId(1), RuntimeEvent(LocalDateTime.now(), ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq()))
@@ -97,24 +79,13 @@ class RuntimeDataTest extends FunSuite {
     intercept[AssertionError](runtimeData.addMetric(Some(SparkStreamingExecutionId(2)), dataObjectId, GenericMetrics("test2-metric1", 1, Map())))
     // another synchronous execution (should not happen in real-life, but nevertheless a test what happens)
     runtimeData.addEvent(SDLExecutionId(2), RuntimeEvent(LocalDateTime.now(), ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq()))
-    runtimeData.addMetric(Some(SDLExecutionId(2)), dataObjectId, GenericMetrics("spark-metric2", 1, Map()))
+    runtimeData.addMetric(None, dataObjectId, GenericMetrics("spark-metric2", 1, Map()))
     // second asynchronous execution
     runtimeData.addEvent(SparkStreamingExecutionId(2), RuntimeEvent(LocalDateTime.now(), ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq()))
     runtimeData.addMetric(Some(SparkStreamingExecutionId(2)), dataObjectId, GenericMetrics("test2-metric1", 1, Map("metric1" -> 1)))
     runtimeData.addMetric(Some(SparkStreamingExecutionId(2)), dataObjectId, GenericMetrics("test2-metric2", 2, Map("metric2" -> 2)))
     assert(runtimeData.getMetrics(dataObjectId, Some(SparkStreamingExecutionId(2))).exists(_.getMainInfos.isDefinedAt("metric2")))
     assert(runtimeData.getMetrics(dataObjectId).exists(_.getMainInfos.isDefinedAt("metric2")))
-  }
-
-  test("get final metrics and exception on late arriving metrics") {
-    val runtimeData = SynchronousRuntimeData(10)
-    val dataObjectId = DataObjectId("test")
-    runtimeData.addEvent(SDLExecutionId(1), RuntimeEvent(LocalDateTime.now(), ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq()))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId, GenericMetrics("test-metric1", 1, Map("metric1" -> 1)))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId, GenericMetrics("test-metric2", 2, Map("metric2" -> 2)))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId+"dummy", GenericMetrics("test-metric99", 2, Map()))
-    assert(runtimeData.getFinalMetrics(dataObjectId).exists(_.getMainInfos.isDefinedAt("metric2")))
-    intercept[LateArrivingMetricException](runtimeData.addMetric(Some(SDLExecutionId(1)), dataObjectId, GenericMetrics("test1-metric3", 3, Map())))
   }
 
   test("get summarized runtime info") {
@@ -124,13 +95,8 @@ class RuntimeDataTest extends FunSuite {
     val now = LocalDateTime.now()
     runtimeData.addEvent(SDLExecutionId(1), RuntimeEvent(now, ExecutionPhase.Exec, RuntimeEventState.STARTED, None, Seq(SparkSubFeed(None, outputDataObjectId, Seq()))))
     runtimeData.addEvent(SDLExecutionId(1), RuntimeEvent(now.plusSeconds(10), ExecutionPhase.Exec, RuntimeEventState.SUCCEEDED, None, Seq(SparkSubFeed(None, outputDataObjectId, Seq()))))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), outputDataObjectId, GenericMetrics("test-metric1", 1, Map()))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), outputDataObjectId, GenericMetrics("test-metric2", 2, Map("test"->999)))
-    runtimeData.addMetric(Some(SDLExecutionId(1)), outputDataObjectId+"dummy", GenericMetrics("test-metric99", 2, Map()))
     val info = runtimeData.getRuntimeInfo(Seq(inputDataObjectId), Seq(outputDataObjectId), Seq())
     assert(info.exists(_.duration.get.getSeconds == 10))
-    val doResults = info.flatMap(_.results.find(_.subFeed.dataObjectId == outputDataObjectId))
-    assert(doResults.exists(_.mainMetrics("test") == 999))
   }
 
   test("housekeeping") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/UnpartitionedTestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/UnpartitionedTestDataObject.scala
@@ -25,6 +25,7 @@ import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, Insta
 import io.smartdatalake.definitions.SaveModeOptions
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -45,8 +46,9 @@ case class UnpartitionedTestDataObject(override val id: DataObjectId,
   }
 
   override def writeSparkDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit context: ActionPipelineContext): Unit = {
+                             (implicit context: ActionPipelineContext): MetricsMap = {
     df.show
+    Map("records_written" -> df.count)
   }
 
   override def factory: FromConfigFactory[DataObject] = UnpartitionedTestDataObject

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -23,11 +23,13 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.definitions._
+import io.smartdatalake.metrics.SparkStageMetricsListener
 import io.smartdatalake.util.hdfs.HdfsUtil.RemoteIteratorWrapper
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.util.misc._
 import io.smartdatalake.util.spark.DataFrameUtil
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.connection.IcebergTableConnection
 import io.smartdatalake.workflow.dataframe.GenericSchema
 import io.smartdatalake.workflow.dataframe.spark.{SparkSchema, SparkSubFeed}
@@ -45,6 +47,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 /**
  * [[DataObject]] of type IcebergTableDataObject.
@@ -249,7 +252,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
   }
 
   override def writeSparkDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
-                             (implicit context: ActionPipelineContext): Unit = {
+                             (implicit context: ActionPipelineContext): MetricsMap = {
     validateSchemaMin(SparkSchema(df.schema), "write")
     validateSchemaHasPartitionCols(df, "write")
     validateSchemaHasPrimaryKeyCols(df, table.primaryKey.getOrElse(Seq()), "write")
@@ -260,7 +263,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
    * Writes DataFrame to HDFS/Parquet and creates Iceberg table.
    */
   def writeDataFrame(df: DataFrame, createTableOnly: Boolean, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions])
-                    (implicit context: ActionPipelineContext): Unit = {
+                    (implicit context: ActionPipelineContext): MetricsMap = {
     implicit val session: SparkSession = context.sparkSession
     implicit val helper: SparkSubFeed.type = SparkSubFeed
     val dfPrepared = if (createTableOnly) {
@@ -275,8 +278,8 @@ case class IcebergTableDataObject(override val id: DataObjectId,
       .format("iceberg")
       .options(options)
       .option("path", hadoopPath.toString)
-    if (isTableExisting) {
-      // check schema
+    val sparkMetrics = if (isTableExisting) {
+      // check scheme
       if (!allowSchemaEvolution) validateSchema(SparkSchema(saveModeTargetDf.schema), SparkSchema(session.table(table.fullName).schema), "write")
       // update table property "spark.accept-any-schema" to allow schema evolution. This disables Spark schema checks as they dont allow missing columns. Iceberg schema checks still apply.
       updateTableProperty(TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA, allowSchemaEvolution.toString, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT.toString)
@@ -284,7 +287,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
       if (finalSaveMode == SDLSaveMode.Merge) {
         // merge operations still need all columns for potential insert/updateConditions. Therefore dfPrepared instead of saveModeTargetDf is passed on.
         mergeDataFrameByPrimaryKey(dfPrepared, saveModeOptions.map(SaveModeMergeOptions.fromSaveModeOptions).getOrElse(SaveModeMergeOptions()))
-      } else {
+      } else SparkStageMetricsListener.execWithMetrics(this.id, {
         // V2 writer can be used if table is existing, it supports overwriting given partitions
         val dfWriterV2 = saveModeTargetDf
           .writeTo(table.fullName)
@@ -297,8 +300,8 @@ case class IcebergTableDataObject(override val id: DataObjectId,
           }
           SDLSaveMode.execV2(finalSaveMode, dfWriterV2, partitionValues)
         }
-      }
-    } else {
+      })
+    } else SparkStageMetricsListener.execWithMetrics(this.id, {
       if (partitions.isEmpty) {
         dfWriter.saveAsTable(table.fullName)
       } else {
@@ -306,13 +309,29 @@ case class IcebergTableDataObject(override val id: DataObjectId,
           .partitionBy(partitions: _*)
           .saveAsTable(table.fullName)
       }
-    }
+    })
+
+    // get iceberg snapshot summary / stats
+    val summary = getIcebergTable.currentSnapshot().summary().asScala
+    assert(summary("spark.app.id") == session.sparkContext.applicationId, s"($id) current iceberg snapshot is not written by this spark application (spark.app.id should be ${summary("spark.app.id")}. Is there someone else writing to this table?!")
+    val icebergMetrics = (summary - "spark.app.id")
+      // normalize names lowercase with underscore
+      .map{case(k,v) => (k.replace("-","_"), Try(v.toLong).getOrElse(v))}
+      // standardize naming
+      // Unfortunately this is not possible yet for merge operation, as we only get added/deleted records. Added records contain inserted + updated rows, deleted records probably updated + deleted rows...
+      .map{
+        case ("added_records", v) if finalSaveMode != SDLSaveMode.Merge => ("rows_inserted", v)
+        case (k,v) => (k,v)
+      }
 
     // vacuum delta lake table
     vacuum
 
     // fix acls
     if (acl.isDefined) AclUtil.addACLs(acl.get, hadoopPath)(filesystem)
+
+    // return
+    sparkMetrics ++ icebergMetrics
   }
 
   private def writeToTempTable(df: DataFrame)(implicit context: ActionPipelineContext): Unit = {
@@ -333,13 +352,15 @@ case class IcebergTableDataObject(override val id: DataObjectId,
    * Table.primaryKey is used as condition to check if a record is matched or not. If it is matched it gets updated (or deleted), otherwise it is inserted.
    * This all is done in one transaction.
    */
-  def mergeDataFrameByPrimaryKey(df: DataFrame, saveModeOptions: SaveModeMergeOptions)(implicit context: ActionPipelineContext): Unit = {
+  def mergeDataFrameByPrimaryKey(df: DataFrame, saveModeOptions: SaveModeMergeOptions)(implicit context: ActionPipelineContext): MetricsMap = {
     implicit val session: SparkSession = context.sparkSession
     assert(table.primaryKey.exists(_.nonEmpty), s"($id) table.primaryKey must be defined to use mergeDataFrameByPrimaryKey")
 
     try {
       // write data to temp table
-      writeToTempTable(df)
+      val metrics = SparkStageMetricsListener.execWithMetrics(this.id,
+        writeToTempTable(df)
+      )
       // override missing columns with null value, as Iceberg needs all target columns be included in insert statement
       val targetCols = session.table(table.fullName).schema.fieldNames
       val missingCols = targetCols.diff(df.columns)
@@ -354,6 +375,8 @@ case class IcebergTableDataObject(override val id: DataObjectId,
       logger.info(s"($id) executing merge statement with options: ${ProductUtil.attributesWithValuesForCaseClass(saveModeOptionsExt).map(e => e._1+"="+e._2).mkString(" ")}")
       logger.debug(s"($id) merge statement: $mergeStmt")
       context.sparkSession.sql(mergeStmt)
+      // return
+      metrics
     } finally {
       // cleanup temp table
       val tmpTableIdentifier = TableIdentifier.of((getIdentifier.namespace :+ tmpTable.name):_*)

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -238,7 +238,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
     if (isTableExisting) {
       val saveModeTargetDf = saveModeOptions.map(_.convertToTargetSchema(df)).getOrElse(df)
       val existingSchema = SparkSchema(getSparkDataFrame().schema)
-      if (allowSchemaEvolution && existingSchema.equalsSchema(SparkSchema(saveModeTargetDf.schema))) evolveTableSchema(saveModeTargetDf.schema)
+      if (allowSchemaEvolution && !existingSchema.equalsSchema(SparkSchema(saveModeTargetDf.schema))) evolveTableSchema(saveModeTargetDf.schema)
       else validateSchema(SparkSchema(saveModeTargetDf.schema), existingSchema, "write")
     }
   }

--- a/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
+++ b/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
@@ -48,9 +48,10 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  private val contextPrep = contextInit.copy(phase = ExecutionPhase.Prepare)
   private val contextExec = contextInit.copy(phase = ExecutionPhase.Exec)
 
-  KafkaTestUtil.start
+  KafkaTestUtil.start()
 
   before {
     instanceRegistry.clear()
@@ -80,9 +81,9 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1, action2))
 
     // exec dag
-    dag.prepare
-    dag.init
-    dag.exec
+    dag.prepare(contextPrep)
+    dag.init(contextInit)
+    dag.exec(contextExec)
 
     // check result
     val dfR1 = tgt2DO.getSparkDataFrame(Seq())
@@ -124,8 +125,8 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1, action2))
 
     // first dag run
-    dag.prepare
-    dag.init
+    dag.prepare(contextPrep)
+    dag.init(contextInit)
     dag.exec(contextExec)
 
     // check
@@ -137,8 +138,8 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
 
     // second dag run - no data to process
     dag.reset
-    dag.prepare
-    dag.init
+    dag.prepare(contextPrep)
+    dag.init(contextInit)
     dag.exec(contextExec)
 
     // check
@@ -152,8 +153,8 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     val df2 = Seq(("r2", TestPerson("doe", "john 2", 10))).toDF("key", "value")
     srcDO.writeSparkDataFrame(df2, Seq())
     dag.reset
-    dag.prepare
-    dag.init
+    dag.prepare(contextPrep)
+    dag.init(contextInit)
     dag.exec(contextExec)
 
     // check
@@ -194,8 +195,8 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     // first dag run
     {
       val dag: ActionDAGRun = ActionDAGRun(Seq(action1Delay10s))
-      dag.prepare
-      dag.init
+      dag.prepare(contextPrep)
+      dag.init(contextInit)
       dag.exec(contextExec)
     }
 
@@ -208,8 +209,8 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
       val action1Delay1s = action1Delay10s.copy(
         executionMode = Some(KafkaStateIncrementalMode(delayedMaxTimestampExpr = Some(s"timestamp_seconds(unix_seconds(now()) - 1)"))))
       val dag: ActionDAGRun = ActionDAGRun(Seq(action1Delay1s))
-      dag.prepare
-      dag.init
+      dag.prepare(contextPrep)
+      dag.init(contextInit)
       dag.exec(contextExec)
     }
 

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
@@ -23,6 +23,7 @@ import com.snowflake.snowpark.types.{ArrayType, StringType, StructField, StructT
 import com.snowflake.snowpark.{Column, functions}
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 import io.smartdatalake.workflow.dataframe._
 import io.smartdatalake.workflow.dataobject.SnowflakeTableDataObject
@@ -38,7 +39,8 @@ case class SnowparkSubFeed(@transient override val dataFrame: Option[SnowparkDat
                            override val isSkipped: Boolean = false,
                            override val isDummy: Boolean = false,
                            override val filter: Option[String] = None,
-                           @transient override val observation: Option[DataFrameObservation] = None
+                           @transient override val observation: Option[DataFrameObservation] = None,
+                           override val metrics: Option[MetricsMap] = None
                           )
   extends DataFrameSubFeed {
   @transient
@@ -137,6 +139,11 @@ case class SnowparkSubFeed(@transient override val dataFrame: Option[SnowparkDat
   override def movePartitionColumnsLast(partitions: Seq[String]): SnowparkSubFeed = {
     withDataFrame(dataFrame.map(x => x.movePartitionColsLast(partitions)))
   }
+
+  override def withMetrics(metrics: MetricsMap): SnowparkSubFeed = {
+    this.copy(metrics = Some(metrics))
+  }
+  def appendMetrics(metrics: MetricsMap): SnowparkSubFeed = withMetrics(this.metrics.getOrElse(Map()) ++ metrics)
 }
 
 object SnowparkSubFeed extends DataFrameSubFeedCompanion {


### PR DESCRIPTION
See #529 

This is a larger refactoring of how metrics are handled.
Changes include:
- subfeeds are enriched with metrics
- spark metrics are collected synchronously
- specific metrics for jdbc, delta, iceberg and snowflake
- standardize naming for inserted/updated/deleted rows
- add metrics to SubFeedsExpressionData so it can be used in executionCondition
- ActionPipelineContext.phase is now implemented immutable
- ActionPipelineContext.currentAction added