### PR TITLE
Feature/613 schema export

### DIFF
--- a/.github/workflows/snapshot_builds.yml
+++ b/.github/workflows/snapshot_builds.yml
@@ -50,7 +50,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: mvn -P scala-2.12,test-sonar -B clean test scoverage:report -f pom.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=smart-data-lake_smart-data-lake
+      # to avoid running tests twice, phase 'compile' instead of 'test îs used, as tests are also executed by scoverage:report
+      run: mvn -P scala-2.12,test-sonar -B clean compile scoverage:report -f pom.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=smart-data-lake_smart-data-lake
 
     - name: Build with Maven for Scala 2.11, only if on develop-spark2* branch
       env:

--- a/.github/workflows/snapshot_builds.yml
+++ b/.github/workflows/snapshot_builds.yml
@@ -50,7 +50,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      # to avoid running tests twice, phase 'compile' instead of 'test îs used, as tests are also executed by scoverage:report
+      # to avoid running tests twice, phase 'compile' instead of 'test' is used, as tests are also executed by scoverage:report
       run: mvn -P scala-2.12,test-sonar -B clean compile scoverage:report -f pom.xml org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=smart-data-lake_smart-data-lake
 
     - name: Build with Maven for Scala 2.11, only if on develop-spark2* branch

--- a/pom.xml
+++ b/pom.xml
@@ -446,10 +446,10 @@
         <splunk.version>1.6.5.0</splunk.version>
         <sshj.version>0.35.0</sshj.version>
         <snowflake-spark.version>2.12.0</snowflake-spark.version>
-        <snowflake-snowpark.version>1.8.0</snowflake-snowpark.version>
+        <snowflake-snowpark.version>1.9.0</snowflake-snowpark.version>
         <keycloak.version>22.0.1</keycloak.version>
         <delta.version>2.4.0</delta.version>
-        <iceberg.version>1.3.0</iceberg.version>
+        <iceberg.version>1.4.1</iceberg.version>
 
         <json4s.version>3.7.0-M11</json4s.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -437,8 +437,8 @@
         <scopt.version>4.0.1</scopt.version>
         <databricks.spark-xml.version>0.14.0</databricks.spark-xml.version>
         <spark.excel.version>${spark.version331}_0.18.6-beta1</spark.excel.version>
-        <ucanaccess.version>5.0.1</ucanaccess.version>
-        <hsqldb.version>2.7.1</hsqldb.version>
+        <hsqldb.version>2.7.2</hsqldb.version>
+        <jackcess.version>4.0.5</jackcess.version>
         <!-- when changing config version, remember to update it in DatabricksSmartDataLakeBuilder main method -->
         <typesafe.config.version>1.4.1</typesafe.config.version>
         <kxbmap.configs.version>0.6.1</kxbmap.configs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2935,6 +2935,11 @@
                 <version>${kxbmap.configs.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.scala-lang.modules</groupId>
+                <artifactId>scala-collection-compat_${scala.minor.version}</artifactId>
+                <version>2.11.0</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>1.5.22</version>

--- a/pom.xml
+++ b/pom.xml
@@ -449,7 +449,8 @@
         <snowflake-snowpark.version>1.9.0</snowflake-snowpark.version>
         <keycloak.version>22.0.1</keycloak.version>
         <delta.version>2.4.0</delta.version>
-        <iceberg.version>1.4.1</iceberg.version>
+        <!-- Version 1.4.x has a problem with deleting partitions, data is deleted but the partition still appears when listing partitions, see IcebergTableDataObjectTest -->
+        <iceberg.version>1.3.1</iceberg.version>
 
         <json4s.version>3.7.0-M11</json4s.version>
 
@@ -1217,6 +1218,13 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- SPARK-38885: After Netty 4.1.76, add the following `Netty` dependencies explicitly
             to ensure `./dev/test-dependencies.sh` produce the same results on Linux and MacOS.

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <scala.minor.version>2.12</scala.minor.version>
         <scala.version>${scala.minor.version}.15</scala.version>
 
-        <spark.version>3.4.1</spark.version>
+        <spark.version>3.4.2</spark.version>
         <spark-extensions.version>3.4.1</spark-extensions.version> <!-- this sdl-specific extensions should match the minor version of property spark.version -->
         <spark.minor.version>3.4</spark.minor.version> <!-- this is used in sdl-snowflake -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -723,9 +723,6 @@
                                     </includes>
                                 </artifactSet>
                                 <transformers>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                        <resource>reference.conf</resource>
-                                    </transformer>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <manifestEntries>
                                             <Main-Class>io.smartdatalake.app.LocalSmartDataLakeBuilder</Main-Class>
@@ -734,16 +731,16 @@
                                         </manifestEntries>
                                     </transformer>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                    <transformer implementation="io.github.edwgiz.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer" />
+                                    <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer" />
                                 </transformers>
                             </configuration>
                         </execution>
                     </executions>
                     <dependencies>
                         <dependency>
-                            <groupId>io.github.edwgiz</groupId>
-                            <artifactId>log4j-maven-shade-plugin-extensions</artifactId>
-                            <version>${log4j.version}</version>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+                            <version>0.1.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -866,6 +863,7 @@
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-tags_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
@@ -1026,11 +1024,13 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>1.10.0</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
@@ -1041,11 +1041,13 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons-codec.version}</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -1077,6 +1079,7 @@
                 <artifactId>commons-logging</artifactId>
                 <!-- Hive uses commons-logging 1.1.3 from 0.13 to 1.2 -->
                 <version>1.1.3</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.ivy</groupId>
@@ -1087,6 +1090,7 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${jsr305.version}</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -1151,6 +1155,7 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <!-- API bridge between log4j 1 and 2 -->
@@ -1409,6 +1414,7 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-compiler</artifactId>
                 <version>${scala.version}</version>
+                <scope>${scala.deps.scope}</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.scala-lang.modules</groupId>
@@ -1420,11 +1426,13 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-reflect</artifactId>
                 <version>${scala.version}</version>
+                <scope>${scala.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
                 <version>${scala.version}</version>
+                <scope>${scala.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang.modules</groupId>
@@ -1594,6 +1602,7 @@
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
                 <version>${avro.version}</version>
+                <scope>${spark.deps.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
         <hive.group>org.apache.hive</hive.group>
         <hive.classifier>core</hive.classifier>
         <!-- Version used in Maven Hive dependency -->
-        <hive.version>3.1.3</hive.version>
+        <hive.version>2.3.9</hive.version>
         <hive23.version>2.3.9</hive23.version>
         <!-- Version used for internal directory structure -->
         <hive.version.short>2.3</hive.version.short>

--- a/pom.xml
+++ b/pom.xml
@@ -758,8 +758,8 @@
                         <filereports>
                             ${project.artifactId}.txt
                         </filereports>
-                        <stdout>WT
-                        </stdout>  <!-- without color, show reminder of failed and canceled tests with short stack traces, see: http://www.scalatest.org/user_guide/using_scalatest_with_sbt-->
+                        <stdout>WFT
+                        </stdout>  <!-- without color, show full stack traces, show reminder of failed and canceled tests with short stack traces see: http://www.scalatest.org/user_guide/using_scalatest_with_sbt-->
                         <environmentVariables>
                             <SPARK_LOCAL_IP>127.0.0.1
                             </SPARK_LOCAL_IP> <!-- Suppresses Spark IP discovery during tests (when executed with mvn test) -->
@@ -1589,6 +1589,20 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <!-- exclusions according to https://github.com/apache/hadoop/blob/trunk/hadoop-client-modules/hadoop-client-api/pom.xml -->
+                    <exclusion>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                    <!-- avoid duplicate -->
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.websocket</groupId>
+                        <artifactId>websocket-client</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -2824,6 +2838,21 @@
                 <artifactId>spark-core_${scala.minor.version}</artifactId>
                 <version>${spark.version}</version>
                 <scope>${spark.deps.scope}</scope>
+                <exclusions>
+                    <!--
+                      Exclude hadoop-client-runtime from spark-core 3.4, as this is a shaded version with relocation.
+                      We need the classes with original location for hadoop-azure otherwise there is ClassNotFoundException: org.apache.hadoop.util.WeakReferenceMap from hadoop-Azure AbfsClient.
+                      hadoop-client library is not shaded and included below.
+                    -->
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client-runtime</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
@@ -2870,7 +2899,21 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-slf4j-impl</artifactId>                    </exclusion>
+                        <artifactId>log4j-slf4j-impl</artifactId>
+                    </exclusion>
+                    <!--
+                      Exclude hadoop-client-runtime from spark-core 3.4, as this is a shaded version with relocation.
+                      We need the classes with original location for hadoop-azure otherwise there is ClassNotFoundException: org.apache.hadoop.util.WeakReferenceMap from hadoop-Azure AbfsClient.
+                      hadoop-client library is not shaded and included below.
+                    -->
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client-runtime</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/sdl-azure/pom.xml
+++ b/sdl-azure/pom.xml
@@ -53,13 +53,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <!-- version 20180813 referenced by azure-relay is vulnerable -->

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -190,12 +190,10 @@
         <dependency>
             <groupId>com.github.kxbmap</groupId>
             <artifactId>configs_${scala.minor.version}</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.scala-lang.modules</groupId>
-                    <artifactId>scala-collection-compat_${scala.minor.version}</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.minor.version}</artifactId>
         </dependency>
 
         <dependency>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -64,14 +64,6 @@
             <version>${scopt.version}</version>
         </dependency>
 
-        <!-- hadoop-common is an used undeclared dependency, but if we would explicitly list it we would need to duplicate the exclusions as in spark-parent.
-             If we don't declare it, we get the exclusion over import of spark-parent dependencyManagement, which is more valuable -->
-        <!--dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
-        </dependency-->
-
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.minor.version}</artifactId>
@@ -81,6 +73,13 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <exclusions>
+                <!-- Avoid "Unable to initialize 'javax.el.ExpressionFactory'. Check that you have the EL dependencies on the classpath" -->
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -215,11 +214,41 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <version>${keycloak.version}</version>
+            <exclusions>
+                <!-- this is a different version than used by spark-core -->
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
             <version>${keycloak.version}</version>
+            <exclusions>
+                <!-- this are different version than used by spark-core -->
+                <exclusion>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -148,17 +148,11 @@
             <version>${hsqldb.version}</version>
             <scope>runtime</scope>
         </dependency>
+
         <dependency>
-            <groupId>net.sf.ucanaccess</groupId>
-            <artifactId>ucanaccess</artifactId>
-            <version>${ucanaccess.version}</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hsqldb</groupId>
-                    <artifactId>hsqldb</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.healthmarketscience.jackcess</groupId>
+            <artifactId>jackcess</artifactId>
+            <version>${jackcess.version}</version>
         </dependency>
 
         <dependency>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -111,19 +111,17 @@
             <scope>${spark.deps.scope}</scope>
         </dependency>
 
-        <!-- this needs to have compile scope, if it's runtime it doesnt compile anymore -->
         <!-- this is an unused declared dependency, but it's needed to override scope -->
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-tags_${scala.minor.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>compile</scope>
+            <scope>${spark.deps.scope}</scope>
         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
         </dependency>
 
         <dependency>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -119,6 +119,13 @@
             <scope>${spark.deps.scope}</scope>
         </dependency>
 
+        <!-- avoid NoClassDefFoundError: javax/xml/bind/annotation/XmlElement in FileTransferActionTest -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>spark-core_${scala.minor.version}</artifactId>
         </dependency>
 
+        <!-- Included instead of hadoop-client-runtime, which is excluded from spark-core, see parent pom -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.minor.version}</artifactId>

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ParsableFromConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ParsableFromConfig.scala
@@ -37,3 +37,8 @@ private[smartdatalake] trait ParsableFromConfig[+CO <: ParsableFromConfig[CO]] {
    */
   def factory: FromConfigFactory[CO]
 }
+
+/**
+ * A marker trait to exclude SdlConfigObject's from the schema export.
+ */
+trait ExcludeFromSchemaExport

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ParsableFromConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ParsableFromConfig.scala
@@ -39,6 +39,6 @@ private[smartdatalake] trait ParsableFromConfig[+CO <: ParsableFromConfig[CO]] {
 }
 
 /**
- * A marker trait to exclude SdlConfigObject's from the schema export.
+ * A marker trait to exclude an SdlConfigObject from the schema export.
  */
 trait ExcludeFromSchemaExport

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/ColumnStatsType.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/ColumnStatsType.scala
@@ -1,0 +1,30 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.definitions
+
+object ColumnStatsType extends Enumeration {
+  type ColumnStatsType = Value
+  val DistinctCount = Value("distinctCount")
+  val NullCount = Value("nullCount")
+  val AvgLen = Value("avgLen")
+  val MaxLen = Value("maxLen")
+  val Min = Value("min")
+  val Max = Value("max")
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/Environment.scala
@@ -472,6 +472,21 @@ object Environment {
   }
   var _hadoopFileStateStoreIndexAppend: Option[Boolean] = None
 
+  /**
+   * Threshold for analyzing table columns.
+   * If table size is bigger than analyzeTableColumnMaxThresholdBytes, table columns are not analyzed.
+   */
+  def analyzeTableColumnMaxBytesThreshold: Int = {
+    if (_analyzeTableColumnMaxBytesThreshold.isEmpty) {
+      _analyzeTableColumnMaxBytesThreshold = Some(
+        EnvironmentUtil.getSdlParameter("analyzeTableColumnMaxBytesThreshold")
+          .map(_.toInt).getOrElse(1024*1024*1024) // 1G
+      )
+    }
+    _analyzeTableColumnMaxBytesThreshold.get
+  }
+  var _analyzeTableColumnMaxBytesThreshold: Option[Int] = None
+
   // static configurations
   def configPathsForLocalSubstitution: Seq[String] = Seq(
       "path", "table.name"

--- a/sdl-core/src/main/scala/io/smartdatalake/definitions/TableStatsType.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/definitions/TableStatsType.scala
@@ -1,0 +1,43 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.definitions
+
+object TableStatsType extends Enumeration {
+  type TableStatsType = Value
+  val SizeInBytes = Value("sizeInBytes")
+  val SizeInBytesCurrent = Value("sizeInBytesCurrent")
+  val TableSizeInBytes = Value("tableSizeInBytes")
+  val CreatedAt = Value("createdAt")
+  val LastModifiedAt = Value("lastModifiedAt")
+  val LastAnalyzedAt = Value("lastAnalyzedAt")
+  val LastAnalyzedColumnsAt = Value("lastAnalyzedColumnsAt")
+  val LastCommitMsg = Value("lastCommitMsg")
+  val Location = Value("location")
+  val Info = Value("info")
+  val NumFiles = Value("numFiles")
+  val NumDataFilesCurrent = Value("numDataFilesCurrent") // for table formats with history (Delta, Iceberg...)
+  val NumRows = Value("numRows")
+  val NumPartitions = Value("numPartitions")
+  val MinPartition = Value("minPartition")
+  val MaxPartition = Value("maxPartition")
+  val OldestSnapshotTs = Value("oldestSnapshotTs")
+  val Branches = Value("branches")
+  val Columns = Value("columns")
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/HdfsUtil.scala
@@ -18,7 +18,7 @@
  */
 package io.smartdatalake.util.hdfs
 
-import io.smartdatalake.definitions.Environment
+import io.smartdatalake.definitions.{Environment, TableStatsType}
 import io.smartdatalake.util.misc.{ResourceUtil, SmartDataLakeLogger}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
@@ -26,6 +26,8 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import java.io.IOException
 import java.net.URI
+import java.sql.Timestamp
+import java.time.Instant
 import scala.collection.AbstractIterator
 import scala.io.{Codec, Source}
 import scala.util.{Try, Using}
@@ -338,6 +340,15 @@ private[smartdatalake] object HdfsUtil extends SmartDataLakeLogger {
     val file = new Path(path, filename)
     touchFile(file)
     filesystem.delete(file, true) // recursive=true
+  }
+
+  def getPathStats(path: Path)(implicit filesystem: FileSystem): Map[String,Any] = {
+    val summary = filesystem.getContentSummary(path)
+    val status = filesystem.getFileStatus(path)
+    val sizeInBytes = summary.getLength
+    val numFiles = summary.getFileCount
+    val lastModifiedAt = status.getModificationTime
+    Map(TableStatsType.SizeInBytes.toString -> sizeInBytes, TableStatsType.NumFiles.toString -> numFiles, TableStatsType.LastModifiedAt.toString -> lastModifiedAt)
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -172,6 +172,14 @@ object PartitionValues {
     val ordering = getOrdering(partitionCols)
     partitionValues.sorted(ordering)
   }
+
+  def fromString(str: String): PartitionValues = {
+    val elements = str.split('/').map { e =>
+      val Array(k,v) = e.split('=')
+      (k,v)
+    }.toMap
+    PartitionValues(elements)
+  }
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -80,7 +80,8 @@ object PartitionValues {
    */
   def getOrdering(partitions: Seq[String]): Ordering[PartitionValues] = new Ordering[PartitionValues] {
     def compare(pv1: PartitionValues, pv2: PartitionValues): Int = {
-      partitions.map{
+      val keys = pv1.keys.intersect(pv2.keys)
+      partitions.filter(keys.contains).map{
         p => (pv1(p), pv2(p)) match {
           case (v1: String, v2: String) => v1.compare(v2)
           case (v1: Byte, v2: Byte) => v1.compare(v2)

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
@@ -717,7 +717,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * Query partitions from catalog
    *
    * Note that for Hive Metastore (HMD) this might not be the best solution, as it depends on up-to-date partition metadata in HMS!
-   * We can do a directory listing for Hive tables. But for Delta Lake directory listing is not suitable, as there might be directories contain only outdated records.
+   * We can do a directory listing for Hive tables. But for Delta Lake directory listing is not suitable, as there might be directories which contain only outdated records.
    * In this case using the catalog is more efficient than quering them using a Spark DataFrame.
    *
    * @return
@@ -727,6 +727,11 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
     metadata.map(p => PartitionValues(p.spec))
   }
 
+  /**
+   * Set table properties by execute and "alter table ... set tblproperties" statement.
+   * Existing properties values will be overwritten.
+   * If existing properties are not included in parameter 'properties', they will survive with their current value.
+   */
   def alterTableProperties(table: Table, properties: Map[String,Any])(implicit session: SparkSession): Unit = {
     execSqlStmt(s"ALTER TABLE ${table.fullName} SET TBLPROPERTIES(${properties.map{case(k,v) => s"$k = '$v'"}.mkString(",")})")
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hive/HiveUtil.scala
@@ -18,9 +18,10 @@
  */
 package io.smartdatalake.util.hive
 
-import io.smartdatalake.definitions.{Environment, HiveTableLocationSuffix, OutputType}
+import io.smartdatalake.definitions._
 import io.smartdatalake.util.evolution.SchemaEvolution
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionLayout, PartitionValues}
+import io.smartdatalake.util.misc.PerformanceUtils.measureTime
 import io.smartdatalake.util.misc.{EnvironmentUtil, SmartDataLakeLogger}
 import io.smartdatalake.workflow.dataobject.Table
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -28,6 +29,7 @@ import org.apache.spark.sql.functions.{array, col}
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
 import java.net.URI
+import java.time.Instant
 import scala.sys.process.{ProcessLogger, _}
 import scala.util.{Failure, Success, Try}
 
@@ -35,18 +37,6 @@ import scala.util.{Failure, Success, Try}
  * Provides utility functions for Hive.
  */
 private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
-
-  /**
-   * Creates a String by concatenating all column names of a table. 
-   * Columns are seperated by ','.
-   *
-   * @param table Hive table
-   */
-  def tableColumnsString(table: Table)(implicit session: SparkSession): String = {
-    import session.implicits._ // Workaround for
-    val tableSchema = execSqlStmt(s"show columns in ${table.fullName}")
-    tableSchema.map(c => c(0).toString.replace(" ","").toLowerCase).collect.mkString(",")
-  }
 
   /**
    * Deletes a Hive table
@@ -72,8 +62,10 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    */
   def analyzeTable(table: Table)(implicit session: SparkSession): Unit = {
     val stmt = s"ANALYZE TABLE ${table.fullName} COMPUTE STATISTICS"
-    Try(execSqlStmt(stmt)) match {
-      case Success(_) => logger.info(s"Gathered table-level statistics on table ${table.fullName}")
+    Try(measureTime(execSqlStmt(stmt))) match {
+      case Success((_,t)) =>
+        alterTableProperties(table, Map(TableStatsType.LastAnalyzedAt.toString -> Instant.now().toEpochMilli))
+        logger.info(s"Gathered table-level statistics on table ${table.fullName} in $t seconds")
       case Failure(throwable) => logger.error(throwable.getMessage)
         throw new AnalyzeTableException(s"Error running: $stmt")
     }
@@ -85,12 +77,15 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * @param table Hive table
    * @param columns Columns to collect statistics from
    */
-  def analyzeTableColumns(table: Table, columns: String)(implicit session: SparkSession): Unit = {
-    val stmt = s"ANALYZE TABLE ${table.fullName} COMPUTE STATISTICS FOR COLUMNS $columns"
-    Try(execSqlStmt(stmt)) match {
-      case Success(_) => logger.info(s"Gathered column-level statistics on table ${table.fullName}")
-      case Failure(throwable) => logger.error(throwable.getMessage)
-        throw new AnalyzeTableException(s"Error running: $stmt")
+  def analyzeTableColumns(table: Table, columns: Seq[String] = Seq(), partitionValue: Option[PartitionValues] = None )(implicit session: SparkSession): Unit = {
+    val columnsClause = if (columns.nonEmpty) s"COLUMNS ${columns.mkString(",")}" else "ALL COLUMNS"
+    val stmt = s"ANALYZE TABLE ${table.fullName} COMPUTE STATISTICS FOR $columnsClause"
+    Try(measureTime(execSqlStmt(stmt))) match {
+      case Success((_,t)) =>
+        alterTableProperties(table, Map(TableStatsType.LastAnalyzedColumnsAt.toString -> Instant.now().toEpochMilli))
+        logger.info(s"Gathered column-level statistics on table ${table.fullName} in $t seconds")
+      case Failure(e) => logger.error(s"${e.getClass.getSimpleName}: ${e.getMessage}")
+        throw new AnalyzeTableException(s"Error ${e.getClass.getSimpleName} ${e.getMessage} running: $stmt")
     }
   }
 
@@ -137,8 +132,8 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
       val stmt = s"ANALYZE TABLE ${table.fullName} PARTITION($partitionSpec) COMPUTE STATISTICS"
       Try(execSqlStmt(stmt)) match {
         case Success(_) => logger.info(s"Gathered partition-level statistics for $partitionSpec on table ${table.fullName}")
-        case Failure(throwable) => logger.error(throwable.getMessage)
-          throw new AnalyzeTableException(s"Error running: $stmt")
+        case Failure(e) => logger.error(s"${e.getClass.getSimpleName}: ${e.getMessage}")
+          throw new AnalyzeTableException(s"Error ${e.getClass.getSimpleName} ${e.getMessage} running: $stmt")
       }
     }
   }
@@ -443,19 +438,33 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    * Collects table statistics for table or table with partitions
    *
    * @param table Hive table
+   * @param columns: Columns to analyse
    * @param partitionCols Partitioned columns
    * @param partitionValues Partition values
    */
-  def analyze(table: Table, partitionCols: Seq[String], partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession): Unit = {
-    // If partitions are present, statistics can't be collected for the table itself
-    // only for partitions or columns
-    val columns = tableColumnsString(table)
-    if (partitionCols.isEmpty){
-      analyzeTableColumns(table, columns)
+  def analyze(table: Table, columns: Seq[String], partitionCols: Seq[String], partitionValues: Seq[PartitionValues] = Seq())(implicit session: SparkSession): Unit = {
+    if (partitionCols.isEmpty) {
       analyzeTable(table)
+      val stats = getCatalogStats(table)
+      val sizeInBytes = stats(TableStatsType.TableSizeInBytes.toString).asInstanceOf[BigInt]
+      if (sizeInBytes <= Environment.analyzeTableColumnMaxBytesThreshold) {
+        analyzeTableColumns(table, columns)
+      } else {
+        logger.warn(s"Column stats for table ${table.fullName} not calculated because table size ($sizeInBytes Bytes) is bigger than setting analyzeTableColumnMaxBytesThreshold (${Environment.analyzeTableColumnMaxBytesThreshold} Bytes)")
+      }
     } else {
       analyzeTablePartitions(table, partitionCols, partitionValues)
-      analyzeTableColumns(table, columns)
+      // sum size for all partitions
+      val sizeInBytes = listPartitions(table, partitionCols)
+        .map(pv => getCatalogPartitionStats(table, pv))
+        .flatMap(s => s.get(TableStatsType.TableSizeInBytes.toString).map(_.asInstanceOf[BigInt])).sum
+      // Note that computing column statistics for selected partitions only is *not* supported by Spark, it will always analyze the whole table
+      // see also log "WARN SparkSqlAstBuilder - Partition specification is ignored when collecting column statistics" when calling ANALYZE TABLE with PARTITION and COLUMN clause.
+      if (sizeInBytes <= Environment.analyzeTableColumnMaxBytesThreshold) {
+        analyzeTableColumns(table, columns)
+      } else {
+        logger.warn(s"Column stats for table ${table.fullName} not calculated because table size ($sizeInBytes Bytes) is bigger than setting analyzeTableColumnMaxBytesThreshold (${Environment.analyzeTableColumnMaxBytesThreshold} Bytes)")
+      }
     }
   }
 
@@ -643,6 +652,83 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
     HdfsUtil.moveFiles( existingPartitionPathWithFilenameGlobs, newPartitionPath, addPrefixIfExisting = true)(filesystem)
     dropPartition(table, tablePath, existingPartition, filesystem)
     execSqlStmt(s"ALTER TABLE ${table.fullName} ADD IF NOT EXISTS PARTITION ($newPartitionDef)")
+  }
+
+  /**
+   * Note: this works only for tables in the Hive Metastore
+   */
+  def getCatalogStats(table: Table)(implicit session: SparkSession): Map[String,Any] = {
+    val metadata = session.sessionState.catalog.getTableMetadata(table.tableIdentifier)
+    val catalogStats = metadata.stats.map( stats =>
+      Seq(stats.rowCount.map(v => TableStatsType.NumRows.toString -> v), Some(TableStatsType.TableSizeInBytes.toString -> stats.sizeInBytes)).flatten.toMap
+    ).getOrElse(Map())
+    val lastAnalyzedAt = metadata.properties.get(TableStatsType.LastAnalyzedAt.toString).map(v => v.toLong)
+    val lastAnalyzedColumnsAt = metadata.properties.get(TableStatsType.LastAnalyzedColumnsAt.toString).map(v => v.toLong)
+    val otherStats = Seq(Some(TableStatsType.CreatedAt.toString -> metadata.createTime), lastAnalyzedAt.map(v =>  TableStatsType.LastAnalyzedAt.toString -> v), lastAnalyzedColumnsAt.map(v =>  TableStatsType.LastAnalyzedColumnsAt.toString -> v)).flatten.toMap
+    otherStats ++ catalogStats
+  }
+
+  /**
+   * Note: this works only for tables in the Hive Metastore
+   */
+  def getCatalogPartitionStats(table: Table, partitionValues: PartitionValues)(implicit session: SparkSession): Map[String, Any] = {
+    val metadata = session.sessionState.catalog.getPartition(table.tableIdentifier, partitionValues.getMapString)
+    val catalogStats = metadata.stats.map(stats =>
+      Seq(stats.rowCount.map(v => TableStatsType.NumRows.toString -> v), Some(TableStatsType.TableSizeInBytes.toString -> stats.sizeInBytes)).flatten.toMap
+    ).getOrElse(Map())
+    catalogStats + (TableStatsType.CreatedAt.toString -> metadata.createTime)
+  }
+
+  /**
+   * Note: this works only for tables in the Hive Metastore
+   */
+  def getCatalogColumnStats(table: Table)(implicit session: SparkSession): Map[String, Map[String, Any]] = {
+    session.sessionState.catalog.getTableMetadata(table.tableIdentifier).stats.toSeq.flatMap(_.colStats).toMap
+      .mapValues (
+        stats => Seq(
+          stats.distinctCount.map(ColumnStatsType.DistinctCount.toString -> _),
+          stats.nullCount.map(ColumnStatsType.NullCount.toString -> _),
+          stats.avgLen.map(ColumnStatsType.AvgLen.toString -> _),
+          stats.maxLen.map(ColumnStatsType.MaxLen.toString -> _),
+          stats.min.map(ColumnStatsType.Min.toString -> _),
+          stats.max.map(ColumnStatsType.Max.toString -> _)
+        ).flatten.toMap
+      )
+  }
+
+  /**
+   * Note: this works only for tables in the Hive Metastore
+   */
+  def getCatalogPartitionColumnStats(table: Table, partitionValues: PartitionValues)(implicit session: SparkSession): Map[String, Map[String, Any]] = {
+    session.sessionState.catalog.getPartition(table.tableIdentifier, partitionValues.getMapString).stats.toSeq.flatMap(_.colStats).toMap
+      .mapValues(
+        stats => Seq(
+          stats.distinctCount.map(ColumnStatsType.DistinctCount.toString -> _),
+          stats.nullCount.map(ColumnStatsType.NullCount.toString -> _),
+          stats.avgLen.map(ColumnStatsType.AvgLen.toString -> _),
+          stats.maxLen.map(ColumnStatsType.MaxLen.toString -> _),
+          stats.min.map(ColumnStatsType.Min.toString -> _),
+          stats.max.map(ColumnStatsType.Max.toString -> _)
+        ).flatten.toMap
+      )
+  }
+
+  /**
+   * Query partitions from catalog
+   *
+   * Note that for Hive Metastore (HMD) this might not be the best solution, as it depends on up-to-date partition metadata in HMS!
+   * We can do a directory listing for Hive tables. But for Delta Lake directory listing is not suitable, as there might be directories contain only outdated records.
+   * In this case using the catalog is more efficient than quering them using a Spark DataFrame.
+   *
+   * @return
+   */
+  def getPartitionValuesFromCatalog(table: Table)(implicit session: SparkSession): Seq[PartitionValues] = {
+    val metadata = session.sessionState.catalog.listPartitions(table.tableIdentifier)
+    metadata.map(p => PartitionValues(p.spec))
+  }
+
+  def alterTableProperties(table: Table, properties: Map[String,Any])(implicit session: SparkSession): Unit = {
+    execSqlStmt(s"ALTER TABLE ${table.fullName} SET TBLPROPERTIES(${properties.map{case(k,v) => s"$k = '$v'"}.mkString(",")})")
   }
 
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/HoconUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/HoconUtil.scala
@@ -46,13 +46,12 @@ object HoconUtil {
       val configObj = config.asInstanceOf[ConfigObject]
       val nextPath = path.takeWhile(!isListIdx(_)).mkString(".")
       val restPath = path.dropWhile(!isListIdx(_))
-      val t = if (restPath.isEmpty) {
+      if (restPath.isEmpty) {
         configObj.toConfig.withValue(nextPath, newValue).root
       } else {
         val nextElement = configObj.toConfig.getValue(nextPath)
         configObj.toConfig.withValue(nextPath, updateConfigValue(nextElement, restPath, newValue)).root
       }
-      t
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/HoconUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/HoconUtil.scala
@@ -1,0 +1,83 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.misc
+
+import com.typesafe.config.{ConfigList, ConfigObject, ConfigValue, ConfigValueFactory, ConfigValueType}
+
+import scala.collection.JavaConverters._
+
+object HoconUtil {
+
+  /**
+   * Hocon does not support config.withValue(path, newValue) if there are array is the path.
+   * This method supports it.
+   */
+  def updateConfigValue(config: ConfigValue, path: Seq[String], newValue: ConfigValue): ConfigValue = {
+    // check if next element is a list
+    if (isListIdx(path.head)) {
+      assert(config.valueType() == ConfigValueType.LIST)
+      val selectedIdx = path.head.stripPrefix("[").stripSuffix("]").toInt
+      ConfigValueFactory.fromIterable(
+        config.asInstanceOf[ConfigList].asScala.zipWithIndex.map {
+          case (element, idx) if idx == selectedIdx =>
+            updateConfigValue(element, path.tail, newValue)
+          case (element, _) => element
+        }.asJava
+      )
+    } else {
+      assert(config.valueType() == ConfigValueType.OBJECT)
+      val configObj = config.asInstanceOf[ConfigObject]
+      val nextPath = path.takeWhile(!isListIdx(_)).mkString(".")
+      val restPath = path.dropWhile(!isListIdx(_))
+      val t = if (restPath.isEmpty) {
+        configObj.toConfig.withValue(nextPath, newValue).root
+      } else {
+        val nextElement = configObj.toConfig.getValue(nextPath)
+        configObj.toConfig.withValue(nextPath, updateConfigValue(nextElement, restPath, newValue)).root
+      }
+      t
+    }
+  }
+
+  /**
+   * Hocon does not support config.getValue(path) if there are array is the path.
+   * This method supports it.
+   */
+  def getConfigValue(config: ConfigValue, path: Seq[String]): ConfigValue = {
+    // element to update found?
+    if (path.isEmpty) return config
+    // check if next element is a list
+    if (isListIdx(path.head)) {
+      assert(config.valueType() == ConfigValueType.LIST)
+      val selectedIdx = path.head.stripPrefix("[").stripSuffix("]").toInt
+      val element = config.asInstanceOf[ConfigList].get(selectedIdx)
+      getConfigValue(element, path.tail)
+    } else {
+      assert(config.valueType() == ConfigValueType.OBJECT)
+      val configObj = config.asInstanceOf[ConfigObject]
+      val nextPath = path.takeWhile(!isListIdx(_)).mkString(".")
+      val restPath = path.dropWhile(!isListIdx(_))
+      val nextElement = configObj.toConfig.getValue(nextPath)
+      getConfigValue(nextElement, restPath)
+    }
+  }
+
+  private def isListIdx(pathElement: String) = pathElement.startsWith("[")
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -89,13 +89,17 @@ private[smartdatalake] object ActionDAGRunState {
     {case json: JString => LocalDateTime.parse(json.s)},
     {case obj: LocalDateTime => JString(obj.toString)}
   ))
-  private val actionIdSerializer = Json4sCompat.getCustomKeySerializer[ActionId](formats => (
+  private val actionIdKeySerializer = Json4sCompat.getCustomKeySerializer[ActionId](formats => (
     {case s: String => ActionId(s)},
     {case obj: ActionId => obj.id}
   ))
-  private val dataObjectIdSerializer = Json4sCompat.getCustomKeySerializer[DataObjectId](formats => (
+  private val dataObjectIdKeySerializer = Json4sCompat.getCustomKeySerializer[DataObjectId](formats => (
     {case s: String => DataObjectId(s)},
     {case obj: DataObjectId => obj.id}
+  ))
+  private val dataObjectIdSerializer = Json4sCompat.getCustomSerializer[DataObjectId](formats => (
+    {case json: JString => DataObjectId(json.s)},
+    {case obj: DataObjectId => JString(obj.id)}
   ))
   private val runtimeEventStateKeySerializer = Json4sCompat.getCustomKeySerializer[RuntimeEventState](formats => (
     {case s: String => RuntimeEventState.withName(s)},
@@ -106,7 +110,7 @@ private[smartdatalake] object ActionDAGRunState {
 
   private lazy val typeHints = ShortTypeHints(ReflectionUtil.getTraitImplClasses[SubFeed].toList ++ ReflectionUtil.getSealedTraitImplClasses[ExecutionId], "type")
   implicit val formats: Formats = Json4sCompat.getStrictSerializationFormat(typeHints) + new EnumNameSerializer(RuntimeEventState) +
-    actionIdSerializer + dataObjectIdSerializer + durationSerializer + localDateTimeSerializer + runtimeEventStateKeySerializer
+    actionIdKeySerializer + dataObjectIdKeySerializer + dataObjectIdSerializer + durationSerializer + localDateTimeSerializer + runtimeEventStateKeySerializer
 
   // write state to Json
   def toJson(actionDAGRunState: ActionDAGRunState): String = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -27,7 +27,7 @@ import io.smartdatalake.workflow.action.{ExecutionId, RuntimeEventState, Runtime
 import org.apache.spark.util.Json4sCompat
 import org.json4s._
 import org.json4s.ext.EnumNameSerializer
-import org.json4s.jackson.Serialization.{read, writePretty}
+import org.json4s.jackson.Serialization.{read, write, writePretty}
 import org.reflections.Reflections
 
 import java.time.{Duration, LocalDateTime}
@@ -114,7 +114,8 @@ private[smartdatalake] object ActionDAGRunState {
   }
 
   def toJson(entry: IndexEntry): String = {
-    writePretty(entry)
+    // index entry should be written compact in one line (not pretty)
+    write(entry)
   }
 
   // read state from json

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ProxyAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ProxyAction.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.communication.agent.AgentClient
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
-import io.smartdatalake.config.{FromConfigFactory, SdlConfigObject}
+import io.smartdatalake.config.{ExcludeFromSchemaExport, FromConfigFactory, SdlConfigObject}
 import io.smartdatalake.definitions.Condition
 import io.smartdatalake.util.dag.DAGHelper.NodeId
 import io.smartdatalake.util.misc.CustomCodeUtil
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.StructType
  * If the execution of @wrappedAction is successful, the ProxyAction will return an empty SparkSubFeed by the correct schema.
  *
  */
-case class ProxyAction(wrappedAction: Action, override val id: SdlConfigObject.ActionId, agent: Agent) extends Action {
+case class ProxyAction(wrappedAction: Action, override val id: SdlConfigObject.ActionId, agent: Agent) extends Action with ExcludeFromSchemaExport {
 
   override def factory: FromConfigFactory[Action] = wrappedAction.factory
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfTransformer.scala
@@ -19,13 +19,13 @@
 
 package io.smartdatalake.workflow.action.generic.transformer
 
-import io.smartdatalake.config.FromConfigFactory
+import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.CustomCodeUtil
 import io.smartdatalake.util.spark.DefaultExpressionData
 import io.smartdatalake.workflow.action.generic.customlogic.CustomGenericDfTransformer
-import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfTransformer
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
@@ -53,5 +53,11 @@ case class ScalaClassGenericDfTransformer(override val name: String = "scalaTran
     customTransformer.transformPartitionValues(options, partitionValues)
   }
 
-  override def factory: FromConfigFactory[GenericDfTransformer] = ScalaClassSparkDfTransformer
+  override def factory: FromConfigFactory[GenericDfTransformer] = ScalaClassGenericDfTransformer
+}
+
+object ScalaClassGenericDfTransformer extends FromConfigFactory[GenericDfTransformer] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): ScalaClassGenericDfTransformer = {
+    extract[ScalaClassGenericDfTransformer](config)
+  }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfsTransformer.scala
@@ -19,13 +19,13 @@
 
 package io.smartdatalake.workflow.action.generic.transformer
 
-import io.smartdatalake.config.FromConfigFactory
+import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.ActionId
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.CustomCodeUtil
 import io.smartdatalake.util.spark.DefaultExpressionData
 import io.smartdatalake.workflow.action.generic.customlogic.CustomGenericDfsTransformer
-import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfsTransformer
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
@@ -53,5 +53,11 @@ case class ScalaClassGenericDfsTransformer(override val name: String = "scalaTra
     customTransformer.transformPartitionValues(options, partitionValues)
   }
 
-  override def factory: FromConfigFactory[GenericDfsTransformer] = ScalaClassSparkDfsTransformer
+  override def factory: FromConfigFactory[GenericDfsTransformer] = ScalaClassGenericDfsTransformer
+}
+
+object ScalaClassGenericDfsTransformer extends FromConfigFactory[GenericDfsTransformer] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): ScalaClassGenericDfsTransformer = {
+    extract[ScalaClassGenericDfsTransformer](config)
+  }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
@@ -29,6 +29,8 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 import org.apache.spark.sql._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.json4s.JString
+import org.json4s.JsonAST.JValue
 
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe.typeOf
@@ -234,6 +236,7 @@ case class SparkField(inner: StructField) extends GenericField {
   override def name: String = inner.name
   override def dataType: SparkDataType = SparkDataType(inner.dataType)
   override def nullable: Boolean = inner.nullable
+  override def comment: Option[String] = inner.getComment()
   override def makeNullable: SparkField = SparkField(inner.copy(dataType = dataType.makeNullable.inner, nullable = true))
   override def toLowerCase: SparkField = SparkField(inner.copy(dataType = dataType.toLowerCase.inner, name = inner.name.toLowerCase))
   override def removeMetadata: SparkField = SparkField(inner.copy(dataType = dataType.removeMetadata.inner, metadata = Metadata.empty))
@@ -257,6 +260,7 @@ case class SparkSimpleDataType(inner: DataType) extends SparkDataType {
   override def toLowerCase: SparkDataType = this
   override def removeMetadata: SparkDataType = this
   override def isSimpleType: Boolean = true
+  def toJson: JValue = JString(inner.typeName)
 }
 case class SparkStructDataType(override val inner: StructType) extends SparkDataType with GenericStructDataType {
   override def makeNullable: SparkDataType = SparkStructDataType(SparkSchema(inner).makeNullable.inner)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
@@ -22,14 +22,12 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, InstanceRegistry, ParsableFromConfig, SdlConfigObject}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.workflow.{ActionPipelineContext, AtlasExportable}
 import io.smartdatalake.workflow.connection.Connection
+import io.smartdatalake.workflow.{ActionPipelineContext, AtlasExportable}
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.sql.SparkSession
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
-import scala.util.Try
 
 /**
  * This is the root trait for every DataObject.
@@ -126,6 +124,22 @@ trait DataObject extends SdlConfigObject with ParsableFromConfig[DataObject] wit
     implicit val registryImpl: InstanceRegistry = registry
     getConnection[T](connectionId)
   }
+
+  /**
+   * Returns statistics about this DataObject from the catalog. Depending on it's type this can be (see also [[io.smartdatalake.definitions.TableStatsType]])
+   * - sizeInBytes
+   * - numFiles
+   * - numRows
+   * - numPartitions, minPartition, maxPartition
+   * - createdAt
+   * - lastModifiedAt
+   * - lastCommitMsg
+   * - location
+   * - columns -> column statistics
+   * @param update if true, more costly operations such as "analyze table" are executed before returning results.
+   * @return a map with statistics about this DataObject
+   */
+  def getStats(update: Boolean = false)(implicit context: ActionPipelineContext): Map[String,Any] = Map()
 
   def toStringShort: String = {
     s"$id[${this.getClass.getSimpleName}]"

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.config.SdlConfigObject.ConnectionId
-import io.smartdatalake.definitions.{Environment, SDLSaveMode}
+import io.smartdatalake.definitions.{Environment, SDLSaveMode, TableStatsType}
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionLayout, PartitionValues}
 import io.smartdatalake.util.misc.{AclDef, AclUtil, SmartDataLakeLogger}
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -320,5 +320,13 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
 
   def extractPartitionValuesFromDirPath(dirPath: String)(implicit context: ActionPipelineContext): PartitionValues = {
     PartitionLayout.extractPartitionValues(partitionLayout().get, relativizePath(dirPath) + separator)
+  }
+
+  override def getStats(update: Boolean = false)(implicit context: ActionPipelineContext): Map[String, Any] = {
+    try {
+      HdfsUtil.getPathStats(hadoopPath)(filesystem) ++ getPartitionStats
+    } catch {
+      case e:Exception => Map(TableStatsType.Info.toString -> e.getMessage)
+    }
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -123,7 +123,7 @@ case class HiveTableDataObject(override val id: DataObjectId,
         val definedPathNormalized = HiveUtil.normalizePath(getAbsolutePath.toString)
 
         if (definedPathNormalized != hadoopPathNormalized)
-          logger.warn(s"($id) Table ${table.fullName} exists already with different path ${path}. The table will be written with new path definition ${hadoopPathHolder}!")
+          logger.warn(s"($id) Table ${table.fullName} exists already with different path ${hadoopPathHolder}. New path definition ${getAbsolutePath} is ignored!")
       }
     }
     hadoopPathHolder

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObject.scala
@@ -306,8 +306,12 @@ case class HiveTableDataObject(override val id: DataObjectId,
       val lastAnalyzedAt = catalogStats.get(TableStatsType.LastAnalyzedAt.toString).map(_.asInstanceOf[Long])
       // analyze only if table is modified after it was last analyzed
       if (update && lastModifiedAt.isDefined && (lastAnalyzedAt.isEmpty || lastAnalyzedAt.exists(lastModifiedAt.get > _))) {
-        logger.info(s"compute statistics: update=$update lastModifiedAt=$lastModifiedAt lastAnalyzedAt=$lastAnalyzedAt")
-        HiveUtil.analyzeTable(table)(context.sparkSession)
+        logger.info(s"($id) compute statistics: update=$update lastModifiedAt=$lastModifiedAt lastAnalyzedAt=$lastAnalyzedAt")
+        try {
+          HiveUtil.analyzeTable(table)(context.sparkSession)
+        } catch {
+          case ex: Exception => logger.warn(s"($id) failed to compute statistics ${ex.getClass.getSimpleName}: ${ex.getMessage}")
+        }
       }
       val columnStats = getColumnStats(update, lastModifiedAt)
       // get catalog stats again, as they might have changed through analyzeTable or getColumnStats

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -126,7 +126,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
   // Define partition columns
   override val partitions: Seq[String] = if (Environment.caseSensitive) virtualPartitions else virtualPartitions.map(_.toLowerCase)
 
-  // TODO: Spark jdbc data source does not execute Spark observations, e.g. CopyWithMergeModeActionTest fails...
+  // Note: Spark jdbc data source does not execute Spark observations, e.g. CopyWithMergeModeActionTest fails...
   // Using generic observations is forced therefore.
   override val forceGenericObservation = true
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/Table.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/Table.scala
@@ -18,14 +18,16 @@
  */
 package io.smartdatalake.workflow.dataobject
 
+import org.apache.spark.sql.catalyst.TableIdentifier
+
 /**
  * Table attributes
  *
  * @param catalog     Optional catalog to be used for this table. If null default catalog is used.
  *                    If there exists a connection with catalog value for the DataObject and this field is not defined, it will be set to the connections catalog value.
- * @param db          database-schema to be used for this table.
-                      If there exists a connection for the DataObject and this field is not defined, it will be set to the connections database value .
- *                    Called db for backwards-compatibility because for hive tables, db and schema mean the same thing.
+ * @param db database-schema to be used for this table.
+ *           If there exists a connection for the DataObject and this field is not defined, it will be set to the connections database value .
+ *           Called db for backwards-compatibility because for hive tables, db and schema mean the same thing.
  * @param name        table name
  * @param query       optional select query
  * @param primaryKey  optional sequence of primary key columns
@@ -62,6 +64,10 @@ case class Table(
   def fullName: String = Seq(catalog,db,Some(name)).flatten.mkString(".")
 
   def nameParts: Seq[String] = fullName.split('.').toSeq
+
+  private[smartdatalake] def tableIdentifier: TableIdentifier = {
+    TableIdentifier(name, db, catalog)
+  }
 }
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
@@ -20,8 +20,6 @@ package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.StructType
 
 import scala.reflect.runtime.universe.Type
 
@@ -62,4 +60,20 @@ trait TableDataObject extends DataObject with CanCreateDataFrame with SchemaVali
   override def atlasQualifiedName(prefix: String): String = s"${table.db.getOrElse("default")}.${table.name}"
 
   override def atlasName: String = id.id
+
+  /**
+   * Returns statistics about this DataObject from the catalog. Depending on it's type this can be
+   * - min
+   * - max
+   * - num_nulls -> Completness %
+   * - distinct_count -> Uniqness %
+   * - avg_col_len	11
+   * - max_col_len	13
+   * - ...
+   * @param update if true, more costly operations such as "analyze table ... compute statistics for all columns" are executed before returning results.*
+   * @param lastModifiedAt can be given to avoid update if there has been no new data written to the table.
+   * @return column statistics about this DataObject
+   */
+  def getColumnStats(update: Boolean = false, lastModifiedAt: Option[Long] = None)(implicit context: ActionPipelineContext): Map[String, Map[String, Any]] = Map()
+
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -194,7 +194,8 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     // analyse
     if (analyzeTableAfterWrite && !createTableOnly) {
       logger.info(s"($id) Analyze table ${table.fullName}.")
-      HiveUtil.analyze(table, partitions, partitionValues)
+      val simpleColumns = SparkSchema(dfPrepared.schema).filter(_.dataType.isSimpleType).columns
+      HiveUtil.analyze(table, simpleColumns, partitions, partitionValues)
     }
 
     // return

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -81,17 +81,17 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
     if (hadoopPathHolder == null) {
       hadoopPathHolder = {
         if (thisIsTableExisting) HiveUtil.removeTickTockFromLocation(new Path(HiveUtil.existingTableLocation(table)))
-        else HdfsUtil.prefixHadoopPath(path.get, connection.flatMap(_.pathPrefix))
+        else getAbsolutePath
       }
 
       // For existing tables, check to see if we write to the same directory. If not, issue a warning.
       if(thisIsTableExisting && path.isDefined) {
         // Normalize both paths before comparing them (remove tick / tock folder and trailing slash)
         val hadoopPathNormalized = HiveUtil.normalizePath(hadoopPathHolder.toString)
-        val definedPathNormalized = HiveUtil.normalizePath(path.get)
+        val definedPathNormalized = HiveUtil.normalizePath(getAbsolutePath.toString)
 
         if (definedPathNormalized != hadoopPathNormalized)
-          logger.warn(s"Table ${table.fullName} exists already with different path $path. The table will be written with new path definition $hadoopPathHolder!")
+          logger.warn(s"($id) Table ${table.fullName} exists already with different path ${hadoopPathHolder}. New path definition ${getAbsolutePath} is ignored!")
       }
     }
     hadoopPathHolder
@@ -104,6 +104,11 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
       filesystemHolder = HdfsUtil.getHadoopFsFromSpark(hadoopPath)
     }
     filesystemHolder
+  }
+
+  private def getAbsolutePath(implicit context: ActionPipelineContext) = {
+    val prefixedPath = HdfsUtil.prefixHadoopPath(path.get, connection.flatMap(_.pathPrefix))
+    HdfsUtil.makeAbsolutePath(prefixedPath)(HdfsUtil.getHadoopFsWithConf(prefixedPath)(context.serializableHadoopConf.conf)) // dont use "filesystem" to avoid loop
   }
 
   override def prepare(implicit context: ActionPipelineContext): Unit = {

--- a/sdl-core/src/test/resources/log4j2.yml
+++ b/sdl-core/src/test/resources/log4j2.yml
@@ -62,3 +62,7 @@ Configuration:
         level: ERROR
       - name: org.apache.hadoop.util.NativeCodeLoader
         level: ERROR
+      - name: org.apache.kafka.clients.admin.AdminClientConfig
+        level: ERROR
+      - name: io.smartdatalake.app.BuildVersionInfo
+        level: ERROR

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameTestHelper.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameTestHelper.scala
@@ -270,4 +270,5 @@ object DataFrameTestHelper {
 
   case class TypedValue(value: Any, dataType: DataType)
 
+  case class ComplexTypeTest(a: String, b: Int)
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionValuesTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionValuesTest.scala
@@ -58,6 +58,14 @@ class PartitionValuesTest extends FunSuite {
         Seq(PartitionValues(Map("dt"->"20170101","cnt"->2)),PartitionValues(Map("dt"->"20181201","cnt"->2)),PartitionValues(Map("dt"->"20181201","cnt"->1)))
     )
 
+    // more columns considered for ordering than available: ordering on available columns
+    val orderingDtCntTest = PartitionValues.getOrdering(Seq("dt","cnt","test"))
+    assert(
+      partValSeq.sorted(orderingDtCntTest)
+        ==
+        Seq(PartitionValues(Map("dt"->"20170101","cnt"->2)),PartitionValues(Map("dt"->"20181201","cnt"->1)),PartitionValues(Map("dt"->"20181201","cnt"->2)))
+    )
+
   }
 
   test("check expected partition values") {

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/HoconUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/HoconUtilTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.misc
+
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import org.scalatest.FunSuite
+
+class HoconUtilTest extends FunSuite {
+
+  val config = ConfigFactory.parseString(
+    """
+      |actions = {
+      | a1 = {
+      |   type = FileTransferAction
+      |   inputId = do3
+      |   outputId = do1
+      |   transformers = [{
+      |      type = ScalaClassSparkDfsTransformer
+      |      className = io.smartdatalake.DummyTransformer
+      |   }]
+      | }
+      |}
+      |""".stripMargin).resolve
+
+  test("reading nested configuration value inside list") {
+    assert(HoconUtil.getConfigValue(config.root, Seq("actions","a1","transformers","[0]","className")).unwrapped == "io.smartdatalake.DummyTransformer")
+  }
+
+  test("set nested configuration value inside list") {
+    val newConfig = HoconUtil.updateConfigValue(config.root, Seq("actions", "a1", "transformers", "[0]", "_sourceDoc"), ConfigValueFactory.fromAnyRef("abc"))
+    assert(HoconUtil.getConfigValue(newConfig, Seq("actions","a1","transformers","[0]","_sourceDoc")).unwrapped == "abc")
+  }
+
+  test("update nested configuration value inside list") {
+    val newConfig = HoconUtil.updateConfigValue(config.root, Seq("actions", "a1", "transformers", "[0]", "className"), ConfigValueFactory.fromAnyRef("abc"))
+    assert(HoconUtil.getConfigValue(newConfig, Seq("actions", "a1", "transformers", "[0]", "className")).unwrapped == "abc")
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
@@ -32,6 +32,8 @@ import org.scalatest.FunSuite
 import java.nio.file.Files
 import java.time.{Duration, LocalDateTime}
 
+import scala.collection.JavaConverters._
+
 class ActionDAGRunTest extends FunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
@@ -84,15 +86,15 @@ class ActionDAGRunTest extends FunSuite {
     // write first state
     {
       stateStore.saveState(state)
-      val index = HdfsUtil.readHadoopFile(tempDir.resolve("index.json").toString)(session.sparkContext.hadoopConfiguration)
-      assert(index.split(HadoopFileActionDAGRunStateStore.indexEntryDelimiter).length == 1)
+      val index = HdfsUtil.readHadoopFile(tempDir.resolve("index").toString)(session.sparkContext.hadoopConfiguration)
+      assert(index.linesIterator.count(_.trim.nonEmpty) == 1)
     }
 
     // write second state
     {
       stateStore.saveState(state)
-      val index = HdfsUtil.readHadoopFile(tempDir.resolve("index.json").toString)(session.sparkContext.hadoopConfiguration)
-      assert(index.split(HadoopFileActionDAGRunStateStore.indexEntryDelimiter).length == 2)
+      val index = HdfsUtil.readHadoopFile(tempDir.resolve("index").toString)(session.sparkContext.hadoopConfiguration)
+      assert(index.linesIterator.count(_.trim.nonEmpty) == 2)
     }
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObjectTest.scala
@@ -18,15 +18,14 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import java.io.File
-import java.nio.file.Paths
-import java.sql.Timestamp
-
 import com.typesafe.config.ConfigFactory
 import io.smartdatalake.testutils.DataObjectTestSuite
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.{DataFrame, Row}
+
+import java.io.File
+import java.nio.file.Paths
+import java.sql.Timestamp
 
 
 class AccessTableDataObjectTest extends DataObjectTestSuite {
@@ -87,30 +86,6 @@ class AccessTableDataObjectTest extends DataObjectTestSuite {
     firstRow.getAs[Int]("field3") shouldEqual 9999
     firstRow.getAs[Boolean]("field4") shouldEqual true
     firstRow.getAs[Timestamp]("field5").toString shouldEqual "2018-05-24 00:00:00.0"
-  }
-
-  test("Reading an access 2016 database using the Ucanaccess driver directly throws an exception") {
-    // prepare
-    val dataObj = AccessTableDataObject.fromConfig(access2016SampleConfig)
-    val executorLogLevel = Logger.getLogger("org.apache.spark.executor.Executor").getLevel
-    val taskSetManagerLogLevel = Logger.getLogger("org.apache.spark.scheduler.TaskSetManager").getLevel
-
-    try {
-      Logger.getLogger("org.apache.spark.executor.Executor").setLevel(Level.OFF)
-      Logger.getLogger("org.apache.spark.scheduler.TaskSetManager").setLevel(Level.OFF)
-
-        // run
-        val thrown = intercept[Exception] {
-          val df = dataObj.getDataFrameByFramework()
-          df.collect()
-        }
-
-        // check
-        thrown.getCause.getMessage shouldEqual "UCAExc:::5.0.1 incompatible data type in conversion: from SQL type CHARACTER to java.lang.Integer, value: ID"
-    } finally {
-        Logger.getLogger("org.apache.spark.executor.Executor").setLevel(executorLogLevel)
-        Logger.getLogger("org.apache.spark.scheduler.TaskSetManager").setLevel(taskSetManagerLogLevel)
-    }
   }
 
   test("It is not possible to read from an non-existing database file.") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableDataObjectTest.scala
@@ -19,9 +19,11 @@
 package io.smartdatalake.workflow.dataobject
 
 import com.typesafe.config.ConfigFactory
-import io.smartdatalake.definitions.{Environment, SDLSaveMode}
+import io.smartdatalake.definitions.{ColumnStatsType, Environment, SDLSaveMode, TableStatsType}
+import io.smartdatalake.testutils.DataFrameTestHelper.ComplexTypeTest
 import io.smartdatalake.testutils.DataObjectTestSuite
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
+import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.workflow.ProcessingLogicException
 
 class HiveTableDataObjectTest extends DataObjectTestSuite {
@@ -31,16 +33,16 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
 
   import session.implicits._
 
-  test("write and analyze table without partitions") {
+  test("write and analyze table without partitions but complex datatypes") {
     val srcTable = Table(Some("default"), "input")
     val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
     srcDO.dropTable
-    val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
+    val df = Seq(("ext", "doe", "john", ComplexTypeTest("a", 5)), ("ext", "smith", "peter", ComplexTypeTest("a", 3)), ("int", "emma", "brown", ComplexTypeTest("a", 7)))
+      .toDF("type", "lastname", "firstname", "complex")
     srcDO.writeSparkDataFrame(df, Seq())
     // check table statistics
-    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
-      .where($"col_name"==="Statistics").head.getAs[String](1)
-    assert(statsStr.contains("3 rows"))
+    assert(srcDO.getStats().get(TableStatsType.NumRows.toString).contains(3))
+    assert(srcDO.getColumnStats().apply("type").get(ColumnStatsType.DistinctCount.toString).contains(2))
     // check table contents
     assert(srcDO.getSparkDataFrame().count==3)
   }
@@ -52,16 +54,9 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df, Seq(PartitionValues(Map("type"->"ext")),PartitionValues(Map("type"->"int"))))
     // check table statistics
-    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
-      .where($"col_name"==="Statistics").head.getAs[String](1)
-    assert(statsStr.contains("3 rows"))
-    // check partition statistics
-    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext')")
-      .where($"col_name"==="Partition Statistics").head.getAs[String](1)
-    assert(statsPart1Str.contains("2 rows"))
-    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int')")
-      .where($"col_name"==="Partition Statistics").head.getAs[String](1)
-    assert(statsPart2Str.contains("1 rows"))
+    assert(srcDO.getStats().get(TableStatsType.NumRows.toString).contains(3))
+    assert(srcDO.getColumnStats().apply("type").get(ColumnStatsType.DistinctCount.toString).contains(2))
+    assert(srcDO.getColumnStats().apply("rating").get(ColumnStatsType.Max.toString).contains("7"))
     // check table contents
     assert(srcDO.getSparkDataFrame().count==3)
   }
@@ -73,16 +68,10 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df, Seq())
     // check table statistics
-    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
-      .where($"col_name"==="Statistics").head.getAs[String](1)
-    assert(statsStr.contains("3 rows"))
+    assert(HiveUtil.getCatalogStats(srcTable).get(TableStatsType.NumRows.toString).contains(3))
     // check partition statistics
-    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext')")
-      .where($"col_name"==="Partition Statistics").head.getAs[String](1)
-    assert(statsPart1Str.contains("2 rows"))
-    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int')")
-      .where($"col_name"==="Partition Statistics").head.getAs[String](1)
-    assert(statsPart2Str.contains("1 rows"))
+    assert(HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "ext"))).get(TableStatsType.NumRows.toString).contains(2))
+    assert(HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "int"))).get(TableStatsType.NumRows.toString).contains(1))
     // check table contents
     assert(srcDO.getSparkDataFrame().count==3)
   }
@@ -92,23 +81,14 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val srcDO = HiveTableDataObject( "input", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type","lastname"), numInitialHdfsPartitions = 1, analyzeTableAfterWrite = true)
     srcDO.dropTable
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
-    srcDO.writeSparkDataFrame(df, Seq(PartitionValues(Map("type"->"ext"))))
+    srcDO.writeSparkDataFrame(df, Seq(PartitionValues(Map("type"->"ext")))) // note: this is not proper use of writeSparkDataFrame, as df contains more partitions than specified
     // check table statistics
-    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
-      .where($"col_name"==="Statistics").select($"data_type").as[String].head
-    assert(statsStr.contains("3 rows"))
+    assert(HiveUtil.getCatalogStats(srcTable).get(TableStatsType.NumRows.toString).contains(3))
     // check partition statistics -> only partition type=ext,name=doe and type=ext,lastname=smith should have been analyzed
-    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='doe')")
-      .where($"col_name"==="Partition Statistics").select($"data_type").as[String].head
-    assert(statsPart1Str.contains("1 rows"))
-    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='smith')")
-      .where($"col_name"==="Partition Statistics").select($"data_type").as[String].head
-    assert(statsPart2Str.contains("1 rows"))
+    assert(HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "ext", "lastname" -> "doe"))).get(TableStatsType.NumRows.toString).contains(1))
+    assert(HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "ext", "lastname" -> "smith"))).get(TableStatsType.NumRows.toString).contains(1))
     // check no partition statistics for type=int,lastname=emma
-    session.sql(s"describe extended ${srcTable.fullName} partition(type='int',lastname='emma')").show
-    val statsPart3Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int',lastname='emma')")
-      .where($"col_name"==="Partition Statistics").select($"data_type").as[String].collect.headOption
-    assert(statsPart3Str.isEmpty)
+    assert(!HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "int", "lastname" -> "emma"))).contains(TableStatsType.NumRows.toString))
     // check table contents
     assert(srcDO.getSparkDataFrame().count==3)
   }
@@ -120,20 +100,12 @@ class HiveTableDataObjectTest extends DataObjectTestSuite {
     val df = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7)).toDF("type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df, Seq(PartitionValues(Map("type"->"ext", "lastname"->"doe")),PartitionValues(Map("type"->"ext", "lastname"->"smith"))))
     // check table statistics
-    val statsStr = session.sql(s"describe extended ${srcTable.fullName}")
-      .where($"col_name"==="Statistics").select($"data_type").as[String].head
-    assert(statsStr.contains("3 rows"))
+    assert(HiveUtil.getCatalogStats(srcTable).get(TableStatsType.NumRows.toString).contains(3))
     // check partition statistics -> only partition type=ext,name=doe and type=ext,lastname=smith should have been analyzed
-    val statsPart1Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='doe')")
-      .where($"col_name"==="Partition Statistics").select($"data_type").as[String].head
-    assert(statsPart1Str.contains("1 rows"))
-    val statsPart2Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='ext',lastname='smith')")
-      .where($"col_name"==="Partition Statistics").select($"data_type").as[String].head
-    assert(statsPart2Str.contains("1 rows"))
+    assert(HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "ext", "lastname" -> "doe"))).get(TableStatsType.NumRows.toString).contains(1))
+    assert(HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "ext", "lastname" -> "smith"))).get(TableStatsType.NumRows.toString).contains(1))
     // check no partition statistics for type=int,lastname=emma
-    val statsPart3Str = session.sql(s"describe extended ${srcTable.fullName} partition(type='int',lastname='emma')")
-      .where($"col_name"==="Partition Statistics").select($"data_type").as[String].collect().headOption
-    assert(statsPart3Str.isEmpty)
+    assert(!HiveUtil.getCatalogPartitionStats(srcTable, PartitionValues(Map("type" -> "int", "lastname" -> "emma"))).contains(TableStatsType.NumRows.toString))
     // check table contents
     assert(srcDO.getSparkDataFrame().count==3)
   }

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -36,7 +36,8 @@ import io.smartdatalake.workflow.dataframe.GenericSchema
 import io.smartdatalake.workflow.dataframe.spark.{SparkColumn, SparkSchema, SparkSubFeed}
 import io.smartdatalake.workflow.{ActionPipelineContext, ProcessingLogicException}
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -452,8 +453,60 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     DeltaTable.forName(session, table.fullName).detail()
   }
 
-  override def factory: FromConfigFactory[DataObject] = DeltaLakeTableDataObject
+  override def getStats(update: Boolean = false)(implicit context: ActionPipelineContext): Map[String, Any] = {
+    try {
+      implicit val session = context.sparkSession
+      import session.implicits._
+      val dfHistory = DeltaTable.forName(session, table.fullName).history()
+        .select("timestamp", "userMetadata").as[(Long,String)]
+      val (_,lastCommitMsg) = dfHistory.head
+      val (oldestSnapshot,_) = dfHistory.head
+      val (createdAt, lastModifiedAt, numDataFilesCurrent, sizeInBytesCurrent, properties) = getDetails
+        .select("createdAt","lastModified","numFiles","sizeInBytes","properties").as[(Long,Long,Long,Long,Map[String,String])].head
+      val numRows = DeltaTable.forName(session, table.fullName).toDF.count // This is actionally calculated by Metadata only :-)
+      val deltaStats = Map(TableStatsType.CreatedAt.toString -> createdAt, TableStatsType.LastModifiedAt.toString -> lastModifiedAt, TableStatsType.LastCommitMsg.toString -> lastCommitMsg, TableStatsType.NumDataFilesCurrent.toString -> numDataFilesCurrent, TableStatsType.SizeInBytesCurrent.toString -> sizeInBytesCurrent, TableStatsType.OldestSnapshotTs.toString -> oldestSnapshot, TableStatsType.NumRows.toString -> numRows)
+      val columnStats = getColumnStats(update, Some(lastModifiedAt))
+      HdfsUtil.getPathStats(hadoopPath)(filesystem) ++ deltaStats ++ getPartitionStats + (TableStatsType.Columns.toString -> columnStats)
+    } catch {
+      case e: Exception =>
+        logger.error(s"($id} Could not get column stats: ${e.getClass.getSimpleName} ${e.getMessage}")
+        Map("info" -> e.getMessage)
+    }
+  }
 
+  override def getColumnStats(update: Boolean, lastModifiedAt: Option[Long])(implicit context: ActionPipelineContext): Map[String, Map[String,Any]] = {
+    try {
+      val session = context.sparkSession
+      import session.implicits._
+      val deltaLog = DeltaLog.forTable(session, table.tableIdentifier)
+      val snapshot = deltaLog.unsafeVolatileSnapshot
+      val columns = snapshot.schema.fieldNames
+      def getAgg(col: String) = struct(
+        min($"stats.minValues"(col)).as("minValue"),
+        max($"stats.maxValues"(col)).as("maxValue"),
+        sum($"stats.nullCount"(col)).as("nullCount")
+      ).as(col)
+      val metricsRow = snapshot.allFiles
+        .select(from_json($"stats", snapshot.statsSchema).as("stats"))
+        .agg(sum($"stats.numRecords").as("numRecords"), columns.map(getAgg):_*).head
+      columns.map {
+        c =>
+          val struct = metricsRow.getStruct(metricsRow.fieldIndex(c))
+          c -> Map(
+            ColumnStatsType.NullCount.toString -> struct.getAs[Long]("nullCount"),
+            ColumnStatsType.Min.toString -> struct.getAs[Any]("minValue"),
+            ColumnStatsType.Max.toString -> struct.getAs[Any]("maxValue")
+          )
+      }.toMap
+    } catch {
+      case e: Exception =>
+        logger.error(s"($id} Could not get column stats: ${e.getClass.getSimpleName} ${e.getMessage}")
+        Map()
+    }
+
+  }
+
+  override def factory: FromConfigFactory[DataObject] = DeltaLakeTableDataObject
 }
 
 object DeltaLakeTableDataObject extends FromConfigFactory[DataObject] {

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -132,7 +132,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
         val definedPathNormalized = HiveUtil.normalizePath(getAbsolutePath.toString)
 
         if (definedPathNormalized != hadoopPathNormalized)
-          logger.warn(s"($id) Table ${table.fullName} exists already with different path $path. The table will use the existing path definition $hadoopPathHolder!")
+          logger.warn(s"($id) Table ${table.fullName} exists already with different path ${hadoopPathHolder}. New path definition ${getAbsolutePath} is ignored!")
       }
     }
     hadoopPathHolder

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.{SDLSaveMode, SaveModeMergeOptions}
+import io.smartdatalake.definitions.{ColumnStatsType, SDLSaveMode, SaveModeMergeOptions, TableStatsType}
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.testutils.custom.TestCustomDfCreator
 import io.smartdatalake.util.hdfs.PartitionValues
@@ -71,6 +71,12 @@ class DeltaLakeTableDataObjectTest extends FunSuite with BeforeAndAfter {
     val resultat = expected.isEqual(actual)
     if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable",Seq())(actual)(expected)
     assert(resultat)
+
+    // check statistics
+    assert(targetDO.getStats().apply(TableStatsType.NumRows.toString) == 2)
+    val colStats = targetDO.getColumnStats()
+    assert(colStats.apply("num").get(ColumnStatsType.Max.toString).contains(1))
+    assert(colStats.apply("text").get(ColumnStatsType.Max.toString).contains("Foo!"))
   }
 
   test("CustomDf2DeltaTable_partitioned") {

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -140,7 +140,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
         val definedPathNormalized = HiveUtil.normalizePath(getAbsolutePath.toString)
 
         if (definedPathNormalized != hadoopPathNormalized)
-          logger.warn(s"($id) Table ${table.fullName} exists already with different path $path. The table will use the existing path definition $hadoopPathHolder!")
+          logger.warn(s"($id) Table ${table.fullName} exists already with different path ${hadoopPathHolder}. New path definition ${getAbsolutePath} is ignored!")
       }
     }
     hadoopPathHolder

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -46,6 +46,7 @@ import org.apache.spark.sql.connector.catalog.{Identifier, SupportsNamespaces, T
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+import java.time.Instant
 import scala.collection.JavaConverters._
 import scala.util.Try
 
@@ -512,6 +513,48 @@ case class IcebergTableDataObject(override val id: DataObjectId,
   override def dropTable(implicit context: ActionPipelineContext): Unit = {
     getIcebergCatalog.dropTable(getTableIdentifier, true) // purge
     HdfsUtil.deletePath(hadoopPath, false)(filesystem)
+  }
+
+  override def getStats(update: Boolean = false)(implicit context: ActionPipelineContext): Map[String, Any] = {
+    try {
+      val icebergTable = getIcebergTable
+      val branches = icebergTable.refs().asScala.filter(_._2.isBranch).keys.toSeq.mkString(",")
+      val oldestSnapshot = icebergTable.history().asScala.minBy(_.timestampMillis())
+      val snapshot = icebergTable.currentSnapshot()
+      val summary = snapshot.summary().asScala
+      val lastModifiedAt = snapshot.timestampMillis()
+      val oldestSnapshotTs = oldestSnapshot.timestampMillis()
+      val icebergStats = Map(TableStatsType.LastModifiedAt.toString -> lastModifiedAt, TableStatsType.NumRows.toString -> summary("total-records").toLong, TableStatsType.NumDataFilesCurrent.toString -> summary("total-data-files").toInt, TableStatsType.Branches.toString -> branches, TableStatsType.OldestSnapshotTs.toString -> oldestSnapshotTs)
+      val columnStats = getColumnStats(update, Some(lastModifiedAt))
+      HdfsUtil.getPathStats(hadoopPath)(filesystem) ++ icebergStats ++ getPartitionStats + (TableStatsType.Columns.toString -> columnStats)
+    } catch {
+      case e: Exception =>
+        logger.error(s"($id} Could not get table stats: ${e.getClass.getSimpleName} ${e.getMessage}")
+        Map(TableStatsType.Info.toString -> e.getMessage)
+    }
+  }
+
+  override def getColumnStats(update: Boolean, lastModifiedAt: Option[Long])(implicit context: ActionPipelineContext): Map[String, Map[String,Any]] = {
+    try {
+      val session = context.sparkSession
+      import session.implicits._
+      val filesDf = context.sparkSession.table(s"${table.toString}.files")
+      val metricsRow = filesDf.select($"readable_metrics.*").head
+      val columns = metricsRow.schema.fieldNames
+      columns.map {
+        c =>
+          val struct = metricsRow.getStruct(metricsRow.fieldIndex(c))
+          c -> Map(
+            ColumnStatsType.NullCount.toString -> struct.getAs[Long]("null_value_count"),
+            ColumnStatsType.Min.toString -> struct.getAs[Any]("lower_bound"),
+            ColumnStatsType.Max.toString -> struct.getAs[Any]("upper_bound")
+          )
+      }.toMap
+    } catch {
+      case e: Exception =>
+        logger.error(s"($id} Could not get column stats: ${e.getClass.getSimpleName} ${e.getMessage}")
+        Map()
+    }
   }
 
   override def factory: FromConfigFactory[DataObject] = IcebergTableDataObject

--- a/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
+++ b/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.definitions.{SDLSaveMode, SaveModeMergeOptions}
+import io.smartdatalake.definitions.{ColumnStatsType, SDLSaveMode, SaveModeMergeOptions, TableStatsType}
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.testutils.custom.TestCustomDfCreator
 import io.smartdatalake.util.hdfs.PartitionValues
@@ -70,6 +70,12 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter {
     val resultat = expected.isEqual(actual)
     if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable",Seq())(actual)(expected)
     assert(resultat)
+
+    // check statistics
+    assert(targetDO.getStats().apply(TableStatsType.NumRows.toString) == 2)
+    val colStats = targetDO.getColumnStats()
+    assert(colStats.apply("num").get(ColumnStatsType.Max.toString).contains(1))
+    assert(colStats.apply("text").get(ColumnStatsType.Max.toString).contains("Foo!"))
   }
 
   test("Write data partitioned") {

--- a/sdl-kafka/pom.xml
+++ b/sdl-kafka/pom.xml
@@ -44,7 +44,7 @@
 
 	<properties>
 		<sdl-core.scope>compile</sdl-core.scope>
-		<confluent.version>7.3.2</confluent.version>
+		<confluent.version>7.5.1</confluent.version>
 	</properties>
 
 	<dependencyManagement>
@@ -86,6 +86,17 @@
 			<artifactId>spark-sql-kafka-0-10_${scala.minor.version}</artifactId>
 			<version>${spark.version}</version>
 			<scope>runtime</scope>
+			<exclusions>
+				<!-- hadoop-client is referenced directly by sdl-core -->
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-client-runtime</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-client-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
@@ -243,7 +254,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/sdl-lang/pom.xml
+++ b/sdl-lang/pom.xml
@@ -43,54 +43,17 @@
             <artifactId>spark-core_${scala.minor.version}</artifactId>
             <version>${spark.version}</version>
             <scope>${spark.deps.scope}</scope>
-            <exclusions>
-                <!-- this is to exclude hadoop-annations, which is shaded into hadoop-client-api -->
-                <!-- Annotation InterfaceAudience causes "illegal cyclic reference involving class InterfaceAudience" when searching for annotations with reflection -->
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-client-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-client-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-        <!-- then we need to include hadoop client on our own: https://github.com/apache/hadoop/blob/trunk/hadoop-client-modules/hadoop-client-api/pom.xml -->
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty.websocket</groupId>
-                    <artifactId>websocket-client</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- all modules needed to create configuration schema, but not as transitive dependencies (-> optional=true) -->
         <dependency>
             <groupId>io.smartdatalake</groupId>
             <artifactId>sdl-core_${scala.minor.version}</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>
-                <!-- this is to exclude hadoop-annations, which is shaded into hadoop-client-api -->
                 <!-- Annotation InterfaceAudience causes "illegal cyclic reference involving class InterfaceAudience" when searching for annotations with reflection -->
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-client-runtime</artifactId>
+                    <artifactId>hadoop-annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/sdl-lang/pom.xml
+++ b/sdl-lang/pom.xml
@@ -50,6 +50,10 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-client-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- then we need to include hadoop client on our own: https://github.com/apache/hadoop/blob/trunk/hadoop-client-modules/hadoop-client-api/pom.xml -->
@@ -82,10 +86,11 @@
             <artifactId>sdl-core_${scala.minor.version}</artifactId>
             <version>${project.parent.version}</version>
             <exclusions>
+                <!-- this is to exclude hadoop-annations, which is shaded into hadoop-client-api -->
                 <!-- Annotation InterfaceAudience causes "illegal cyclic reference involving class InterfaceAudience" when searching for annotations with reflection -->
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-annotations</artifactId>
+                    <artifactId>hadoop-client-runtime</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -112,6 +117,14 @@
             <artifactId>sdl-kafka_${scala.minor.version}</artifactId>
             <version>${project.parent.version}</version>
             <optional>true</optional>
+            <exclusions>
+                <!-- this is to exclude hadoop-annations, which is shaded into hadoop-client-api -->
+                <!-- Annotation InterfaceAudience causes "illegal cyclic reference involving class InterfaceAudience" when searching for annotations with reflection -->
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.smartdatalake</groupId>

--- a/sdl-lang/pom.xml
+++ b/sdl-lang/pom.xml
@@ -117,13 +117,11 @@
             <groupId>com.github.andyglow</groupId>
             <artifactId>scaladoc-ast_${scala.minor.version}</artifactId>
             <version>0.0.14</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.github.andyglow</groupId>
             <artifactId>scaladoc-parser_${scala.minor.version}</artifactId>
             <version>0.0.14</version>
-            <optional>true</optional>
         </dependency>
 
         <!-- TEST dependencies -->

--- a/sdl-lang/pom.xml
+++ b/sdl-lang/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.minor.version}</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.andyglow</groupId>
             <artifactId>scaladoc-ast_${scala.minor.version}</artifactId>
             <version>0.0.14</version>

--- a/sdl-lang/pom.xml
+++ b/sdl-lang/pom.xml
@@ -127,6 +127,27 @@
             <artifactId>scalatest_${scala.minor.version}</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--		 sdl-core test utils-->
+        <dependency>
+            <groupId>io.smartdatalake</groupId>
+            <artifactId>sdl-core_${scala.minor.version}</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>test-jar</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-core</artifactId>
+            <version>${sshd.test.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>2.25.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
@@ -68,11 +68,15 @@ case class LabSparkDataObjectWrapper[T <: DataObject with CanCreateSparkDataFram
     case _ => throw NotSupportedException(dataObject.id, "is not partitioned")
   }
 
-  def infos: Map[String,String] = {
+  /**
+   * Returns information about this DataObject, such as statistics, table name, ...
+   * @param updateStats if true, more costly operations such as "analyze table" are executed before returning results.
+   */
+  def infos(updateStats: Boolean = false): Map[String,String] = {
     Seq(
       Some(dataObject).collect{case o: TableDataObject => ("table", o.table.fullName)},
       Some(dataObject).collect{case o: FileRefDataObject => ("path", o.getPath(context))}
-    ).flatten.toMap
+    ).flatten.toMap ++ dataObject.getStats(updateStats)(context).mapValues(_.toString)
   }
 
   def partitionColumns: Seq[String] = dataObject match {

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/ScaladocUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/ScaladocUtil.scala
@@ -75,4 +75,12 @@ private[smartdatalake] object ScaladocUtil {
       .flatMap(_.tree.children.collectFirst { case x: AssignOrNamedArg => x.rhs.toString })
     rawScaladoc.map(d => scaladoc.Scaladoc.fromString(d).right.get)
   }
+
+  def getClassScalaDoc(className: String): Option[Scaladoc] = {
+    val cls = getClass.getClassLoader.loadClass(className)
+    val tpe = mirror.classSymbol(cls).toType
+    val annotations = tpe.typeSymbol.annotations
+    extractScalaDoc(annotations)
+  }
+  private lazy val mirror = scala.reflect.runtime.currentMirror
 }

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
@@ -11,8 +11,6 @@ import scopt.OptionParser
 
 import java.nio.file.{Files, Paths, StandardOpenOption}
 import scala.collection.JavaConverters._
-import scala.io.Source
-import scala.util.{Failure, Try, Using}
 
 case class ConfigJsonExporterConfig(configPaths: Seq[String] = null, filename: String = "exportedConfig.json", enrichOrigin: Boolean = true, descriptionPath: Option[String] = None)
 

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
@@ -40,7 +40,7 @@ object ConfigJsonExporter extends SmartDataLakeLogger {
     opt[String]('d', "descriptionPath")
       .optional()
       .action((value, c) => c.copy(descriptionPath = Some(value)))
-      .text("Path of description markdown files for parsing optional column columns from DataObject descriptions and exporting them for the visualizer.")
+      .text("Path to markdown files that contain column descriptions of DataObjects. If set, these descriptions are exported to the visualizer.")
     help("help").text("Display the help text.")
   }
 

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
@@ -103,7 +103,7 @@ object ConfigJsonExporter extends SmartDataLakeLogger {
       RemoteIteratorWrapper(filesystem.listStatusIterator(hadoopPath)).filterNot(_.isDirectory).toSeq
       .map { p =>
         val dataObjectId = p.getPath.getName.split('.').head
-        val descriptions = HdfsUtil.readHadoopFile(p.getPath).lines().iterator().asScala
+        val descriptions = HdfsUtil.readHadoopFile(p.getPath).linesIterator
           .collect {
             case columnDescriptionRegex(name, description) =>
               (name, description.trim)

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporter.scala
@@ -5,11 +5,15 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.{ConfigToolbox, ConfigurationException}
 import io.smartdatalake.util.misc.{SerializableHadoopConfiguration, SmartDataLakeLogger}
 import io.smartdatalake.workflow.action.SDLExecutionId
+import io.smartdatalake.workflow.dataframe.GenericSchema
 import io.smartdatalake.workflow.dataobject.CanCreateDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.json4s.jackson.JsonMethods.pretty
+import org.json4s.jackson.Serialization
+import org.json4s.{Formats, NoTypeHints}
 import scopt.OptionParser
 
+import java.io.File
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import java.time.LocalDateTime
 import scala.io.Source
@@ -19,6 +23,7 @@ case class DataObjectSchemaExporterConfig(configPaths: Seq[String] = null,
                                           exportPath: String = "./schema",
                                           includeRegex: String = ".*",
                                           excludeRegex: Option[String] = None,
+                                          updateStats: Boolean = true,
                                           descriptionPath: Option[String] = None,
                                           master: String = "local[2]"
                                          )
@@ -26,6 +31,7 @@ case class DataObjectSchemaExporterConfig(configPaths: Seq[String] = null,
 object DataObjectSchemaExporter extends SmartDataLakeLogger {
 
   val appType: String = getClass.getSimpleName.replaceAll("\\$$", "") // remove $ from object name and use it as appType
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
   protected val parser: OptionParser[DataObjectSchemaExporterConfig] = new OptionParser[DataObjectSchemaExporterConfig](appType) {
     override def showUsageOnError: Option[Boolean] = Some(true)
@@ -45,9 +51,13 @@ object DataObjectSchemaExporter extends SmartDataLakeLogger {
       .optional()
       .action((value, c) => c.copy(excludeRegex = Some(value)))
       .text("Regular expression used to exclude DataObjects from export, matching DataObject ids. `excludeRegex` is applied after `includeRegex`. Default: no excludes")
+    opt[String]('u', "updateStats")
+      .optional()
+      .action((value, c) => c.copy(updateStats = value.toBoolean))
+      .text("If true, more costly operations to update statistics such as \"analyze table\" are executed before returning statistics. Default: true")
     opt[String]('m', "master")
       .optional()
-      .action((value, c) => c.copy(excludeRegex = Some(value)))
+      .action((value, c) => c.copy(master = value))
       .text("Spark session master configuration. As schemas might be inferred by Spark, there might be a need to tune this for some DataObjects. Default: local[2]")
     help("help").text("Export DataObject schemas as Json-files which can be used by the visualizer. A Json file with the DataObject Id as name is created in `exportPath` for every DataObject to be exported.")
   }
@@ -62,52 +72,89 @@ object DataObjectSchemaExporter extends SmartDataLakeLogger {
       case Some(exporterConfig) =>
 
         // export data object schemas to json format
-        val schemas = exportSchemas(exporterConfig)
-
-        // write file
-        logger.info(s"Writing ${schemas.size} data object schemas to json files in path ${exporterConfig.exportPath}")
-        val path = Paths.get(exporterConfig.exportPath)
-        Files.createDirectories(path)
-        schemas.foreach {
-          case (dataObjectId, jsonStr) => writeSchemaIfChanged(dataObjectId, jsonStr, path)
-        }
+        exportSchemas(exporterConfig)
 
       case None =>
-        logAndThrowException(s"Aborting ${appType} after error", new ConfigurationException("Couldn't set command line parameters correctly."))
+        logAndThrowException(s"Aborting $appType after error", new ConfigurationException("Couldn't set command line parameters correctly."))
     }
   }
 
-  def exportSchemas(config: DataObjectSchemaExporterConfig): Seq[(DataObjectId,String)] = {
+  def exportSchemas(config: DataObjectSchemaExporterConfig): Unit = {
+
+    // get DataObjects
     val (registry, globalConfig) = ConfigToolbox.loadAndParseConfig(config.configPaths)
     val hadoopConf = globalConfig.getHadoopConfiguration
+    val path = Paths.get(config.exportPath)
+    Files.createDirectories(path)
     implicit val context: ActionPipelineContext = ActionPipelineContext("feedTest", "appTest", SDLExecutionId.executionId1, registry, Some(LocalDateTime.now()), SmartDataLakeBuilderConfig("DataObjectSchemaExporter", Some("DataObjectSchemaExporter"), master=Some(config.master)), phase = ExecutionPhase.Init, serializableHadoopConf = new SerializableHadoopConfiguration(hadoopConf), globalConfig = globalConfig)
-    registry.getDataObjects
+    val dataObjects = registry.getDataObjects
       .filter(d => d.id.id.matches(config.includeRegex) && (config.excludeRegex.isEmpty || !d.id.id.matches(config.excludeRegex.get)))
-      .collect {
-        case dataObject: CanCreateDataFrame =>
-          // get schema
-          val df = dataObject.getDataFrame(Seq(), dataObject.getSubFeedSupportedTypes.head)
-          val schemaJson = df.schema.toJson
-          (dataObject.id, pretty(schemaJson))
+    logger.info(s"Writing ${dataObjects.size} data object schemas to json files in path ${config.exportPath}")
+
+    // get and write Schemas
+    dataObjects.foreach {
+      case dataObject: CanCreateDataFrame =>
+        val df = dataObject.getDataFrame(Seq(), dataObject.getSubFeedSupportedTypes.head)
+        writeSchemaIfChanged(dataObject.id, df.schema, path)
+    }
+
+    // get and write Stats
+    dataObjects.foreach { dataObject =>
+      val stats = dataObject.getStats(config.updateStats)
+      writeStatsIfChanged(dataObject.id, stats, path)
     }
   }
 
-  def writeSchemaIfChanged(dataObjectId: DataObjectId, newSchema: String, path: Path): Unit = {
-    val indexFile = path.resolve(s"${dataObjectId.id}.index")
-    val newSchemaFilename = s"${dataObjectId.id}.${System.currentTimeMillis() / 1000}.json"
-    val newSchemaFile = path.resolve(newSchemaFilename)
-    // get latest schema
-    val lastIndexEntry = Using(Source.fromFile(indexFile.toFile)) {
-      _.getLines().toSeq.filter(_.trim.nonEmpty).lastOption
-    }.toOption.flatten
-    val lastestSchemaFile = lastIndexEntry.map(path.resolve).map(_.toFile)
-    val latestSchema = lastestSchemaFile.map(f => Using(Source.fromFile(f)) {
-      _.getLines().mkString(System.lineSeparator)
-    }.get)
-    if (!latestSchema.contains(newSchema)) {
-      logger.info(s"Writing schema file $newSchemaFile and updating index")
-      Files.write(newSchemaFile, newSchema.getBytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
-      Files.write(indexFile, (newSchemaFilename + System.lineSeparator).getBytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+  def writeSchemaIfChanged(dataObjectId: DataObjectId, newSchemaJson: GenericSchema, path: Path): Unit = {
+    val newSchemaStr =  pretty(newSchemaJson.toJson)
+    val indexFile = getIndexPath(dataObjectId, "schema", path)
+    val (newFilename, newFile) = getDataPath(dataObjectId, "schema", path)
+    val latestSchema = getLatestData(dataObjectId, "schema", path)
+    if (!latestSchema.contains(newSchemaStr)) {
+      logger.info(s"Writing schema file $newFile and updating index")
+      Files.write(newFile, newSchemaStr.getBytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+      Files.write(indexFile, (newFilename + System.lineSeparator).getBytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
     }
+  }
+
+  def writeStatsIfChanged(dataObjectId: DataObjectId, stats: Map[String,Any], path: Path): Unit = {
+    val statsStr = Serialization.writePretty(stats)
+    val indexFile = getIndexPath(dataObjectId, "stats", path)
+    val (newFilename, newFile) = getDataPath(dataObjectId, "stats", path)
+    val latestStats = getLatestData(dataObjectId, "stats", path).map(Serialization.read[Map[String, Any]])
+    if (!latestStats.contains(stats)) {
+      logger.info(s"Writing stats file $newFile and updating index")
+      Files.write(newFile, statsStr.getBytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+      Files.write(indexFile, (newFilename + System.lineSeparator).getBytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+    }
+  }
+
+  private[configexporter] def getLatestData(dataObjectId: DataObjectId, tpe: String, path: Path): Option[String] ={
+    val lastIndexEntry = readIndex(dataObjectId, tpe, path).lastOption
+    val latestFile = lastIndexEntry.map(path.resolve).map(_.toFile)
+    latestFile.map(readFile)
+  }
+
+  private[configexporter] def readIndex(dataObjectId: DataObjectId, tpe: String, path: Path): Seq[String] = {
+    val indexFile = getIndexPath(dataObjectId, tpe, path)
+    Using(Source.fromFile(indexFile.toFile)) {
+      _.getLines().filter(_.trim.nonEmpty).toVector
+    }.getOrElse(Seq())
+  }
+
+  private def getIndexPath(dataObjectId: DataObjectId, tpe: String, path: Path) = {
+    path.resolve(s"${dataObjectId.id}.$tpe.index")
+  }
+
+  private def getDataPath(dataObjectId: DataObjectId, tpe: String, path: Path) = {
+    val filename = s"${dataObjectId.id}.$tpe.${System.currentTimeMillis() / 1000}.json"
+    val file = path.resolve(filename)
+    (filename, file)
+  }
+
+  private def readFile(file: File): String = {
+    Using(Source.fromFile(file)) {
+      _.getLines().mkString(System.lineSeparator)
+    }.get
   }
 }

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporter.scala
@@ -1,0 +1,95 @@
+package io.smartdatalake.meta.configexporter
+
+import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.config.{ConfigToolbox, ConfigurationException}
+import io.smartdatalake.util.misc.{SerializableHadoopConfiguration, SmartDataLakeLogger}
+import io.smartdatalake.workflow.action.SDLExecutionId
+import io.smartdatalake.workflow.dataobject.CanCreateDataFrame
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
+import org.json4s.jackson.JsonMethods.pretty
+import scopt.OptionParser
+
+import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.time.LocalDateTime
+
+case class DataObjectSchemaExporterConfig(configPaths: Seq[String] = null,
+                                          exportPath: String = "./schema",
+                                          includeRegex: String = ".*",
+                                          excludeRegex: Option[String] = None,
+                                          descriptionPath: Option[String] = None,
+                                          master: String = "local[2]"
+                                         )
+
+object DataObjectSchemaExporter extends SmartDataLakeLogger {
+
+  val appType: String = getClass.getSimpleName.replaceAll("\\$$", "") // remove $ from object name and use it as appType
+
+  protected val parser: OptionParser[DataObjectSchemaExporterConfig] = new OptionParser[DataObjectSchemaExporterConfig](appType) {
+    override def showUsageOnError: Option[Boolean] = Some(true)
+    opt[String]('c', "config")
+      .required()
+      .action((value, c) => c.copy(configPaths = value.split(',')))
+      .text("One or multiple configuration files or directories containing configuration files for SDLB, separated by comma.")
+    opt[String]('p', "exportPath")
+      .optional()
+      .action((value, c) => c.copy(exportPath = value))
+      .text("Path to export configuration to. Default: ./schema")
+    opt[String]('i', "includeRegex")
+      .optional()
+      .action((value, c) => c.copy(includeRegex = value))
+      .text("Regular expression used to include DataObjects in export, matching DataObject ids. Default: .*")
+    opt[String]('e', "excludeRegex")
+      .optional()
+      .action((value, c) => c.copy(excludeRegex = Some(value)))
+      .text("Regular expression used to exclude DataObjects from export, matching DataObject ids. `excludeRegex` is applied after `includeRegex`. Default: no excludes")
+    opt[String]('m', "master")
+      .optional()
+      .action((value, c) => c.copy(excludeRegex = Some(value)))
+      .text("Spark session master configuration. As schemas might be inferred by Spark, there might be a need to tune this for some DataObjects. Default: local[2]")
+    help("help").text("Export DataObject schemas as Json-files which can be used by the visualizer. A Json file with the DataObject Id as name is created in `exportPath` for every DataObject to be exported.")
+  }
+
+  /**
+   * Takes as input a SDL Config and exports the schema of all DataObjects for the visualizer.
+   */
+  def main(args: Array[String]): Unit = {
+    val exporterConfig = DataObjectSchemaExporterConfig()
+    // Parse all command line arguments
+    parser.parse(args, exporterConfig) match {
+      case Some(exporterConfig) =>
+
+        // export data object schemas to json format
+        val schemas = exportSchemas(exporterConfig)
+
+        // write file
+        logger.info(s"Writing ${schemas.size} data object schemas to json files in path ${exporterConfig.exportPath}")
+        val path = Paths.get(exporterConfig.exportPath)
+        Files.createDirectories(path)
+        schemas.foreach{
+          case (dataObjectId, jsonStr) =>
+            val file = path.resolve(s"${dataObjectId.id}.${System.currentTimeMillis() / 1000}.json")
+            logger.debug(s"Writing file $file")
+            Files.write(file, jsonStr.getBytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+        }
+
+      case None =>
+        logAndThrowException(s"Aborting ${appType} after error", new ConfigurationException("Couldn't set command line parameters correctly."))
+    }
+  }
+
+  def exportSchemas(config: DataObjectSchemaExporterConfig): Seq[(DataObjectId,String)] = {
+    val (registry, globalConfig) = ConfigToolbox.loadAndParseConfig(config.configPaths)
+    val hadoopConf = globalConfig.getHadoopConfiguration
+    implicit val context: ActionPipelineContext = ActionPipelineContext("feedTest", "appTest", SDLExecutionId.executionId1, registry, Some(LocalDateTime.now()), SmartDataLakeBuilderConfig("DataObjectSchemaExporter", Some("DataObjectSchemaExporter"), master=Some(config.master)), phase = ExecutionPhase.Init, serializableHadoopConf = new SerializableHadoopConfiguration(hadoopConf), globalConfig = globalConfig)
+    registry.getDataObjects
+      .filter(d => d.id.id.matches(config.includeRegex) && (config.excludeRegex.isEmpty || !d.id.id.matches(config.excludeRegex.get)))
+      .collect {
+        case dataObject: CanCreateDataFrame =>
+          // get schema
+          val df = dataObject.getDataFrame(Seq(), dataObject.getSubFeedSupportedTypes.head)
+          val schemaJson = df.schema.toJson
+          (dataObject.id, pretty(schemaJson))
+    }
+  }
+}

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/dagexporter/SimplifiedAction.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/dagexporter/SimplifiedAction.scala
@@ -21,4 +21,4 @@ package io.smartdatalake.meta.dagexporter
 
 import io.smartdatalake.workflow.action.ActionMetadata
 
-case class SimplifiedAction(metadata: Option[ActionMetadata], inputIds: Seq[String], outputIds: Seq[String])
+private[dagexporter] case class SimplifiedAction(metadata: Option[ActionMetadata], inputIds: Seq[String], outputIds: Seq[String])

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.meta.jsonschema
 
 import io.smartdatalake.app.GlobalConfig
 import io.smartdatalake.config.SdlConfigObject.ConfigObjectId
-import io.smartdatalake.config.{ParsableFromConfig, SdlConfigObject}
+import io.smartdatalake.config.{ExcludeFromSchemaExport, ParsableFromConfig, SdlConfigObject}
 import io.smartdatalake.meta.{GenericAttributeDef, GenericTypeDef, GenericTypeUtil, ScaladocUtil, jsonschema}
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.util.secrets.StringOrSecret
@@ -59,6 +59,7 @@ private[smartdatalake] object JsonSchemaUtil extends SmartDataLakeLogger {
     // get generic type definitions
     val typeDefs = GenericTypeUtil.typeDefs(reflections)
       .filter(_.isFinal) // only case classes
+      .filter(typeDef => ! (typeDef.tpe <:< typeOf[ExcludeFromSchemaExport])) // remove classes that should not be shown in the schema
 
     // define registry and converter
     val registry = new DefinitionRegistry

--- a/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
+++ b/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
@@ -225,7 +225,7 @@ actions {
     outputId = dataObjectParquet13
     transformers = [{
       type = ScalaClassGenericDfTransformer
-      className = io.smartdatalake.meta.configexporter.TestTransformer
+      className = io.smartdatalake.meta.configexporter.ScalaDocExportTestTransformer
     }]
     metadata.feed = actionId
   }

--- a/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
+++ b/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
@@ -224,7 +224,7 @@ actions {
     inputId = dataObjectParquet12
     outputId = dataObjectParquet13
     transformers = [{
-      type = ScalaClassSparkDfsTransformer
+      type = ScalaClassGenericDfTransformer
       className = io.smartdatalake.meta.configexporter.TestTransformer
     }]
     metadata.feed = actionId

--- a/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
+++ b/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
@@ -10,7 +10,7 @@ dataObjects {
 
   dataObjectCsv1 {
     type = CsvFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     csv-options {
       delimiter = ","
       header = true
@@ -21,7 +21,7 @@ dataObjects {
 
   dataObjectCsv2 {
     type = CsvFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     csv-options {
       delimiter = ","
       header = true
@@ -32,7 +32,7 @@ dataObjects {
 
   dataObjectCsv3 {
     type = CsvFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     csv-options {
       delimiter = ","
       header = true
@@ -43,7 +43,7 @@ dataObjects {
 
   dataObjectCsv4 {
     type = CsvFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     csv-options {
       delimiter = ","
       header = true
@@ -54,7 +54,7 @@ dataObjects {
 
   dataObjectCsv5 {
     type = CsvFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     csv-options {
       delimiter = ","
       header = true
@@ -65,46 +65,55 @@ dataObjects {
 
   dataObjectParquet6 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b array<struct<b1: string, b2: long>>, c struct<c1: string, c2: long>"""
   }
 
   dataObjectParquet7 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b string, c string"""
   }
   dataObjectParquet8 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b string, c string"""
   }
 
   dataObjectParquet9 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b string, c string"""
   }
 
   dataObjectParquet10 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b string, c string"""
   }
   dataObjectParquet11 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b string, c string"""
   }
   dataObjectParquet12 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b string, c string"""
   }
   dataObjectParquet13 {
     type = ParquetFileDataObject
-    path = "~{id}"
+    path = "target/~{id}"
     schema = """a string, b string, c string"""
+  }
+
+  dataObjectHive14 {
+    type = HiveTableDataObject
+    path = "target/~{id}"
+    table = {
+      db = default
+      name = hive14
+    }
   }
 }
 
@@ -216,6 +225,4 @@ actions {
     outputId = dataObjectParquet13
     metadata.feed = actionId
   }
-
-
 }

--- a/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
+++ b/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
@@ -223,6 +223,10 @@ actions {
     type = CopyAction
     inputId = dataObjectParquet12
     outputId = dataObjectParquet13
+    transformers = [{
+      type = ScalaClassSparkDfsTransformer
+      className = io.smartdatalake.meta.configexporter.TestTransformer
+    }]
     metadata.feed = actionId
   }
 }

--- a/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
+++ b/sdl-lang/src/test/resources/dagexporter/dagexporterTest.conf
@@ -66,7 +66,7 @@ dataObjects {
   dataObjectParquet6 {
     type = ParquetFileDataObject
     path = "~{id}"
-    schema = """a string, b string, c string"""
+    schema = """a string, b array<struct<b1: string, b2: long>>, c struct<c1: string, c2: long>"""
   }
 
   dataObjectParquet7 {

--- a/sdl-lang/src/test/resources/dagexporter/description/dataObjects/dataObjectParquet6.md
+++ b/sdl-lang/src/test/resources/dagexporter/description/dataObjects/dataObjectParquet6.md
@@ -1,0 +1,10 @@
+## Stammdaten
+Ein paar Spalten Beschreibungen
+@column `a` Beschreibung A
+@column `b` Die Beschreibung für B
+@column `b.[].b1` Beschreibung B1
+
+## Stammdaten 2
+Und noch ein paar Beschreibungen in einem Array
+@column `c.c1` Beschreibung C1
+@column `c.c2` {kW} Kilowattstunden Gesamt C2

--- a/sdl-lang/src/test/resources/dagexporter/description/dataObjects/dataObjectParquet6.md
+++ b/sdl-lang/src/test/resources/dagexporter/description/dataObjects/dataObjectParquet6.md
@@ -7,4 +7,4 @@ Ein paar Spalten Beschreibungen
 ## Stammdaten 2
 Und noch ein paar Beschreibungen in einem Array
 @column `c.c1` Beschreibung C1
-@column `c.c2` {kW} Kilowattstunden Gesamt C2
+@column `c.c2` Beschreibung C2

--- a/sdl-lang/src/test/resources/dagexporter/description/dataObjects/dataObjectParquet6.md
+++ b/sdl-lang/src/test/resources/dagexporter/description/dataObjects/dataObjectParquet6.md
@@ -3,6 +3,7 @@ Ein paar Spalten Beschreibungen
 @column `a` Beschreibung A
 @column `b` Die Beschreibung für B
 @column `b.[].b1` Beschreibung B1
+2nd line B1 text
 
 ## Stammdaten 2
 Und noch ein paar Beschreibungen in einem Array

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -40,6 +40,7 @@ class ConfigJsonExporterTest extends FunSuite {
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "path" === JString("dagexporterTest.conf"))
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "a" === JString("Beschreibung A"))
     assert((actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "b.[].b1").asInstanceOf[JString].s.linesIterator.toSeq === Seq("Beschreibung B1","2nd line B1 text"))
+    assert((actualJsonOutput \ "actions" \ "actionId8" \ "transformers")(0) \ "_sourceDoc" === JString("Documentation for TestTransformer.\nThis should be exported by ConfigJsonExporter!"))
   }
 
   test("test main") {

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -26,17 +26,19 @@ import java.io.File
 class ConfigJsonExporterTest extends FunSuite {
 
   test("export config") {
-    val exporterConfig = ConfigJsonExporterConfig(Seq(getClass.getResource("/dagexporter/dagexporterTest.conf").getPath))
+    val exporterConfig = ConfigJsonExporterConfig(Seq(getClass.getResource("/dagexporter").getPath), descriptionPath = Some(getClass.getResource("/dagexporter/description").getPath))
     val actualOutput = ConfigJsonExporter.exportConfigJson(exporterConfig)
-    assert(actualOutput.contains("origin"))
-    assert(actualOutput.contains("dagexporter/dagexporterTest.conf"))
+    println(actualOutput)
+    assert(actualOutput.contains("_origin"))
+    assert(actualOutput.contains("dagexporterTest.conf"))
     assert(actualOutput.contains("lineNumber"))
     assert(actualOutput.contains("actionId1"))
+    assert(actualOutput.contains("_columnDescription"))
   }
 
   test("test main") {
     val fileName = "target/exportedConfig.json"
-    ConfigJsonExporter.main(Array("-c", getClass.getResource("/dagexporter/dagexporterTest.conf").getPath, "-f", fileName))
+    ConfigJsonExporter.main(Array("-c", getClass.getResource("/dagexporter/dagexporterTest.conf").getFile, "-f", fileName))
     assert(new File(fileName).exists())
   }
 

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -28,7 +28,6 @@ class ConfigJsonExporterTest extends FunSuite {
   test("export config") {
     val exporterConfig = ConfigJsonExporterConfig(Seq(getClass.getResource("/dagexporter").getPath), descriptionPath = Some(getClass.getResource("/dagexporter/description").getPath))
     val actualOutput = ConfigJsonExporter.exportConfigJson(exporterConfig)
-    println(actualOutput)
     assert(actualOutput.contains("_origin"))
     assert(actualOutput.contains("dagexporterTest.conf"))
     assert(actualOutput.contains("lineNumber"))

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -39,6 +39,7 @@ class ConfigJsonExporterTest extends FunSuite {
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "endLineNumber" === JNothing)
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "path" === JString("dagexporterTest.conf"))
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "a" === JString("Beschreibung A"))
+    assert((actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "b.[].b1").asInstanceOf[JString].s.linesIterator.toSeq === Seq("Beschreibung B1","2nd line B1 text"))
   }
 
   test("test main") {

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -19,20 +19,26 @@
 
 package io.smartdatalake.meta.configexporter
 
+import org.json4s.StringInput
+import org.json4s.jackson.JsonMethods
 import org.scalatest.FunSuite
 
 import java.io.File
+import org.json4s.JsonDSL._
+import org.json4s._
 
 class ConfigJsonExporterTest extends FunSuite {
 
   test("export config") {
     val exporterConfig = ConfigJsonExporterConfig(Seq(getClass.getResource("/dagexporter").getPath), descriptionPath = Some(getClass.getResource("/dagexporter/description").getPath))
     val actualOutput = ConfigJsonExporter.exportConfigJson(exporterConfig)
-    assert(actualOutput.contains("_origin"))
-    assert(actualOutput.contains("dagexporterTest.conf"))
-    assert(actualOutput.contains("lineNumber"))
-    assert(actualOutput.contains("actionId1"))
-    assert(actualOutput.contains("_columnDescription"))
+    val actualJsonOutput = JsonMethods.parse(StringInput(actualOutput))
+    assert((actualJsonOutput \ "actions").children.size === 8)
+    assert((actualJsonOutput \ "dataObjects").children.size === 14)
+    assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "lineNumber" === JInt(66))
+    assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "endLineNumber" === JNothing)
+    assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "path" === JString("dagexporterTest.conf"))
+    assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "a" === JString("Beschreibung A"))
   }
 
   test("test main") {

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
@@ -46,7 +46,9 @@ class DataObjectSchemaExporterTest extends FunSuite {
     val actualOutput = DataObjectSchemaExporter.getLatestData("dataObjectCsv1", "schema", Paths.get(exporterConfig.exportPath))
 
     val expectedFieldsJson = """
-      |  [ {
+      | {
+      | "schema": [
+      |  {
       |    "name" : "a",
       |    "dataType" : "string",
       |    "nullable" : true
@@ -58,7 +60,8 @@ class DataObjectSchemaExporterTest extends FunSuite {
       |    "name" : "c",
       |    "dataType" : "string",
       |    "nullable" : true
-      |  } ]
+      |  }
+      | ]}
       |""".stripMargin
     val expectedFields = JsonMethods.parse(StringInput(expectedFieldsJson)).values
     val actualFields = JsonMethods.parse(StringInput(actualOutput.get)).values
@@ -70,8 +73,9 @@ class DataObjectSchemaExporterTest extends FunSuite {
     DataObjectSchemaExporter.exportSchemas(exporterConfig)
     val actualOutput = DataObjectSchemaExporter.getLatestData("dataObjectParquet6", "schema", Paths.get(exporterConfig.exportPath))
     val expectedFieldsJson =
-      """
-        |  [ {
+      """ {
+        | "schema": [
+        |  {
         |    "name" : "a",
         |    "dataType" : "string",
         |    "nullable" : true
@@ -108,7 +112,8 @@ class DataObjectSchemaExporterTest extends FunSuite {
         |      } ]
         |    },
         |    "nullable" : true
-        |  } ]
+        |  }
+        | ]}
         |""".stripMargin
     val expectedFields = JsonMethods.parse(StringInput(expectedFieldsJson)).values
     val actualFields = JsonMethods.parse(StringInput(actualOutput.get)).values
@@ -129,15 +134,15 @@ class DataObjectSchemaExporterTest extends FunSuite {
     FileUtils.deleteDirectory(path.toFile)
     Files.createDirectories(path)
     // first write
-    DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), SparkSchema(StructType(Seq(StructField("a", StringType)))), path)
+    DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), Some(SparkSchema(StructType(Seq(StructField("a", StringType))))), None, path)
     assert(DataObjectSchemaExporter.readIndex(dataObjectId, "schema", path).length==1)
     Thread.sleep(1000)
     // second write -> no update
-    DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), SparkSchema(StructType(Seq(StructField("a", StringType)))), path)
+    DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), Some(SparkSchema(StructType(Seq(StructField("a", StringType))))), None, path)
     assert(DataObjectSchemaExporter.readIndex(dataObjectId, "schema", path).length == 1)
     Thread.sleep(1000)
     // third write -> update
-    DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), SparkSchema(StructType(Seq(StructField("a", IntegerType)))), path)
+    DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), Some(SparkSchema(StructType(Seq(StructField("a", IntegerType))))), None, path)
     assert(DataObjectSchemaExporter.readIndex(dataObjectId, "schema", path).length == 2)
   }
 

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
@@ -139,11 +139,11 @@ class DataObjectSchemaExporterTest extends FunSuite with BeforeAndAfter {
     // first write
     DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), Some(SparkSchema(StructType(Seq(StructField("a", StringType))))), None, path)
     assert(DataObjectSchemaExporter.readIndex(dataObjectId, "schema", path).length==1)
-    Thread.sleep(1000)
+    Thread.sleep(1000) // timestamp in filename has seconds resolution, make sure we dont overwrite previous file.
     // second write -> no update
     DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), Some(SparkSchema(StructType(Seq(StructField("a", StringType))))), None, path)
     assert(DataObjectSchemaExporter.readIndex(dataObjectId, "schema", path).length == 1)
-    Thread.sleep(1000)
+    Thread.sleep(1000) // timestamp in filename has seconds resolution, make sure we dont overwrite previous file.
     // third write -> update
     DataObjectSchemaExporter.writeSchemaIfChanged(DataObjectId("test"), Some(SparkSchema(StructType(Seq(StructField("a", IntegerType))))), None, path)
     assert(DataObjectSchemaExporter.readIndex(dataObjectId, "schema", path).length == 2)

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
@@ -1,0 +1,111 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2022 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.meta.configexporter
+
+import org.json4s.StringInput
+import org.json4s.jackson.JsonMethods
+import org.scalatest.FunSuite
+
+import java.io.File
+
+class DataObjectSchemaExporterTest extends FunSuite {
+
+  test("export simple schema") {
+    val exporterConfig = DataObjectSchemaExporterConfig(Seq(getClass.getResource("/dagexporter/dagexporterTest.conf").getPath), includeRegex = "dataObjectCsv1")
+    val actualOutput = DataObjectSchemaExporter.exportSchemas(exporterConfig).head
+    assert(actualOutput._1.id == "dataObjectCsv1")
+
+    val expectedFieldsJson = """
+      |  [ {
+      |    "name" : "a",
+      |    "dataType" : "string",
+      |    "nullable" : true
+      |  }, {
+      |    "name" : "b",
+      |    "dataType" : "string",
+      |    "nullable" : true
+      |  }, {
+      |    "name" : "c",
+      |    "dataType" : "string",
+      |    "nullable" : true
+      |  } ]
+      |""".stripMargin
+    val expectedFields = JsonMethods.parse(StringInput(expectedFieldsJson)).values
+    val actualFields = JsonMethods.parse(StringInput(actualOutput._2)).values
+    assert(actualFields == expectedFields)
+  }
+
+  test("export complex schema") {
+    val exporterConfig = DataObjectSchemaExporterConfig(Seq(getClass.getResource("/dagexporter/dagexporterTest.conf").getPath), includeRegex = "dataObjectParquet6")
+    val actualOutput = DataObjectSchemaExporter.exportSchemas(exporterConfig).head
+    assert(actualOutput._1.id == "dataObjectParquet6")
+    val expectedFieldsJson =
+      """
+        |  [ {
+        |    "name" : "a",
+        |    "dataType" : "string",
+        |    "nullable" : true
+        |  }, {
+        |    "name" : "b",
+        |    "dataType" : {
+        |      "dataType" : "array",
+        |      "elementType" : {
+        |        "dataType" : "struct",
+        |        "fields" : [ {
+        |          "name" : "b1",
+        |          "dataType" : "string",
+        |          "nullable" : true
+        |        }, {
+        |          "name" : "b2",
+        |          "dataType" : "long",
+        |          "nullable" : true
+        |        } ]
+        |      }
+        |    },
+        |    "nullable" : true
+        |  }, {
+        |    "name" : "c",
+        |    "dataType" : {
+        |      "dataType" : "struct",
+        |      "fields" : [ {
+        |        "name" : "c1",
+        |        "dataType" : "string",
+        |        "nullable" : true
+        |      }, {
+        |        "name" : "c2",
+        |        "dataType" : "long",
+        |        "nullable" : true
+        |      } ]
+        |    },
+        |    "nullable" : true
+        |  } ]
+        |""".stripMargin
+    val expectedFields = JsonMethods.parse(StringInput(expectedFieldsJson)).values
+    val actualFields = JsonMethods.parse(StringInput(actualOutput._2)).values
+    assert(actualFields == expectedFields)
+  }
+
+  test("test main with includes and excludes") {
+    val path = "target/schema"
+    new File(path).delete()
+    DataObjectSchemaExporter.main(Array("-c", getClass.getResource("/dagexporter/dagexporterTest.conf").getPath, "-p", path, "-i", "dataObjectCsv[0-9]", "-e", "dataObjectCsv5"))
+    assert(new File(path).listFiles().map(_.getName.split('.').head).toSet == Set("dataObjectCsv1","dataObjectCsv2","dataObjectCsv3","dataObjectCsv4"))
+  }
+}

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ScalaDocExportTestTransformer.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ScalaDocExportTestTransformer.scala
@@ -27,7 +27,7 @@ import scala.collection.immutable.Map
  * Documentation for TestTransformer.
  * This should be exported by ConfigJsonExporter!
  */
-class TestTransformer extends CustomGenericDfTransformer {
+class ScalaDocExportTestTransformer extends CustomGenericDfTransformer {
   override def transform(helper: DataFrameFunctions, options: Map[String, String], df: GenericDataFrame, dataObjectId: String): GenericDataFrame = {
     df
   }

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/TestTransformer.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/TestTransformer.scala
@@ -1,0 +1,34 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.meta.configexporter
+
+import io.smartdatalake.workflow.action.generic.customlogic.CustomGenericDfTransformer
+import io.smartdatalake.workflow.dataframe.DataFrameFunctions
+import io.smartdatalake.workflow.dataframe.GenericDataFrame
+import scala.collection.immutable.Map
+
+/**
+ * Documentation for TestTransformer.
+ * This should be exported by ConfigJsonExporter!
+ */
+class TestTransformer extends CustomGenericDfTransformer {
+  override def transform(helper: DataFrameFunctions, options: Map[String, String], df: GenericDataFrame, dataObjectId: String): GenericDataFrame = {
+    df
+  }
+}

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
@@ -29,6 +29,8 @@ import io.smartdatalake.util.misc.SchemaUtil
 import io.smartdatalake.workflow.dataframe._
 import io.smartdatalake.workflow.dataobject.SnowflakeTableDataObject
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
+import org.json4s.JString
+import org.json4s.JsonAST.JValue
 
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe.{Type, typeOf}
@@ -231,6 +233,7 @@ case class SnowparkField(inner: StructField) extends GenericField {
   override def name: String = inner.name
   override def dataType: SnowparkDataType = SnowparkDataType(inner.dataType)
   override def nullable: Boolean = inner.nullable
+  override def comment: Option[String] = None
   override def makeNullable: SnowparkField = SnowparkField(inner.copy(dataType = dataType.makeNullable.inner, nullable = true))
   override def toLowerCase: SnowparkField = SnowparkField(inner.copy(dataType = dataType.toLowerCase.inner, columnIdentifier = ColumnIdentifier(inner.name.toLowerCase)))
   override def removeMetadata: SnowparkField = this // metadata is not existing in Snowpark
@@ -251,6 +254,7 @@ case class SnowparkSimpleDataType(inner: DataType) extends SnowparkDataType {
   override def makeNullable: SnowparkDataType = this
   override def toLowerCase: SnowparkDataType = this
   override def isSimpleType: Boolean = true
+  def toJson: JValue = JString(inner.typeName)
 }
 case class SnowparkStructDataType(override val inner: StructType) extends SnowparkDataType with GenericStructDataType {
   override def makeNullable: SnowparkDataType = SnowparkStructDataType(SnowparkSchema(inner).makeNullable.inner)

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -82,7 +82,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
     throw ConfigurationException(s"($id) A SnowFlake schema name must be added as the 'db' parameter of a SnowflakeTableDataObject.")
   }
 
-  // TODO: Spark snowflake data source does not execute Spark observations. This is the same for Spark jdbc data source, see also JdbcTableDataObject.
+  // Note: Spark snowflake data source does not execute Spark observations. This is the same for Spark jdbc data source, see also JdbcTableDataObject.
   // Using generic observations is forced therefore.
   override val forceGenericObservation = true
 

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -82,6 +82,9 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
     throw ConfigurationException(s"($id) A SnowFlake schema name must be added as the 'db' parameter of a SnowflakeTableDataObject.")
   }
 
+  // TODO: Spark snowflake data source does not execute Spark observations. This is the same for Spark jdbc data source, see also JdbcTableDataObject.
+  // Using generic observations is forced therefore.
+  override val forceGenericObservation = true
 
   // Get a Spark DataFrame with the table contents for Spark transformations
   override def getSparkDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): spark.DataFrame = {


### PR DESCRIPTION
### What changes are included in the pull request?
see #613 and #614
Additional bugfixes for:
- solve sporadic stackoverflow in schema export
- exclude ProxyAction from schema export as it should not be instantiated by configuration
- improve exclusion of hadoop-annotations with Spark 3.4
- revert upgrading hive version, as Spark 3.4 is still compiled with Hive 2.3.9
- update snowflake and iceberg libraries
- avoid running tests twice (regular + scoverage plugin)