### PR TITLE
Improve and unify dataobject schema scaladoc

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/SchemaUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/SchemaUtil.scala
@@ -337,7 +337,8 @@ object SchemaProviderType extends Enumeration {
   val JavaBean: SchemaProviderType.Value = Value("javabean")
 
   /**
-   * Get schema from an XSD file (XML schema definition), using spark-xml's XSD support: [[https://github.com/databricks/spark-xml#xsd-support]]
+   * Get schema from an XSD file (XML schema definition).
+   * This is using a customized version of spark-xml's XSD support: [[https://github.com/databricks/spark-xml#xsd-support]]
    * Parameters (semicolon separated):
    * - the hadoop path of the XSD file.
    * - row tag to extract a subpart from the schema, see also XML source rowTag option. Put an emtpy string to use root tag.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
@@ -39,18 +39,6 @@ import io.smartdatalake.workflow.dataframe.GenericSchema
  *
  * @param avroOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *                    [[org.apache.spark.sql.DataFrameWriter]].
- * @param schema An optional schema for the spark data frame to be validated on read and write. Note: Existing Avro files
- *               contain a source schema. Therefore, this schema is ignored when reading from existing Avro files.
- *               As this corresponds to the schema on write, it must not include the optional filenameColumn on read.
- *               Define the schema by using one of the schema providers DDL, jsonSchemaFile, avroSchemaFile, xsdFile or caseClassName.
- *               The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
- *               A DDL-formatted string is a comma separated list of field definitions, e.g., a INT, b STRING.
- * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
  *
  * @see [[org.apache.spark.sql.DataFrameReader]]
  * @see [[org.apache.spark.sql.DataFrameWriter]]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CanHandlePartitions.scala
@@ -33,6 +33,8 @@ trait CanHandlePartitions { this: DataObject =>
 
   /**
    * Definition of partition columns
+   *
+   * Example: `[dt]`
    */
   def partitions: Seq[String]
 
@@ -40,7 +42,11 @@ trait CanHandlePartitions { this: DataObject =>
    * Definition of partitions that are expected to exists.
    * This is used to validate that partitions being read exists and don't return no data.
    * Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
-   * example: "elements['yourColName'] > 2017"
+   *
+   * Example: "elements['yourColName'] > 2017"
+   *
+   * If empty (default) all partition are expected to exists.
+   *
    * @return true if partition is expected to exist.
    */
   private[smartdatalake] def expectedPartitionsCondition: Option[String]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
@@ -62,19 +62,8 @@ import org.apache.spark.sql.types.{DateType, StringType}
  * @see [[org.apache.spark.sql.DataFrameReader]]
  * @see [[org.apache.spark.sql.DataFrameWriter]]
  *
- * @param schema An optional data object schema. If defined, any automatic schema inference is avoided.
- *               As this corresponds to the schema on write, it must not include the optional filenameColumn on read.
- *               Define the schema by using one of the schema providers DDL, jsonSchemaFile, xsdFile or caseClassName.
- *               The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
- *               A DDL-formatted string is a comma separated list of field definitions, e.g., a INT, b STRING.
  * @param csvOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
  * @param dateColumnType Specifies the string format used for writing date typed data.
- * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
  **/
 case class CsvFileDataObject( override val id: DataObjectId,
                               override val path: String,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DataObject.scala
@@ -47,6 +47,7 @@ trait DataObject extends SdlConfigObject with ParsableFromConfig[DataObject] wit
 
   /**
    * Configure a housekeeping mode to e.g cleanup, archive and compact partitions.
+   *
    * Default is None.
    */
   def housekeepingMode: Option[HousekeepingMode] = None

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
@@ -52,17 +52,6 @@ import org.apache.spark.sql.DataFrame
  * When no schema is provided and `inferSchema` is disabled, all columns are assumed to be of string type.
  *
  * @param excelOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
- * @param schema An optional data object schema. If defined, any automatic schema inference is avoided.
- *               As this corresponds to the schema on write, it must not include the optional filenameColumn on read.
- *               Define the schema by using one of the schema providers DDL, DDLFile, jsonSchemaFile, xsdFile, caseClass, avroSchemaFile, javaBean.
- *               The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
- *               A DDL-formatted string is a comma separated list of field definitions, e.g., a INT, b STRING.
- * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop. Default is numberOfTasksPerPartition = 1.
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
  */
 case class ExcelFileDataObject(override val id: DataObjectId,
                                override val path: String,
@@ -88,16 +77,10 @@ case class ExcelFileDataObject(override val id: DataObjectId,
   // spark excel data source doesnt support reading all files in a directory. Each file must be read one by one.
   override val handleFilesOneByOne: Boolean = true
 
-  /**
-   * @inheritdoc
-   */
   override val options: Map[String, String] = excelOptions.toMap(schema).filter {
       case (_, v) => v.isDefined
   }.mapValues(_.get.toString).map(identity) // make serializable
 
-  /**
-   * @inheritdoc
-   */
   override def afterRead(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
     val dfSuper = super.afterRead(df)
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/FileDataObject.scala
@@ -27,6 +27,11 @@ private[smartdatalake] trait FileDataObject extends DataObject with CanHandlePar
   /**
    * The root path of the files that are handled by this DataObject.
    * For most DataObjects this can be a directory or a specific file.
+   *
+   * If it doesn't contain scheme and authority, the connections pathPrefix is applied. If pathPrefix is not
+   * defined or doesn't define scheme and authority, default schema and authority is applied.
+   *
+   * Optionally defined partitions are appended with hadoop standard partition layout to this path.
    */
   protected def path: String
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
@@ -39,20 +39,9 @@ import org.apache.spark.sql.DataFrame
  * Reading and writing details are delegated to Apache Spark [[org.apache.spark.sql.DataFrameReader]]
  * and [[org.apache.spark.sql.DataFrameWriter]] respectively.
  *
- * @param stringify Set the data type for all values to string.
+ * @param stringify Set the data type for all values to string. Use action/transformers instead.
  * @param jsonOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *                    [[org.apache.spark.sql.DataFrameWriter]].
- * @param schema An optional data object schema. If defined, any automatic schema inference is avoided.
- *               As this corresponds to the schema on write, it must not include the optional filenameColumn on read.
- *               Define the schema by using one of the schema providers DDL, jsonSchemaFile, xsdFile or caseClassName.
- *               The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
- *               A DDL-formatted string is a comma separated list of field definitions, e.g., a INT, b STRING.
- * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
  *
  * @note By default, the JSON option `multiline` is enabled.
  *
@@ -67,7 +56,7 @@ case class JsonFileDataObject( override val id: DataObjectId,
                                override val schemaMin: Option[GenericSchema] = None,
                                override val saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                                override val sparkRepartition: Option[SparkRepartitionDef] = None,
-                               stringify: Boolean = false,
+                               @Deprecated @deprecated("Use action/transformers instead", "2.6.0") stringify: Boolean = false,
                                override val acl: Option[AclDef] = None,
                                override val connectionId: Option[ConnectionId] = None,
                                override val filenameColumn: Option[String] = None,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
@@ -43,31 +43,8 @@ import org.apache.spark.sql.{DataFrame, SaveMode}
  * @see [[org.apache.spark.sql.DataFrameReader]]
  * @see [[org.apache.spark.sql.DataFrameWriter]]
 
- * @param id unique name of this data object
- * @param path Hadoop directory where this data object reads/writes it's files.
- *             If it doesn't contain scheme and authority, the connections pathPrefix is applied. If pathPrefix is not
- *             defined or doesn't define scheme and authority, default schema and authority is applied.
- *             Optionally defined partitions are appended with hadoop standard partition layout to this path.
- *             Only files ending with *.parquet* are considered as data for this DataObject.
- * @param partitions partition columns for this data object
  * @param parquetOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *                       [[org.apache.spark.sql.DataFrameWriter]].
- * @param schema An optional schema for the spark data frame to be validated on read and write. Note: Existing Parquet files
- *               contain a source schema. Therefore, this schema is ignored when reading from existing Parquet files.
- *               As this corresponds to the schema on write, it must not include the optional filenameColumn on read.
- *               Define the schema by using one of the schema providers DDL, jsonSchemaFile, xsdFile or caseClassName.
- *               The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
- *               A DDL-formatted string is a comma separated list of field definitions, e.g., a INT, b STRING.
- * @param saveMode spark [[SaveMode]] to use when writing files, default is "overwrite"
- * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
- * @param acl override connections permissions for files created with this connection
- * @param connectionId optional id of [[io.smartdatalake.workflow.connection.HadoopFileConnection]]
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
- * @param metadata Metadata describing this data object.
  */
 case class ParquetFileDataObject( override val id: DataObjectId,
                                   override val path: String,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
@@ -33,7 +33,7 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSchema
  * DataObject of type raw for files with unknown content.
  * Provides details to an Action to access raw files.
  *
- * By specifying format binary or text files can used with Spark.
+ * By specifying customFormat, binary or text files can read with Spark.
  *
  * @param customFormat Custom Spark data source format, e.g. binaryFile or text.
  *                     Only needed if you want to read/write this DataObject with Spark.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
@@ -32,17 +32,13 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 /**
  * DataObject of type raw for files with unknown content.
  * Provides details to an Action to access raw files.
- * By specifying format you can custom Spark data formats
  *
- * @param customFormat Custom Spark data source format, e.g. binaryFile or text. Only needed if you want to read/write this DataObject with Spark.
- * @param options Options for custom Spark data source format. Only of use if you want to read/write this DataObject with Spark.
- * @param fileName Definition of fileName. This is concatenated with path and partition layout to search for files. Default is an asterix to match everything.
- * @param saveMode Overwrite or Append new data.
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
+ * By specifying format binary or text files can used with Spark.
+ *
+ * @param customFormat Custom Spark data source format, e.g. binaryFile or text.
+ *                     Only needed if you want to read/write this DataObject with Spark.
+ * @param options Options for custom Spark data source format.
+ *                Only of use if you want to read/write this DataObject with Spark.
  */
 case class RawFileDataObject( override val id: DataObjectId,
                               override val path: String,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
@@ -46,22 +46,12 @@ import scala.reflect.runtime.universe.typeOf
  * If mode is permissive you can retrieve the corrupt input record by adding <options.columnNameOfCorruptRecord> as field to the schema.
  * RelaxCsvFileDataObject also supports getting an error msg by adding "<options.columnNameOfCorruptRecord>_msg" as field to the schema.
  *
- * @param schema The data object schema.
- *               Define the schema by using one of the schema providers DDL, jsonSchemaFile, xsdFile or caseClassName.
- *               The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
- *               A DDL-formatted string is a comma separated list of field definitions, e.g., a INT, b STRING.
  * @param csvOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
  * @param dateColumnType Specifies the string format used for writing date typed data.
  * @param treatMissingColumnsAsCorrupt If set to true records from files with missing columns in its header are treated as corrupt (default=false).
  *                                   Corrupt records are handled according to options.mode (default=permissive).
  * @param treatSuperfluousColumnsAsCorrupt If set to true records from files with superfluous columns in its header are treated as corrupt (default=false).
  *                                   Corrupt records are handled according to options.mode (default=permissive).
- * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
  **/
 case class RelaxedCsvFileDataObject(override val id: DataObjectId,
                                     override val path: String,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/UserDefinedSchema.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/UserDefinedSchema.scala
@@ -22,20 +22,57 @@ import io.smartdatalake.workflow.dataframe.GenericSchema
 
 /**
  * A [[DataObject]] that allows optional user-defined schema definition.
+ *
+ * Some [[DataObject]]s support optional schema inference.
+ * Specifying the schema attribute disables automatic schema inference.
+
+ * Note: This is only used by the functionality defined in [[CanCreateDataFrame]], that is,
+ * when reading data frames from the underlying data container.
+ * [[io.smartdatalake.workflow.action.Action]]s that bypass data frames ignore the `schema` attribute
+ * if it is defined.
  */
 trait UserDefinedSchema {
 
   /**
-   * An optional [[DataObject]] user-defined schema definition.
+   * An optional user-defined schema definition for this DataObject.
+   * If defined, any automatic schema inference is avoided.
    *
-   * Some [[DataObject]]s support optional schema inference.
-   * Specifying this attribute disables automatic schema inference. When the wrapped data source contains a source
-   * schema, this `schema` attribute is ignored.
+   * The schema corresponds to the schema on write, it must not include optional columns on read, e.g. the filenameColumn for SparkFileDataObjects.
    *
-   * Note: This is only used by the functionality defined in [[CanCreateDataFrame]], that is,
-   * when reading Spark data frames from the underlying data container.
-   * [[io.smartdatalake.workflow.action.Action]]s that bypass Spark data frames ignore the `schema` attribute
-   * if it is defined.
+   * Define the schema by using one of the schema providers below, default is DDL.
+   * The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
+   *
+   * Schema Providers available are (see also [[io.smartdatalake.util.misc.SchemaProviderType]]):
+   * - ddl: create the schema from a Spark ddl string, e.g. `ddl#a string, b array<struct<b1: string, b2: long>>, c struct<c1: string, c2: long>`
+   * - ddlFile: read a Spark ddl definition from a file and create a schema, e.g. `ddlFile#abc/xyz.ddl`
+   * - caseClass: convert a Scala Case Class to a schema using Spark encoders, e.g. `caseClass#com.sample.XyzClass`
+   * - javaBean: convert a Java Bean to a schema using Spark encoders, e.g. `javaBean#com.sample.XyzClass`
+   * - xsdFile: read an Xml Schema Definition file and create a schema, e.g. `xsdFile#abc/xyz.xsd`
+   *   The following parameters allow to customize the behavior: `xsdFile#<path-to-xsd-file>;<row-tag>;<maxRecursion:Int>;<jsonCompatibility:Boolean>`
+   *   <row-tag>: configure the path of the element to extract from the xsd schema. Leave empty to extract the root.
+   *   <maxRecursion>: if xsd schema is recursive, this configures the number of levels to create in the schema.
+   *   Default is 10 levels.
+   *   <jsonCompatibility>: In XML array elements are modeled with their own tag named with singular name.
+   *   In JSON an array attribute has unnamed array entries, but the array attribute has a plural name.
+   *   If true, the singular name of the array element in the XSD is converted to a plural name by adding an 's'
+   *   in order to read corresponding json files.
+   *   Default is false.
+   * - jsonSchemaFile: read a Json Schema file and create a schema, e.g. `xsdFile#abc/xyz.json`
+   *   The following parameters allow to customize the behavior: `xsdFile#<path-to-json-file>;<row-tag>;<strictTyping:Boolean>;<additionalPropertiesDefault:Boolean>`
+   *   <row-tag>: configure the path of the element to extract from the json schema. Leave empty to extract the root.
+   *   <strictTyping>: if true
+   *   union types (oneOf) are merged if rational, otherwise they are simply mapped to StringType;
+   *   additional properties are ignored, otherwise the corresponding schema object is mapped to MapType(String,String).
+   *   Default is strictTyping=false.
+   *   <additionalPropertiesDefault>: Set to true or false.
+   *   This is used as default value for 'additionalProperties'-field if it is missing in a schema with type='object'.
+   *   Default value is additionalPropertiesDefault=true, as this is conform with the specification.
+   * - avroSchemaFile: read an Avro Schema file and create a schema, e.g. `xsdFile#abc/xyz.avsc`
+   *   The following parameters allow to customize the behavior: `xsdFile#<path-to-avsc-file>;<row-tag>`
+   *   <row-tag>: configure the path of the element to extract from the avro schema. Leave empty to extract the root.
+   *
+   * Note that all schema files are configured as Hadoop path. The custom prefix 'cp' can be used to read schema files
+   * from the classpath, e.g. `xsdFile#cp:/xyz.xsd`.
    */
   def schema: Option[GenericSchema]
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
@@ -49,31 +49,22 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * Note that writing XML-file partitioned is not supported by spark-xml.
  *
  * @param xmlOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
- * @param schema An optional data object schema. If defined, any automatic schema inference is avoided.
- *               As this corresponds to the schema on write, it must not include the optional filenameColumn on read.
- *               Define the schema by using one of the schema providers DDL, jsonSchemaFile, xsdFile or caseClassName.
- *               The schema provider and its configuration value must be provided in the format <PROVIDERID>#<VALUE>.
- *               A DDL-formatted string is a comma separated list of field definitions, e.g., a INT, b STRING.
- * @param sparkRepartition Optional definition of repartition operation before writing DataFrame with Spark to Hadoop.
- * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
- *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
- *                                    Default is to expect all partitions to exist.
- * @param housekeepingMode Optional definition of a housekeeping mode applied after every write. E.g. it can be used to cleanup, archive and compact partitions.
- *                         See HousekeepingMode for available implementations. Default is None.
- *
+ * @param rowTag Define rowTag in xmlOptions instead
+ * @param flatten Use action/transformers instead
  * @see [[org.apache.spark.sql.DataFrameReader]]
  * @see [[org.apache.spark.sql.DataFrameWriter]]
  */
 case class XmlFileDataObject(override val id: DataObjectId,
                              override val path: String,
-                             rowTag: Option[String] = None, // this is for backward compatibility, it can also be given in xmlOptions
+                             @Deprecated @deprecated("Define rowTag in xmlOptions instead", "2.6.0")
+                             rowTag: Option[String] = None,
                              xmlOptions: Option[Map[String,String]] = None,
                              override val partitions: Seq[String] = Seq(),
                              override val schema: Option[GenericSchema] = None,
                              override val schemaMin: Option[GenericSchema] = None,
                              override val saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                              override val sparkRepartition: Option[SparkRepartitionDef] = None,
-                             flatten: Boolean = false,
+                             @Deprecated @deprecated("Use action/transformers instead", "2.6.0") flatten: Boolean = false,
                              override val acl: Option[AclDef] = None,
                              override val connectionId: Option[ConnectionId] = None,
                              override val filenameColumn: Option[String] = None,

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaDef.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaDef.scala
@@ -56,7 +56,8 @@ private[smartdatalake] case class JsonObjectDef(
                           title: String,
                           required: Seq[String] = Seq(),
                           additionalProperties: Boolean = false,
-                          description: Option[String] = None
+                          description: Option[String] = None,
+                          deprecated: Option[Boolean] = None
                         ) extends JsonTypeDef {
   override val `type`: Option[JsonTypeEnum] = Some(JsonTypeEnum.Object)
 }


### PR DESCRIPTION
### What changes are included in the pull request?
Improve scaladoc description of schema providers available to define DataObject schemas (DataObject.schema attribute).
Cleanup using super-method Scaladoc, instead of rewriting attribute descriptions in every DataObject (Schema export is searching scaladoc on super-method if not present on case class directly).

Fix marking CustomDataFrameAction.transformer as deprecated in Schema Viewer.

### Why are the changes needed?
Schema provider options where not described previously.