### PR TITLE
784 implement flattendftransformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ spark-warehouse
 .idea/**/shelf
 .idea/misc.xml
 .idea/scala_compiler.xml
+.vscode
+.metals
+.bloop
 
 # Generated files
 .idea/**/contentModel.xml

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDfTransformer.scala
@@ -61,7 +61,6 @@ case class SparkFlattenDfTransformer(override val name: String = "sparkFlattenDa
     }.toSeq
   }
 
-  @tailrec
   private def flattenDf(df: DataFrame): DataFrame = {
     val complexFields = getComplexFields(df)
     complexFields.foldLeft(df){

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDfTransformer.scala
@@ -1,0 +1,81 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2024 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.spark.transformer
+
+import com.typesafe.config.Config
+import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.action.generic.transformer.{GenericDfTransformer, SparkDfTransformer}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions.{col, explode_outer}
+import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
+import scala.annotation.tailrec
+
+/**
+ * Returns a flattened Dataframe from another DataFrame
+ * with a nested schema. Schemas in the form:
+ *
+ * |---parent
+ *
+ * |------|child1
+ *
+ * |------|child2
+ *
+ * are transformed to the following flat columns:
+ *
+ * |---parent_child1
+ *
+ * |---parent_child2
+ * @param name         name of the transformer
+ * @param description  Optional description of the transformer
+ */
+case class SparkFlattenDfTransformer(override val name: String = "standardizeSparkDatatypes", override val description: Option[String] = None) extends SparkDfTransformer {
+
+  private def getComplexFields(df: DataFrame): List[(String, DataType)] = {
+    (for (field <- df.schema.fields
+          if (field.dataType.isInstanceOf[StructType] || field.dataType.isInstanceOf[ArrayType]))
+    yield (field.name, field.dataType)).toList
+  }
+  @tailrec
+  private def flattenDf(df: DataFrame): DataFrame = {
+    val complex_fields = getComplexFields(df)
+    if (complex_fields.isEmpty) return df;
+    val (col_name, col_type) = complex_fields.head
+    val new_df = col_type match {
+      case StructType(fields) => {
+        val inner = for (n <- fields) yield n.name
+        val expanded = for (k <- inner) yield col(col_name + '.' + k).alias(col_name + '_' + k)
+        df.select(col("*") +: expanded: _*).drop(col_name)
+      }
+      case a: ArrayType => df.withColumn(col_name, explode_outer(col(col_name)))
+    }
+    flattenDf(new_df)
+  }
+  override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: DataFrame, dataObjectId: DataObjectId)(implicit context: ActionPipelineContext): DataFrame =
+    flattenDf(df)
+  override def factory: FromConfigFactory[GenericDfTransformer] = SparkFlattenDfTransformer
+}
+object SparkFlattenDfTransformer extends FromConfigFactory[GenericDfTransformer] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): SparkFlattenDfTransformer = {
+    extract[SparkFlattenDfTransformer](config)
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
@@ -45,19 +45,23 @@ class SparkFlattenDFTransformerTest extends FunSuite {
       .add("name", StringType, true)
       .add("info", new StructType()
         .add("age", IntegerType, true)
-        .add("address", StringType, true), true)
+        .add("address", new StructType()
+          .add("street", StringType)
+          .add("number", StringType)
+        ))
 
     //createDataFrame requires Java Lists
     val nestedData = new ArrayList[Row]()
-    nestedData.add(Row("Michael", Row(30, "123 Main St")))
-    nestedData.add(Row("Bob", Row(25, "456 Elm St")))
+    nestedData.add(Row("Michael", Row(30, Row("Main St","123"))))
+    nestedData.add(Row("Bob", Row(25, Row("Elm St","456"))))
 
     val nested_df = session.createDataFrame(nestedData, nestedSchema)
     val new_df = flattenDfTransformer.transform(ActionId("ActionId"), Seq(), nested_df, DataObjectId("dataObjectId"))
     val expectedSchema = new StructType()
       .add("name", StringType, true)
       .add("info_age", IntegerType, true)
-      .add("info_address", StringType, true)
+      .add("info_address_street", StringType)
+      .add("info_address_number", StringType)
     assert(new_df.schema.equals(expectedSchema))
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
@@ -40,7 +40,7 @@ class SparkFlattenDFTransformerTest extends FunSuite {
   implicit val instanceRegistry = new InstanceRegistry()
   implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
-  test("Nested DataFrame returns an flat Dataframe") {
+  test("Nested DataFrame returns a flat Dataframe") {
     val flattenDfTransformer = SparkFlattenDfTransformer()
     val nestedSchema: StructType = new StructType()
       .add("name", StringType, true)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
@@ -1,0 +1,102 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.spark.transformer
+
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import io.smartdatalake.config.SdlConfigObject.ActionId
+import org.apache.spark.sql.{SparkSession, Row}
+import org.scalatest.FunSuite
+import org.apache.spark.sql.types.{StructType, IntegerType, StringType, ArrayType}
+import java.util.ArrayList
+
+
+
+class SparkFlattenDFTransformerTest extends FunSuite {
+
+  protected implicit val session: SparkSession = TestUtil.session
+  import session.implicits._
+
+  implicit val instanceRegistry = new InstanceRegistry()
+  implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+
+  test("Nested DataFrame returns an flat Dataframe") {
+    val flattenDfTransformer = SparkFlattenDfTransformer()
+    val nestedSchema: StructType = new StructType()
+      .add("name", StringType, true)
+      .add("info", new StructType()
+        .add("age", IntegerType, true)
+        .add("address", StringType, true), true)
+
+    //createDataFrame requires Java Lists
+    val nestedData = new ArrayList[Row]()
+    nestedData.add(Row("Michael", Row(30, "123 Main St")))
+    nestedData.add(Row("Bob", Row(25, "456 Elm St")))
+
+    val nested_df = session.createDataFrame(nestedData, nestedSchema)
+    val new_df = flattenDfTransformer.transform(ActionId("ActionId"), Seq(), nested_df, DataObjectId("dataObjectId"))
+    val expectedSchema = new StructType()
+      .add("name", StringType, true)
+      .add("info_age", IntegerType, true)
+      .add("info_address", StringType, true)
+    assert(new_df.schema.equals(expectedSchema))
+  }
+
+
+  test("Flat schema remains unchanged") {
+    val flattenDfTransformer = SparkFlattenDfTransformer()
+
+    val normalSchema: StructType = new StructType()
+      .add("name", StringType, true)
+      .add("age", IntegerType, true)
+
+    val unNestedData = new ArrayList[Row]()
+    unNestedData.add(Row("Michael", 30))
+    unNestedData.add(Row("Bob", 25))
+    val unNested_df = session.createDataFrame(unNestedData, normalSchema)
+    val new_df = flattenDfTransformer.transform(ActionId("ActionId"), Seq(), unNested_df, DataObjectId("dataObjectId"))
+    assert(new_df.schema.equals(normalSchema))
+  }
+
+
+  test("Array explode works") {
+    val flattenDfTransformer = SparkFlattenDfTransformer()
+    val flattenDfTransformerNoExplode = SparkFlattenDfTransformer(enableExplode = false)
+
+    val arraySchema: StructType = new StructType()
+      .add("name", StringType, true)
+      .add("hobbies", ArrayType(StringType), true)
+
+    val arrayData = new ArrayList[Row]()
+    arrayData.add(Row("Michael", Seq("football", "programming")))
+    arrayData.add(Row("Bob", Seq("playing piano", "reading")))
+
+    val array_df = session.createDataFrame(arrayData, arraySchema)
+    val exploded_df = flattenDfTransformer.transform(ActionId("ActionId"), Seq(), array_df, DataObjectId("dataObjectId"))
+    val non_exploded_df = flattenDfTransformerNoExplode.transform(ActionId("ActionId2"), Seq(), array_df, DataObjectId("dataObjectId2"))
+    assert(exploded_df.count() == 4 && non_exploded_df.count() == 2)
+  }
+
+
+
+}


### PR DESCRIPTION
Implementation of a Transformer that flattens Spark Dataframes with a nested schema. Child columns inherit the names of the parents in order to be uniquely identifiable.  For example, the following schema...

root
|-- name: string (nullable = true)
|-- age: string (nullable = true)
|-- jsonData: struct (nullable = true)
| |-- jobs: array (nullable = true)
| | |-- element: struct (containsNull = true)
| | | |-- years: string (nullable = true)
| | | |-- job_name: string (nullable = true)

is converted to...

root
|-- name: string (nullable = true)
|-- age: string (nullable = true)
|-- jsonData_jobs_years: string (nullable = true)
|-- jsonData_jobs_job_name: string (nullable = true)

The Transformer can also explode cells that are defined as an array. This can be enabled in the configuration using the option "enableExplode = true".

The Transformer is only implemented for Spark as the necessary functionality is not yet available for Snowflake.