### PR TITLE
Implement virtual partitions for SnowflakeTableDataObject

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -18,9 +18,8 @@
  */
 package io.smartdatalake.util.hdfs
 
-import io.smartdatalake.workflow.dataframe.GenericColumn
 import io.smartdatalake.workflow.DataFrameSubFeedCompanion
-import org.apache.spark.sql.DataFrame
+import io.smartdatalake.workflow.dataframe.{GenericColumn, GenericDataFrame}
 
 import scala.util.matching.Regex
 
@@ -156,10 +155,10 @@ object PartitionValues {
    * Read DataFrame and convert to PartitionValues
    * @param df DataFrame with partition columns only selected. All columns will be handled as string.
    */
-  def fromDataFrame(df: DataFrame): Seq[PartitionValues] = {
-    val cols = df.columns
-    df.distinct().collect().map {
-      row => PartitionValues(cols.map(c => (c,row.getAs[Any](c).toString)).toMap)
+  def fromDataFrame(df: GenericDataFrame): Seq[PartitionValues] = {
+    val cols = df.schema.columns
+    df.distinct.collect.map {
+      row => PartitionValues(cols.zipWithIndex.map{ case (c,idx) => (c,row.getAs[Any](idx).toString)}.toMap)
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/JdbcUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/JdbcUtil.scala
@@ -1,0 +1,206 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2024 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.misc
+
+import io.smartdatalake.config.SdlConfigObject.ConfigObjectId
+import io.smartdatalake.workflow.connection.Connection
+import org.apache.commons.pool2.impl.{DefaultPooledObject, GenericObjectPool}
+import org.apache.commons.pool2.{BasePooledObjectFactory, PooledObject}
+import org.apache.spark.sql.jdbc.JdbcDialect
+
+import java.sql.{ResultSet, Statement, Connection => SqlConnection}
+import java.time.Duration
+
+object JdbcUtil {
+
+  /**
+   * Create a JDBC Connection Pool
+   *
+   * @param maxParallelConnections max number of parallel jdbc connections created by an instance of this connection, default is 3
+   * @param connectionPoolMaxIdleTimeSec timeout to close unused connections in the pool
+   * @param connectionPoolMaxWaitTimeSec timeout when waiting for connection in pool to become available. Default is 600 seconds (10 minutes).
+   * @param factoryFun factory method for JDBC Connections
+   * @param initSql sql statement to be executed on new connections
+   * @param autoCommit if auto-commit should be enabled
+   */
+  def createConnectionPool(maxParallelConnections: Int, connectionPoolMaxIdleTimeSec: Int, connectionPoolMaxWaitTimeSec: Int, factoryFun: () => SqlConnection, initSql: Option[String], autoCommit: Boolean): GenericObjectPool[SqlConnection] = {
+    // setup connection pool
+    val pool = new GenericObjectPool[SqlConnection](new JdbcClientPoolFactory(factoryFun, initSql, autoCommit))
+    pool.setMaxTotal(maxParallelConnections)
+    pool.setMinEvictableIdle(Duration.ofSeconds(connectionPoolMaxIdleTimeSec)) // timeout to close jdbc connection if not in use
+    pool.setMaxWait(Duration.ofSeconds(connectionPoolMaxWaitTimeSec))
+    return pool
+  }
+
+  def createTransaction(pool: GenericObjectPool[SqlConnection], autoCommit: Boolean, logging: Boolean, id: ConfigObjectId): JdbcTransaction = {
+    new JdbcTransaction(pool, autoCommit, logging, id)
+  }
+
+
+  def execWithJdbcStatement[A](conn: SqlConnection, doCommit: Boolean, autoCommit: Boolean)(func: Statement => A): A = {
+    var stmt: Statement = null
+    try {
+      stmt = conn.createStatement
+      val result = func(stmt)
+      if (doCommit && !autoCommit) conn.commit()
+      result
+    } catch {
+      case e: Exception =>
+        conn.rollback()
+        throw e
+    } finally {
+      if (stmt != null) stmt.close()
+    }
+  }
+}
+
+/**
+ * Class for handling database transactions. If all operations succeeded call [[commit]], otherwise [[rollback]].
+ */
+private[smartdatalake] class JdbcTransaction(pool: GenericObjectPool[SqlConnection], autoCommit: Boolean, logging: Boolean, id: ConfigObjectId) extends SmartDataLakeLogger {
+  logger.info(s"($id) begin transaction $transactionId")
+  private val jdbcConnection: SqlConnection = pool.borrowObject()
+
+  def execJdbcStatement(sql:String, logging: Boolean = true) : Boolean = {
+    JdbcUtil.execWithJdbcStatement(jdbcConnection, doCommit = false, autoCommit = autoCommit) { stmt =>
+      if (logging) logger.info(s"($id) execJdbcStatement in transaction $transactionId: $sql")
+      if (autoCommit) logger.warn("autoCommit is enabled, so statement will be committed immediately")
+      stmt.execute(sql)
+    }
+  }
+
+  def commit(): Unit = {
+    if (!autoCommit) {
+      logger.info(s"($id) commit transaction $transactionId")
+      jdbcConnection.commit()
+    };
+    close()
+  }
+
+  def rollback(): Unit = {
+    try {
+      if (!autoCommit) {
+        logger.info(s"($id) roll back transaction $transactionId")
+        jdbcConnection.rollback()
+      };
+    } finally {
+      close()
+    }
+  }
+
+  private def close(): Unit = {
+    pool.returnObject(jdbcConnection)
+  }
+
+  private def transactionId: Int = {
+    hashCode()
+  }
+}
+
+
+private[smartdatalake] class JdbcClientPoolFactory(factoryFun: () => SqlConnection, initSql: Option[String], autoCommit: Boolean) extends BasePooledObjectFactory[SqlConnection] {
+  override def create(): SqlConnection = {
+    val connection = factoryFun()
+    initConnection(connection)
+  }
+
+  private def initConnection(connection: SqlConnection): SqlConnection = {
+    initSql.foreach(initSql => {
+      var stmt: Statement = null
+      try {
+        stmt = connection.createStatement()
+        stmt.execute(initSql)
+      } finally {
+        if (stmt != null) stmt.close()
+      }
+    })
+    connection.setAutoCommit(autoCommit)
+    connection
+  }
+
+  override def wrap(con: SqlConnection): PooledObject[SqlConnection] = new DefaultPooledObject(con)
+  override def destroyObject(p: PooledObject[SqlConnection]): Unit = p.getObject.close()
+}
+
+trait JdbcExecution { this: Connection with SmartDataLakeLogger =>
+
+  def pool: GenericObjectPool[SqlConnection]
+
+  def autoCommit: Boolean
+
+  def jdbcDialect: JdbcDialect
+
+  /**
+   * Get a connection from the pool and execute an arbitrary function
+   */
+  def execWithJdbcConnection[A]( func: SqlConnection => A ): A = {
+    WithResourcePool.exec(pool){
+      con => func(con)
+    }
+  }
+
+  /**
+   * Get a JDBC connection from the pool, create a JDBC statement and execute an arbitrary sql statement
+   * @return true if the first result is a ResultSet object; false if it is an update count or there are no results (see also Jdbc.Statement.execute())
+   */
+  def execJdbcStatement(sql:String, logging: Boolean = true) : Boolean = {
+    execWithJdbcConnection(JdbcUtil.execWithJdbcStatement(_, doCommit = true, autoCommit = autoCommit) { stmt =>
+      if (logging) logger.info(s"($id) execJdbcStatement: $sql")
+      stmt.execute(sql)
+    })
+  }
+
+  /**
+   * Get a JDBC connection from the pool, create a JDBC statement and execute an arbitrary function
+   * @return row count for SQL Data Manipulation Language (DML) statements (see also Jdbc.Statement.execute())
+   */
+  def execJdbcDmlStatement(sql: String, logging: Boolean = true): Int = {
+    execWithJdbcConnection(JdbcUtil.execWithJdbcStatement(_, doCommit = true, autoCommit = autoCommit) { stmt =>
+      if (logging) logger.info(s"($id) execJdbcDmlStatement: $sql")
+      stmt.executeUpdate(sql)
+    })
+  }
+
+  /**
+   * Execute an SQL query and evaluate its ResultSet
+   * @param sql sql query to execute
+   * @param evalResultSet function to evaluate the JDBC ResultSet
+   * @return the evaluated result
+   */
+  def execJdbcQuery[A](sql:String, evalResultSet: ResultSet => A ) : A = {
+    execWithJdbcConnection(JdbcUtil.execWithJdbcStatement(_, doCommit = true, autoCommit = autoCommit) { stmt =>
+      var rs: ResultSet = null
+      try {
+        logger.info(s"($id) execJdbcQuery: $sql")
+        rs = stmt.executeQuery(sql)
+        evalResultSet(rs)
+      } finally {
+        if (rs != null) rs.close()
+      }
+    })
+  }
+
+  /**
+   * Begin database transaction. Note that depending on the isolation level of the database, changes from concurrent
+   * connections might not be available inside the transaction once it is started. So make sure that any required writes
+   * from Spark are finished before beginning a transaction.
+   */
+  def beginTransaction(): JdbcTransaction = JdbcUtil.createTransaction(pool, autoCommit, logging = true, id)
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -61,6 +61,8 @@ trait GenericDataFrame extends GenericTypedObject {
 
   def collect: Seq[GenericRow]
 
+  def distinct: GenericDataFrame
+
   def withColumn(colName: String, expression: GenericColumn): GenericDataFrame
 
   def drop(colName: String): GenericDataFrame

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
@@ -80,6 +80,7 @@ case class SparkDataFrame(inner: DataFrame) extends GenericDataFrame {
     }
   }
   override def collect: Seq[GenericRow] = inner.collect().map(SparkRow)
+  override def distinct: SparkDataFrame = SparkDataFrame(inner.distinct())
   override def getDataFrameSubFeed(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): SparkSubFeed = {
     SparkSubFeed(Some(this), dataObjectId, partitionValues, filter = filter)
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -32,7 +32,7 @@ import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.connection.jdbc.JdbcTableConnection
 import io.smartdatalake.workflow.dataframe.GenericSchema
-import io.smartdatalake.workflow.dataframe.spark.{SparkField, SparkSchema}
+import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkField, SparkSchema}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql.custom.ExpressionEvaluator
 import org.apache.spark.sql.functions._
@@ -465,7 +465,7 @@ case class JdbcTableDataObject(override val id: DataObjectId,
    */
   override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
     if (partitions.nonEmpty) {
-      PartitionValues.fromDataFrame(getSparkDataFrame().select(partitions.map(col):_*).distinct())
+      PartitionValues.fromDataFrame(SparkDataFrame(getSparkDataFrame().select(partitions.map(col):_*).distinct()))
     } else Seq()
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/MockDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/MockDataObject.scala
@@ -70,7 +70,7 @@ case class MockDataObject(override val id: DataObjectId, override val partitions
 
     if (partitions.nonEmpty) {
       // mimick partition overwrite
-      val inferredPartitionValues = if (partitionValues.isEmpty && partitions.nonEmpty) PartitionValues.fromDataFrame(df.select(partitions.map(col):_*))
+      val inferredPartitionValues = if (partitionValues.isEmpty && partitions.nonEmpty) PartitionValues.fromDataFrame(SparkDataFrame(df.select(partitions.map(col):_*)))
       else partitionValues
       val newDataFrames = inferredPartitionValues.map(pv => (pv, df.where(getPartitionValueFilter(pv)))).toMap
       partitionedDataFrameMock = Some(

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -33,7 +33,7 @@ import io.smartdatalake.util.spark.{DataFrameUtil, SparkQueryUtil}
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.connection.DeltaLakeTableConnection
 import io.smartdatalake.workflow.dataframe.GenericSchema
-import io.smartdatalake.workflow.dataframe.spark.{SparkColumn, SparkSchema, SparkSubFeed}
+import io.smartdatalake.workflow.dataframe.spark.{SparkColumn, SparkDataFrame, SparkSchema, SparkSubFeed}
 import io.smartdatalake.workflow.{ActionPipelineContext, ProcessingLogicException}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.DeltaLog
@@ -441,7 +441,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
    */
   override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
     val (pvs,d) = PerformanceUtils.measureDuration(
-      if(isTableExisting) PartitionValues.fromDataFrame(context.sparkSession.table(table.fullName).select(partitions.map(col):_*).distinct())
+      if(isTableExisting) PartitionValues.fromDataFrame(SparkDataFrame(context.sparkSession.table(table.fullName).select(partitions.map(col):_*).distinct()))
       else Seq()
     )
     logger.debug(s"($id) listPartitions took $d")

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
@@ -77,6 +77,7 @@ case class SnowparkDataFrame(inner: DataFrame) extends GenericDataFrame {
     }
   }
   override def collect: Seq[GenericRow] = inner.collect().map(SnowparkRow)
+  override def distinct: SnowparkDataFrame = SnowparkDataFrame(inner.distinct())
   override def getDataFrameSubFeed(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): DataFrameSubFeed = {
     SnowparkSubFeed(Some(this), dataObjectId, partitionValues, filter = filter)
   }

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -263,7 +263,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
   }
 
   override def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    if (sqlOpt.nonEmpty) connection.execSnowflakeStatement(sqlOpt.get).next()
+    if (sqlOpt.nonEmpty) connection.execJdbcStatement(sqlOpt.get)
   }
 
   /**

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -19,24 +19,25 @@
 
 package io.smartdatalake.workflow.dataobject
 
+import com.snowflake.snowpark
+import com.snowflake.snowpark.SaveMode
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchema}
 import io.smartdatalake.definitions.SDLSaveMode._
-import io.smartdatalake.definitions.{SDLSaveMode, SaveModeOptions}
+import io.smartdatalake.definitions.{Environment, SDLSaveMode, SaveModeOptions}
+import io.smartdatalake.metrics.SparkStageMetricsListener
 import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
+import io.smartdatalake.util.misc.{SQLUtil, SchemaUtil}
+import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.connection.SnowflakeConnection
+import io.smartdatalake.workflow.dataframe.snowflake.{SnowparkDataFrame, SnowparkSchema, SnowparkSubFeed}
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSchema, SparkSubFeed}
+import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchema}
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
+import net.snowflake.spark.snowflake.Utils
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import org.apache.spark.{sql => spark}
-import com.snowflake.snowpark
-import com.snowflake.snowpark.SaveMode
-import io.smartdatalake.metrics.SparkStageMetricsListener
-import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
-import io.smartdatalake.workflow.dataframe.snowflake.{SnowparkDataFrame, SnowparkSubFeed}
 
 import scala.reflect.runtime.universe.{Type, typeOf}
 
@@ -56,6 +57,10 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param postWriteSql SQL-statement to be executed in exec phase after writing output table. It uses the SnowflakeConnection for the target database.
  * @param saveMode     spark [[SDLSaveMode]] to use when writing files, default is "overwrite"
  * @param connectionId The SnowflakeTableConnection to use for the table
+ * @param virtualPartitions Virtual partition columns. Note that Snowflake has no partition concept, and SDLB is emulating partitions on its own.
+ * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
+ *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
+ *                                    Default is to expect all partitions to exist.
  * @param comment      An optional comment to add to the table after writing a DataFrame to it
  * @param sparkOptions Options for the Snowflake Spark Connector, see https://docs.snowflake.com/en/user-guide/spark-connector-use#additional-options.
  *                     These options override connection.options.
@@ -74,13 +79,17 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
                                     saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                                     connectionId: ConnectionId,
                                     sparkOptions: Map[String, String] = Map(),
+                                    virtualPartitions: Seq[String] = Seq(),
+                                    override val expectedPartitionsCondition: Option[String] = None,
                                     comment: Option[String] = None,
                                     override val metadata: Option[DataObjectMetadata] = None)
                                    (@transient implicit val instanceRegistry: InstanceRegistry)
-  extends TransactionalTableDataObject with ExpectationValidation {
+  extends TransactionalTableDataObject with CanHandlePartitions with ExpectationValidation {
 
   private val connection = getConnection[SnowflakeConnection](connectionId)
-  val fullyQualifiedTableName = connection.database + "." + table.fullName
+
+  // Define partition columns
+  override val partitions: Seq[String] = if (Environment.caseSensitive) virtualPartitions else virtualPartitions.map(_.toLowerCase)
 
   def snowparkSession: snowpark.Session = {
     connection.getSnowparkSession(table.db.get)
@@ -89,9 +98,10 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
   // check for invalid save modes
   assert(Seq(SDLSaveMode.Overwrite,SDLSaveMode.Append,SDLSaveMode.ErrorIfExists,SDLSaveMode.Ignore).contains(saveMode), s"($id) Unsupported saveMode $saveMode")
 
-  if (table.db.isEmpty) {
-    throw ConfigurationException(s"($id) A SnowFlake schema name must be added as the 'db' parameter of a SnowflakeTableDataObject.")
-  }
+  // prepare final table
+  table = table.overrideCatalogAndDb(Some(connection.database), None)
+  if(table.catalog.isEmpty) throw ConfigurationException(s"($id) A Snowflake database name must be added as the 'table.catalog' parameter of SnowflakeTableDataObject or 'connection.database' of SnowflakeConnection.")
+  if (table.db.isEmpty) throw ConfigurationException(s"($id) A Snowflake schema name must be added as the 'table.db' parameter of a SnowflakeTableDataObject.")
 
   // Note: Spark snowflake data source does not execute Spark observations. This is the same for Spark jdbc data source, see also JdbcTableDataObject.
   // Using generic observations is forced therefore.
@@ -101,7 +111,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
 
   // Get a Spark DataFrame with the table contents for Spark transformations
   override def getSparkDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): spark.DataFrame = {
-    val queryOrTable = Map(table.query.map(q => ("query", q)).getOrElse("dbtable" -> fullyQualifiedTableName))
+    val queryOrTable = Map(table.query.map(q => ("query", q)).getOrElse("dbtable" -> table.fullName))
     val df = context.sparkSession
       .read
       .format(SNOWFLAKE_SOURCE_NAME)
@@ -134,14 +144,14 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connection.getSnowflakeAuthOptions(table.db.get))
         .options(instanceSparkOptions)
-        .options(Map("dbtable" -> fullyQualifiedTableName))
+        .options(Map("dbtable" -> table.fullName))
         .mode(SparkSaveMode.from(finalSaveMode))
         .save()
     )
 
     if (comment.isDefined) {
-      val sql = s"comment on table ${connection.database}.${table.fullName} is '$comment';"
-      connection.execSnowflakeStatement(sql)
+      val sql = s"comment on table ${table.fullName} is '$comment';"
+      connection.execJdbcStatement(sql)
     }
 
     // return
@@ -178,19 +188,37 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
   }
   private[smartdatalake] override def writeSubFeedSupportedTypes: Seq[Type] = Seq(typeOf[SnowparkSubFeed], typeOf[SparkSubFeed]) // order matters... if possible Snowpark is preferred to Spark
 
-  override def isDbExisting(implicit context: ActionPipelineContext): Boolean = {
-    val sql = s"SHOW DATABASES LIKE '${connection.database}'"
-    connection.execSnowflakeStatement(sql).next()
-  }
 
+  // cache response to avoid jdbc query.
+  private var cachedIsDbExisting: Option[Boolean] = None
+  override def isDbExisting(implicit context: ActionPipelineContext): Boolean = {
+    cachedIsDbExisting.getOrElse {
+      cachedIsDbExisting = Option(connection.catalog.isDbExisting(table.db.get))
+      cachedIsDbExisting.get
+    }
+  }
+  // cache if table is existing to avoid jdbc query.
+  private var cachedIsTableExisting: Option[Boolean] = None
   override def isTableExisting(implicit context: ActionPipelineContext): Boolean = {
-    val sql = s"SHOW TABLES LIKE '${table.name}' IN SCHEMA ${connection.database}.${table.db.get}"
-    connection.execSnowflakeStatement(sql).next()
+    cachedIsTableExisting.getOrElse {
+      val existing = connection.catalog.isTableExisting(table.fullName)
+      if (existing) cachedIsTableExisting = Some(existing) // only cache if existing, otherwise query again later
+      existing
+    }
+  }
+  // cache response to avoid jdbc query.
+  private var cachedExistingSchema: Option[GenericSchema] = None
+  private def getExistingSchema(implicit context: ActionPipelineContext): Option[GenericSchema] = {
+    if (isTableExisting && cachedExistingSchema.isEmpty) {
+      cachedExistingSchema = Some(SnowparkSchema(getSnowparkDataFrame().schema))
+      // convert to lowercase when Spark is in non-casesensitive mode
+      if (!Environment.caseSensitive) cachedExistingSchema = Some(SchemaUtil.prepareSchemaForDiff(cachedExistingSchema.get, ignoreNullable = false, caseSensitive = false))
+    }
+    cachedExistingSchema
   }
 
   override def dropTable(implicit context: ActionPipelineContext): Unit = {
-    val sql = s"DROP TABLE IF EXISTS $fullyQualifiedTableName"
-    connection.execSnowflakeStatement(sql).next()
+    connection.execJdbcStatement(s"drop table ${table.fullName}")
   }
 
   override def factory: FromConfigFactory[DataObject] = SnowflakeTableDataObject
@@ -200,7 +228,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
    */
   def getSnowparkDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): snowpark.DataFrame = {
     //val helper: DataFrameSubFeedCompanion = SnowparkSubFeed
-    this.snowparkSession.table(fullyQualifiedTableName)
+    this.snowparkSession.table(table.fullName)
   }
 
   /**
@@ -232,6 +260,39 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
 
   override def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     if (sqlOpt.nonEmpty) connection.execSnowflakeStatement(sqlOpt.get).next()
+  }
+
+  /**
+   * Listing virtual partitions by a "select distinct partition-columns" query
+   */
+  override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
+    if (partitions.nonEmpty) {
+      PartitionValues.fromDataFrame(SnowparkDataFrame(getSnowparkDataFrame().select(partitions.map(snowpark.functions.col)).distinct()))
+    } else Seq()
+  }
+
+  override def deletePartitions(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    if (partitionValues.nonEmpty) {
+      connection.execSnowflakeStatement(deletePartitionsStatement(partitionValues))
+    }
+  }
+
+  /**
+   * Delete virtual partitions by "delete from" statement
+   * @param partitionValues nonempty list of partition values
+   */
+  private def deletePartitionsStatement(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): String = {
+    SQLUtil.createDeletePartitionStatement(table.fullName, partitionValues, quoteCaseSensitiveColumn(_))
+  }
+
+  /**
+   * if we generate sql statements with column names we need to care about quoting them properly
+   */
+  private def quoteCaseSensitiveColumn(column: String)(implicit context: ActionPipelineContext): String = {
+    if (Environment.caseSensitive) Utils.quotedName(column)
+    // quote identifier if it contains special characters
+    else if (SQLUtil.hasIdentifierSpecialChars(column)) Utils.quotedName(column)
+    else column
   }
 }
 

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeConnectionConfig.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeConnectionConfig.scala
@@ -22,6 +22,7 @@ package io.smartdatalake.workflow.snowflake
 import io.smartdatalake.definitions.BasicAuthMode
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.connection.SnowflakeConnection
+import io.smartdatalake.workflow.dataobject.HttpProxyConfig
 
 /**
  * Configuration of Snowflake connection for integration tests
@@ -35,6 +36,7 @@ object SnowflakeConnectionConfig {
     warehouse = sys.env("SNOWFLAKE_WAREHOUSE"),
     database = sys.env("SNOWFLAKE_DATABASE"),
     role = sys.env("SNOWFLAKE_ROLE"),
-    authMode = BasicAuthMode(Some(StringOrSecret(sys.env("SNOWFLAKE_USER"))), Some(StringOrSecret(sys.env("SNOWFLAKE_PASSWORD"))))
+    authMode = BasicAuthMode(Some(StringOrSecret(sys.env("SNOWFLAKE_USER"))), Some(StringOrSecret(sys.env("SNOWFLAKE_PASSWORD")))),
+    //proxy = Some(HttpProxyConfig(host = "<host>", port = <port>))
   )
 }

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeConnectionConfig.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeConnectionConfig.scala
@@ -25,7 +25,7 @@ import io.smartdatalake.workflow.connection.SnowflakeConnection
 
 /**
  * Configuration of Snowflake connection for integration tests
- * Please ensure that the environnement Variables SNOWFLAKE_URL, SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE, SNOWFLAKE_ROLE,
+ * Please ensure that the environment Variables SNOWFLAKE_URL, SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE, SNOWFLAKE_ROLE,
  * SNOWFLAKE_USER and SNOWFLAKE_PASSWORD are set in order to connect to Snowflake.
  */
 object SnowflakeConnectionConfig {
@@ -38,4 +38,3 @@ object SnowflakeConnectionConfig {
     authMode = BasicAuthMode(Some(StringOrSecret(sys.env("SNOWFLAKE_USER"))), Some(StringOrSecret(sys.env("SNOWFLAKE_PASSWORD"))))
   )
 }
-

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeDataObjectIT.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeDataObjectIT.scala
@@ -20,46 +20,76 @@
 package io.smartdatalake.workflow.snowflake
 
 import io.smartdatalake.config.{ConfigToolbox, InstanceRegistry}
+import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.dataobject.{SnowflakeTableDataObject, Table}
+import org.scalatest.FunSuite
+import org.scalatest.Matchers.intercept
 
 /**
  * This is an integration test to read & write to Snowflake with Spark and Snowpark.
  * It needs to be run manually because you need to provide a Snowflake environment.
  * Please configure this in SnowflakeConnectionConfig.
  */
-object SnowflakeDataObjectIT extends App {
+object SnowflakeDataObjectIT extends App with SmartDataLakeLogger {
 
   implicit val sparkSession = TestUtil.session
   implicit val instanceRegistry = new InstanceRegistry()
   implicit val context =  ConfigToolbox.getDefaultActionPipelineContext
 
   instanceRegistry.register(SnowflakeConnectionConfig.sfConnection)
-  val testDO = SnowflakeTableDataObject("test1", Table(Some(System.getenv("SNOWFLAKE_SCHEMA")), "abc"), connectionId = "sfCon")
+
+  val testDO = SnowflakeTableDataObject("test1", Table(Some(System.getenv("SNOWFLAKE_SCHEMA")), "abc"), connectionId = "sfCon", virtualPartitions = Seq("dt"), saveMode = SDLSaveMode.Overwrite)
   instanceRegistry.register(testDO)
+
+  // cleanup
+  testDO.dropTable
 
   // create table & write some data with Snowpark
   val sfSession = testDO.snowparkSession
   import sfSession.implicits._
-  val dfComplex = Seq(
-    (1, "a", "A"),
-    (2, "b", "B"),
-    (3, "c", "C"),
-    (4, "d", "D"),
-    (5, "e", "E")
-  ).toDF("id","s1", "s2")
-  testDO.writeSnowparkDataFrame(dfComplex, partitionValues = Seq())
+  {
+    val df = Seq(
+      (1, "a", "A", "20210201"),
+      (2, "b", "B", "20210201"),
+      (3, "c", "C", "20210201"),
+      (4, "d", "D", "20210201"),
+      (5, "e", "E", "20210202")
+    ).toDF("id","s1", "s2", "dt")
+    val metrics = testDO.writeSnowparkDataFrame(df, partitionValues = Seq(PartitionValues(Map("dt"->"20210201")),PartitionValues(Map("dt"->"20210202"))))
+    logger.info("Finished writing using Snowpark " + metrics)
 
-  // read data with Snowpark and Spark
-  println("SNOWPARK")
-  val dfTestDOSnowparkTestDO = testDO.getSnowparkDataFrame()
-  dfTestDOSnowparkTestDO.show
-  assert(dfTestDOSnowparkTestDO.count() == 5)
+    // read data with Snowpark and Spark
+    println("SNOWPARK")
+    val dfTestSnowpark = testDO.getSnowparkDataFrame()
+    dfTestSnowpark.select("id","s1","S2","dt").show
+    assert(dfTestSnowpark.count() == 5)
 
-  println("SPARK")
-  val dfTestDOSparkTestDO = testDO.getSparkDataFrame()
-  dfTestDOSparkTestDO.show
-  assert(dfTestDOSparkTestDO.count() == 5)
+    println("SPARK")
+    val dfTestSpark = testDO.getSparkDataFrame()
+    dfTestSpark.select("id","s1","S2","dt").show
+    assert(dfTestSpark.count() == 5)
+  }
+
+  // overwrite virtualPartition dt=20210201, add dt=20210203
+  {
+    val df = Seq(
+      (4, "d", "D", "20210201"),
+      (6, "f", "F", "20210203")
+    ).toDF("id", "s1", "s2", "dt")
+    val metrics = testDO.writeSnowparkDataFrame(df, partitionValues = Seq(PartitionValues(Map("dt"->"20210201")),PartitionValues(Map("dt"->"20210203"))))
+    logger.info("Finished writing using Snowpark " + metrics)
+    assert(metrics("rows_inserted") == 2)
+
+    // read data with Snowpark
+    println("SNOWPARK: 20210201 overwritten, 20210203 added")
+    val dfTestSnowpark = testDO.getSnowparkDataFrame()
+    dfTestSnowpark.select("id","s1","S2","dt").show
+    assert(dfTestSnowpark.count() == 3)
+    assert(dfTestSnowpark.schema.names == Seq("ID","S1","S2","DT")) // note that non-case-sensitive column names are uppercased by Snowflake.
+  }
 
   // cleanup
   testDO.dropTable


### PR DESCRIPTION
see #810

Notes:
- for Snowflake/Snowpark is difficult to create unit tests, as it is only available as a service. To test the virtual partitions i extended and executed SnowflakeDataObjectIT (integration tests).
- JdbcUtil.scala is not new code, but extracted from JdbcTableConnection.scala, in order to reuse it in SnowflakeConnection.scala.