### PR TITLE
791 pre post sql for delta tables

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkQueryUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkQueryUtil.scala
@@ -1,0 +1,43 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2024 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.spark
+
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import org.apache.spark.sql.SparkSession
+import io.smartdatalake.workflow.dataobject.Table
+
+object SparkQueryUtil extends SmartDataLakeLogger {
+  def executeSqlStatementBasedOnTable(session: SparkSession, stmt: String, table: Table): Unit = {
+    try {
+      val newStmt: String = (table.catalog, table.db) match {
+        case (None, None) => stmt;
+        case (Some(cat), None) => f"USE CATALOG $cat; $stmt";
+        case (None, Some(db)) => f"USE SCHEMA $db;$stmt";
+        case (Some(cat), Some(db)) => f"USE CATALOG $cat;USE SCHEMA $db;$stmt";
+      }
+      logger.info(s"Executing SQL statement: $newStmt")
+      session.sql(newStmt)
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Error in SQL statement '$stmt':\n${e.getMessage}")
+        throw e
+    }
+  }
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkQueryUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkQueryUtil.scala
@@ -24,6 +24,14 @@ import org.apache.spark.sql.SparkSession
 import io.smartdatalake.workflow.dataobject.Table
 
 object SparkQueryUtil extends SmartDataLakeLogger {
+  /**
+   * This method is used to execute SQL-statements configured at the DataObject-level.
+   * In order to avoid using another catalog that is not explicitly stated in the SQL-Statement,
+   * the catalogs and schemas of the given DataObject are set as default.
+   * @param session Spark Session
+   * @param stmt Desired SQL statement to be executed.
+   * @param table DataObject in which the SQLStatement is configured
+   */
   def executeSqlStatementBasedOnTable(session: SparkSession, stmt: String, table: Table): Unit = {
     try {
       val newStmt: String = (table.catalog, table.db) match {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkQueryUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkQueryUtil.scala
@@ -36,12 +36,12 @@ object SparkQueryUtil extends SmartDataLakeLogger {
     try {
       val newStmt: String = (table.catalog, table.db) match {
         case (None, None) => stmt;
-        case (Some(cat), None) => f"USE CATALOG $cat; $stmt";
+        case (Some(cat), None) => f"USE CATALOG $cat;$stmt";
         case (None, Some(db)) => f"USE SCHEMA $db;$stmt";
         case (Some(cat), Some(db)) => f"USE CATALOG $cat;USE SCHEMA $db;$stmt";
       }
       logger.info(s"Executing SQL statement: $newStmt")
-      session.sql(newStmt)
+      newStmt.split(";").foreach(session.sql(_))
     } catch {
       case e: Exception =>
         logger.warn(s"Error in SQL statement '$stmt':\n${e.getMessage}")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -90,10 +90,10 @@ import scala.util.Try
  */
 case class JdbcTableDataObject(override val id: DataObjectId,
                                createSql: Option[String] = None,
-                               preReadSql: Option[String] = None,
-                               postReadSql: Option[String] = None,
-                               preWriteSql: Option[String] = None,
-                               postWriteSql: Option[String] = None,
+                               override val preReadSql: Option[String] = None,
+                               override val postReadSql: Option[String] = None,
+                               override val preWriteSql: Option[String] = None,
+                               override val postWriteSql: Option[String] = None,
                                override val schemaMin: Option[GenericSchema] = None,
                                override var table: Table,
                                override val constraints: Seq[Constraint] = Seq(),
@@ -402,23 +402,8 @@ case class JdbcTableDataObject(override val id: DataObjectId,
     )
   }
 
-  override def preRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    super.preRead(partitionValues)
-    prepareAndExecSql(preReadSql, Some("preReadSql"), partitionValues)
-  }
-  override def postRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    super.postRead(partitionValues)
-    prepareAndExecSql(postReadSql, Some("postReadSql"), partitionValues)
-  }
-  override def preWrite(implicit context: ActionPipelineContext): Unit = {
-    super.preWrite
-    prepareAndExecSql(preWriteSql, Some("preWriteSql"), Seq()) // no partition values here...
-  }
-  override def postWrite(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    super.postWrite(partitionValues)
-    prepareAndExecSql(postWriteSql, Some("postWriteSql"), partitionValues)
-  }
-  private def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+
+  def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     sqlOpt.foreach { sql =>
       val data = DefaultExpressionData.from(context, partitionValues)
       val preparedSql = SparkExpressionUtil.substitute(id, configName, sql, data)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.workflow.dataobject
 
+import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
@@ -76,4 +77,30 @@ trait TableDataObject extends DataObject with CanCreateDataFrame with SchemaVali
    */
   def getColumnStats(update: Boolean = false, lastModifiedAt: Option[Long] = None)(implicit context: ActionPipelineContext): Map[String, Map[String, Any]] = Map()
 
+  val preReadSql: Option[String] = None
+  val postReadSql: Option[String] = None
+  val preWriteSql: Option[String] = None
+  val postWriteSql: Option[String] = None
+
+  override def preRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    super.preRead(partitionValues)
+    prepareAndExecSql(preReadSql, Some("preReadSql"), partitionValues)
+  }
+
+  override def postRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    super.postRead(partitionValues)
+    prepareAndExecSql(postReadSql, Some("postReadSql"), partitionValues)
+  }
+
+  override def preWrite(implicit context: ActionPipelineContext): Unit = {
+    super.preWrite
+    prepareAndExecSql(preWriteSql, Some("preWriteSql"), Seq()) // no partition values here...
+  }
+
+  override def postWrite(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    super.postWrite(partitionValues)
+    prepareAndExecSql(postWriteSql, Some("postWriteSql"), partitionValues)
+  }
+
+  def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TableDataObject.scala
@@ -18,7 +18,6 @@
  */
 package io.smartdatalake.workflow.dataobject
 
-import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
@@ -76,31 +75,4 @@ trait TableDataObject extends DataObject with CanCreateDataFrame with SchemaVali
    * @return column statistics about this DataObject
    */
   def getColumnStats(update: Boolean = false, lastModifiedAt: Option[Long] = None)(implicit context: ActionPipelineContext): Map[String, Map[String, Any]] = Map()
-
-  val preReadSql: Option[String] = None
-  val postReadSql: Option[String] = None
-  val preWriteSql: Option[String] = None
-  val postWriteSql: Option[String] = None
-
-  override def preRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    super.preRead(partitionValues)
-    prepareAndExecSql(preReadSql, Some("preReadSql"), partitionValues)
-  }
-
-  override def postRead(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    super.postRead(partitionValues)
-    prepareAndExecSql(postReadSql, Some("postReadSql"), partitionValues)
-  }
-
-  override def preWrite(implicit context: ActionPipelineContext): Unit = {
-    super.preWrite
-    prepareAndExecSql(preWriteSql, Some("preWriteSql"), Seq()) // no partition values here...
-  }
-
-  override def postWrite(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
-    super.postWrite(partitionValues)
-    prepareAndExecSql(postWriteSql, Some("postWriteSql"), partitionValues)
-  }
-
-  def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -49,6 +49,10 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
                                        override var table: Table,
                                        override val constraints: Seq[Constraint] = Seq(),
                                        override val expectations: Seq[Expectation] = Seq(),
+                                       override val preReadSql: Option[String] = None,
+                                       override val postReadSql: Option[String] = None,
+                                       override val preWriteSql: Option[String] = None,
+                                       override val postWriteSql: Option[String] = None,
                                        numInitialHdfsPartitions: Int = 16,
                                        saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                                        acl: Option[AclDef] = None,
@@ -241,6 +245,11 @@ case class TickTockHiveTableDataObject(override val id: DataObjectId,
   }
 
   override def factory: FromConfigFactory[DataObject] = TickTockHiveTableDataObject
+
+  def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    implicit val session: SparkSession = context.sparkSession
+    sqlOpt.foreach( stmt => SparkQueryUtil.executeSqlStatementBasedOnTable(session, stmt, table))
+  }
 }
 
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/TickTockHiveTableDataObject.scala
@@ -29,7 +29,7 @@ import io.smartdatalake.metrics.SparkStageMetricsListener
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.util.misc.{AclDef, AclUtil, EnvironmentUtil}
-import io.smartdatalake.util.spark.DataFrameUtil
+import io.smartdatalake.util.spark.{DataFrameUtil, SparkQueryUtil}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.connection.HiveTableConnection

--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestDataObject.scala
@@ -27,6 +27,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.dataobject._
+import jdk.jshell.spi.ExecutionControl.NotImplementedException
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -65,6 +66,7 @@ case class TestDataObject( id: DataObjectId,
 
   override def factory: FromConfigFactory[DataObject] = TestDataObject
 
+  def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {}
 }
 
 object TestDataObject extends FromConfigFactory[DataObject] {

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/MockDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/MockDataObject.scala
@@ -113,6 +113,9 @@ case class MockDataObject(override val id: DataObjectId, override val partitions
 
   override def factory: FromConfigFactory[DataObject] = MockDataObject
 
+  def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {}
+
+
 }
 
 object MockDataObject extends FromConfigFactory[DataObject] {

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -72,6 +72,14 @@ import scala.util.Try
  *                  Define schema by using a DDL-formatted string, which is a comma separated list of field definitions, e.g., a INT, b STRING.
  * @param table DeltaLake table to be written by this output
  * @param constraints List of row-level [[Constraint]]s to enforce when writing to this data object.
+ * @param preReadSql SQL-statement to be executed in exec phase before reading input table. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
+ * @param postReadSql SQL-statement to be executed in exec phase after reading input table and before action is finished. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
+ * @param preWriteSql SQL-statement to be executed in exec phase before writing output table. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
+ * @param postWriteSql SQL-statement to be executed in exec phase after writing output table. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
  * @param expectations List of [[Expectation]]s to enforce when writing to this data object. Expectations are checks based on aggregates over all rows of a dataset.
  * @param saveMode [[SDLSaveMode]] to use when writing files, default is "overwrite". Overwrite, Append and Merge are supported for now.
  * @param allowSchemaEvolution If set to true schema evolution will automatically occur when writing to this DataObject with different schema, otherwise SDL will stop with error.

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -113,7 +113,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
                                   override val preReadSql: Option[String] = None,
                                   override val postReadSql: Option[String] = None,
                                   override val preWriteSql: Option[String] = None,
-                                  override val postWriteSql: Option[String] = None),
+                                  override val postWriteSql: Option[String] = None)
                                  (@transient implicit val instanceRegistry: InstanceRegistry)
   extends TransactionalTableDataObject with CanMergeDataFrame with CanEvolveSchema with CanHandlePartitions with HasHadoopStandardFilestore with ExpectationValidation {
 

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -93,6 +93,14 @@ import scala.util.Try
  *                         See HousekeepingMode for available implementations. Default is None.
  * @param connectionId optional id of [[io.smartdatalake.workflow.connection.HiveTableConnection]]
  * @param metadata meta data
+ * @param preReadSql SQL-statement to be executed in exec phase before reading input table. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
+ * @param postReadSql SQL-statement to be executed in exec phase after reading input table and before action is finished. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
+ * @param preWriteSql SQL-statement to be executed in exec phase before writing output table. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
+ * @param postWriteSql SQL-statement to be executed in exec phase after writing output table. If the catalog and/or schema are not
+ *                   explicitly defined, the ones present in the configured "table" object are used.
  */
 case class IcebergTableDataObject(override val id: DataObjectId,
                                   path: Option[String],

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -50,6 +50,10 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param table        Snowflake table to be written by this output
  * @param constraints  List of row-level [[Constraint]]s to enforce when writing to this data object.
  * @param expectations List of [[Expectation]]s to enforce when writing to this data object. Expectations are checks based on aggregates over all rows of a dataset.
+ * @param preReadSql SQL-statement to be executed in exec phase before reading input table. It uses the SnowflakeConnection for the target database.
+ * @param postReadSql SQL-statement to be executed in exec phase after reading input table and before action is finished. It uses the SnowflakeConnection for the target database.
+ * @param preWriteSql SQL-statement to be executed in exec phase before writing output table. It uses the SnowflakeConnection for the target database.
+ * @param postWriteSql SQL-statement to be executed in exec phase after writing output table. It uses the SnowflakeConnection for the target database.
  * @param saveMode     spark [[SDLSaveMode]] to use when writing files, default is "overwrite"
  * @param connectionId The SnowflakeTableConnection to use for the table
  * @param comment      An optional comment to add to the table after writing a DataFrame to it

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -63,6 +63,10 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
                                     override val schemaMin: Option[GenericSchema] = None,
                                     override val constraints: Seq[Constraint] = Seq(),
                                     override val expectations: Seq[Expectation] = Seq(),
+                                    override val preReadSql: Option[String] = None,
+                                    override val postReadSql: Option[String] = None,
+                                    override val preWriteSql: Option[String] = None,
+                                    override val postWriteSql: Option[String] = None,
                                     saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                                     connectionId: ConnectionId,
                                     sparkOptions: Map[String, String] = Map(),
@@ -220,6 +224,10 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
         case ("number_of_rows_deleted", v) => "rows_deleted" -> v
         case (k, v) => k -> v
       }
+  }
+
+  override def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
+    if (sqlOpt.nonEmpty) connection.execSnowflakeStatement(sqlOpt.get).next()
   }
 }
 


### PR DESCRIPTION
See #791 .

The methods that were part of JdbcTableDataObject were passed to trait TransactionTableDataObject.
Logic implemented for IcebergTableDataObject, DeltaLakeTableDataObject, SnowflakeTableDataObject and TickTockHiveTableDataObject.
