### PR TITLE
Feature/col encrypt improve

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/crypt/DatabricksCrypt.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/crypt/DatabricksCrypt.scala
@@ -5,7 +5,7 @@ import org.apache.hadoop.hive.ql.exec.UDF
 class EncryptColumn extends UDF with EncryptDecryptSupport {
   def evaluate(message: String, key: String, algorithm: String): String = {
     val keyBytes: Array[Byte] = key.getBytes
-    val crypt: EncryptDecrypt = algorithm match {
+    val crypt: EncryptDecrypt = algorithm.toUpperCase() match {
       case "GCM" => new EncryptDecryptGCM(keyBytes)
       case "ECB" => new EncryptDecryptECB(keyBytes)
       case classname if classname.contains(".") => loadEncryptDecryptClass(classname, keyBytes)
@@ -19,7 +19,7 @@ class EncryptColumn extends UDF with EncryptDecryptSupport {
 class DecryptColumn extends UDF with EncryptDecryptSupport {
   def evaluate(message: String, key: String, algorithm: String): String = {
     val keyBytes: Array[Byte] = key.getBytes
-    val crypt: EncryptDecrypt = algorithm match {
+    val crypt: EncryptDecrypt = algorithm.toUpperCase() match {
       case "GCM" => new EncryptDecryptGCM(keyBytes)
       case "ECB" => new EncryptDecryptECB(keyBytes)
       case classname if classname.contains(".") => loadEncryptDecryptClass(classname, keyBytes)

--- a/sdl-core/src/main/scala/io/smartdatalake/util/crypt/EncryptDecrypt.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/crypt/EncryptDecrypt.scala
@@ -31,7 +31,7 @@ import javax.crypto.spec.SecretKeySpec
 /**
  * implements columns wise encryption/decryptions
  *  encrypted columns have data type String.
- *  The original data type is stored in DataFrame metadata and stored if supported.
+ *  The original data type is stored in DataFrame metadata and saved to output format if supported (Parquet, Hive, Delta, Iceberg).
  *  During the decryption the original data type is restored, metadata is maintained.
  */
 trait EncryptDecrypt extends Serializable {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/crypt/EncryptDecryptECB.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/crypt/EncryptDecryptECB.scala
@@ -40,11 +40,13 @@ class EncryptDecryptECB(keyBytes: Array[Byte]) extends EncryptDecrypt {
   }
 
   override def encrypt(message: String): String = {
+    if (message == null) return message
     val data = cipherEncrypt.doFinal(message.getBytes())
     Base64.getEncoder.encodeToString(data)
   }
 
   override def decrypt(encryptedDataString: String): String = {
+    if (encryptedDataString == null) return encryptedDataString
     val data = Base64.getDecoder.decode(encryptedDataString)
     val message = cipherDecrypt.doFinal(data)
     new String(message)

--- a/sdl-core/src/main/scala/io/smartdatalake/util/crypt/EncryptDecryptGCM.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/crypt/EncryptDecryptGCM.scala
@@ -36,6 +36,7 @@ class EncryptDecryptGCM(keyBytes: Array[Byte]) extends EncryptDecrypt {
   private val aesKey: SecretKey = generateAesKey(keyAsBytes)
 
   override def encrypt(message: String): String = {
+    if (message == null) return message
     val gcmParameterSpec = generateGcmParameterSpec()
     val cipher = Cipher.getInstance(ALGORITHM_STRING)
     cipher.init(Cipher.ENCRYPT_MODE, aesKey, gcmParameterSpec, new SecureRandom())
@@ -45,6 +46,7 @@ class EncryptDecryptGCM(keyBytes: Array[Byte]) extends EncryptDecrypt {
   }
 
   override def decrypt(encryptedDataString: String): String = {
+    if (encryptedDataString == null) return encryptedDataString
     val (gcmParameterSpec, encryptedMessage) = decodeData(encryptedDataString)
 
     val cipher = Cipher.getInstance(ALGORITHM_STRING)
@@ -62,6 +64,7 @@ class EncryptDecryptGCM(keyBytes: Array[Byte]) extends EncryptDecrypt {
 
   private def encodeData(gcmParameterSpec: GCMParameterSpec, encryptedMessage: Array[Byte]): String = {
     val data = gcmParameterSpec.getIV ++ encryptedMessage
+    println(Base64.getEncoder.encodeToString(gcmParameterSpec.getIV), Base64.getEncoder.encodeToString(encryptedMessage))
     Base64.getEncoder.encodeToString(data)
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -20,7 +20,7 @@
 package io.smartdatalake.workflow.action.generic.transformer
 
 import io.smartdatalake.testutils.TestUtil
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{SaveMode, SparkSession}
 import org.scalatest.FunSuite
 import com.typesafe.config.ConfigFactory
 import io.smartdatalake.config.SdlConfigObject.stringToDataObjectId
@@ -30,20 +30,33 @@ import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.util.hdfs.HdfsUtil
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, GlobalConfig, SmartDataLakeBuilderConfig}
-import io.smartdatalake.testutils.TestUtil.sparkSessionBuilder
+import io.smartdatalake.util.crypt.{EncryptDecrypt, EncryptDecryptECB}
 import io.smartdatalake.workflow.action.SDLExecutionId
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.types._
 
 import java.nio.file.Files
 import java.time.LocalDateTime
 
+case class Test_Record(
+                        id: Integer,
+                        str: String,
+                        fl: Float,
+                        db: Double,
+                        lo: Long
+                      )
+
 class EncryptColumnsTransformerTest extends FunSuite {
+  implicit val session: SparkSession = TestUtil.session
+  import session.implicits._
   private val tempDir = Files.createTempDirectory("test")
 
   val statePath = "target/stateTest/"
   implicit val filesystem: FileSystem = HdfsUtil.getHadoopFsWithDefaultConf(new Path(statePath))
+  val test_key = "A%D*G-KaPdSgVkYp"
 
   def run_test(enc_type: String): sql.DataFrame = {
     val sdlb = new DefaultSmartDataLakeBuilder()
@@ -61,7 +74,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = EncryptColumnsTransformer
         |       encryptColumns = ["c2","c3"]
-        |       key = "A%D*G-KaPdSgVkYp"
+        |       key = ${test_key}
         |       algorithm = ${enc_type}
         |     }]
         |   }
@@ -75,7 +88,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = DecryptColumnsTransformer
         |       decryptColumns = ["c2","c3"]
-        |       key = "A%D*G-KaPdSgVkYp"
+        |       key = ${test_key}
         |       algorithm = ${enc_type}
         |     }]
         |   }
@@ -99,8 +112,6 @@ class EncryptColumnsTransformerTest extends FunSuite {
 
     val globalConfig = GlobalConfig.from(config)
     implicit val instanceRegistry: InstanceRegistry = ConfigParser.parse(config)
-    implicit val session: SparkSession = TestUtil.session
-    import session.implicits._
 
     implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
     val sdlConfig = SmartDataLakeBuilderConfig(feedSel = s"ids:actenc,ids:actdec")
@@ -161,5 +172,45 @@ class EncryptColumnsTransformerTest extends FunSuite {
   test("test column encryption and decryption with Class Name") {
     val df = run_test("io.smartdatalake.util.crypt.EncryptDecryptECB")
     assert(df.select("c2").take(2)(1).getAs[String]("c2") === "0RK5Cr5ax1OXlBO7Q+BHxA==")
+  }
+
+  test("colEncrypt null value test") {
+    val df = Seq(
+      (1, "a"), (2, null)
+    ).toDF("id", "str")
+    val cols = Seq("id","str")
+    val crypt: EncryptDecrypt = new EncryptDecryptECB(test_key.getBytes())
+    val df_enc = crypt.encryptColumns(df, cols)
+    // null values should result in null values during column encryption
+    assert(df_enc.select("str").take(2)(1).isNullAt(0))
+  }
+
+  test("colEncrypt data type test") {
+    val df = Seq(
+      (1,"a"), (2, "b"), (3, null)
+    ).toDF("id", "str")
+      .withColumn("fl", lit(3.41f))
+      .withColumn("db", lit(3.41d))
+      .withColumn("lo", lit(3456L))
+
+    val cols = Seq("id","str", "fl", "db", "lo")
+    val crypt: EncryptDecrypt = new EncryptDecryptECB(test_key.getBytes())
+    val df_enc = crypt.encryptColumns(df, cols)
+    val file = "./test_enc.parquet"
+
+    // write/read to CSV file -> would result in String columns, since CSV does not store Metadata
+    //df_enc.write.mode(SaveMode.Overwrite).format("csv").option("header", true).save(file)
+    //val df_enc_file = session.read.format("csv").option("header", true).load(file)
+
+    // write/read to parquet file
+    df_enc.write.mode(SaveMode.Overwrite).parquet(file)
+    val df_enc_file = session.read.parquet(file)
+
+    val df_dec = crypt.decryptColumns(df_enc_file, cols)
+    assert(df_dec.schema("id").dataType == IntegerType)
+    assert(df_dec.schema("str").dataType == StringType)
+    assert(df_dec.schema("fl").dataType == FloatType)
+    assert(df_dec.schema("db").dataType == DoubleType)
+    assert(df_dec.schema("lo").dataType == LongType)
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -74,7 +74,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = EncryptColumnsTransformer
         |       encryptColumns = ["c2","c3"]
-        |       key = ${test_key}
+        |       key = "${test_key}"
         |       algorithm = ${enc_type}
         |     }]
         |   }
@@ -88,7 +88,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
         |     transformers = [{
         |       type = DecryptColumnsTransformer
         |       decryptColumns = ["c2","c3"]
-        |       key = ${test_key}
+        |       key = "${test_key}"
         |       algorithm = ${enc_type}
         |     }]
         |   }
@@ -154,7 +154,7 @@ class EncryptColumnsTransformerTest extends FunSuite {
     dfEnc
   }
 
-  test("test column encryption and decryption") {
+  test("test GCM column encryption and decryption") {
     run_test("GCM")
   }
 


### PR DESCRIPTION
### What changes are included in the pull request?
The column encryption can now handle also null values. 
Furthermore, the original column data type is stored to the metadata, and if maintained in the file format, the data type is restored during decryption. 

### Why are the changes needed?
solves #825 