### PR TITLE
fix typo in CompletenessExpectation class name (#880)

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/expectation/CompletenessExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/expectation/CompletenessExpectation.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.workflow.action.expectation
 
 import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
-import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.spark.SparkColumn
@@ -29,7 +29,6 @@ import io.smartdatalake.workflow.dataframe.{DataFrameFunctions, GenericColumn}
 import io.smartdatalake.workflow.dataobject.expectation.ExpectationScope.ExpectationScope
 import io.smartdatalake.workflow.dataobject.expectation.ExpectationSeverity.ExpectationSeverity
 import io.smartdatalake.workflow.dataobject.expectation.{ActionExpectation, ExpectationFractionMetricDefaultImpl, ExpectationScope, ExpectationSeverity}
-import org.apache.spark.sql.Column
 
 
 /**
@@ -41,7 +40,7 @@ import org.apache.spark.sql.Column
  *                    If no expectation is defined, the aggExpression evaluation result is just recorded in metrics.
  * @param precision Number of digits to keep when calculating fraction. Default is 4.
  */
-case class CompletnessExpectation(
+case class CompletenessExpectation(
                                     override val name: String = "pctComplete",
                                     override val expectation: Option[String] = Some("= 1"),
                                     override val precision: Short = 4,
@@ -66,11 +65,12 @@ case class CompletnessExpectation(
     val updatedMetrics = metrics + (name -> pct)
     (col.map(SparkColumn).toSeq, updatedMetrics)
   }
-  override def factory: FromConfigFactory[ActionExpectation] = CompletnessExpectation
+
+  override def factory: FromConfigFactory[ActionExpectation] = CompletenessExpectation
 }
 
-object CompletnessExpectation extends FromConfigFactory[ActionExpectation] {
-  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): CompletnessExpectation = {
-    extract[CompletnessExpectation](config)
+object CompletenessExpectation extends FromConfigFactory[ActionExpectation] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): CompletenessExpectation = {
+    extract[CompletenessExpectation](config)
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -26,13 +26,13 @@ import io.smartdatalake.util.dag.TaskFailedException
 import io.smartdatalake.util.dag.TaskFailedException.getRootCause
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.executionMode.{FileIncrementalMoveMode, PartitionDiffMode}
-import io.smartdatalake.workflow.action.expectation.{CompletnessExpectation, TransferRateExpectation}
+import io.smartdatalake.workflow.action.expectation.{CompletenessExpectation, TransferRateExpectation}
 import io.smartdatalake.workflow.action.generic.transformer.{AdditionalColumnsTransformer, FilterTransformer, SQLDfTransformer}
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfTransformer
 import io.smartdatalake.workflow.action.spark.transformer.{ScalaClassSparkDfTransformer, ScalaCodeSparkDfTransformer, SparkRepartitionTransformer}
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject._
-import io.smartdatalake.workflow.dataobject.expectation.{CountExpectation, ExpectationScope, ExpectationValidationException, SQLExpectation, SQLFractionExpectation, SQLQueryExpectation, UniqueKeyExpectation}
+import io.smartdatalake.workflow.dataobject.expectation._
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, InitSubFeed}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.functions.{lit, substring}
@@ -221,7 +221,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val customTransformerConfig2 = SQLDfTransformer(name = "sql2", code = "select * from %{inputViewName} where rating = 5") // test multiple transformers - it doesnt matter if they do the same.
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id,
       transformers = Seq(customTransformerConfig1, customTransformerConfig2),
-      expectations = Seq(TransferRateExpectation(), CompletnessExpectation(expectation = None))
+      expectations = Seq(TransferRateExpectation(), CompletenessExpectation(expectation = None))
     )
     val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDataFrameActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDataFrameActionTest.scala
@@ -25,7 +25,7 @@ import io.smartdatalake.testutils.{MockDataObject, TestUtil}
 import io.smartdatalake.util.dag.TaskSkippedDontStopWarning
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.executionMode.{CustomMode, CustomModeLogic, ExecutionModeResult, PartitionDiffMode}
-import io.smartdatalake.workflow.action.expectation.{CompletnessExpectation, TransferRateExpectation}
+import io.smartdatalake.workflow.action.expectation.{CompletenessExpectation, TransferRateExpectation}
 import io.smartdatalake.workflow.action.generic.transformer.SQLDfsTransformer
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformer
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfsTransformer
@@ -427,7 +427,7 @@ class CustomDataFrameActionTest extends FunSuite with BeforeAndAfter {
     val customTransformerConfig2 = SQLDfsTransformer(code = Map(tgtDO2.id.id -> "select * from src2"))
     val action1 = CustomDataFrameAction("ca", List(srcDO1.id, srcDO2.id), List(tgtDO1.id, tgtDO2.id), mainInputId = Some(srcDO1.id), mainOutputId = Some(tgtDO1.id),
       transformers = Seq(customTransformerConfig1, customTransformerConfig2),
-      expectations = Seq(TransferRateExpectation(), CompletnessExpectation(expectation = None))
+      expectations = Seq(TransferRateExpectation(), CompletenessExpectation(expectation = None))
     )
     instanceRegistry.register(action1)
     val dfInput = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
@@ -471,7 +471,7 @@ class CustomDataFrameActionTest extends FunSuite with BeforeAndAfter {
     val customTransformerConfig2 = SQLDfsTransformer(code = Map(tgtDO2.id.id -> "select * from src2"))
     val action1 = CustomDataFrameAction("ca", List(srcDO1.id, srcDO2.id), List(tgtDO1.id, tgtDO2.id), mainInputId = Some(srcDO1.id), mainOutputId = Some(tgtDO1.id),
       transformers = Seq(customTransformerConfig1, customTransformerConfig2),
-      expectations = Seq(TransferRateExpectation(), CompletnessExpectation(expectation = None))
+      expectations = Seq(TransferRateExpectation(), CompletenessExpectation(expectation = None))
     )
     instanceRegistry.register(action1)
     val dfInput = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")


### PR DESCRIPTION
See #880

Note that this is a breaking change, but as CompletenessExpectation was introduced recently in Release 2.7.0, we can assume that its not yet largely in use.