### PR TITLE
Add scaladoc comments to schema from case class (#765)

### DIFF
--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -251,6 +251,18 @@
             <version>${scaladoc.reader.version}</version>
         </dependency>
 
+        <!-- parser for scaladoc annotations -->
+        <dependency>
+            <groupId>com.github.andyglow</groupId>
+            <artifactId>scaladoc-ast_${scala.minor.version}</artifactId>
+            <version>0.0.14</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.andyglow</groupId>
+            <artifactId>scaladoc-parser_${scala.minor.version}</artifactId>
+            <version>0.0.14</version>
+        </dependency>
+
         <!-- needed for AirbyteDataObject Json handling -->
         <dependency>
             <groupId>com.networknt</groupId>

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ProductUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ProductUtil.scala
@@ -22,6 +22,7 @@ import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.ConfigObjectId
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.{DeserializerBuildHelper, ScalaReflection, SerializerBuildHelper}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset}
 
 import java.time.format.DateTimeFormatter
@@ -160,6 +161,15 @@ private[smartdatalake] object ProductUtil {
     val msg = StringBuilder.newBuilder
     addObjToBuilder(msg, obj, spacing = false)
     msg.toString
+  }
+
+  /**
+   * Create an Schema for a product based on it's type given as parameter (not as type parameter).
+   */
+  def createSchema(tpe: Type): StructType = {
+    val mirror = ScalaReflection.mirror
+    val cls = mirror.runtimeClass(tpe)
+    ScalaReflection.encoderFor(tpe).schema
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
@@ -1,7 +1,7 @@
 /*
  * Smart Data Lake - Build your data lake the smart way.
  *
- * Copyright © 2019-2023 ELCA Informatique SA (<https://www.elca.ch>)
+ * Copyright © 2019-2024 ELCA Informatique SA (<https://www.elca.ch>)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,10 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package io.smartdatalake.meta
+package io.smartdatalake.util.misc
 
 import com.github.takezoe.scaladoc.{Scaladoc => ScaladocAnnotation}
-import scaladoc.Markup.{CodeBlock, Document, Heading, Paragraph, Span}
+import scaladoc.Markup._
 import scaladoc.{Markup, Scaladoc, Tag}
 
 import scala.reflect.runtime.universe.Annotation

--- a/sdl-lang/pom.xml
+++ b/sdl-lang/pom.xml
@@ -119,17 +119,6 @@
             <artifactId>scala-collection-compat_${scala.minor.version}</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.andyglow</groupId>
-            <artifactId>scaladoc-ast_${scala.minor.version}</artifactId>
-            <version>0.0.14</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.andyglow</groupId>
-            <artifactId>scaladoc-parser_${scala.minor.version}</artifactId>
-            <version>0.0.14</version>
-        </dependency>
-
         <!-- TEST dependencies -->
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/GenericTypeUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/GenericTypeUtil.scala
@@ -1,7 +1,7 @@
 package io.smartdatalake.meta
 
 import io.smartdatalake.definitions.SaveModeOptions
-import io.smartdatalake.meta.ScaladocUtil.{extractScalaDoc, formatScaladocString, formatScaladocWithTags}
+import io.smartdatalake.util.misc.ScaladocUtil.{extractScalaDoc, formatScaladocString, formatScaladocWithTags}
 import io.smartdatalake.util.misc.{ReflectionUtil, SmartDataLakeLogger}
 import io.smartdatalake.workflow.action.executionMode.ExecutionMode
 import io.smartdatalake.workflow.action.generic.transformer.{GenericDfTransformer, GenericDfsTransformer, ValidationRule}

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
@@ -6,11 +6,10 @@ import io.smartdatalake.app.{AppUtil, UploadDefaults}
 import io.smartdatalake.config.SdlConfigObject.{ActionId, ConfigObjectId, ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigLoader, ConfigParser, ConfigurationException}
 import io.smartdatalake.definitions.Environment
-import io.smartdatalake.meta.ScaladocUtil
 import io.smartdatalake.util.hdfs.HdfsUtil
 import io.smartdatalake.util.hdfs.HdfsUtil.RemoteIteratorWrapper
 import io.smartdatalake.util.misc.HoconUtil.{getConfigValue, updateConfigValue}
-import io.smartdatalake.util.misc.{CustomCodeUtil, HoconUtil, SmartDataLakeLogger}
+import io.smartdatalake.util.misc.{CustomCodeUtil, HoconUtil, ScaladocUtil, SmartDataLakeLogger}
 import io.smartdatalake.util.spark.DataFrameUtil
 import io.smartdatalake.workflow.action.spark.customlogic.{CustomTransformMethodDef, CustomTransformMethodWrapper}
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfsTransformer

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/jsonschema/JsonSchemaUtil.scala
@@ -22,8 +22,8 @@ package io.smartdatalake.meta.jsonschema
 import io.smartdatalake.app.GlobalConfig
 import io.smartdatalake.config.SdlConfigObject.ConfigObjectId
 import io.smartdatalake.config.{ExcludeFromSchemaExport, ParsableFromConfig, SdlConfigObject}
-import io.smartdatalake.meta.{GenericAttributeDef, GenericTypeDef, GenericTypeUtil, ScaladocUtil, jsonschema}
-import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.meta.{GenericAttributeDef, GenericTypeDef, GenericTypeUtil, jsonschema}
+import io.smartdatalake.util.misc.{ScaladocUtil, SmartDataLakeLogger}
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.action.Action
 import io.smartdatalake.workflow.connection.Connection
@@ -34,11 +34,11 @@ import org.apache.spark.sql.types.StructType
 import org.reflections.Reflections
 import scaladoc.Tag
 
-import scala.jdk.CollectionConverters._
+import scala.collection.compat._
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe.{ClassSymbol, Type, TypeRef, typeOf}
-import scala.collection.compat._
 
 /**
  * Create Json schema elements from generic type definitions.


### PR DESCRIPTION
### What changes are included in the pull request?
The Schema of a DataObject can be defined from a case class.
This PR adds that the schema is enriched with column comments from the ScalaDoc param tags.

### Why are the changes needed?
Good feature, and preparation for #765.