### PR TITLE
595 snowflake read transformer

### DIFF
--- a/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestAction.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/objects/TestAction.scala
@@ -23,6 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.Condition
 import io.smartdatalake.workflow.action.executionMode.ExecutionMode
+import io.smartdatalake.workflow.action.generic.transformer.GenericDfTransformer
 import io.smartdatalake.workflow.action.{Action, ActionMetadata}
 import io.smartdatalake.workflow.dataobject.{CanCreateDataFrame, DataObject, HousekeepingMode, TransactionalTableDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, SubFeed}
@@ -41,6 +42,7 @@ case class TestAction(override val id: ActionId,
                       arg1: Option[String],
                       executionMode: Option[ExecutionMode] = None,
                       housekeepingMode: Option[HousekeepingMode] = None,
+                      transformers: Seq[GenericDfTransformer] = Seq(),
                       override val executionCondition: Option[Condition] = None,
                       override val metricsFailCondition: Option[String] = None,
                       override val metadata: Option[ActionMetadata] = None
@@ -50,8 +52,8 @@ case class TestAction(override val id: ActionId,
   override def init(subFeed: Seq[SubFeed])(implicit context: ActionPipelineContext): Seq[SubFeed] = { /*NOP*/ Seq() }
   override def exec(subFeed: Seq[SubFeed])(implicit context: ActionPipelineContext): Seq[SubFeed] = { /*NOP*/ Seq() }
 
-  private[config] val input = instanceRegistry.get[DataObject with CanCreateDataFrame](inputId)
-  private[config] val output = instanceRegistry.get[TransactionalTableDataObject](outputId)
+  private[config] val input = getInputDataObject[DataObject with CanCreateDataFrame](inputId)
+  private[config] val output = getOutputDataObject[TestDataObject](outputId)
   override val inputs: Seq[DataObject with CanCreateDataFrame] = Seq(input)
   override val outputs: Seq[TransactionalTableDataObject] = Seq(output)
   override val recursiveInputs:Seq[DataObject with CanCreateDataFrame] = Seq()

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -62,7 +62,6 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
  *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
  *                                    Default is to expect all partitions to exist.
- * @param comment      An optional comment to add to the table after writing a DataFrame to it
  * @param sparkOptions Options for the Snowflake Spark Connector, see https://docs.snowflake.com/en/user-guide/spark-connector-use#additional-options.
  *                     These options override connection.options.
  * @param metadata     meta data
@@ -81,7 +80,6 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
                                     sparkOptions: Map[String, String] = Map(),
                                     virtualPartitions: Seq[String] = Seq(),
                                     override val expectedPartitionsCondition: Option[String] = None,
-                                    comment: Option[String] = None,
                                     override val metadata: Option[DataObjectMetadata] = None)
                                    (@transient implicit val instanceRegistry: InstanceRegistry)
   extends TransactionalTableDataObject with CanHandlePartitions with ExpectationValidation {
@@ -148,7 +146,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
         .save()
     )
 
-    if (comment.isDefined) {
+    metadata.flatMap(_.description).foreach { comment =>
       val sql = s"comment on table ${table.fullName} is '$comment';"
       connection.execJdbcStatement(sql)
     }

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -35,6 +35,7 @@ import io.smartdatalake.workflow.connection.SnowflakeConnection
 import io.smartdatalake.workflow.dataframe.snowflake.{SnowparkDataFrame, SnowparkSchema, SnowparkSubFeed}
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSchema, SparkSubFeed}
 import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchema}
+import io.smartdatalake.workflow.dataobject.SnowflakeTableDataObject.{convertColNamesLowercase, snowparkCastIntegralTypesToDecimal, sparkCastIntegralTypesToDecimal}
 import io.smartdatalake.workflow.dataobject.expectation.Expectation
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 import net.snowflake.spark.snowflake.Utils
@@ -49,6 +50,17 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * Can be used both for interacting with Snowflake through Spark with JDBC,
  * as well as for actions written in the Snowpark API that run directly on Snowflake
  *
+ * Note 1: Snowflake does not support partitioning.
+ * But SDLB emulates partitions through the `virtualPartitions` attribute.
+ *
+ * Note 2: Snowflake is tricky with Datatypes.
+ * As Integral types like Long, Int, Short don't exist in Snowflake, they all become a Decimal(38,0) by default.
+ * SDLB improves the default by automatically converting Integral types to Decimals with accurate precision on write, e.g. Int => Decimal(10,0).
+ * For adapting types on read, use the `readTransformer` attribute.
+ *
+ * Note 3: case-insensitive column names are all uppercase in Snowflake tables. This is opposite from Spark when Spark is in case-insensitive mode (see also `Environment.caseSensitive`)
+ * If `Environment.caseSensitive=false` then SDLB converts all case-insensitive column names to lowercase when reading from Snowflake with Spark Connector.
+ *
  * @param id           unique name of this data object
  * @param table        Snowflake table to be written by this output
  * @param constraints  List of row-level [[Constraint]]s to enforce when writing to this data object.
@@ -60,7 +72,7 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param saveMode     spark [[SDLSaveMode]] to use when writing files, default is "overwrite"
  * @param connectionId The SnowflakeTableConnection to use for the table
  * @param virtualPartitions Virtual partition columns. Note that Snowflake has no partition concept, and SDLB is emulating partitions on its own.
- * @param readTransformer   An optional transformer that is applied on read. This is often used to adapt Snowflake decimal datatype to more accurate IntegralTypes like Long, Integer, Byte.
+ * @param readTransformer   An optional transformer that is applied on read. This is often used to adapt Snowflakes Decimal datatype to more accurate IntegralTypes like Long, Integer, Byte.
  * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
  *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
  *                                    Default is to expect all partitions to exist.
@@ -120,19 +132,23 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
       .options(instanceSparkOptions)
       .options(queryOrTable)
       .load()
-    applyReadTransformer(partitionValues, SparkDataFrame(df))
+    // convert case-insensitive column names to lowercase
+    val dfLower = if (!Environment.caseSensitive) convertColNamesLowercase(SparkDataFrame(df)) else SparkDataFrame(df)
+    applyReadTransformer(partitionValues, dfLower)
       .asInstanceOf[SparkDataFrame].inner
   }
 
   // Write a Spark DataFrame to the Snowflake table
   override def writeSparkDataFrame(df: spark.DataFrame, partitionValues: Seq[PartitionValues], isRecursiveInput: Boolean, saveModeOptions: Option[SaveModeOptions])
                                   (implicit context: ActionPipelineContext): MetricsMap = {
-    assert(partitionValues.isEmpty, s"($id) SnowflakeTableDataObject can not handle partitions for now")
     validateSchemaMin(SparkSchema(df.schema), role = "write")
     var finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
 
     // TODO: merge mode not yet implemented
     assert(finalSaveMode != SDLSaveMode.Merge, "($id) SaveMode.Merge not implemented for writeSparkDataFrame")
+
+    // convert IntegralTypes to Decimal (Snowflake does not support IntegralTypes)
+    val dfPrep = sparkCastIntegralTypesToDecimal(df)
 
     // Handle overwrite partitions: delete partitions data and then append data
     if (partitionValues.nonEmpty && finalSaveMode == SDLSaveMode.Overwrite) {
@@ -141,7 +157,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
     }
 
     val metrics = SparkStageMetricsListener.execWithMetrics(this.id,
-      df.write
+      dfPrep.write
         .format(SNOWFLAKE_SOURCE_NAME)
         .options(connection.getJdbcAuthOptions(table.db.get))
         .options(instanceSparkOptions)
@@ -207,7 +223,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
       existing
     }
   }
-  // cache response to avoid jdbc query.
+  // cache response to avoid schema query.
   private var cachedExistingSchema: Option[GenericSchema] = None
   private def getExistingSchema(implicit context: ActionPipelineContext): Option[GenericSchema] = {
     if (isTableExisting && cachedExistingSchema.isEmpty) {
@@ -245,10 +261,14 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
    */
   def writeSnowparkDataFrame(df: snowpark.DataFrame, partitionValues: Seq[PartitionValues], isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
                             (implicit context: ActionPipelineContext): MetricsMap = {
+    validateSchemaMin(SnowparkSchema(df.schema), role = "write")
     var finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
 
     // TODO: merge mode not yet implemented
     assert(finalSaveMode != SDLSaveMode.Merge, "($id) SaveMode.Merge not implemented for writeSparkDataFrame")
+
+    // convert IntegralTypes to Decimal (Snowflake does not support IntegralTypes)
+    val dfPrep = snowparkCastIntegralTypesToDecimal(df)
 
     // Handle overwrite partitions: delete partitions data and then append data
     if (partitionValues.nonEmpty && finalSaveMode == SDLSaveMode.Overwrite && isTableExisting) {
@@ -257,7 +277,7 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
     }
 
     // use asynchronous writer to get query id
-    val asyncWriter = df.write.mode(SnowparkSaveMode.from(finalSaveMode)).async.saveAsTable(table.fullName)
+    val asyncWriter = dfPrep.write.mode(SnowparkSaveMode.from(finalSaveMode)).async.saveAsTable(table.fullName)
     asyncWriter.getResult()
 
     // retrieve metrics from result scan
@@ -315,6 +335,47 @@ object SnowflakeTableDataObject extends FromConfigFactory[DataObject] {
   override def fromConfig(config: Config)
                          (implicit instanceRegistry: InstanceRegistry): SnowflakeTableDataObject = {
     extract[SnowflakeTableDataObject](config)
+  }
+
+  def convertColNamesLowercase(df: GenericDataFrame): GenericDataFrame = {
+    val functions = DataFrameSubFeed.getFunctions(df.subFeedType)
+    import functions._
+    val targetCols = df.schema.columns.map { n =>
+      // if name is all uppercase, SDLB assumes it is not case sensitive and will convert it to lowercase.
+      if (n.matches("[A-Z0-9_]+")) col(n.toLowerCase)
+      else col(n)
+    }
+    df.select(targetCols)
+  }
+
+  def sparkCastIntegralTypesToDecimal(df: spark.DataFrame): spark.DataFrame = {
+    val targetCols = df.schema.fields.map { f =>
+      val targetType = f.dataType match {
+        case spark.types.ByteType => spark.types.DecimalType(3,0)
+        case spark.types.ShortType => spark.types.DecimalType(5,0)
+        case spark.types.IntegerType => spark.types.DecimalType(10,0)
+        case spark.types.LongType => spark.types.DecimalType(19,0)
+        case _ => f.dataType
+      }
+      if (f.dataType != targetType) spark.functions.col(f.name).cast(targetType)
+      else spark.functions.col(f.name)
+    }
+    df.select(targetCols:_*)
+  }
+
+  def snowparkCastIntegralTypesToDecimal(df: snowpark.DataFrame): snowpark.DataFrame = {
+    val targetCols = df.schema.fields.map { f =>
+      val targetType = f.dataType match {
+        case snowpark.types.ByteType => snowpark.types.DecimalType(3,0)
+        case snowpark.types.ShortType => snowpark.types.DecimalType(5,0)
+        case snowpark.types.IntegerType => snowpark.types.DecimalType(10,0)
+        case snowpark.types.LongType => snowpark.types.DecimalType(19,0)
+        case _ => f.dataType
+      }
+      if (f.dataType != targetType) snowpark.functions.col(f.name).cast(targetType).as(f.name)
+      else snowpark.functions.col(f.name)
+    }
+    df.select(targetCols)
   }
 }
 


### PR DESCRIPTION
See #595
- make column names lowercase on read with Spark Connector (if Spark is in case-insensitiv mode, which is the default)
- convert IntegralTypes to Decimal on write with Spark Connector
- implement SnowflakeTableDataObject.readTransformer configuration
