### PR TITLE
make SparkSmartDataLakeBuilder master/deploy-mode optionally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,7 @@
                         <archive>
                             <manifest>
                                 <addClasspath>true</addClasspath>
-                                <mainClass>io.smartdatalake.app.LocalSmartDataLakeBuilder</mainClass>
+                                <mainClass>io.smartdatalake.app.SparkSmartDataLakeBuilder</mainClass>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             </manifest>
                         </archive>
@@ -732,7 +732,7 @@
                                 <transformers>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <manifestEntries>
-                                            <Main-Class>io.smartdatalake.app.LocalSmartDataLakeBuilder</Main-Class>
+                                            <Main-Class>io.smartdatalake.app.SparkSmartDataLakeBuilder</Main-Class>
                                             <Implementation-Version>${project.version}</Implementation-Version>
                                             <Multi-Release>true</Multi-Release>
                                         </manifestEntries>

--- a/sdl-core/src/main/scala/io/smartdatalake/app/AppUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/AppUtil.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.app
 
 import io.smartdatalake.config.ConfigurationException
 import io.smartdatalake.definitions.Environment
-import io.smartdatalake.util.misc.{EnvironmentUtil, GraphUtil, SmartDataLakeLogger}
+import io.smartdatalake.util.misc.{GraphUtil, SmartDataLakeLogger}
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.util.spark.SDLSparkExtension
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -54,7 +54,7 @@ object AppUtil extends SmartDataLakeLogger {
                          sparkOptionsOpt: Map[String,StringOrSecret] = Map(),
                          enableHive: Boolean = true
                         ): SparkSession = {
-    logger.info(s"Creating spark session. Note that None means that the Defaults of the Spark Environment apply." +
+    logger.info(s"Creating spark session. Note that None means that the Defaults of the Spark Environment apply: " +
       s"name=$name master=$masterOpt deployMode=$deployModeOpt enableHive=$enableHive kryoClassNamesOpt=$kryoClassNamesOpt sparkOptionsOpt=$sparkOptionsOpt")
 
     // prepare extensions

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SparkSmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SparkSmartDataLakeBuilder.scala
@@ -24,8 +24,8 @@ import scopt.OParser
 /**
  * Smart Data Lake Builder application for running SDL with Spark.
  * Allows to explicitly override master and deploy-mode settings of Spark using the command-line.
- * This entrypoint should be used when there is no existing Spark-Settings on the environment where SDLB is running,
- * for example for running SDLB locally on your laptop with Spark.
+ * This entrypoint should be used when there is no existing Spark-Session running on the environment where SDLB is started,
+ * for example for starting SDLB locally on your laptop with Spark.
  */
 object SparkSmartDataLakeBuilder extends SmartDataLakeBuilder {
 
@@ -36,12 +36,10 @@ object SparkSmartDataLakeBuilder extends SmartDataLakeBuilder {
       parserGeneric(),
       opt[String]('m', "master")
         .action((arg, config) => config.copy(master = Some(arg)))
-        .text("The Spark master URL passed to SparkContext (default=local[*], yarn, spark://HOST:PORT, mesos://HOST:PORT, k8s://HOST:PORT).")
-      .required(),
+        .text("The Spark master URL passed to SparkContext (default=local[*], yarn, spark://HOST:PORT, mesos://HOST:PORT, k8s://HOST:PORT)."),
       opt[String]('x', "deploy-mode")
         .action((arg, config) => config.copy(deployMode = Some(arg)))
         .text("The Spark deploy mode passed to SparkContext (default=client, cluster).")
-        .required()
     )
   }
 


### PR DESCRIPTION
### What changes are included in the pull request?
make SparkSmartDataLakeBuilder arguments master and deploy-mode optionally

### Why are the changes needed?
Make behaviour backward compatible.
