### PR TITLE
Cmd Line: add default value master=local[*]

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/app/AppUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/AppUtil.scala
@@ -26,9 +26,9 @@ import io.smartdatalake.util.spark.SDLSparkExtension
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.{Action, SDLExecutionId}
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.spark.SparkEnv
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
 import org.apache.spark.util.ChildFirstURLClassLoader
+import org.apache.spark.{SparkEnv, SparkException}
 import org.slf4j.MDC
 
 import java.net.{InetAddress, URL, URLClassLoader}
@@ -54,8 +54,8 @@ object AppUtil extends SmartDataLakeLogger {
                          sparkOptionsOpt: Map[String,StringOrSecret] = Map(),
                          enableHive: Boolean = true
                         ): SparkSession = {
-    logger.info(s"Creating spark session. Note that None means that the Defaults of the Spark Environment apply: " +
-      s"name=$name master=$masterOpt deployMode=$deployModeOpt enableHive=$enableHive kryoClassNamesOpt=$kryoClassNamesOpt sparkOptionsOpt=$sparkOptionsOpt")
+    if (masterOpt.isDefined) logger.info(s"Get or create spark session with parameters: name=$name master=$masterOpt deployMode=$deployModeOpt enableHive=$enableHive kryoClassNamesOpt=$kryoClassNamesOpt sparkOptionsOpt=$sparkOptionsOpt")
+    else logger.info(s"Trying to get spark session from environment (master=None)")
 
     // prepare extensions
     val noDataExtension = if (Environment.enableSparkPlanNoDataCheck) Some(new SDLSparkExtension) else None
@@ -74,7 +74,14 @@ object AppUtil extends SmartDataLakeLogger {
       .optionalExtension(noDataExtension)
 
     // create session
-    val session = sessionBuilder.getOrCreate()
+    val session = try {
+      sessionBuilder.getOrCreate()
+    } catch {
+      case e: SparkException if masterOpt.isEmpty && e.getMessage.startsWith("A master URL must be set in your configuration") =>
+        throw new IllegalArgumentException(s"This is not an environment with an existing Spark Session. Use SparkSmartDataLakeBuilder instead of e.g. DefaultSmartDataLakeBuilder to configure and create a new Spark session and '--master' and '--deploy-mode' parameter to customize the Spark session.")
+    }
+
+    // check partitionOverwriteMode
     if (!Try(session.conf.get("spark.sql.sources.partitionOverwriteMode")).toOption.contains("dynamic"))
       logger.warn("Spark property 'spark.sql.sources.partitionOverwriteMode' is not set to 'dynamic'. Overwriting Hadoop/Hive partitions will always overwrite the whole path/table and you might experience data loss!")
 

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SparkSmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SparkSmartDataLakeBuilder.scala
@@ -59,8 +59,11 @@ object SparkSmartDataLakeBuilder extends SmartDataLakeBuilder {
         require(!EnvironmentUtil.isWindowsOS || System.getenv("HADOOP_HOME") != null, "Env variable HADOOP_HOME needs to be set in local mode in Windows!")
         require(!config.master.contains("yarn") || System.getenv("SPARK_HOME") != null, "Env variable SPARK_HOME needs to be set in local mode with master=yarn!")
 
+        // set master default value
+        val updatedConfig = config.copy(master = config.master.orElse(Some("local[*]")))
+
         // run
-        val stats = run(config)
+        val stats = run(updatedConfig)
         logStats(stats)
 
       case None =>


### PR DESCRIPTION
### What changes are included in the pull request and why?

Add default value master=local[*] to SparkSmartDataLakeBuilder in order to be backward compatible. (#618)

Improve error message if Spark Session doesnt exist in environment for other SmartDataLakeBuilder apps, e.g. DefaultSmartDataLakeBuilder. The new error message will guide the user to use SparkSmartDataLakeBuilder in this case.