### PR TITLE
Bump some library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <scala.minor.version>2.12</scala.minor.version>
         <scala.version>${scala.minor.version}.15</scala.version>
 
-        <spark.version>3.5.2</spark.version>
+        <spark.version>3.5.4</spark.version>
         <spark-extensions.version>3.5.2
         </spark-extensions.version> <!-- this sdl-specific extensions should match the minor version of property spark.version -->
         <spark.minor.version>3.5</spark.minor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -442,21 +442,21 @@
         <!-- SPARK-PARENT finished -->
 
         <!-- other dependency versions -->
-        <scopt.version>4.0.1</scopt.version>
+        <scopt.version>4.1.0</scopt.version>
         <databricks.spark-xml.version>0.18.0</databricks.spark-xml.version>
         <spark.excel.version>${spark.version331}_0.18.6-beta1</spark.excel.version>
         <hsqldb.version>2.7.2</hsqldb.version>
         <jackcess.version>4.0.5</jackcess.version>
         <!-- when changing config version, remember to update it in DatabricksSmartDataLakeBuilder main method -->
-        <typesafe.config.version>1.4.1</typesafe.config.version>
+        <typesafe.config.version>1.4.3</typesafe.config.version>
         <kxbmap.configs.version>0.6.1</kxbmap.configs.version>
-        <monix.version>3.4.0</monix.version>
+        <monix.version>3.4.1</monix.version>
         <splunk.version>1.6.5.0</splunk.version>
         <sshj.version>0.35.0</sshj.version>
         <snowflake-spark.version>3.1.1</snowflake-spark.version>
         <snowflake-snowpark.version>1.15.0</snowflake-snowpark.version>
-        <delta.version>3.2.0</delta.version>
-        <iceberg.version>1.6.1</iceberg.version>
+        <delta.version>3.3.0</delta.version>
+        <iceberg.version>1.7.1</iceberg.version>
 
         <json4s.version>3.7.0-M11</json4s.version>
 

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -35,6 +35,7 @@ import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.action.{Action, DataFrameActionImpl, RuntimeInfo, SDLExecutionId}
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.SparkSession
 import scopt.{OParser, OParserBuilder}
 
 import java.time.{Duration, LocalDateTime}

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -18,7 +18,6 @@
  */
 package io.smartdatalake.app
 
-import com.typesafe.config.Config
 import io.smartdatalake.app
 import io.smartdatalake.communication.statusinfo.StatusInfoServer
 import io.smartdatalake.communication.statusinfo.api.SnapshotStatusInfoListener
@@ -300,7 +299,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
           val latestRunState = stateStore.recoverRunState(latestStateId)
           if (!latestRunState.isFinal || latestRunState.isFailed) {
             // start recovery
-            assert(appConfig == latestRunState.appConfig, s"There is a failed run to be recovered. Either you clean-up this state fail or the command line parameters given must match the parameters of the run to be recovered: ConfigToRecover=${latestRunState.appConfig} ConfigGiven=${appConfig}")
+            assert(appConfig == latestRunState.appConfig, s"There is a failed run to be recovered. Either you clean-up this state file or the command line parameters given must match the parameters of the run to be recovered: ConfigToRecover=${latestRunState.appConfig} ConfigGiven=${appConfig}")
             recoverRun(appConfig, stateStore, latestRunState)._2
           } else {
             val nextExecutionId = SDLExecutionId(latestRunState.runId + 1)

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.app
 
+import com.typesafe.config.Config
 import io.smartdatalake.app
 import io.smartdatalake.communication.statusinfo.StatusInfoServer
 import io.smartdatalake.communication.statusinfo.api.SnapshotStatusInfoListener
@@ -34,7 +35,6 @@ import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
 import io.smartdatalake.workflow.action.{Action, DataFrameActionImpl, RuntimeInfo, SDLExecutionId}
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.sql.SparkSession
 import scopt.{OParser, OParserBuilder}
 
 import java.time.{Duration, LocalDateTime}


### PR DESCRIPTION
Update Spark version 3.5.2 -> 3.5.4
Minor/patch version bumps of deltalake, iceberg, scopt, monix and typesafe.config libraries