### PR TITLE
HadoopFileDataObject: use listFiles instead of globFiles

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -21,11 +21,12 @@ package io.smartdatalake.workflow.dataobject
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.definitions.{Environment, SDLSaveMode, TableStatsType}
+import io.smartdatalake.util.hdfs.HdfsUtil.RemoteIteratorWrapper
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionLayout, PartitionValues}
 import io.smartdatalake.util.misc.{AclDef, AclUtil, SmartDataLakeLogger}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.connection.HadoopFileConnection
-import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, FileSystem, Path}
+import org.apache.hadoop.fs._
 
 import java.io.{FileNotFoundException, InputStream, OutputStream}
 import scala.util.{Failure, Success, Try}
@@ -81,16 +82,32 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
    * Check if the input files exist.
    * Note that hadoopDir can be a specific file or a directory.
    */
-  private[smartdatalake] def checkFilesExisting(implicit context: ActionPipelineContext): Boolean = {
+  def checkFilesExisting(implicit context: ActionPipelineContext): Boolean = {
     val status = try {
       filesystem.getFileStatus(hadoopPath)
     } catch {
       case _: FileNotFoundException => return false
     }
-    status.isFile || {
-      val globPath = if (partitions.nonEmpty) new Path(hadoopPath, PartitionValues(Map()).getPartitionString(partitionLayout().get)) else hadoopPath
-      status.isDirectory && filesystem.globStatus(new Path(globPath, fileName)).exists(_.isFile)
-    }
+    status.isFile || (status.isDirectory && listDataFiles().nonEmpty)
+  }
+
+  def listDataFiles(pv: PartitionValues = PartitionValues(Map()))(implicit context: ActionPipelineContext): Iterator[Path] = {
+    val pathPattern = if (partitions.nonEmpty) new GlobPattern(new Path(new Path(hadoopPath, pv.getPartitionString(partitionLayout().get)), fileName).toString)
+    else new GlobPattern(new Path(hadoopPath, fileName).toString)
+    RemoteIteratorWrapper(filesystem.listFiles(hadoopPath, partitions.nonEmpty /*recursive*/))
+      .filter(_.isFile)
+      .map(_.getPath)
+      .filter(p => pathPattern.matches(p.toString))
+  }
+
+  def listPartitionPathsStatus(pv: PartitionValues = PartitionValues(Map()), partitionLayoutParam: String = partitionLayout().get)(implicit context: ActionPipelineContext): Seq[FileStatus] = {
+    assert(partitions.nonEmpty)
+    val pathPattern = new Path(hadoopPath, pv.getPartitionString(partitionLayoutParam))
+    filesystem.globStatus(pathPattern).filter(_.isDirectory)
+  }
+
+  def listPartitionPaths(pv: PartitionValues = PartitionValues(Map()), partitionLayoutParam: String = partitionLayout().get)(implicit context: ActionPipelineContext): Seq[Path] = {
+    listPartitionPathsStatus(pv, partitionLayoutParam).map(_.getPath)
   }
 
   override def deleteFile(file: String)(implicit context: ActionPipelineContext): Unit = {
@@ -154,11 +171,9 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     } else {
       // prepare partitions to include in path search
       val partitionsToInclude = partitions.reverse.dropWhile(!pv.keys.contains(_)).reverse // get all partition columns until last given partition value
-      // create path with wildcards
       val partitionLayout = HdfsUtil.getHadoopPartitionLayout(partitionsToInclude)
-      val globPartitionPath = new Path(hadoopPath, pv.getPartitionString(partitionLayout))
       logger.info(s"($id) getConcretePaths with globs needed because ${pv.keys.mkString(",")} is not an init of partition columns ${partitions.mkString(",")}")
-      filesystem.globStatus(globPartitionPath).filter(_.isDirectory).map(_.getPath)
+      listPartitionPaths(pv, partitionLayout).toSeq
     }
   }
 
@@ -171,15 +186,14 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     assert(partitions.nonEmpty)
     // check partitions completely defined -> then we can read all at once, otherwise we need to search with globs as DataFrameReader.load doesnt support wildcards
     if (pv.isComplete(partitions)) {
-      val path = new Path(hadoopPath, pv.getPartitionString(partitionLayout().get))
-      if (returnFiles) filesystem.globStatus(new Path(path, fileName)).filter(_.isFile).map(_.getPath).toSeq
-      else Seq(path)
+      if (returnFiles) listDataFiles(pv).toSeq
+      else Seq(new Path(hadoopPath, pv.getPartitionString(partitionLayout().get)))
     } else {
       // create path with wildcards
       val globPartitionPath = new Path(hadoopPath, pv.getPartitionString(partitionLayout().get))
       logger.info(s"($id) getConcretePaths with globs needed because ${pv.keys.mkString(",")} does not define all partition columns ${partitions.mkString(",")}")
-      if (returnFiles) filesystem.globStatus(new Path(globPartitionPath, fileName)).filter(_.isFile).map(_.getPath)
-      else filesystem.globStatus(globPartitionPath).filter(_.isDirectory).map(_.getPath)
+      if (returnFiles) listDataFiles(pv).toSeq
+      else listPartitionPaths(pv).toSeq
     }
   }
 
@@ -188,19 +202,12 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
    */
   override def listPartitions(implicit context: ActionPipelineContext): Seq[PartitionValues] = {
     getPartitionPathsStatus
-      .map(path => extractPartitionValuesFromDirPath(path.getPath.toString))
+      .map(s => extractPartitionValuesFromDirPath(s.getPath.toString))
   }
 
   def getPartitionPathsStatus(implicit context: ActionPipelineContext): Seq[FileStatus] = {
-    partitionLayout().map {
-      partitionLayout =>
-        // get search pattern for root directory
-        val pattern = PartitionLayout.replaceTokens(partitionLayout, PartitionValues(Map()))
-        // list directories and extract partition values
-        filesystem.globStatus(new Path(hadoopPath, pattern))
-          .filter { fs => fs.isDirectory }
-          .toSeq
-    }.getOrElse(Seq())
+    if (partitions.nonEmpty) listPartitionPathsStatus().toSeq
+    else Seq()
   }
 
   override def relativizePath(path: String)(implicit context: ActionPipelineContext): String = {
@@ -302,14 +309,14 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   }
 
   /**
-   * delete all files inside given path recursively
+   * delete all files inside given path recursively, but keep main directory
    */
   def deleteAllFiles(path: Path)(implicit context: ActionPipelineContext): Unit = {
     logger.info(s"($id) deleteAllFiles $path")
-    val dirEntries = filesystem.globStatus(new Path(path, "*")).map(_.getPath)
-    dirEntries.foreach { p =>
-      if (filesystem.isDirectory(p)) deleteAllFiles(p)
-      else filesystem.delete(p, /*recursive*/ false)
+    val dirEntries = RemoteIteratorWrapper(filesystem.listFiles(path, false))
+    dirEntries.foreach { s =>
+      if (s.isDirectory) filesystem.delete(hadoopPath, /*recursive*/ true)
+      else filesystem.delete(s.getPath, false)
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -94,7 +94,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   def listDataFiles(pv: PartitionValues = PartitionValues(Map()))(implicit context: ActionPipelineContext): Iterator[Path] = {
     val pathPattern = if (partitions.nonEmpty) new GlobPattern(new Path(new Path(hadoopPath, pv.getPartitionString(partitionLayout().get)), fileName).toString)
     else new GlobPattern(new Path(hadoopPath, fileName).toString)
-    RemoteIteratorWrapper(filesystem.listFiles(hadoopPath, partitions.nonEmpty /*recursive*/))
+    RemoteIteratorWrapper(filesystem.listFiles(hadoopPath, partitions.nonEmpty))
       .filter(_.isFile)
       .map(_.getPath)
       .filter(p => pathPattern.matches(p.toString))
@@ -103,7 +103,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   def listPartitionPathsStatus(pv: PartitionValues = PartitionValues(Map()), partitionLayoutParam: String = partitionLayout().get)(implicit context: ActionPipelineContext): Seq[FileStatus] = {
     assert(partitions.nonEmpty)
     val pathPattern = new Path(hadoopPath, pv.getPartitionString(partitionLayoutParam))
-    filesystem.globStatus(pathPattern).filter(_.isDirectory)
+    filesystem.globStatus(pathPattern).filter(_.isDirectory).toSeq
   }
 
   def listPartitionPaths(pv: PartitionValues = PartitionValues(Map()), partitionLayoutParam: String = partitionLayout().get)(implicit context: ActionPipelineContext): Seq[Path] = {
@@ -173,7 +173,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
       val partitionsToInclude = partitions.reverse.dropWhile(!pv.keys.contains(_)).reverse // get all partition columns until last given partition value
       val partitionLayout = HdfsUtil.getHadoopPartitionLayout(partitionsToInclude)
       logger.info(s"($id) getConcretePaths with globs needed because ${pv.keys.mkString(",")} is not an init of partition columns ${partitions.mkString(",")}")
-      listPartitionPaths(pv, partitionLayout).toSeq
+      listPartitionPaths(pv, partitionLayout)
     }
   }
 
@@ -189,11 +189,9 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
       if (returnFiles) listDataFiles(pv).toSeq
       else Seq(new Path(hadoopPath, pv.getPartitionString(partitionLayout().get)))
     } else {
-      // create path with wildcards
-      val globPartitionPath = new Path(hadoopPath, pv.getPartitionString(partitionLayout().get))
       logger.info(s"($id) getConcretePaths with globs needed because ${pv.keys.mkString(",")} does not define all partition columns ${partitions.mkString(",")}")
       if (returnFiles) listDataFiles(pv).toSeq
-      else listPartitionPaths(pv).toSeq
+      else listPartitionPaths(pv)
     }
   }
 
@@ -206,7 +204,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   }
 
   def getPartitionPathsStatus(implicit context: ActionPipelineContext): Seq[FileStatus] = {
-    if (partitions.nonEmpty) listPartitionPathsStatus().toSeq
+    if (partitions.nonEmpty) listPartitionPathsStatus()
     else Seq()
   }
 
@@ -220,7 +218,7 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
     new Path(parent, child).toString
   }
 
-  override def isAbsolutePath(path: String) = {
+  override def isAbsolutePath(path: String): Boolean = {
     new Path(path).isAbsolute
   }
 

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkDataObjectWrapper.scala
@@ -24,8 +24,8 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSubFeed}
 import io.smartdatalake.workflow.dataobject._
-import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, DataFrame}
 
 import java.time.{Instant, LocalDateTime, ZoneId}
 import java.util.TimeZone
@@ -118,7 +118,7 @@ case class LabSparkDataObjectWrapper[T <: DataObject with CanCreateSparkDataFram
   def partitionModDates(timezoneId: ZoneId = TimeZone.getDefault.toZoneId): Seq[(PartitionValues,LocalDateTime)] = dataObject match {
     case o: HadoopFileDataObject with CanHandlePartitions =>
       o.getPartitionPathsStatus(context)
-        .map( s => (o.extractPartitionValuesFromDirPath(s.getPath.toString)(context), LocalDateTime.ofInstant(Instant.ofEpochMilli(s.getModificationTime), timezoneId)))
+        .map(s => (o.extractPartitionValuesFromDirPath(s.getPath.toString)(context), LocalDateTime.ofInstant(Instant.ofEpochMilli(s.getModificationTime), timezoneId)))
     case _ => throw NotSupportedException(dataObject.id, "is not partitioned or has no hadoop directory layout")
   }
   def schema: StructType = dataObject.getSparkDataFrame()(context).schema


### PR DESCRIPTION
Use listFiles instead of globFiles in HadoopFileDataObject.
As listFiles returns an iterator instead of an array as globFiles, it is much more memory efficient. Checking if a directory is empty is much faster.
This avoids driver out of memory exceptions to check if the DataObjects Hadoop directory has data files in environments with many files.

