### PR TITLE
945 sdl iceberg getsparkdataframe partitionvalues

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/hdfs/Partition.scala
@@ -30,36 +30,48 @@ private[smartdatalake] object Partition {
     assert(partitionCol.matches(regexStr), "partition column name $partitionCol doesn't match the regex $regexStr")
   }
 }
+
 /**
  * A partition is defined by values for its partition columns.
  * It can be represented by a Map. The key of the Map are the partition column names.
  */
 case class PartitionValues(elements: Map[String, Any]) {
-  private[smartdatalake] def getPartitionString(partitionLayout: String): String= {
+  private[smartdatalake] def getPartitionString(partitionLayout: String): String = {
     PartitionLayout.replaceTokens(partitionLayout, this)
   }
+
   private[smartdatalake] def getFilterExpr(implicit helper: DataFrameSubFeedCompanion): GenericColumn = {
     import helper._
     // "and" filter concatenation of each element
-    elements.map {case (k,v) => col(k) === lit(v)}.reduce( (a,b) => a and b)
+    elements.map { case (k, v) => col(k) === lit(v) }.reduce((a, b) => a and b)
   }
+
   override def toString: String = {
-    elements.map {case (k,v) => s"$k=$v"}.mkString("/")
+    elements.map { case (k, v) => s"$k=$v" }.mkString("/")
   }
+
   def apply(colName: String): Any = elements(colName)
+
   def get(colName: String): Option[Any] = elements.get(colName)
+
   def isEmpty: Boolean = elements.isEmpty
+
   def nonEmpty: Boolean = elements.nonEmpty
+
   def keys: Set[String] = elements.keySet
+
   def isDefinedAt(colName: String): Boolean = elements.isDefinedAt(colName)
+
   def filterKeys(colNames: Seq[String]): PartitionValues = this.copy(elements = elements.filterKeys(colNames.contains).toMap)
-  def addKey(key: String, value: Any): PartitionValues = if(!elements.contains(key)) this.copy(elements = elements + (key -> value)) else this
-  def getMapString: Map[String,String] = elements.mapValues(_.toString).toMap
+
+  def addKey(key: String, value: Any): PartitionValues = if (!elements.contains(key)) this.copy(elements = elements + (key -> value)) else this
+
+  def getMapString: Map[String, String] = elements.mapValues(_.toString).toMap
 
   /**
    * Returns true if all given partitions are defined in this partition values instance
    */
-  def isComplete(partitions: Seq[String]) = this.keys == partitions.toSet
+  def isComplete(partitions: Seq[String]): Boolean = this.keys == partitions.toSet
 
   /**
    * Returns true if partition defined by this instance are a valid "init" of given partitions
@@ -80,14 +92,15 @@ object PartitionValues {
    * Defines an Ordering for sorting PartitionValues.
    * Sorting a list of partition values is only possible, if the partition columns to be considered are defined.
    * As PartitionValues is a generic structure, the type of a value needs to be inferred for comparision.
+   *
    * @param partitions partition columns to use for sorting
    * @return Ordering to be used e.g. with Seq.sort|sortBy
    */
-  def getOrdering(partitions: Seq[String]): Ordering[PartitionValues] = new Ordering[PartitionValues] {
-    def compare(pv1: PartitionValues, pv2: PartitionValues): Int = {
-      val keys = pv1.keys.intersect(pv2.keys)
-      partitions.filter(keys.contains).map{
-        p => (pv1(p), pv2(p)) match {
+  def getOrdering(partitions: Seq[String]): Ordering[PartitionValues] = (pv1: PartitionValues, pv2: PartitionValues) => {
+    val keys = pv1.keys.intersect(pv2.keys)
+    partitions.filter(keys.contains).map {
+      p =>
+        (pv1(p), pv2(p)) match {
           case (v1: String, v2: String) => v1.compare(v2)
           case (v1: Byte, v2: Byte) => v1.compare(v2)
           case (v1: Short, v2: Short) => v1.compare(v2)
@@ -96,27 +109,28 @@ object PartitionValues {
           case (v1: Char, v2: Char) => v1.compare(v2)
           case _ => 0 // if not an ordered type, we don't use it for sorting
         }
-      }.find(_!=0).getOrElse(0)
-    }
+    }.find(_ != 0).getOrElse(0)
   }
-  def parseSingleColArg(arg: String): Seq[PartitionValues] ={
+
+  def parseSingleColArg(arg: String): Seq[PartitionValues] = {
     val keyValues = arg.split("=")
-    if (keyValues.size!=2) throw new IllegalArgumentException(s"partition values $arg doesn't match format $singleColFormat")
+    if (keyValues.size != 2) throw new IllegalArgumentException(s"partition values $arg doesn't match format $singleColFormat")
     val partitionCol = keyValues(0)
     Partition.validateColName(partitionCol)
     val partitionValues = keyValues(1).split(",").toSeq
-    partitionValues.map( v => PartitionValues(Map(partitionCol->v)))
+    partitionValues.map(v => PartitionValues(Map(partitionCol -> v)))
   }
+
   def parseMultiColArg(arg: String): Seq[PartitionValues] = {
     val entries = arg.split(";")
     entries.toSeq.map { entry =>
       val colValues = entry.split(",")
       val singlePartitionValues = try {
-        colValues.map( v => parseSingleColArg(v).head)
+        colValues.map(v => parseSingleColArg(v).head)
       } catch {
-        case x:IllegalArgumentException => throw new IllegalArgumentException(s"multi partition values $arg doesn't match format $multiColFormat", x)
+        case x: IllegalArgumentException => throw new IllegalArgumentException(s"multi partition values $arg doesn't match format $multiColFormat", x)
       }
-      singlePartitionValues.reduce( (a,b) => PartitionValues(a.elements ++ b.elements))
+      singlePartitionValues.reduce((a, b) => PartitionValues(a.elements ++ b.elements))
     }
   }
 
@@ -137,29 +151,33 @@ object PartitionValues {
   /**
    * Checks if expected partition values are covered by existing partition values
    * challenge: handle multiple partition columns correctly and performant
+   *
    * @return list of missing partition values
    */
   def checkExpectedPartitionValues(existingPartitionValues: Seq[PartitionValues], expectedPartitionValues: Seq[PartitionValues]): Seq[PartitionValues] = {
     val partitionColCombinations = expectedPartitionValues.map(_.keys).distinct
+
     // recursively check every partitionColCombination
     def diffPartitionValues(inputPartitions: Seq[PartitionValues], expectedPartitionValues: Seq[PartitionValues], partitionColCombinations: Seq[Set[String]]): Seq[PartitionValues] = {
       if (partitionColCombinations.isEmpty) return Seq()
       val partitionColCombination = partitionColCombinations.head
-      val (partitionValuesCurrentCombination, partitionValuesOtherCombination) = expectedPartitionValues.partition(_.keys==partitionColCombination)
+      val (partitionValuesCurrentCombination, partitionValuesOtherCombination) = expectedPartitionValues.partition(_.keys == partitionColCombination)
       val missingPartitionValuesCurrentCombination = partitionValuesCurrentCombination.diff(inputPartitions.map(_.filterKeys(partitionColCombination.toSeq)))
       missingPartitionValuesCurrentCombination ++ diffPartitionValues(inputPartitions, partitionValuesOtherCombination, partitionColCombinations.tail)
     }
+
     diffPartitionValues(existingPartitionValues, expectedPartitionValues, partitionColCombinations)
   }
 
   /**
    * Read DataFrame and convert to PartitionValues
+   *
    * @param df DataFrame with partition columns only selected. All columns will be handled as string.
    */
   def fromDataFrame(df: GenericDataFrame): Seq[PartitionValues] = {
     val cols = if (Environment.caseSensitive) df.schema.columns else df.schema.columns.map(_.toLowerCase)
     df.distinct.collect.map {
-      row => PartitionValues(cols.zipWithIndex.map{ case (c,idx) => (c,row.getAs[Any](idx).toString)}.toMap)
+      row => PartitionValues(cols.zipWithIndex.map { case (c, idx) => (c, row.getAs[Any](idx).toString) }.toMap)
     }
   }
 
@@ -171,7 +189,7 @@ object PartitionValues {
     else helper.lit(true)
   }
 
-  def oneToOneMapping(partitionValues: Seq[PartitionValues]): Map[PartitionValues,PartitionValues] = partitionValues.map(x => (x,x)).toMap
+  def oneToOneMapping(partitionValues: Seq[PartitionValues]): Map[PartitionValues, PartitionValues] = partitionValues.map(x => (x, x)).toMap
 
   def sort(partitionCols: Seq[String], partitionValues: Seq[PartitionValues]): Seq[PartitionValues] = {
     val ordering = getOrdering(partitionCols)
@@ -180,8 +198,8 @@ object PartitionValues {
 
   def fromString(str: String): PartitionValues = {
     val elements = str.split('/').map { e =>
-      val Array(k,v) = e.split('=')
-      (k,v)
+      val Array(k, v) = e.split('=')
+      (k, v)
     }.toMap
     PartitionValues(elements)
   }
@@ -205,25 +223,25 @@ object PartitionLayout {
 
   def extractTokens(partitionLayout: String): Seq[String] = {
     tokenRegex.findAllMatchIn(partitionLayout)
-      .map( m => m.group(1)).toSeq
+      .map(m => m.group(1)).toSeq
   }
 
   def extractPartitionValues(partitionLayout: String, path: String): PartitionValues = {
     val tokens = extractTokens(partitionLayout)
     var partitionLayoutPattern = partitionLayout
     // quote regexp characters in partition layout
-    partitionLayoutPattern = raw"[\.\[\]]".r.replaceAllIn(partitionLayoutPattern, quoteMatch => raw"\\" + quoteMatch.group(0))
+    partitionLayoutPattern = raw"[.\[\]]".r.replaceAllIn(partitionLayoutPattern, quoteMatch => raw"\\" + quoteMatch.group(0))
     // replace * to regexp .*
     partitionLayoutPattern = partitionLayoutPattern.replace("*", ".*")
     // replace tokens in partition layout with a defined or default regexp
-    partitionLayoutPattern = tokenRegex.replaceAllIn( partitionLayoutPattern, {
+    partitionLayoutPattern = tokenRegex.replaceAllIn(partitionLayoutPattern, {
       tokenMatch => if (tokenMatch.group(3) != null) s"(${tokenMatch.group(3)})" else "(.*?)"
     })
     // create regex and match with path.
     val partitionLayoutRegex = s"^$partitionLayoutPattern$$".r
     partitionLayoutRegex.findFirstMatchIn(path) match {
       case Some(regexMatch) =>
-        val tokenValues = (1 to regexMatch.groupCount).map( i => regexMatch.group(i))
+        val tokenValues = (1 to regexMatch.groupCount).map(i => regexMatch.group(i))
         val tokenMap = tokens.zip(tokenValues).toMap
         PartitionValues(tokenMap)
       case None => throw new RuntimeException(s"""prepared regexp partition layout "$partitionLayoutRegex" didn't match path "$path"""")

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -37,6 +37,7 @@ import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSchema, S
 import io.smartdatalake.workflow.dataobject.expectation.Expectation
 import io.smartdatalake.workflow.{ActionPipelineContext, ProcessingLogicException}
 import org.apache.hadoop.fs.Path
+import org.apache.iceberg
 import org.apache.iceberg.catalog.{Catalog, Namespace, TableIdentifier}
 import org.apache.iceberg.hadoop.HadoopCatalog
 import org.apache.iceberg.spark.Spark3Util.{CatalogAndIdentifier, identifierToTableIdentifier}
@@ -78,30 +79,30 @@ import scala.util.Try
  * - [[CanEvolveSchema]] by using internal Iceberg API.
  * - Overwriting partitions is implemented by using DataFrameWriterV2.overwrite(condition) API in one transaction.
  *
- * @param path hadoop directory for this table. If it doesn't contain scheme and authority, the connections pathPrefix is applied.
- *             If pathPrefix is not defined or doesn't define scheme and authority, default schema and authority is applied.
- *             If Iceberg table is defined on a hadoop catalog, path must be None as it is defined through the catalog directory structure.
- * @param options Options for Iceberg tables see: [[https://iceberg.apache.org/docs/latest/configuration/]]
- * @param table Iceberg table to be written by this output
- * @param saveMode [[SDLSaveMode]] to use when writing files, default is "overwrite". Overwrite, Append and Merge are supported for now.
- * @param allowSchemaEvolution If set to true schema evolution will automatically occur when writing to this DataObject with different schema, otherwise SDL will stop with error.
+ * @param path                   hadoop directory for this table. If it doesn't contain scheme and authority, the connections pathPrefix is applied.
+ *                               If pathPrefix is not defined or doesn't define scheme and authority, default schema and authority is applied.
+ *                               If Iceberg table is defined on a hadoop catalog, path must be None as it is defined through the catalog directory structure.
+ * @param options                Options for Iceberg tables see: [[https://iceberg.apache.org/docs/latest/configuration/]]
+ * @param table                  Iceberg table to be written by this output
+ * @param saveMode               [[SDLSaveMode]] to use when writing files, default is "overwrite". Overwrite, Append and Merge are supported for now.
+ * @param allowSchemaEvolution   If set to true schema evolution will automatically occur when writing to this DataObject with different schema, otherwise SDL will stop with error.
  * @param historyRetentionPeriod Optional Iceberg retention threshold in hours. Files required by the table for reading versions younger than retentionPeriod will be preserved and the rest of them will be deleted.
- * @param acl override connection permissions for files created tables hadoop directory with this connection
- * @param connectionId optional id of [[io.smartdatalake.workflow.connection.HiveTableConnection]]
- * @param metadata meta data
- * @param preReadSql SQL-statement to be executed in exec phase before reading input table. If the catalog and/or schema are not
- *                   explicitly defined, the ones present in the configured "table" object are used.
- * @param postReadSql SQL-statement to be executed in exec phase after reading input table and before action is finished. If the catalog and/or schema are not
- *                   explicitly defined, the ones present in the configured "table" object are used.
- * @param preWriteSql SQL-statement to be executed in exec phase before writing output table. If the catalog and/or schema are not
- *                   explicitly defined, the ones present in the configured "table" object are used.
- * @param postWriteSql SQL-statement to be executed in exec phase after writing output table. If the catalog and/or schema are not
- *                   explicitly defined, the ones present in the configured "table" object are used.
+ * @param acl                    override connection permissions for files created tables hadoop directory with this connection
+ * @param connectionId           optional id of [[io.smartdatalake.workflow.connection.HiveTableConnection]]
+ * @param metadata               meta data
+ * @param preReadSql             SQL-statement to be executed in exec phase before reading input table. If the catalog and/or schema are not
+ *                               explicitly defined, the ones present in the configured "table" object are used.
+ * @param postReadSql            SQL-statement to be executed in exec phase after reading input table and before action is finished. If the catalog and/or schema are not
+ *                               explicitly defined, the ones present in the configured "table" object are used.
+ * @param preWriteSql            SQL-statement to be executed in exec phase before writing output table. If the catalog and/or schema are not
+ *                               explicitly defined, the ones present in the configured "table" object are used.
+ * @param postWriteSql           SQL-statement to be executed in exec phase after writing output table. If the catalog and/or schema are not
+ *                               explicitly defined, the ones present in the configured "table" object are used.
  */
 case class IcebergTableDataObject(override val id: DataObjectId,
                                   path: Option[String] = None,
                                   override val partitions: Seq[String] = Seq(),
-                                  override val options: Map[String,String] = Map(),
+                                  override val options: Map[String, String] = Map(),
                                   override val schemaMin: Option[GenericSchema] = None,
                                   override var table: Table,
                                   override val constraints: Seq[Constraint] = Seq(),
@@ -152,7 +153,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
         val definedPathNormalized = HiveUtil.normalizePath(getAbsolutePath.toString)
 
         if (definedPathNormalized != hadoopPathNormalized)
-          logger.warn(s"($id) Table ${table.fullName} exists already with different path ${hadoopPathHolder}. New path definition ${getAbsolutePath} is ignored!")
+          logger.warn(s"($id) Table ${table.fullName} exists already with different path $hadoopPathHolder. New path definition $getAbsolutePath is ignored!")
       }
     }
     hadoopPathHolder
@@ -174,9 +175,9 @@ case class IcebergTableDataObject(override val id: DataObjectId,
 
   assert(Seq(SDLSaveMode.Overwrite, SDLSaveMode.Append, SDLSaveMode.Merge).contains(saveMode), s"($id) Only saveMode Overwrite, Append and Merge supported for now.")
 
-  def getMetadataPath(implicit context: ActionPipelineContext) = {
+  def getMetadataPath(implicit context: ActionPipelineContext): Path = {
     options.get("write.metadata.path").map(new Path(_))
-      .getOrElse(new Path(hadoopPath,"metadata"))
+      .getOrElse(new Path(hadoopPath, "metadata"))
   }
 
   @tailrec
@@ -287,18 +288,19 @@ case class IcebergTableDataObject(override val id: DataObjectId,
     getIcebergCatalog.createTable(getTableIdentifier, schema, partitionSpec, hadoopPath.toString, options.asJava)
   }
 
-  override def getSparkDataFrame(partitionValues: Seq[PartitionValues] = Seq())(implicit context: ActionPipelineContext): DataFrame = {
+  override def getSparkDataFrame(partitionValues: Seq[PartitionValues] = Seq.empty)
+                                (implicit context: ActionPipelineContext): DataFrame = {
 
     val df = incrementalOutputExpr match {
       case Some(snapshotId) =>
         require(table.primaryKey.isDefined, s"($id) PrimaryKey for table [${table.fullName}] needs to be defined when using DataObjectStateIncrementalMode")
-        val icebergTable = if(snapshotId == "0") context.sparkSession.table(table.fullName)
-          else {
+        val icebergTable = if (snapshotId == "0") context.sparkSession.table(table.fullName)
+        else {
 
           // activate temporary cdc view
           context.sparkSession.sql(
             s"""CALL ${getIcebergCatalog.name}.system.create_changelog_view(table => '${getIdentifier.toString}'
-               |, options => map('start-snapshot-id', '${snapshotId}')
+               |, options => map('start-snapshot-id', '$snapshotId')
                |, compute_updates => true
                |, identifier_columns => array('${table.primaryKey.get.mkString("','")}')
                |)""".stripMargin)
@@ -424,12 +426,12 @@ case class IcebergTableDataObject(override val id: DataObjectId,
     // add all summary entries except spark application id to metrics
     val icebergMetrics = (summary - "spark.app.id")
       // normalize names lowercase with underscore
-      .map{case(k,v) => (k.replace("-","_"), Try(v.toLong).getOrElse(v))}
+      .map { case (k, v) => (k.replace("-", "_"), Try(v.toLong).getOrElse(v)) }
       // standardize naming
       // Unfortunately this is not possible yet for merge operation, as we only get added/deleted records. Added records contain inserted + updated rows, deleted records probably updated + deleted rows...
-      .map{
+      .map {
         case ("added_records", v) if finalSaveMode != SDLSaveMode.Merge => ("rows_inserted", v)
-        case (k,v) => (k,v)
+        case (k, v) => (k, v)
       }
 
     // vacuum iceberg table
@@ -445,13 +447,13 @@ case class IcebergTableDataObject(override val id: DataObjectId,
   private def writeToTempTable(df: DataFrame)(implicit context: ActionPipelineContext): Unit = {
     implicit val session: SparkSession = context.sparkSession
     // check if temp-table existing
-    if(getIcebergCatalog.tableExists(getTableIdentifier)) {
+    if (getIcebergCatalog.tableExists(getTableIdentifier)) {
       logger.error(s"($id) Temporary table ${tmpTable.fullName} for merge already exists! There might be a potential conflict with another job. It will be replaced.")
     }
     // write to temp-table
     df.write
       .format("iceberg")
-      .option("path", hadoopPath.toString+"_sdltmp")
+      .option("path", hadoopPath.toString + "_sdltmp")
       .saveAsTable(tmpTable.fullName)
   }
 
@@ -472,7 +474,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
 
       // update existing does not work with SQL merge stmt
       val updateExistingStatement = SQLUtil.createUpdateExistingStatement(table, df.columns.toSeq, tmpTable.fullName, saveModeOptions, SQLUtil.sparkQuoteCaseSensitiveColumn(_))
-      updateExistingStatement.foreach{stmt =>
+      updateExistingStatement.foreach { stmt =>
         logger.info(s"($id) executing update existing statement with options: ${ProductUtil.attributesWithValuesForCaseClass(saveModeOptions).map(e => e._1 + "=" + e._2).mkString(" ")}")
         context.sparkSession.sql(stmt)
       }
@@ -488,22 +490,22 @@ case class IcebergTableDataObject(override val id: DataObjectId,
       // note that we pass all target cols instead of new df columns as parameter, but with customized saveModeOptionsExt
       val mergeStmt = SQLUtil.createMergeStatement(table, targetCols, tmpTable.fullName, saveModeOptionsExt, SQLUtil.sparkQuoteCaseSensitiveColumn(_))
       // execute
-      logger.info(s"($id) executing merge statement with options: ${ProductUtil.attributesWithValuesForCaseClass(saveModeOptionsExt).map(e => e._1+"="+e._2).mkString(" ")}")
+      logger.info(s"($id) executing merge statement with options: ${ProductUtil.attributesWithValuesForCaseClass(saveModeOptionsExt).map(e => e._1 + "=" + e._2).mkString(" ")}")
       logger.debug(s"($id) merge statement: $mergeStmt")
       context.sparkSession.sql(mergeStmt)
       // return
       metrics
     } finally {
       // cleanup temp table
-      val tmpTableIdentifier = TableIdentifier.of((getIdentifier.namespace :+ tmpTable.name):_*)
+      val tmpTableIdentifier = TableIdentifier.of(getIdentifier.namespace :+ tmpTable.name: _*)
       getIcebergCatalog.dropTable(tmpTableIdentifier)
     }
   }
 
-  def updateTableProperty(name: String, value: String, default: String)(implicit context: ActionPipelineContext) = {
+  def updateTableProperty(name: String, value: String, default: String)(implicit context: ActionPipelineContext): Unit = {
     val currentValue = getIcebergTable.properties.asScala.getOrElse(name, default)
     if (currentValue != value) {
-      getIcebergTable.updateProperties.set(name, value).commit
+      getIcebergTable.updateProperties().set(name, value).commit()
     }
     logger.info(s"($id) updated Iceberg table property $name to $value")
   }
@@ -522,7 +524,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
     val newSchema = SparkSchemaUtil.convertWithFreshIds(table.schema, dsSchema, caseSensitive)
 
     // update the table to get final id assignments and validate the changes
-    val update = table.updateSchema.caseSensitive(caseSensitive).unionByNameWith(newSchema)
+    val update = table.updateSchema().caseSensitive(caseSensitive).unionByNameWith(newSchema)
     val mergedSchema = update.apply
 
     // reconvert the dsSchema without assignment to use the ids assigned by UpdateSchema
@@ -549,30 +551,36 @@ case class IcebergTableDataObject(override val id: DataObjectId,
   def getIcebergCatalog(implicit context: ActionPipelineContext): Catalog = {
     getSparkCatalog.icebergCatalog
   }
+
   def getSparkCatalog(implicit context: ActionPipelineContext): TableCatalog with SupportsNamespaces with HasIcebergCatalog = {
     getCatalogAndIdentifier.catalog match {
       case c: TableCatalog with HasIcebergCatalog with SupportsNamespaces => c
       case c => throw new IllegalStateException(s"($id) ${c.name}:${c.getClass.getSimpleName} is not a TableCatalog with SupportsNamespaces with HasIcebergCatalog implementation")
     }
   }
+
   def getIdentifier(implicit context: ActionPipelineContext): Identifier = {
     getCatalogAndIdentifier.identifier
   }
+
   def getTableIdentifier(implicit context: ActionPipelineContext): TableIdentifier = {
     convertToTableIdentifier(getIdentifier)
   }
+
   def convertToTableIdentifier(identifier: Identifier): TableIdentifier = {
-    TableIdentifier.of(Namespace.of(identifier.namespace:_*), identifier.name)
+    TableIdentifier.of(Namespace.of(identifier.namespace: _*), identifier.name)
   }
+
   private def getCatalogAndIdentifier(implicit context: ActionPipelineContext): CatalogAndIdentifier = {
     if (_catalogAndIdentifier.isEmpty) {
       _catalogAndIdentifier = Some(Spark3Util.catalogAndIdentifier(context.sparkSession, table.nameParts.asJava))
     }
     _catalogAndIdentifier.get
   }
+
   private var _catalogAndIdentifier: Option[CatalogAndIdentifier] = None
 
-  def getIcebergTable(implicit context: ActionPipelineContext) = {
+  def getIcebergTable(implicit context: ActionPipelineContext): iceberg.Table = {
     // Note: loadTable is cached by default in Iceberg catalog
     getIcebergCatalog.loadTable(identifierToTableIdentifier(getIdentifier))
   }
@@ -640,7 +648,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
 
   override def dropTable(implicit context: ActionPipelineContext): Unit = {
     getIcebergCatalog.dropTable(getTableIdentifier, true) // purge
-    HdfsUtil.deletePath(hadoopPath, false)(filesystem)
+    HdfsUtil.deletePath(hadoopPath, doWarn = false)(filesystem)
   }
 
   override def getStats(update: Boolean = false)(implicit context: ActionPipelineContext): Map[String, Any] = {
@@ -662,7 +670,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
     }
   }
 
-  override def getColumnStats(update: Boolean, lastModifiedAt: Option[Long])(implicit context: ActionPipelineContext): Map[String, Map[String,Any]] = {
+  override def getColumnStats(update: Boolean, lastModifiedAt: Option[Long])(implicit context: ActionPipelineContext): Map[String, Map[String, Any]] = {
     try {
       val session = context.sparkSession
       import session.implicits._
@@ -701,7 +709,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
     incrementalOutputExpr = state.orElse(Some("0"))
   }
 
-   /**
+  /**
    * Return the state of the last increment or empty if no increment was processed.
    */
   override def getState: Option[String] = {

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -33,7 +33,7 @@ import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.connection.IcebergTableConnection
 import io.smartdatalake.workflow.dataframe.GenericSchema
-import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSchema, SparkSubFeed}
+import io.smartdatalake.workflow.dataframe.spark.{SparkColumn, SparkDataFrame, SparkSchema, SparkSubFeed}
 import io.smartdatalake.workflow.dataobject.expectation.Expectation
 import io.smartdatalake.workflow.{ActionPipelineContext, ProcessingLogicException}
 import org.apache.hadoop.fs.Path
@@ -290,7 +290,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
 
   override def getSparkDataFrame(partitionValues: Seq[PartitionValues] = Seq.empty)
                                 (implicit context: ActionPipelineContext): DataFrame = {
-
+    implicit val helper: SparkSubFeed.type = SparkSubFeed
     val df = incrementalOutputExpr match {
       case Some(snapshotId) =>
         require(table.primaryKey.isDefined, s"($id) PrimaryKey for table [${table.fullName}] needs to be defined when using DataObjectStateIncrementalMode")
@@ -324,10 +324,16 @@ case class IcebergTableDataObject(override val id: DataObjectId,
     validateSchemaMin(SparkSchema(df.schema), "read")
     validateSchemaHasPartitionCols(df, "read")
 
-    df
+    if (partitionValues.isEmpty) df else {
+      val partitionFilter = partitionValues.map(_.getFilterExpr).reduce(_ or _).asInstanceOf[SparkColumn]
+      df.where(partitionFilter.inner)
+    }
   }
 
-  override def initSparkDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues], saveModeOptions: Option[SaveModeOptions] = None)(implicit context: ActionPipelineContext): Unit = {
+  override def initSparkDataFrame(df: DataFrame,
+                                  partitionValues: Seq[PartitionValues],
+                                  saveModeOptions: Option[SaveModeOptions] = None)
+                                 (implicit context: ActionPipelineContext): Unit = {
     val genericDf = SparkDataFrame(df)
     val targetDf = saveModeOptions.map(_.convertToTargetSchema(genericDf)).getOrElse(genericDf).inner
     val targetSchema = targetDf.schema
@@ -352,10 +358,12 @@ case class IcebergTableDataObject(override val id: DataObjectId,
   /**
    * Writes DataFrame to HDFS/Parquet and creates Iceberg table.
    */
-  override def writeSparkDataFrame(df: DataFrame, partitionValues: Seq[PartitionValues] = Seq(), isRecursiveInput: Boolean = false, saveModeOptions: Option[SaveModeOptions] = None)
+  override def writeSparkDataFrame(df: DataFrame,
+                                   partitionValues: Seq[PartitionValues] = Seq(),
+                                   isRecursiveInput: Boolean = false,
+                                   saveModeOptions: Option[SaveModeOptions] = None)
                                   (implicit context: ActionPipelineContext): MetricsMap = {
     implicit val session: SparkSession = context.sparkSession
-    implicit val helper: SparkSubFeed.type = SparkSubFeed
 
     val genericDf = SparkDataFrame(df)
     val targetDf = saveModeOptions.map(_.convertToTargetSchema(genericDf)).getOrElse(genericDf).inner

--- a/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
+++ b/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
@@ -36,14 +36,16 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
+import java.nio.file
 import java.nio.file.Files
 
 class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
-  protected implicit val session : SparkSession = IcebergTestUtils.session
+  protected implicit val session: SparkSession = IcebergTestUtils.session
+
   import session.implicits._
 
-  val tempDir = Files.createTempDirectory("tempHadoopDO")
+  val tempDir: file.Path = Files.createTempDirectory("tempHadoopDO")
   val tempPath: String = tempDir.toAbsolutePath.toString
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
@@ -57,10 +59,10 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   test("Write data") {
 
     // setup DataObjects
-    val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
+    val sourceDO = CustomDfDataObject(id = "source", creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "custom_df_copy", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable)
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
     targetDO.prepare
@@ -73,7 +75,7 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
     val expected = sourceDO.getSparkDataFrame()
     val actual = targetDO.getSparkDataFrame()
     val resultat = expected.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable",Seq())(actual)(expected)
+    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable", Seq())(actual)(expected)
     assert(resultat)
 
     // check statistics
@@ -86,10 +88,10 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   test("Write data partitioned") {
 
     // setup DataObjects
-    val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
+    val sourceDO = CustomDfDataObject(id = "source", creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "custom_df_copy_partitioned", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", partitions=Seq("num"), path=Some(targetTablePath), table=targetTable)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", partitions = Seq("num"), path = Some(targetTablePath), table = targetTable)
     targetDO.dropTable
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
@@ -102,172 +104,172 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
     val expected = sourceDO.getSparkDataFrame()
     val actual = targetDO.getSparkDataFrame()
     val resultat: Boolean = expected.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable_partitioned",Seq())(actual)(expected)
+    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable_partitioned", Seq())(actual)(expected)
     assert(resultat)
     assert(targetDO.listPartitions.map(_.elements).toSet == Set(Map("num" -> "0"), Map("num" -> "1")))
   }
 
   test("SaveMode overwrite with different schema") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_overwrite", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Overwrite, allowSchemaEvolution = true)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Overwrite, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val resultat: Boolean = df1.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(resultat)
 
     // 2nd load: overwrite all with different schema
-    val df2 = Seq(("ext","doe","john",10,"test"),("ext","smith","peter",1,"test"))
+    val df2 = Seq(("ext", "doe", "john", 10, "test"), ("ext", "smith", "peter", 1, "test"))
       .toDF("type", "lastname", "firstname", "rating2", "test")
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
     val resultat2: Boolean = df2.isEqual(actual2)
-    if (!resultat2) TestUtil.printFailedTestResult("SaveMode overwrite",Seq())(actual2)(df2)
+    if (!resultat2) TestUtil.printFailedTestResult("SaveMode overwrite", Seq())(actual2)(df2)
     assert(resultat2)
   }
 
   test("SaveMode append with different schema") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_append", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Append, allowSchemaEvolution = true)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Append, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: append all with different schema
-    val df2 = Seq(("ext","doe","john",10,"test"),("ext","smith","peter",1,"test"))
+    val df2 = Seq(("ext", "doe", "john", 10, "test"), ("ext", "smith", "peter", 1, "test"))
       .toDF("type", "lastname", "firstname", "rating2", "test")
     targetDO.initSparkDataFrame(df2, Seq()) // for applying schema evolution
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame().filter($"lastname" === "doe")
     val result2 = actual2.count() == 2 && (df1.columns ++ df2.columns).toSet == actual2.columns.toSet
-    if (!result2) TestUtil.printFailedTestResult("SaveMode append with different schema",Seq())(actual2)(df2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode append with different schema", Seq())(actual2)(df2)
     assert(result2)
   }
 
   test("SaveMode overwrite and delete partition") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_overwrite", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, partitions = Seq("type")
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, partitions = Seq("type")
       , saveMode = SDLSaveMode.Overwrite, options = Map("partitionOverwriteMode" -> "static")
     )
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
-    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type"->"ext")), PartitionValues(Map("type"->"int"))))
+    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type" -> "ext")), PartitionValues(Map("type" -> "int"))))
 
     // 2nd load: overwrite partition type=ext
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     intercept[ProcessingLogicException](targetDO.writeSparkDataFrame(df2)) // not allowed to overwrite all partitions
-    targetDO.writeSparkDataFrame(df2, partitionValues = Seq(PartitionValues(Map("type"->"ext"))))
-    val expected2 = df2.union(df1.where($"type"=!="ext"))
+    targetDO.writeSparkDataFrame(df2, partitionValues = Seq(PartitionValues(Map("type" -> "ext"))))
+    val expected2 = df2.union(df1.where($"type" =!= "ext"))
     val actual2 = targetDO.getSparkDataFrame()
     val resul2 = expected2.isEqual(actual2)
-    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite and delete partition",Seq())(actual2)(expected2)
+    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite and delete partition", Seq())(actual2)(expected2)
     assert(resul2)
 
     // delete partition
-    targetDO.deletePartitions(Seq(PartitionValues(Map("type"->"int"))))
-    assert(targetDO.listPartitions == Seq(PartitionValues(Map("type"->"ext"))))
+    targetDO.deletePartitions(Seq(PartitionValues(Map("type" -> "int"))))
+    assert(targetDO.listPartitions == Seq(PartitionValues(Map("type" -> "ext"))))
   }
 
   test("SaveMode overwrite partitions dynamically") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_overwrite_dynamic", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, partitions = Seq("type")
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, partitions = Seq("type")
       , saveMode = SDLSaveMode.Overwrite, options = Map("partitionOverwriteMode" -> "dynamic")
     )
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
-    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type"->"ext")), PartitionValues(Map("type"->"int"))))
+    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type" -> "ext")), PartitionValues(Map("type" -> "int"))))
 
     // 2nd load: dynamically overwrite partition type=ext
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2) // allowed overwriting partitions because of partitionOverwriteMode=dynamic
-    val expected2 = df2.union(df1.where($"type"=!="ext"))
+    val expected2 = df2.union(df1.where($"type" =!= "ext"))
     val actual2 = targetDO.getSparkDataFrame()
     val resul2 = expected2.isEqual(actual2)
-    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite partitions dynamically",Seq())(actual2)(expected2)
+    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite partitions dynamically", Seq())(actual2)(expected2)
     assert(resul2)
   }
 
   test("SaveMode append") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_append", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Append)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Append)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: append data
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
     val expected2 = df2.union(df1)
     val resultat2: Boolean = expected2.isEqual(actual2)
-    if (!resultat2) TestUtil.printFailedTestResult("SaveMode append",Seq())(actual2)(expected2)
+    if (!resultat2) TestUtil.printFailedTestResult("SaveMode append", Seq())(actual2)(expected2)
     assert(resultat2)
   }
 
 
   test("throw NoDataToProcessWarning if no new snapshot created (no data)") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_nodata", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
     // Iceberg doesnt create a new snapshot if no data is written with dynamic partition mode
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, partitions = Seq("type"))
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, partitions = Seq("type"))
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: no data -> NoDataToProcessWarning
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     Environment._enableSparkPlanNoDataCheck = Some(false) // disable triggering SparkPlanNoDataWarning, as this test is about another case
     intercept[NoDataToProcessWarning](targetDO.writeSparkDataFrame(df2.where(lit(false))))
@@ -279,57 +281,57 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
 
 
   test("SaveMode merge") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: merge data by primary key
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
-    val expected2 = Seq(("ext","doe","john",10),("ext","smith","peter",3),("int","emma","brown",7))
+    val expected2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     val result2 = expected2.isEqual(actual2)
-    if (!result2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode merge", Seq())(actual2)(expected2)
     assert(result2)
   }
 
 
   test("SaveMode merge with updateCols") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: merge data by primary key
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2, saveModeOptions = Some(SaveModeMergeOptions(updateColumns = Seq("rating"))))
     val actual2 = targetDO.getSparkDataFrame()
-    val expected2 = Seq(("ext","doe","john",10),("ext","smith","peter",3),("int","emma","brown",7))
+    val expected2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     val result2 = expected2.isEqual(actual2)
-    if (!result2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode merge", Seq())(actual2)(expected2)
     assert(result2)
   }
 
@@ -337,32 +339,32 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   // We test for failure to be notified once it is working...
   // Once this works again, also enable 3rd load in IcebergHistorizeWithMergeActionTest and IcebergDeduplicateWithMergeActionTest test cases again
   test("SaveMode merge with schema evolution") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("tpe", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: merge data by primary key with different schema
     // - column 'rating' deleted -> existing records will keep column rating untouched (values are preserved and not set to null), new records will get new column rating set to null.
     // - column 'rating2' added -> existing records will get new column rating2 set to null
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("tpe", "lastname", "firstname", "rating2")
     targetDO.initSparkDataFrame(df2, Seq())
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
-    val expected2 = Seq(("ext","doe","john",Some(5),Some(10)),("ext","smith","peter",Some(3),None),("int","emma","brown",None,Some(7)))
+    val expected2 = Seq(("ext", "doe", "john", Some(5), Some(10)), ("ext", "smith", "peter", Some(3), None), ("int", "emma", "brown", None, Some(7)))
       .toDF("tpe", "lastname", "firstname", "rating", "rating2")
     val result2 = expected2.isEqual(actual2)
-    if (!result2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode merge", Seq())(actual2)(expected2)
     assert(result2)
   }
 
@@ -370,24 +372,24 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   // We test for failure to be notified once it is working...
   // Once this works again, also enable 3rd load in IcebergHistorizeWithMergeActionTest and IcebergDeduplicateWithMergeActionTest test cases again
   test("SaveMode merge with updateCols and schema evolution - fails in deltalake 1.x") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("tpe", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val resultat = df1.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(resultat)
 
     // 2nd load: merge data by primary key with different schema
     // - column 'rating' deleted -> existing records will keep column rating untouched (values are preserved and not set to null), new records will get new column rating set to null.
     // - column 'rating2' added -> existing records will get new column rating2 set to null
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("tpe", "lastname", "firstname", "rating2")
     intercept[AnalysisException](targetDO.writeSparkDataFrame(df2, saveModeOptions = Some(SaveModeMergeOptions(updateColumns = Seq("lastname", "firstname", "rating", "rating2")))))
   }
@@ -395,7 +397,7 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   test("incremental output mode with inserts") {
 
     // create data object
-    val targetTable = Table(catalog =  Some("iceberg1"), db = Some("default"), name = "test_inc", primaryKey = Some(Seq("id")))
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_inc", primaryKey = Some(Seq("id")))
     val targetTablePath = tempPath + s"/${targetTable.fullName}"
     val targetDO = IcebergTableDataObject("icebergDO1", table = targetTable, path = Some(targetTablePath), saveMode = SDLSaveMode.Append)
     targetDO.dropTable


### PR DESCRIPTION
### What changes are included in the pull request?
`getSparkDataFrame` uses parameter `partitionValues` to filter the data

### Why are the changes needed?
When I specify the parameter `partitionValues` then I want data from these partitions only.
Currently `getSparkDataFrame` ignorse that parameter.

### Issue
https://github.com/smart-data-lake/smart-data-lake/issues/945
