### PR TITLE
Fix path filter in `listDataFiles` (#976)

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -92,12 +92,12 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
   }
 
   def listDataFiles(pv: PartitionValues = PartitionValues(Map()))(implicit context: ActionPipelineContext): Iterator[Path] = {
-    val pathPattern = if (partitions.nonEmpty) new GlobPattern(new Path(new Path(hadoopPath, pv.getPartitionString(partitionLayout().get)), fileName).toString)
-    else new GlobPattern(new Path(hadoopPath, fileName).toString)
+    val pathPattern = if (partitions.nonEmpty) new GlobPattern(new Path(pv.getPartitionString(partitionLayout().get), fileName).toString)
+    else new GlobPattern(fileName)
     RemoteIteratorWrapper(filesystem.listFiles(hadoopPath, partitions.nonEmpty))
       .filter(_.isFile)
       .map(_.getPath)
-      .filter(p => pathPattern.matches(p.toString))
+      .filter(p => pathPattern.matches(relativizePath(p.toString)))
   }
 
   def listPartitionPathsStatus(pv: PartitionValues = PartitionValues(Map()), partitionLayoutParam: String = partitionLayout().get)(implicit context: ActionPipelineContext): Seq[FileStatus] = {


### PR DESCRIPTION
### What changes are included in the pull request?
Use the relative path of the file instead of the absolute path as the Regex pattern for filtering only contains the relative path. 

**Note**: The `hadoopPath` has been removed from the Regex pattern as the method `relativizePath` removes this part of the path. Because only files in the `hadoopPath` are listed, this should not be a problem in my opinion.


### Why are the changes needed?
To fix the problem in issue #976.