### PR TITLE
Add indentation handling for Python blocks (#938)

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
@@ -87,8 +87,8 @@ object PythonCodeDfTransformer extends FromConfigFactory[GenericDfTransformer] {
   def dedent(code: String): String = {
     val lines = code.stripMargin.linesIterator.toList
     val nonEmptyLines = lines.filter(line => line.trim.nonEmpty)
-    val commonIndent = if (nonEmptyLines.isEmpty) "" else nonEmptyLines.map(_.takeWhile(c => c == ' ' || c == '\t')).min
-    val dedentedLines = lines.map(_.drop(commonIndent.length))
+    val minIndentLength = if (nonEmptyLines.isEmpty) 0 else nonEmptyLines.map(_.prefixLength(c => c == ' ' || c == '\t')).min
+    val dedentedLines = lines.map(_.drop(minIndentLength))
     dedentedLines.mkString(System.lineSeparator())
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
@@ -87,22 +87,8 @@ object PythonCodeDfTransformer extends FromConfigFactory[GenericDfTransformer] {
   def dedent(code: String): String = {
     val lines = code.stripMargin.linesIterator.toList
     val nonEmptyLines = lines.filter(line => line.trim.nonEmpty)
-    val indents = nonEmptyLines.map(_.takeWhile(c => c == ' ' || c == '\t'))
-    val commonIndent: String = if (indents.isEmpty) {
-      ""
-    } else {
-      val firstIndent = indents.head
-      indents.tail.foldLeft(firstIndent) { (common, next) =>
-        common.zip(next)
-          .takeWhile { case (c1, c2) => c1 == c2 }
-          .map(_._1)
-          .mkString
-      }
-    }
-    val dedentedLines = lines.map { line =>
-      if (line.startsWith(commonIndent)) line.drop(commonIndent.length)
-      else line
-    }
+    val commonIndent = if (nonEmptyLines.isEmpty) "" else nonEmptyLines.map(_.takeWhile(c => c == ' ' || c == '\t')).min
+    val dedentedLines = lines.map(_.drop(commonIndent.length))
     dedentedLines.mkString(System.lineSeparator())
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
@@ -69,7 +69,7 @@ case class PythonCodeDfTransformer(override val name: String = "pythonSparkTrans
           |def setOutputDf( df ):
           |    entryPoint.setOutputDf(df._jdf)
           """.stripMargin
-      PythonUtil.execPythonSparkCode(entryPoint, additionalInitCode + sys.props("line.separator") + pythonCode.stripMargin)
+      PythonUtil.execPythonSparkCode(entryPoint, additionalInitCode + sys.props("line.separator") + PythonCodeDfTransformer.dedent(pythonCode))
       entryPoint.outputDf.getOrElse(throw new IllegalStateException(s"($actionId.transformers.$name) Python transformation must set output DataFrame (call setOutputDf(df))"))
     } catch {
       case e: Throwable => throw new PythonTransformationException(s"($actionId.transformers.$name) Could not execute Python code. Error: ${e.getMessage}", e)
@@ -82,8 +82,30 @@ object PythonCodeDfTransformer extends FromConfigFactory[GenericDfTransformer] {
   override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): PythonCodeDfTransformer = {
     extract[PythonCodeDfTransformer](config)
   }
-}
 
+  /** Dedent multiline strings by removing common leading spaces */
+  def dedent(code: String): String = {
+    val lines = code.stripMargin.linesIterator.toList
+    val nonEmptyLines = lines.filter(line => line.trim.nonEmpty)
+    val indents = nonEmptyLines.map(_.takeWhile(c => c == ' ' || c == '\t'))
+    val commonIndent: String = if (indents.isEmpty) {
+      ""
+    } else {
+      val firstIndent = indents.head
+      indents.tail.foldLeft(firstIndent) { (common, next) =>
+        common.zip(next)
+          .takeWhile { case (c1, c2) => c1 == c2 }
+          .map(_._1)
+          .mkString
+      }
+    }
+    val dedentedLines = lines.map { line =>
+      if (line.startsWith(commonIndent)) line.drop(commonIndent.length)
+      else line
+    }
+    dedentedLines.mkString(System.lineSeparator())
+  }
+}
 
 private[smartdatalake] class DfTransformerPythonSparkEntryPoint(override val session: SparkSession, options: Map[String,String], inputDf: DataFrame, dataObjectId: String, var outputDf: Option[DataFrame] = None) extends PythonSparkEntryPoint(session, options) {
   // it seems that py4j needs getter functions for attributes

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfsTransformer.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.spark.{DefaultExpressionData, PythonSparkEntryPoint, PythonUtil}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.generic.transformer.{GenericDfsTransformer, OptionsSparkDfsTransformer}
+import io.smartdatalake.workflow.action.spark.transformer.PythonCodeDfTransformer.dedent
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
@@ -88,7 +89,7 @@ case class PythonCodeDfsTransformer(
           """.stripMargin
       PythonUtil.execPythonSparkCode(
         entryPoint,
-        additionalInitCode + sys.props("line.separator") + pythonCode.stripMargin
+        additionalInitCode + sys.props("line.separator") + dedent(pythonCode)
       )
       entryPoint.outputDfs.getOrElse(
         throw new IllegalStateException(

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeDfTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeDfTransformerTest.scala
@@ -24,6 +24,10 @@ import org.scalatest.FunSuite
 
 class PythonCodeDfTransformerTest extends FunSuite {
 
+	// To ensure consistent comparisons across different environments, we normalize line endings.
+	def normalizeLineEndings(text: String): String =
+		text.replace("\r\n", "\n")
+
 	test("dedent maintaining relative indentation") {
 		val input = """
 			def foo():
@@ -38,7 +42,7 @@ class PythonCodeDfTransformerTest extends FunSuite {
 			|	if True:
 			|		print("again")
 			|""".stripMargin
-		assert(output == expected)
+		assert(normalizeLineEndings(output) == normalizeLineEndings(expected))
 	}
 
 	test("ignore empty lines") {
@@ -63,7 +67,7 @@ class PythonCodeDfTransformerTest extends FunSuite {
 			|	print("again")
 			|
 			|""".stripMargin
-		assert(output == expected)
+		assert(normalizeLineEndings(output) == normalizeLineEndings(expected))
 	}
 
 	test("handle scala margin indicator") {
@@ -74,7 +78,7 @@ class PythonCodeDfTransformerTest extends FunSuite {
 		val output = dedent(input)
 		val expected = """
 			|print("test")""".stripMargin
-	assert(output == expected)
+		assert(normalizeLineEndings(output) == normalizeLineEndings(expected))
 	}
 }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeDfTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeDfTransformerTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2025 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.workflow.action.spark.transformer
+
+import io.smartdatalake.workflow.action.spark.transformer.PythonCodeDfTransformer.dedent
+import org.scalatest.FunSuite
+
+class PythonCodeDfTransformerTest extends FunSuite {
+
+	test("dedent maintaining relative indentation") {
+		val input = """
+			def foo():
+				print("hi")
+				if True:
+					print("again")
+			"""
+		val output = dedent(input)
+		val expected = """
+			|def foo():
+			|	print("hi")
+			|	if True:
+			|		print("again")
+			|""".stripMargin
+		assert(output == expected)
+	}
+
+	test("ignore empty lines") {
+		val input = """
+
+			def foo():
+
+
+				print("hi")
+
+				print("again")
+
+			"""
+		val output = dedent(input)
+		val expected = """
+			|
+			|def foo():
+			|
+			|
+			|	print("hi")
+			|
+			|	print("again")
+			|
+			|""".stripMargin
+		assert(output == expected)
+	}
+
+	test("handle scala margin indicator") {
+		val input = """
+			|		print("test")
+			|"""
+
+		val output = dedent(input)
+		val expected = """
+			|print("test")""".stripMargin
+	assert(output == expected)
+	}
+}
+


### PR DESCRIPTION
### What changes are included in the pull request?
A function is defined which aims to translate Python's in-built [textwrap.dedent()](https://github.com/python/cpython/blob/main/Lib/textwrap.py) function into Scala. The function allows for indentations in python codeblocks by finding the largest common whitespace, handling both tabs and spaces.

### Why are the changes needed?
Allows for better indented config files.