### PR TITLE
Improve code documentation parsing (#989)

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
@@ -59,30 +59,61 @@ private[smartdatalake] object ScaladocUtil {
     }
   }
 
-  def formatScaladocStringLinkTag(capture_group1: String, capture_group2: String): String = {
+  // Remove leading spaces in code blocks
+  def dedentCodeBlock(code: String): String = {
+    val lines = code.stripMargin.linesIterator.toList
+    val nonEmptyLines = lines.filter(line => line.trim.nonEmpty && ! List("{{{", "}}}").contains(line.trim))
+    val firstLineIndentation = if (nonEmptyLines.isEmpty) (0, 0) else spacesAndTabs(nonEmptyLines.head) // Assume nicely formatted code
+    val dedentedLines = lines.map(removeSpacesAndTabs(_, firstLineIndentation))
+    dedentedLines.mkString("\n")
+  }
+
+  // Leading number of (spaces, tabs)
+  def spacesAndTabs(line: String): (Int, Int) = {
+    line.takeWhile(Seq(' ', '\t').contains(_)).foldLeft((0, 0))((spacesTabs, char) => {
+      if (char == ' ') (spacesTabs._1 + 1, spacesTabs._2) else (spacesTabs._1, spacesTabs._2 + 1)
+    })
+  }
+
+  def removeSpacesAndTabs(line: String, spacesTabs: (Int, Int)): String = {
+    require(spacesTabs._1 >= 0 && spacesTabs._2 >= 0, "Indentation error. The line has either too many spaces or too many tabs")
+    if (line.isEmpty) ""
+    else if (List("{{{","}}}").contains(line.trim)) line.trim
+    else line.head match {
+      case c if ((0, 0) == spacesTabs) => line
+      case ' ' => removeSpacesAndTabs(line.tail, (spacesTabs._1 - 1, spacesTabs._2))
+      case '\t' => removeSpacesAndTabs(line.tail, (spacesTabs._1, spacesTabs._2 - 1))
+      case _ => throw new Exception("The line doesn't have enough indentation characters to remove the entire common indentation")
+    }
+  }
+
+  def formatScaladocLinkTag(captureGroup1: String, captureGroup2: String): String = {
+    var parsedLink = ""
+
     // Do not wrap urls in inline code blocks
-    if (capture_group1.contains("https://")){
-      val split_hyperref = capture_group1.split(" ")
-      if (split_hyperref.length > 1){
-        // If the Url contained an alias (pretty name), preserve it
-        s" [${split_hyperref.drop(1).mkString(" ")}](${split_hyperref(0)}) "
-      } else {
-        s" ${capture_group1} "
+    if (captureGroup1.contains("https://")){
+      val splitHyperref = captureGroup1.split(" ")
+      if (splitHyperref.length > 1){
+        // If the Url contains an alias (pretty name), preserve it
+        parsedLink = s"[${splitHyperref.drop(1).mkString(" ")}](${splitHyperref(0)})"
+      }else{
+        parsedLink = captureGroup1
       }
     } else {
-      // Plural s handling
-      if (capture_group2 != null && capture_group2.nonEmpty) s" `${capture_group1}`s " else s" `${capture_group1}` "
+      parsedLink = s"`${captureGroup1}`"
     }
+
+    s"${parsedLink}${if (captureGroup2 != null) captureGroup2 else " "}"
   }
 
   def formatScaladocString(str: String): String = {
     // Remove link square brackets (including plural s handling)
     // If the link is followed by a single s, remove the space
-    val bracket_removal_pattern = raw"\[\[(.+?)\]\](\s?s(?![a-zA-Z]))?".r
-    bracket_removal_pattern.replaceAllIn(str, m =>
-      formatScaladocStringLinkTag(m.group(1), m.group(2))
+    val bracketRemovalPattern = raw"\[\[(.+?)\]\] (\.|s|,)?".r
+    bracketRemovalPattern.replaceAllIn(str, m =>
+      formatScaladocLinkTag(m.group(1), m.group(2))
     )
-      .replaceAll(raw"[^\S\n]+(,|\.|[^\S\n]|\))", "$1") // Reduce multiple spaces down to one
+      .replaceAll(raw"\.\n(?!\n)", ".  \n") // Add carriage return for Markdown formatting
       .replaceAll(raw"(\\r)?\\n", "\n") // convert & standardize line separator
       .replaceAll(raw"\n\h*\*\h*", "\n") // remove trailing asterisk
       .replace("->", "\u2192") // Prettify right arrow
@@ -93,14 +124,13 @@ private[smartdatalake] object ScaladocUtil {
     markup match {
       case x: Heading => s"\n\n${x.trimmed.plainString}\n\n"
       case x: Paragraph => s"\n\n${x.trimmed.plainString}"
-      case x: CodeBlock => s"\n${x.trimmed.plainString}\n"
+      case x: CodeBlock => dedentCodeBlock(s"\n${x.plainString}\n")
       case x: Span => s" ${x.trimmed.plainString}"
       case x: Document =>
         val contentStr = x.elements.map(formatScaladocMarkup).mkString("")
         formatScaladocString(contentStr)
-          // Additional new line char inside the code block for correct rendering in markdown
-          .replaceAll(raw"\{\{\{", "```\n") // convert wiki code block to markup code block
-          .replaceAll(raw"(.*)}}}", "$1\n```") // convert wiki code block to markup code block
+          .replaceAll(raw"\{\{\{\n?", "```\n") // convert wiki code block to markup code block
+          .replaceAll(raw"(.*)\n?}}}", "$1\n```\n") // convert wiki code block to markup code block
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
@@ -20,7 +20,7 @@
 package io.smartdatalake.util.misc
 
 import com.github.takezoe.scaladoc.{Scaladoc => ScaladocAnnotation}
-import scaladoc.Markup._
+import scaladoc.Markup._ // https://github.com/andyglow/scaladoc
 import scaladoc.{Markup, Scaladoc, Tag}
 
 import scala.reflect.runtime.universe.Annotation
@@ -59,9 +59,33 @@ private[smartdatalake] object ScaladocUtil {
     }
   }
 
+  def formatScaladocStringLinkTag(capture_group1: String, capture_group2: String): String = {
+    // Do not wrap urls in inline code blocks
+    if (capture_group1.contains("https://")){
+      val split_hyperref = capture_group1.split(" ")
+      if (split_hyperref.length > 1){
+        // If the Url contained an alias (pretty name), preserve it
+        s" [${split_hyperref.drop(1).mkString(" ")}](${split_hyperref(0)}) "
+      }else{
+        s" ${capture_group1} "
+      }
+    } else {
+      // Plural s handling
+      if (capture_group2 != null && capture_group2.nonEmpty) s" `${capture_group1}`s " else s" `${capture_group1}` "
+    }
+  }
+
   def formatScaladocString(str: String): String = {
-    str.replaceAll(raw"(\\r)?\\n", "\n") // convert & standardize line separator
+    // Remove link square brackets (including plural s handling)
+    // If the link is followed by a single s, remove the space
+    val bracket_removal_pattern = raw"\[\[(.+?)\]\](\s?s(?![a-zA-Z]))?".r
+    bracket_removal_pattern.replaceAllIn(str, m =>
+      formatScaladocStringLinkTag(m.group(1), m.group(2))
+    )
+      .replaceAll(raw"\s+(,|\.|\s|\))", "$1") // Reduce multiple spaces down to one
+      .replaceAll(raw"(\\r)?\\n", "\n") // convert & standardize line separator
       .replaceAll(raw"\n\h*\*\h*", "\n") // remove trailing asterisk
+      .replace("->", "\u2192") // Prettify right arrow
       .trim // remove leading and trailing line separators
   }
 
@@ -74,8 +98,9 @@ private[smartdatalake] object ScaladocUtil {
       case x: Document =>
         val contentStr = x.elements.map(formatScaladocMarkup).mkString("")
         formatScaladocString(contentStr)
-          .replaceAll(raw"\{\{\{", "```") // convert wiki code block to markup code block
-          .replaceAll(raw"}}}", "```"); // convert wiki code block to markup code block
+          // Additional new line char inside the code block for correct rendering in markdown
+          .replaceAll(raw"\{\{\{", "```\n") // convert wiki code block to markup code block
+          .replaceAll(raw"(.*)}}}", "$1\n```") // convert wiki code block to markup code block
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
@@ -66,7 +66,7 @@ private[smartdatalake] object ScaladocUtil {
       if (split_hyperref.length > 1){
         // If the Url contained an alias (pretty name), preserve it
         s" [${split_hyperref.drop(1).mkString(" ")}](${split_hyperref(0)}) "
-      }else{
+      } else {
         s" ${capture_group1} "
       }
     } else {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
@@ -82,7 +82,7 @@ private[smartdatalake] object ScaladocUtil {
     bracket_removal_pattern.replaceAllIn(str, m =>
       formatScaladocStringLinkTag(m.group(1), m.group(2))
     )
-      .replaceAll(raw"\s+(,|\.|\s|\))", "$1") // Reduce multiple spaces down to one
+      .replaceAll(raw"[^\S\n]+(,|\.|[^\S\n]|\))", "$1") // Reduce multiple spaces down to one
       .replaceAll(raw"(\\r)?\\n", "\n") // convert & standardize line separator
       .replaceAll(raw"\n\h*\*\h*", "\n") // remove trailing asterisk
       .replace("->", "\u2192") // Prettify right arrow

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/GenericTypeUtil.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/GenericTypeUtil.scala
@@ -133,7 +133,7 @@ private[smartdatalake] object GenericTypeUtil extends SmartDataLakeLogger {
     else Seq()
     val name = tpe.typeSymbol.name.toString
     val scaladoc = extractScalaDoc(tpe.typeSymbol.annotations)
-    val description = scaladoc.map(formatScaladocWithTags(_, !_.isInstanceOf[Tag.Param]))
+    val description = scaladoc.map(formatScaladocWithTags(_, tag => !(tag.isInstanceOf[Tag.Param] || tag.isInstanceOf[Tag.OtherTag])))
     val attributes = if (tpe.typeSymbol.asClass.isCaseClass) attributesForCaseClass(tpe, scaladoc.map(_.textParams.mapValues(formatScaladocString).toMap).getOrElse(Map())) else Seq()
     GenericTypeDef(name, baseType, tpe, description, tpe.typeSymbol.asClass.isCaseClass, parentTypes.toSet, attributes)
   }

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -43,7 +43,7 @@ class GenericTypeUtilTest extends FunSuite {
   test("scala doc from case class attribute and from overridden method as fallback") {
     val testObjectTypeDef = GenericTypeUtil.typeDefForClass(typeOf[TestObject])
     assert(testObjectTypeDef.name == "TestObject")
-    assert(testObjectTypeDef.description.contains("ScalaDoc on case class\n\nTest line break\n\nSEE: OverrideTest for details"))
+    assert(testObjectTypeDef.description.contains("ScalaDoc on case class\n\nTest line break\n\nSEE: `OverrideTest` for details"))
     assert(testObjectTypeDef.attributes.find(_.name == "id").get.description.contains("parameter test"))
     assert(testObjectTypeDef.attributes.find(_.name == "overrideTestFirstMethod").get.description.contains("override test first method"))
     assert(testObjectTypeDef.attributes.find(_.name == "overrideTestSecondMethod").get.description.contains("override test second method"))

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -110,13 +110,13 @@ case class TestCodeBlocks() {
  * @see [[OverrideTest]] for details
  */
 case class TestObject (
-                        id: String,
-                        @Deprecated javaDeprecated: String,
-                        @deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
-                        optional: Option[String], default: String = "",
-                        override val overrideTestFirstMethod: String,
-                        override val overrideTestSecondMethod: String
-                      ) extends OverrideTest
+                       id: String,
+                       @Deprecated javaDeprecated: String,
+                       @deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
+                       optional: Option[String], default: String = "",
+                       override val overrideTestFirstMethod: String,
+                       override val overrideTestSecondMethod: String
+                     ) extends OverrideTest
 
 trait OverrideTest {
   /**
@@ -126,7 +126,7 @@ trait OverrideTest {
 
   /**
    * override test second method
-   */
+  */
   def overrideTestSecondMethod: String
 
   def methodTest(): String = ""

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -49,6 +49,55 @@ class GenericTypeUtilTest extends FunSuite {
     assert(testObjectTypeDef.attributes.find(_.name == "overrideTestSecondMethod").get.description.contains("override test second method"))
   }
 
+  test("scala doc link tag parsing"){
+    val testObjectTypeDef = GenericTypeUtil.typeDefForClass(typeOf[TestLinkTag])
+    assert(testObjectTypeDef.description.contains("This is an example of a raw URI https://www.example.com.  \nThis is an example of a [Pretty Link](https://www.example.com).  \nThis is a `DataObject` containing multiple `ActionObject`s."))
+  }
+
+  test("scala doc code indention correction"){
+    val testObjectTypeDef = GenericTypeUtil.typeDefForClass(typeOf[TestCodeBlocks])
+    assert(testObjectTypeDef.description.exists(_.contains("```\nspaces {\n  assert = true\n}\n```")))
+    assert(testObjectTypeDef.description.exists(_.contains("```\nmixed {\n  assert = true\n  config = \"test/directory\"\n  config2 = \"test/directory\"\n}\n```")))
+    assert(testObjectTypeDef.description.exists(_.contains("```\ntabs {\n\tassert = true\n}\n```")))
+  }
+}
+
+/**
+ * This is an example of a raw URI [[https://www.example.com]].
+ * This is an example of a [[https://www.example.com Pretty Link]].
+ * This is a [[DataObject]] containing multiple [[ActionObject]]s.
+ */
+
+case class TestLinkTag() {
+
+}
+
+/**
+ * See the following Example:
+ * {{{
+ *   spaces {
+ *     assert = true
+ *   }
+ * }}}
+ *
+ * {{{
+ * 	 	mixed {
+ * 		   assert = true
+ *		    config = "test/directory"
+ *	  	  config2 = "test/directory"
+ * 		 }
+ * }}}
+ *
+ * {{{
+ *	tabs {
+ *		assert = true
+ *	}
+ * }}}
+ *
+ */
+
+case class TestCodeBlocks() {
+
 }
 
 /**
@@ -61,23 +110,23 @@ class GenericTypeUtilTest extends FunSuite {
  * @see [[OverrideTest]] for details
  */
 case class TestObject (
-                       id: String,
-                       @Deprecated javaDeprecated: String,
-                       @deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
-                       optional: Option[String], default: String = "",
-                       override val overrideTestFirstMethod: String,
-                       override val overrideTestSecondMethod: String
-                     ) extends OverrideTest
+												id: String,
+												@Deprecated javaDeprecated: String,
+												@deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
+												optional: Option[String], default: String = "",
+												override val overrideTestFirstMethod: String,
+												override val overrideTestSecondMethod: String
+											) extends OverrideTest
 
 trait OverrideTest {
-  /**
-   * override test first method
-    */
-  def overrideTestFirstMethod: String
+	/**
+	 * override test first method
+	 */
+	def overrideTestFirstMethod: String
 
-  /**
-   * override test second method
-   */
+	/**
+	 * override test second method
+	 */
   def overrideTestSecondMethod: String
 
   def methodTest(): String = ""

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -121,12 +121,12 @@ case class TestObject (
 trait OverrideTest {
   /**
    * override test first method
-   */
+    */
   def overrideTestFirstMethod: String
 
   /**
    * override test second method
-  */
+   */
   def overrideTestSecondMethod: String
 
   def methodTest(): String = ""

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -110,23 +110,23 @@ case class TestCodeBlocks() {
  * @see [[OverrideTest]] for details
  */
 case class TestObject (
-												id: String,
-												@Deprecated javaDeprecated: String,
-												@deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
-												optional: Option[String], default: String = "",
-												override val overrideTestFirstMethod: String,
-												override val overrideTestSecondMethod: String
-											) extends OverrideTest
+            id: String,
+            @Deprecated javaDeprecated: String,
+            @deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
+            optional: Option[String], default: String = "",
+            override val overrideTestFirstMethod: String,
+            override val overrideTestSecondMethod: String
+           ) extends OverrideTest
 
 trait OverrideTest {
-	/**
-	 * override test first method
-	 */
-	def overrideTestFirstMethod: String
+ /**
+  * override test first method
+  */
+ def overrideTestFirstMethod: String
 
-	/**
-	 * override test second method
-	 */
+ /**
+  * override test second method
+  */
   def overrideTestSecondMethod: String
 
   def methodTest(): String = ""

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -43,7 +43,7 @@ class GenericTypeUtilTest extends FunSuite {
   test("scala doc from case class attribute and from overridden method as fallback") {
     val testObjectTypeDef = GenericTypeUtil.typeDefForClass(typeOf[TestObject])
     assert(testObjectTypeDef.name == "TestObject")
-    assert(testObjectTypeDef.description.contains("ScalaDoc on case class\n\nTest line break\n\nSEE: [[OverrideTest]] for details"))
+    assert(testObjectTypeDef.description.contains("ScalaDoc on case class\n\nTest line break\n\nSEE: OverrideTest for details"))
     assert(testObjectTypeDef.attributes.find(_.name == "id").get.description.contains("parameter test"))
     assert(testObjectTypeDef.attributes.find(_.name == "overrideTestFirstMethod").get.description.contains("override test first method"))
     assert(testObjectTypeDef.attributes.find(_.name == "overrideTestSecondMethod").get.description.contains("override test second method"))

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -110,23 +110,23 @@ case class TestCodeBlocks() {
  * @see [[OverrideTest]] for details
  */
 case class TestObject (
-            id: String,
-            @Deprecated javaDeprecated: String,
-            @deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
-            optional: Option[String], default: String = "",
-            override val overrideTestFirstMethod: String,
-            override val overrideTestSecondMethod: String
-           ) extends OverrideTest
+                        id: String,
+                        @Deprecated javaDeprecated: String,
+                        @deprecated scalaDeprecated: String, // scala annotations are *not* kept for runtime and will not be reflected in type def...
+                        optional: Option[String], default: String = "",
+                        override val overrideTestFirstMethod: String,
+                        override val overrideTestSecondMethod: String
+                      ) extends OverrideTest
 
 trait OverrideTest {
- /**
-  * override test first method
-  */
- def overrideTestFirstMethod: String
+  /**
+   * override test first method
+   */
+  def overrideTestFirstMethod: String
 
- /**
-  * override test second method
-  */
+  /**
+   * override test second method
+   */
   def overrideTestSecondMethod: String
 
   def methodTest(): String = ""

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -44,7 +44,7 @@ class ConfigJsonExporterTest extends FunSuite {
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "a" === JString("Beschreibung A"))
     assert((actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "b.[].b1").asInstanceOf[JString].s.linesIterator.toSeq === Seq("Beschreibung B1", "2nd line B1 text"))
     assert(((actualJsonOutput \ "actions" \ "actionId6" \ "transformers")(0) \ "_parameters")(0) \ "name" === JString("session"))
-    assert((actualJsonOutput \ "actions" \ "actionId8" \ "transformers")(0) \ "_sourceDoc" === JString("Documentation for TestTransformer.\nThis should be exported by ConfigJsonExporter!"))
+    assert((actualJsonOutput \ "actions" \ "actionId8" \ "transformers")(0) \ "_sourceDoc" === JString("Documentation for TestTransformer.  \nThis should be exported by ConfigJsonExporter!"))
   }
 
   test("test main file export") {

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
@@ -155,7 +155,7 @@ class JsonTypeConverterTest extends FunSuite {
     val jsonTypeDef = jsonTypeConverter.fromGenericTypeDef(typeDef)
 
     assert(jsonTypeDef.properties("secret").isInstanceOf[JsonStringDef])
-    assert(jsonTypeDef.properties("secret").asInstanceOf[JsonStringDef].description.get.contains("```###<PROVIDERID>#<SECRETNAME>###```"))
+    assert(jsonTypeDef.properties("secret").asInstanceOf[JsonStringDef].description.get.contains("```\n###<PROVIDERID>#<SECRETNAME>###\n```"))
   }
 
   case class TestClassWithSecretsInOptions(options: Map[String, StringOrSecret])
@@ -165,7 +165,7 @@ class JsonTypeConverterTest extends FunSuite {
     val jsonTypeDef = jsonTypeConverter.fromGenericTypeDef(typeDef)
 
     assert(jsonTypeDef.properties("options").isInstanceOf[JsonMapDef])
-    assert(jsonTypeDef.properties("options").asInstanceOf[JsonMapDef].description.get.contains("```###<PROVIDERID>#<SECRETNAME>###```"))
+    assert(jsonTypeDef.properties("options").asInstanceOf[JsonMapDef].description.get.contains("```\n###<PROVIDERID>#<SECRETNAME>###\n```"))
   }
 
   case class TestClassWithoutSecretsInOptions(options: Map[String, String])


### PR DESCRIPTION
### What changes are included in the pull request?
- Remove double square brackets around Link elements
  - Retain hyperrefs to keep them as an <a> Tag in the SchemaViewer
  - Fix spaces around the Link elements
  - Handle the plural `s` correctly
- Filter out `OtherTag` instead of just `ParamTag`
- Add Github URL to scaladoc import
- Replace `->` with `\u2192`
- Improve conversion from wiki code block (`{{{...}}}`) to Markdown code block

### Why are the changes needed?
It is hard to read the documentation in the SchemaViewer.