### PR TITLE
Fix applying parquet read schema

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/NestedColumnUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/NestedColumnUtil.scala
@@ -21,6 +21,8 @@ package io.smartdatalake.util.misc
 
 import io.smartdatalake.workflow.DataFrameSubFeed
 import io.smartdatalake.workflow.dataframe._
+import io.smartdatalake.workflow.dataframe.spark.SparkMapDataType
+import org.apache.spark.sql.types.{MapType, StringType}
 
 
 /**
@@ -57,6 +59,9 @@ object NestedColumnUtil extends SmartDataLakeLogger {
         val keyTransformed = functions.transform_keys(column, (k, v) => selectColumn(k, ct.valueDataType, tt.keyDataType))
         val mapTransformed = functions.transform_values(keyTransformed, (k, v) => selectColumn(v, ct.valueDataType, tt.valueDataType))
         mapTransformed
+      // special case json object: string -> map<string,string>
+      case (ct: GenericSimpleDataType, tt: GenericMapDataType) if ct.typeName == "string" && tt.keyDataType.typeName == "string" && tt.valueDataType.typeName == "string" =>
+        functions.from_json(column, SparkMapDataType(MapType(StringType, StringType)))
       case (ct, tt) if ct.sql != tt.sql => column.cast(tt)
       case _ => column
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -118,7 +118,7 @@ object ActionHelper extends SmartDataLakeLogger {
     Some(input.getDataFrame(partitionValues, subFeedType))
   } catch {
     case e: IllegalArgumentException if e.getMessage.contains("DataObject schema is undefined") => None
-    case e: AnalysisException if e.getMessage.contains("[TABLE_OR_VIEW_NOT_FOUND]") => None
+    case e: AnalysisException if e.getMessage().contains("[TABLE_OR_VIEW_NOT_FOUND]") || e.getMessage().contains("[UNABLE_TO_INFER_SCHEMA]") => None
     case _: NoDataToProcessWarning => None
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/CmdScript.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/CmdScript.scala
@@ -20,12 +20,11 @@
 package io.smartdatalake.workflow.action.script
 
 import com.typesafe.config.Config
-import io.smartdatalake.config.SdlConfigObject.{ActionId, ConfigObjectId}
+import io.smartdatalake.config.SdlConfigObject.ConfigObjectId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{EnvironmentUtil, SmartDataLakeLogger}
 import io.smartdatalake.workflow.ActionPipelineContext
-import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable
 
@@ -121,7 +120,7 @@ trait CmdScriptBase extends ParsableScriptDef with SmartDataLakeLogger {
   private def translateWinToWslPath(path: String): String = {
     assert(EnvironmentUtil.isWindowsOS)
     import sys.process._
-    val wslPath = s"wsl wslpath '$path'".!!
+    val wslPath = s"wsl wslpath '${path.replace('\\', '/')}'".!!
     wslPath.linesIterator.find(_.nonEmpty).get.trim
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/DataFrameFunctions.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/DataFrameFunctions.scala
@@ -69,6 +69,8 @@ trait DataFrameFunctions {
   def regexp_extract(e: GenericColumn, regexp: String, groupIdx: Int): GenericColumn
   def raise_error(column: GenericColumn): GenericColumn
 
+  def from_json(column: GenericColumn, dataType: GenericDataType): GenericColumn
+
   def hash(column: GenericColumn): GenericColumn
   /**
    * Get a DataFrame with the result of the given sql statement.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
@@ -263,6 +263,13 @@ object SparkSubFeed extends DataFrameSubFeedCompanion {
     }
   }
 
+  override def from_json(column: GenericColumn, dataType: GenericDataType): GenericColumn = {
+    (column, dataType) match {
+      case (sparkColumn: SparkColumn, sparkDataType: SparkDataType) => SparkColumn(functions.from_json(sparkColumn.inner, sparkDataType.inner))
+      case _ => DataFrameSubFeed.throwIllegalSubFeedTypeException(column)
+    }
+  }
+
   override def hash(column: GenericColumn): GenericColumn = {
     column match {
       case sparkColumn: SparkColumn => SparkColumn(functions.hash(sparkColumn.inner))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
@@ -23,9 +23,12 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
-import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
-import io.smartdatalake.util.misc.AclDef
+import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.misc.{AclDef, NestedColumnUtil}
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.GenericSchema
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import org.apache.spark.sql.DataFrame
 
 /**
  * A [[io.smartdatalake.workflow.dataobject.DataObject]] backed by an Avro data source.
@@ -66,6 +69,19 @@ case class AvroFileDataObject( override val id: DataObjectId,
   override val fileName: String = "*.avro*"
 
   override val options: Map[String, String] = avroOptions.getOrElse(Map())
+
+  // Avro files implicitly contain a schema.
+  // If a schema is defined for the DataObject, it will be applied in customizeContent and not by SparkFileDataObject.getDataFrame directly.
+  override val ignoreSchemaForReader: Boolean = true
+
+  /**
+   * Convert to target schema if defined
+   */
+  override def customizeContent(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
+    schema.map(s => NestedColumnUtil.selectSchema(SparkDataFrame(df), s).asInstanceOf[SparkDataFrame].inner)
+      .getOrElse(df)
+  }
+
 
   override def factory: FromConfigFactory[DataObject] = AvroFileDataObject
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
@@ -23,12 +23,12 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
-import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
-import io.smartdatalake.util.misc.AclDef
-import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
+import io.smartdatalake.util.hdfs.SparkRepartitionDef
+import io.smartdatalake.util.misc.{AclDef, NestedColumnUtil}
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.GenericSchema
-import org.apache.spark.sql.{DataFrame, SaveMode}
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import org.apache.spark.sql.DataFrame
 
 /**
  *
@@ -68,6 +68,18 @@ case class ParquetFileDataObject( override val id: DataObjectId,
   override val fileName: String = "*.parquet*"
 
   override val options: Map[String, String] = parquetOptions.getOrElse(Map())
+
+  // Parquet files implicitly contain a schema.
+  // If a schema is defined for the DataObject, it will be applied in customizeContent and not by SparkFileDataObject.getDataFrame directly.
+  override val ignoreSchemaForReader: Boolean = true
+
+  /**
+   * Convert to target schema if defined
+   */
+  override def customizeContent(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame = {
+    schema.map(s => NestedColumnUtil.selectSchema(SparkDataFrame(df), s).asInstanceOf[SparkDataFrame].inner)
+      .getOrElse(df)
+  }
 
   override def factory: FromConfigFactory[DataObject] = ParquetFileDataObject
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -26,7 +26,7 @@ import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues, SparkRepartitionDe
 import io.smartdatalake.util.misc.{CompactionUtil, EnvironmentUtil, SmartDataLakeLogger}
 import io.smartdatalake.util.spark.CollectSetDeterministic.collect_set_deterministic
 import io.smartdatalake.util.spark.DataFrameUtil
-import io.smartdatalake.util.spark.DataFrameUtil.{DataFrameReaderUtils, DataFrameWriterUtils}
+import io.smartdatalake.util.spark.DataFrameUtil.{DataFrameReaderUtils, DataFrameWriterUtils, getEmptyDataFrame}
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.dataframe.GenericSchema
@@ -208,7 +208,8 @@ trait SparkFileDataObject extends HadoopFileDataObject
     assert(wrongPartitionValues.isEmpty, s"getDataFrame got request with PartitionValues keys ${wrongPartitionValues.mkString(",")} not included in $id partition columns ${partitions.mkString(", ")}")
 
     val schemaOpt = getSchema.map(_.inner)
-    if (schemaOpt.isEmpty && !checkFilesExisting) {
+    val filesExisting = checkFilesExisting
+    if (schemaOpt.isEmpty && !filesExisting) {
       //without either schema or data, no data frame can be created
       require(schema.isDefined, s"($id) DataObject schema is undefined. A schema must be defined if there are no existing files.")
     }
@@ -221,18 +222,20 @@ trait SparkFileDataObject extends HadoopFileDataObject
     else Map[String,String]()
 
     // get and customize content
-    var df = if (handleFilesOneByOne) getContentFilesOneByOne(partitionValues, schemaOpt.filter(_ => !ignoreSchemaForReader), incrementalOutputOptions)
+    val doCreateEmptyDataFrame = (!context.isExecPhase || !filesExisting) && schema.isDefined && format == readFormat
+    var df = if (doCreateEmptyDataFrame) createEmptyDataFrame(schema.get)
+    else if (handleFilesOneByOne) getContentFilesOneByOne(partitionValues, schemaOpt.filter(_ => !ignoreSchemaForReader), incrementalOutputOptions)
     else if (isV2ReadDataSource) getContentV2(partitionValues, schemaOpt.filter(_ => !ignoreSchemaForReader), incrementalOutputOptions)
     else getContentV1(partitionValues, schemaOpt.filter(_ => !ignoreSchemaForReader), incrementalOutputOptions)
     df = customizeContent(df)
 
     // early check for no data to process.
     // This also prevents an error on Databricks when using filesObserver if there are no files to process. See also [[CollectSetDeterministic]].
-    if (context.isExecPhase && Environment.enableSparkFileDataObjectNoDataCheck && SparkFileDataObject.tryGetFilesProcessedFromSparkPlan(id.id, df).exists(_.isEmpty))
+    if (context.isExecPhase && ((!filesExisting && doCreateEmptyDataFrame) || (Environment.enableSparkFileDataObjectNoDataCheck && SparkFileDataObject.tryGetFilesProcessedFromSparkPlan(id.id, df).exists(_.isEmpty))))
       throw NoDataToProcessWarning(id.id, s"($id) No files to process found in execution plan")
 
     // add filename column
-    df = df.withOptionalColumn(filenameColumn, input_file_name())
+    df = df.withOptionalColumn(filenameColumn, if (!doCreateEmptyDataFrame) input_file_name() else lit(""))
 
     // configure observer to get files processed for incremental execution mode
     if (filesObservers.nonEmpty && context.isExecPhase) {
@@ -241,6 +244,12 @@ trait SparkFileDataObject extends HadoopFileDataObject
 
     // finalize & return DataFrame
     afterRead(df)
+  }
+
+  private[smartdatalake] def createEmptyDataFrame(schema: GenericSchema)(implicit session: SparkSession): DataFrame = {
+    var df = getEmptyDataFrame(schema.asInstanceOf[SparkSchema].inner)
+    partitions.foreach(p => if (!df.columns.contains(p)) df = df.withColumn(p, lit(null).cast(StringType))) // add missing partition columns as null
+    df
   }
 
   /**

--- a/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectId.conf
+++ b/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectId.conf
@@ -15,11 +15,13 @@ dataObjects {
   src1Ds {
     type = CsvFileDataObject
     path = "target/src1Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src2Ds {
     type = CsvFileDataObject
     path = "target/src2Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   tgt1Ds {

--- a/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectOrdering.conf
+++ b/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectOrdering.conf
@@ -14,11 +14,13 @@ dataObjects {
   src1Ds {
     type = CsvFileDataObject
     path = "target/src1Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src2Ds {
     type = CsvFileDataObject
     path = "target/src2Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   tgt1Ds {

--- a/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectOrdering9Inputs.conf
+++ b/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectOrdering9Inputs.conf
@@ -14,46 +14,55 @@ dataObjects {
   src1 {
     type = CsvFileDataObject
     path = "target/src1DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src2 {
     type = CsvFileDataObject
     path = "target/src2DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src3 {
     type = CsvFileDataObject
     path = "target/src3DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src4 {
     type = CsvFileDataObject
     path = "target/src4DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src5 {
     type = CsvFileDataObject
     path = "target/src5DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src6 {
     type = CsvFileDataObject
     path = "target/src6DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src7 {
     type = CsvFileDataObject
     path = "target/src7DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src8 {
     type = CsvFileDataObject
     path = "target/src8DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src9 {
     type = CsvFileDataObject
     path = "target/src9DsNto1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   tgt1 {

--- a/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectOrdering9InputsWrongTransformer.conf
+++ b/sdl-core/src/test/resources/configScalaClassSparkDsNto1Transformer/usingDataObjectOrdering9InputsWrongTransformer.conf
@@ -14,46 +14,55 @@ dataObjects {
   src1Ds {
     type = CsvFileDataObject
     path = "target/src1Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src2Ds {
     type = CsvFileDataObject
     path = "target/src2Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src3Ds {
     type = CsvFileDataObject
     path = "target/src1Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src4Ds {
     type = CsvFileDataObject
     path = "target/src2Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src5Ds {
     type = CsvFileDataObject
     path = "target/src1Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src6Ds {
     type = CsvFileDataObject
     path = "target/src2Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src7Ds {
     type = CsvFileDataObject
     path = "target/src1Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src8Ds {
     type = CsvFileDataObject
     path = "target/src2Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   src9Ds {
     type = CsvFileDataObject
     path = "target/src2Ds2to1"
+    partitions = [name]
     schema = """name string, rating int"""
   }
   tgt1Ds {

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
@@ -33,7 +33,7 @@ import io.smartdatalake.workflow.action.generic.transformer.SQLDfTransformer
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfTransformer
 import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.workflow.dataobject.{CsvFileDataObject, HiveTableDataObject, Table}
-import io.smartdatalake.workflow.{ActionDAGRunState, ActionPipelineContext, HadoopFileActionDAGRunStateStore}
+import io.smartdatalake.workflow.{ActionDAGRunState, ActionPipelineContext, ExecutionPhase, HadoopFileActionDAGRunStateStore}
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.streaming.{StreamingQueryException, StreamingQueryListener}
@@ -75,7 +75,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val feedName = "test"
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     val srcTable = Table(Some("default"), "ap_input")
@@ -162,7 +162,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(checkpointPath), false)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partitions columns dt and type
@@ -266,7 +266,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(checkpointPath), false)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partition columns dt and type
@@ -345,7 +345,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(checkpointPath), false)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partition columns dt and type
@@ -436,7 +436,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(checkpointPath), false)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partition columns dt and type
@@ -506,7 +506,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(checkpointPath), false)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partition columns dt and type
@@ -592,7 +592,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(checkpointPath), false)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partition columns dt and type

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameTestHelper.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameTestHelper.scala
@@ -200,7 +200,7 @@ object DataFrameTestHelper {
       (dfExpected, dfActual)
     }
 
-    assertSchemasEqual(expectedPrime.schema, actualPrime.schema)
+    assertSchemasEqual(expectedPrime.schema, actualPrime.schema, ignoreNullability)
 
     // now compare data
     val expectedPrimeCount = expectedPrime.groupBy(expectedPrime.columns.map(col): _*).agg(count("*").as("rowcount"))
@@ -209,21 +209,25 @@ object DataFrameTestHelper {
     val sameData = expectedMinusActual.count() == 0 && actualMinusExpected.count() == 0
 
     if (!sameData) {
-      val messageRows = s"non-equal rows\nrows which appear in expected but not in actual:\n " +
-        s"${DatasetHelper.showString(expectedMinusActual, 100)}\n" +
-        s"rows which appear in actual but not in expected:\n ${DatasetHelper.showString(actualMinusExpected, 100)}"
+      val messageRows =
+        s"""
+        non-equal rows
+        rows which appear in expected but not in actual:
+        ${DatasetHelper.showString(expectedMinusActual, 100)}
+        rows which appear in actual but not in expected:
+        ${DatasetHelper.showString(actualMinusExpected, 100)}
+      """
 
       // compute difference at column-level. This is tricky because the equality of rows involve all columns
       // What we can do is to take the rows which show a difference at row-level, and check whether we have columns
       // which do not appear in the other df
       val colsToCheck = expectedMinusActual.columns
-      val colsWhichDiff = colsToCheck.collect { case c if {
+      val colsWhichDiff = colsToCheck.filter { c =>
         val (lmr, rml) = symmetricDifference(expectedMinusActual, actualMinusExpected, col(c))
         lmr.union(rml).count() > 0 // col diffs
-      } => c
       }
       val messageColumns = if (colsWhichDiff.nonEmpty) s"The difference is probably in columns : ${colsWhichDiff.mkString(",")}" else ""
-      assert(assertion = false, Seq(messageRows, messageColumns).filter(message => !message.isEmpty).mkString("\n"))
+      assert(assertion = false, Seq(messageRows, messageColumns).filter(message => message.nonEmpty).mkString("\n"))
     }
   }
 
@@ -246,19 +250,19 @@ object DataFrameTestHelper {
     }
 
     if (!sameSchema) {
-      val expectedTypes = expected.map(structType => structType.name -> structType.dataType).toMap
-      val actualTypes = actual.map(structType => structType.name -> structType.dataType).toMap
       val differentTypes = expected.toSet.diff(actual.toSet)
       val differentTypesString = differentTypes.map(structType => {
-        val treeStringExpected = new StructType(Array(StructField(structType.name, expectedTypes(structType.name), structType.nullable))).treeString
-        val treeStringActual = new StructType(Array(StructField(structType.name, actualTypes(structType.name), structType.nullable))).treeString
-        s"Actual schema differs from expected schema.\n" +
-          s"Column: ${structType.name}\n" +
-          s"Expected type: $treeStringExpected,\n" +
-          s"Actual type:   $treeStringActual" +
-          (if (treeStringActual.length > 20 && treeStringExpected.length > 20) s"In expected but not actual:    ${treeStringExpected diff treeStringActual}\nIn actual but not expected:   ${treeStringActual diff treeStringExpected}" else "")
-      }).mkString("\n\n")
-      assert(differentTypes.isEmpty, differentTypesString)
+        val treeStringExpected = StructType(expected.fields.filter(_.name == structType.name)).treeString
+        val treeStringActual = StructType(actual.fields.filter(_.name == structType.name)).treeString
+        s"""
+           |- Column: ${structType.name}
+           |  Expected type:
+           |  ${treeStringExpected.linesIterator.drop(1).mkString(System.lineSeparator() + "  ")}
+           |  Actual type:
+           |  ${treeStringActual.linesIterator.drop(1).mkString(System.lineSeparator() + "  ")}
+        """.stripMargin.trim
+      }).mkString("\n")
+      assert(differentTypes.isEmpty, "Actual schema differs from expected schema:\n" + differentTypesString)
     }
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
@@ -19,12 +19,13 @@
 package io.smartdatalake.workflow.dataobject
 
 import com.typesafe.config.ConfigFactory
+import io.smartdatalake.testutils.DataFrameTestHelper.assertDataFramesEqual
 import io.smartdatalake.testutils.{DataObjectTestSuite, TestUtil}
 import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
 import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import org.apache.commons.io.{FileUtils, IOUtils}
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SaveMode}
 
 import java.io.FileInputStream
 import java.nio.file.Files
@@ -118,13 +119,12 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
   test("User-defined schema takes precedence over schema inference from header.") {
     val tempDir = Files.createTempDirectory("csv")
 
-    session.createDataFrame(session.sparkContext.makeRDD(Seq(
-      Row.fromTuple("A", "B"),
-      Row.fromTuple("B", "1")
-    )),
-      StructType.fromDDL("h1 STRING, h2 STRING"))
-      .write.mode(SaveMode.Overwrite).format("com.databricks.spark.csv")
-      .save(tempDir.toFile.getPath)
+    val dfInput = Seq(("B", "1")).toDF("h1", "h2")
+    val dfExpected = Seq(("B", 1)).toDF("header1", "header2")
+
+    dfInput.write.mode(SaveMode.Overwrite)
+      .option("header", "true")
+      .csv(tempDir.toFile.getPath)
 
     try {
       val config = ConfigFactory.parseString(
@@ -140,23 +140,10 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
            | path = "${escapedFilePath(tempDir.toFile.getPath)}"
            |}
          """.stripMargin)
-
       val dataObj = CsvFileDataObject.fromConfig(config)
+      val df = dataObj.getSparkDataFrame()(contextExec)
 
-      val df = dataObj.getSparkDataFrame()
-
-      df.schema should contain theSameElementsInOrderAs Seq(
-        StructField("header1", StringType, nullable = true),
-        StructField("header2", IntegerType, nullable = true)
-      )
-      df.count() shouldBe 1
-      df.collect().foreach { row =>
-        row(0).isInstanceOf[String] shouldBe true
-        row(0) should equal ("B")
-        row(1).isInstanceOf[Int] shouldBe true
-        row(1) should equal (1)
-      }
-
+      assertDataFramesEqual(df, dfExpected)
     } finally {
       FileUtils.forceDelete(tempDir.toFile)
     }
@@ -165,13 +152,14 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
   test("User-defined schema takes precedence over schema inference.") {
     val tempDir = Files.createTempDirectory("csv")
 
-    session.createDataFrame(session.sparkContext.makeRDD(Seq(
-      Row.fromTuple("A", "B"),
-      Row.fromTuple("B", "1")
-    )),
-      StructType.fromDDL("h1 STRING, h2 STRING"))
-      .write.mode(SaveMode.Overwrite).format("com.databricks.spark.csv")
-      .save(tempDir.toFile.getPath)
+    val dfInput = Seq(("B", "1")).toDF("h1", "h2")
+    // header is expected in output, as csv is read using header=false
+    // h2 is null because it cannot be cast to INT
+    val dfExpected = Seq(("h1", None), ("B", Some(1))).toDF("header1", "header2")
+
+    dfInput.write.mode(SaveMode.Overwrite)
+      .option("header", "true")
+      .csv(tempDir.toFile.getPath)
 
     try {
       val config = ConfigFactory.parseString(
@@ -187,17 +175,10 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
            | path = "${escapedFilePath(tempDir.toFile.getPath)}"
            |}
          """.stripMargin)
-
       val dataObj = CsvFileDataObject.fromConfig(config)
+      val df = dataObj.getSparkDataFrame()(contextExec)
 
-      val df = dataObj.getSparkDataFrame()
-
-      df.schema should contain theSameElementsInOrderAs Seq(
-        StructField("header1", StringType, nullable = true),
-        StructField("header2", IntegerType, nullable = true)
-      )
-      df.count() shouldBe 2
-
+      assertDataFramesEqual(df, dfExpected)
     } finally {
       FileUtils.forceDelete(tempDir.toFile)
     }
@@ -308,7 +289,7 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     val dataObj = CsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), partitions = Seq("h1"), schema = Some(SparkSchema(df1.schema)), filenameColumn = Some("_filename"))
     dataObj.writeSparkDataFrame(df1, pv1)
 
-    val dfResult = dataObj.getSparkDataFrame(pv1).cache
+    val dfResult = dataObj.getSparkDataFrame(pv1)(contextExec).cache
 
     assert(dfResult.columns.toSet == Set("h2", "h3", "h1", "_filename"))
     assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == data1.toSet)
@@ -326,7 +307,7 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
       schema = Some(SparkSchema(df1.drop("h1").schema)), filenameColumn = Some("_filename"))
     dataObj.writeSparkDataFrame(df1, pv1)
 
-    val dfResult = dataObj.getSparkDataFrame(pv1).cache
+    val dfResult = dataObj.getSparkDataFrame(pv1)(contextExec).cache
 
     assert(dfResult.columns.toSet == Set("h2", "h3", "h1", "_filename"))
     assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == data1.toSet)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectSchemaBehavior.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectSchemaBehavior.scala
@@ -76,9 +76,6 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
                       (implicit context: ActionPipelineContext): Unit = {
 
     test("Reading an empty file creates an empty data frame with the user-defined schema.") {
-      val embeddedSchema = Seq(
-        StructField("_c1", StringType, nullable = true)
-      )
       val userSchema = Seq(
         StructField("header1", StringType, nullable = true),
         StructField("header2", IntegerType, nullable = true)
@@ -87,7 +84,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
       val path = tempFilePath(fileExtension)
       implicit val session: SparkSession = context.sparkSession
       Environment._enableSparkPlanNoDataCheck = Some(false)
-      createFile(path, DataFrameUtil.getEmptyDataFrame(StructType(embeddedSchema)))
+      createFile(path, DataFrameUtil.getEmptyDataFrame(StructType(userSchema)))
       Environment._enableSparkPlanNoDataCheck = Some(true)
       try {
         val dataObj = createDataObject(path, Some(StructType(userSchema)))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
@@ -253,7 +253,9 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     )
 
     // test received DataFrame
-    val df = dataObject.getSparkDataFrame()
+    val dfInit = dataObject.getSparkDataFrame()(contextInit)
+    dfInit.columns.contains(sourceFileColName) //retrieved Dataframe has sourcefile column appended
+    val df = dataObject.getSparkDataFrame()(contextExec)
     df.columns.contains(sourceFileColName) //retrieved Dataframe has sourcefile column appended
     df.select(sourceFileColName).collect().head.getAs[String](0).endsWith(resourceFile) //content of sourcefile column corresponds to sourcefile
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObjectTest.scala
@@ -62,13 +62,13 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     assert(dataObjPartitioned.getFileRefs(pv1).size == 2)
 
     // read with list of partition values
-    val dfResult1 = dataObjPartitioned.getSparkDataFrame(pv1).cache
+    val dfResult1 = dataObjPartitioned.getSparkDataFrame(pv1)(contextExec).cache
     assert(dfResult1.columns.toSet == Set("h1", "h2", "h3", "_filename"))
     assert(dfResult1.drop("_filename").isEqual(df1))
     assert(dfResult1.where($"_filename".isNull).isEmpty)
 
     // read all
-    val dfResult2 = dataObjPartitioned.getSparkDataFrame().cache
+    val dfResult2 = dataObjPartitioned.getSparkDataFrame()(contextExec).cache
     assert(dfResult2.columns.toSet == Set("h1", "h2", "h3", "_filename"))
     assert(dfResult2.drop("_filename").isEqual(df1))
     assert(dfResult2.where($"_filename".isNull).isEmpty)
@@ -123,7 +123,7 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     session.conf.set("spark.sql.optimizer.expression.nestedPruning.enabled", false)
     session.conf.set("spark.sql.optimizer.nestedSchemaPruning.enabled", false)
     // test L0: should include 1 updated L0 and 1 deleted record
-    val dfResultL0 = dataObj.getSparkDataFrame().cache
+    val dfResultL0 = dataObj.getSparkDataFrame()(contextExec).cache
       .withColumn("cntDesc", functions.size($"descriptions.description"))
       .withColumn("cntChildren", functions.size($"nodes.node"))
     val resultL0 = dfResultL0.select($"name",$"cntDesc",$"cntChildren").as[(String,Int,Int)].collect.toSeq
@@ -159,7 +159,7 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     )
 
     // read and check
-    val dfResult = dataObj.getSparkDataFrame().cache
+    val dfResult = dataObj.getSparkDataFrame()(contextExec).cache
     val cntDescriptions = dfResult.select(functions.size($"descriptions.description")).as[Int].collect.toSeq
     assert(cntDescriptions == Seq(2))
   }

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
@@ -250,6 +250,10 @@ object SnowparkSubFeed extends DataFrameSubFeedCompanion with SmartDataLakeLogge
     }
   }
 
+  override def from_json(column: GenericColumn, dataType: GenericDataType): GenericColumn = {
+    throw new NotImplementedError("from_json is not implemented in Snowpark")
+  }
+
   override def hash(column: GenericColumn): GenericColumn = {
     column match {
       case snowparkColumn: SnowparkColumn => SnowparkColumn(functions.hash(snowparkColumn.inner))


### PR DESCRIPTION
### What changes are included in the pull request?
Parquet/AvroFileDataObject: apply read schema correctly

### Why are the changes needed?
It doesn't make sense / work to pass a potentially defined schema to spark Parquet DataSource, as the Parquet files already have a schema implicitly. If a schema is defined, it must be used afterwards to convert the DataFrame read by Spark into the defined schema.