### PR TITLE
SparkFileDataObjects: fix using option pathGlobFilter

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/FileIncrementalMoveMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/FileIncrementalMoveMode.scala
@@ -20,8 +20,8 @@
 package io.smartdatalake.workflow.action.executionMode
 
 import com.typesafe.config.Config
-import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.config.SdlConfigObject.ActionId
+import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
@@ -73,7 +73,7 @@ case class FileIncrementalMoveMode(archivePath: Option[String] = None, archiveIn
         if (fileRefs.isEmpty) throw NoDataToProcessWarning(actionId.id, s"($actionId) No files to process found for ${inputDataObject.id}, partitionValues=${inputSubFeed.partitionValues.mkString(", ")}")
         Some(ExecutionModeResult(fileRefs = Some(fileRefs), inputPartitionValues = inputSubFeed.partitionValues, outputPartitionValues = inputSubFeed.partitionValues))
       case (inputDataObject: SparkFileDataObject, inputSubFeed: SparkSubFeed) =>
-        if (!inputDataObject.checkFilesExisting) throw NoDataToProcessWarning(actionId.id, s"($actionId) No files to process found for ${mainInput.id} by FileIncrementalMoveMode.")
+        if (!inputDataObject.checkFilesExisting()) throw NoDataToProcessWarning(actionId.id, s"($actionId) No files to process found for ${mainInput.id} by FileIncrementalMoveMode.")
         if (inputDataObject.isV2ReadDataSource) { // for V1 DataSources this needs to be implemented in postExec
           // setup observation of files processed
           sparkFilesObserver = Some(inputDataObject.setupFilesObserver(actionId))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
@@ -68,7 +68,7 @@ case class AvroFileDataObject( override val id: DataObjectId,
   // this is only needed for FileRef actions
   override val fileName: String = "*.avro*"
 
-  override val options: Map[String, String] = avroOptions.getOrElse(Map())
+  override val options: Map[String, String] = Map("pathGlobFilter" -> fileName) ++ avroOptions.getOrElse(Map())
 
   // Avro files implicitly contain a schema.
   // If a schema is defined for the DataObject, it will be applied in customizeContent and not by SparkFileDataObject.getDataFrame directly.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
@@ -24,7 +24,7 @@ import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.DateColumnType.DateColumnType
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.definitions.{DateColumnType, SDLSaveMode}
-import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
+import io.smartdatalake.util.hdfs.SparkRepartitionDef
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -92,7 +92,8 @@ case class CsvFileDataObject( override val id: DataObjectId,
     "header" -> "true",
     "inferSchema" -> "false",
     "delimiter" -> ",",
-    "quote" -> null
+    "quote" -> null,
+    "pathGlobFilter" -> fileName
   )
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
-import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
+import io.smartdatalake.util.hdfs.SparkRepartitionDef
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.spark.DataFrameUtil
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -77,7 +77,7 @@ case class ExcelFileDataObject(override val id: DataObjectId,
   // spark excel data source doesnt support reading all files in a directory. Each file must be read one by one.
   override val handleFilesOneByOne: Boolean = true
 
-  override val options: Map[String, String] = excelOptions.toMap(schema).filter {
+  override val options: Map[String, String] = Map("pathGlobFilter" -> fileName) ++ excelOptions.toMap(schema).filter {
       case (_, v) => v.isDefined
   }.mapValues(_.get.toString).toMap.map(identity) // make serializable
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/HadoopFileDataObject.scala
@@ -82,19 +82,19 @@ private[smartdatalake] trait HadoopFileDataObject extends FileRefDataObject with
    * Check if the input files exist.
    * Note that hadoopDir can be a specific file or a directory.
    */
-  def checkFilesExisting(implicit context: ActionPipelineContext): Boolean = {
+  def checkFilesExisting(recursive: Boolean = false)(implicit context: ActionPipelineContext): Boolean = {
     val status = try {
       filesystem.getFileStatus(hadoopPath)
     } catch {
       case _: FileNotFoundException => return false
     }
-    status.isFile || (status.isDirectory && listDataFiles().nonEmpty)
+    status.isFile || (status.isDirectory && listDataFiles(recursive = recursive).nonEmpty)
   }
 
-  def listDataFiles(pv: PartitionValues = PartitionValues(Map()))(implicit context: ActionPipelineContext): Iterator[Path] = {
+  def listDataFiles(pv: PartitionValues = PartitionValues(Map()), recursive: Boolean = false)(implicit context: ActionPipelineContext): Iterator[Path] = {
     val pathPattern = if (partitions.nonEmpty) new GlobPattern(new Path(pv.getPartitionString(partitionLayout().get), fileName).toString)
     else new GlobPattern(fileName)
-    RemoteIteratorWrapper(filesystem.listFiles(hadoopPath, partitions.nonEmpty))
+    RemoteIteratorWrapper(filesystem.listFiles(hadoopPath, recursive || partitions.nonEmpty))
       .filter(_.isFile)
       .map(_.getPath)
       .filter(p => pathPattern.matches(relativizePath(p.toString)))

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
-import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
+import io.smartdatalake.util.hdfs.SparkRepartitionDef
 import io.smartdatalake.util.misc.AclDef
 import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -68,10 +68,9 @@ case class JsonFileDataObject( override val id: DataObjectId,
 
   override val format = "json"
 
-  // this is only needed for FileRef actions
   override val fileName: String = "*.json*"
 
-  private val formatOptionsDefault = Map("multiLine" -> "true")
+  private val formatOptionsDefault = Map("multiLine" -> "true", "pathGlobFilter" -> fileName)
   override val options: Map[String, String] = formatOptionsDefault ++ jsonOptions.getOrElse(Map())
 
   override def afterRead(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame  = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
@@ -67,7 +67,7 @@ case class ParquetFileDataObject( override val id: DataObjectId,
   // this is only needed for FileRef actions
   override val fileName: String = "*.parquet*"
 
-  override val options: Map[String, String] = parquetOptions.getOrElse(Map())
+  override val options: Map[String, String] = Map("pathGlobFilter" -> fileName) ++ parquetOptions.getOrElse(Map())
 
   // Parquet files implicitly contain a schema.
   // If a schema is defined for the DataObject, it will be applied in customizeContent and not by SparkFileDataObject.getDataFrame directly.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
@@ -7,7 +7,7 @@ import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.DateColumnType.DateColumnType
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.definitions.{DateColumnType, SDLSaveMode}
-import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
+import io.smartdatalake.util.hdfs.SparkRepartitionDef
 import io.smartdatalake.util.misc.{AclDef, SmartDataLakeLogger}
 import io.smartdatalake.util.spark.DataFrameUtil._
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -15,7 +15,7 @@ import io.smartdatalake.workflow.dataframe.GenericSchema
 import io.smartdatalake.workflow.dataframe.spark.{SparkSchema, SparkSubFeed}
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.csv.{CSVExprUtils, CSVOptions, UnivocityParser}
-import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
@@ -101,6 +101,7 @@ case class RelaxedCsvFileDataObject(override val id: DataObjectId,
   private val formatOptionsOverride = Map(
     "header" -> "true", // header must be the first line of every file
     "inferSchema" -> "false", // no schema inference, schema is given for the DataObject
+    "pathGlobFilter" -> fileName
   )
 
   override val options: Map[String, String] = formatOptionsDefault ++ csvOptions ++ formatOptionsOverride

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -189,10 +189,16 @@ trait SparkFileDataObject extends HadoopFileDataObject
 
   override def options: Map[String, String] = Map() // override options because of conflicting definitions in CanCreateSparkDataFrame and CanWriteSparkDataFrame
 
+  protected def recursiveFileLookup: Boolean = options.get("recursiveFileLookup").contains("true")
+
   /**
    * Hook to use different options for reading
    */
   protected def readOptions: Map[String, String] = options // hook to use different provider for reading
+
+  override def checkFilesExisting(recursive: Boolean = recursiveFileLookup)(implicit context: ActionPipelineContext): Boolean = {
+    super.checkFilesExisting(recursive)
+  }
 
   /**
    * Constructs an Apache Spark [[DataFrame]] from the underlying file content.
@@ -208,7 +214,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
     assert(wrongPartitionValues.isEmpty, s"getDataFrame got request with PartitionValues keys ${wrongPartitionValues.mkString(",")} not included in $id partition columns ${partitions.mkString(", ")}")
 
     val schemaOpt = getSchema.map(_.inner)
-    val filesExisting = checkFilesExisting
+    val filesExisting = checkFilesExisting()
     if (schemaOpt.isEmpty && !filesExisting) {
       //without either schema or data, no data frame can be created
       require(schema.isDefined, s"($id) DataObject schema is undefined. A schema must be defined if there are no existing files.")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
@@ -23,19 +23,14 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
-import io.smartdatalake.util.hdfs.{PartitionValues, SparkRepartitionDef}
+import io.smartdatalake.util.hdfs.SparkRepartitionDef
 import io.smartdatalake.util.json.DefaultFlatteningParser
 import io.smartdatalake.util.misc.AclDef
-import io.smartdatalake.util.spark.DataFrameUtil
-import io.smartdatalake.util.spark.DataFrameUtil.DataFrameReaderUtils
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
-import io.smartdatalake.workflow.action.NoDataToProcessWarning
-import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
-import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchema}
-import org.apache.hadoop.fs.{Path, PathFilter}
-import org.apache.spark.sql.functions.{input_file_name, lit}
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import io.smartdatalake.workflow.dataframe.GenericSchema
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.DataFrame
 
 /**
  * A [[DataObject]] backed by an XML data source.
@@ -79,7 +74,7 @@ case class XmlFileDataObject(override val id: DataObjectId,
   // this is only needed for FileRef actions
   override val fileName: String = "*.xml*"
 
-  override val options: Map[String, String] = xmlOptions.getOrElse(Map()) ++ Seq(rowTag.map("rowTag" -> _)).flatten
+  override val options: Map[String, String] = Map("pathGlobFilter" -> fileName) ++ xmlOptions.getOrElse(Map()) ++ Seq(rowTag.map("rowTag" -> _)).flatten
 
   override def afterRead(df: DataFrame)(implicit context: ActionPipelineContext): DataFrame  = {
     val dfSuper = super.afterRead(df)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
@@ -41,7 +41,7 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
 
   test("Reading from an empty file with header=true and inferSchema=false results in an empty, schema-less data frame.") {
     val tempDir = Files.createTempDirectory("csv")
-    val tempFile = Files.createTempFile(tempDir, "temp", "csv") // attention, this creates not a proper .csv file type, but just appends <filename>csv...
+    val tempFile = Files.createTempFile(tempDir, "temp", ".csv")
     try {
       val config = ConfigFactory.parseString(
         s"""
@@ -66,7 +66,7 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
 
   test("Reading from an empty file with header=true and inferSchema=true results in an empty, schema-less data frame.") {
     val tempDir = Files.createTempDirectory("csv")
-    val tempFile = Files.createTempFile(tempDir, "temp", "csv")
+    val tempFile = Files.createTempFile(tempDir, "temp", ".csv")
     try {
       val config = ConfigFactory.parseString(
         s"""
@@ -91,7 +91,7 @@ class CsvFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
 
   test("Reading from an empty file with header=false and inferSchema=true results in an empty, schema-less data frame.") {
     val tempDir = Files.createTempDirectory("csv")
-    val tempFile = Files.createTempFile(tempDir, "temp", "csv")
+    val tempFile = Files.createTempFile(tempDir, "temp", ".csv")
     try {
       val config = ConfigFactory.parseString(
         s"""


### PR DESCRIPTION
### What changes are included in the pull request?
Use Spark option pathGlobFilter=<filetype> when reading files with Spark

### Why are the changes needed?
To be consistent with checkExistingFiles which only checks for files with the specified filetype according to the DataObject type.
