### PR TITLE
java compiler release upgrade 8 -> 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,6 @@
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <version>4.5.6</version>
                         <executions>
                             <execution>
                                 <id>scala-doc</id>
@@ -418,9 +417,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <license.header.file>src/license/gplv3-header.txt</license.header.file>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
         <scala.deps.scope>compile</scala.deps.scope>
         <spark.deps.scope>compile</spark.deps.scope>
         <hadoop.deps.scope>compile</hadoop.deps.scope>
@@ -676,7 +673,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>4.5.6</version> <!-- attention: maven build fails when upgrading version -->
+                    <version>4.9.6</version>
                     <executions>
                         <execution>
                             <goals>
@@ -695,7 +692,7 @@
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
                             <arg>-explaintypes</arg>
-                            <arg>-target:jvm-1.${maven.compiler.release}</arg>
+                            <arg>-release:${maven.compiler.release}</arg>
                         </args>
                         <jvmArgs>
                             <jvmArg>-Xms64m</jvmArg>
@@ -876,7 +873,7 @@
                                 <version>2.0.6</version>
                             </requireMavenVersion>
                             <requireJavaVersion>
-                                <version>1.8</version>
+                                <version>11</version>
                             </requireJavaVersion>
                             <dependencyConvergence/>
                             <requireProperty>

--- a/sdl-core/src/main/scala/io/smartdatalake/util/evolution/SchemaEvolution.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/evolution/SchemaEvolution.scala
@@ -202,7 +202,7 @@ object SchemaEvolution extends SmartDataLakeLogger {
 
       // log information
       val infoList = tgtColumns.flatMap(_.infoMsg).map("-> " + _).mkString("\n")
-      val infoTxt = s"$infoList\nold schema:\n${oldDf.schema.treeString().stripTrailing()}\nnew schema:\n${newDf.schema.treeString().stripTrailing()}".indent(2)
+      val infoTxt = indent(s"$infoList\nold schema:\n${oldDf.schema.treeString().stripTrailing()}\nnew schema:\n${newDf.schema.treeString().stripTrailing()}", 2)
       logger.info(s"schema evolution needed. mapping is:\n$infoTxt"
       )
 
@@ -213,6 +213,11 @@ object SchemaEvolution extends SmartDataLakeLogger {
       // return
       (oldExtendedDf, newExtendedDf)
     }
+  }
+
+  def indent(s: String, spaces: Int): String = {
+    val pad = " " * spaces
+    s.linesIterator.map("  " + _).mkString(System.lineSeparator())
   }
 
   def isStringListEqual(a: Seq[String], b: Seq[String], caseSensitiveComparison: Boolean): Boolean = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/InitSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/InitSubFeed.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
+import org.apache.commons.lang3.NotImplementedException
 
 /**
  * An InitSubFeed is used to initialize first Nodes of a [[DAG]].


### PR DESCRIPTION
### What changes are included in the pull request?

maven java compiler release version: update from 8 to 11
-> SDLB artifacts will be built for java 11
-> we already use java 11 api, which is inconsistent

update scala-maven-plugin
-> update broke the build in the past, now it works
-> with current version incremental maven build works
-> compatibility errors using java 11 api in a build for java 8 are detected now as errors

### Why are the changes needed?
- fix scala maven incremental build
- detect and fix java compatibility errors