### PR TITLE
Remove -release argument from compiler configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -694,7 +694,6 @@
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
                             <arg>-explaintypes</arg>
-                            <arg>-release:${maven.compiler.release}</arg>
                         </args>
                         <jvmArgs>
                             <jvmArg>-Xms64m</jvmArg>


### PR DESCRIPTION
### What changes are included in the pull request?
Remove -release argument from scala-maven-plugin compiler configuration

### Why are the changes needed?
Build of projects using SDLB parent pom might fail.