### PR TITLE
1034 extend dataset testtool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv
 *.js
 *.log
 /sdl-core/src/main/resources/application.conf
+/sdl-core/test_enc.parquet/
 spark-warehouse
 **/spark-warehouse
 *.versionsBackup
@@ -15,16 +16,16 @@ spark-warehouse
 **/pom.xml.versionsBackup
 
 # User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
+.bloop
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/workspace.xml
 .idea/misc.xml
 .idea/scala_compiler.xml
-.vscode
 .metals
-.bloop
+.vscode
 
 # Generated files
 .idea/**/contentModel.xml

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,9 @@
   ~
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.smartdatalake</groupId>
@@ -57,10 +59,10 @@
 
     <developers>
         <developer>
-          <name>Smart Data Lake</name>
-          <email>smartdatalake@elca.ch</email>
-          <organization>ELCA Informatik AG</organization>
-          <organizationUrl>http://www.elca.ch</organizationUrl>
+            <name>Smart Data Lake</name>
+            <email>smartdatalake@elca.ch</email>
+            <organization>ELCA Informatik AG</organization>
+            <organizationUrl>http://www.elca.ch</organizationUrl>
         </developer>
     </developers>
 
@@ -436,8 +438,10 @@
         <jetty.deps.scope>compile</jetty.deps.scope>
         <scala.minor.version>2.12</scala.minor.version>
         <scala.version>${scala.minor.version}.15</scala.version>
-        <spark.version>3.5.5</spark.version><!-- delta-lake 3.3.2 is not yet compatible with Spark 3.5.6 because of https://github.com/delta-io/delta/issues/4671 -->
-        <spark-extensions.version>3.5.4</spark-extensions.version> <!-- this sdl-specific extensions should match the minor version of property spark.version -->
+        <spark.version>3.5.5
+        </spark.version><!-- delta-lake 3.3.2 is not yet compatible with Spark 3.5.6 because of https://github.com/delta-io/delta/issues/4671 -->
+        <spark-extensions.version>3.5.4
+        </spark-extensions.version> <!-- this sdl-specific extensions should match the minor version of property spark.version -->
         <spark.minor.version>3.5</spark.minor.version>
         <spark.version331>3.3.1</spark.version331>
         <!-- some libraries are still only available for spark 3.3, e.g. spark-excel -->
@@ -590,7 +594,8 @@
 
         <scaladoc.reader.version>1.0.3</scaladoc.reader.version>
 
-        <scalatest.test.version>3.0.8</scalatest.test.version>
+        <scalatest.test.version>3.2.19</scalatest.test.version>
+        <scalatest.plus.version>${scalatest.test.version}.0</scalatest.plus.version>
         <sshd.test.version>2.10.0</sshd.test.version>
         <debezium.version>3.1.0.Final</debezium.version>
 
@@ -831,7 +836,18 @@
                             <SPARK_LOCAL_IP>127.0.0.1
                             </SPARK_LOCAL_IP> <!-- Suppresses Spark IP discovery during tests (when executed with mvn test) -->
                         </environmentVariables>
-                        <argLine>--add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED</argLine>
+                        <argLine>--add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                            --add-opens=java.base/java.lang=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                            --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED
+                            --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED
+                            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+                            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+                            --add-opens=java.base/sun.security.action=ALL-UNNAMED
+                            --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+                        </argLine>
                     </configuration>
                     <executions>
                         <execution>
@@ -1997,7 +2013,7 @@
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
                     <exclusion>
-                    <groupId>org.slf4j</groupId>
+                        <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                     <exclusion>
@@ -3052,17 +3068,18 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.scalatestplus</groupId>
+                <artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
+                <version>${scalatest.plus.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.scalactic</groupId>
                 <artifactId>scalactic_${scala.minor.version}</artifactId>
                 <version>${scalatest.test.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.scalacheck</groupId>
-                <artifactId>scalacheck_${scala.minor.version}</artifactId>
-                <version>1.14.3</version>
-                <scope>test</scope>
-            </dependency>
+
 
             <!-- Vulnerable Dependencies Upgrades -->
             <dependency>

--- a/sdl-core/pom.xml
+++ b/sdl-core/pom.xml
@@ -101,10 +101,10 @@
             <artifactId>spark-sql_${scala.minor.version}</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-hive_${scala.minor.version}</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.minor.version}</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -278,13 +278,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.scalactic</groupId>
-            <artifactId>scalactic_${scala.minor.version}</artifactId>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.scalacheck</groupId>
-            <artifactId>scalacheck_${scala.minor.version}</artifactId>
+            <groupId>org.scalactic</groupId>
+            <artifactId>scalactic_${scala.minor.version}</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -462,10 +462,12 @@
                             <includes>
                                 <include>**/testutils/**</include>
                                 <include>log4j2.yml</include> <!-- Add logging configuration for testing. -->
-                                <include>test_keystore.pkcs12</include> <!-- Add key store for wiremock server for testing. -->
+                                <include>test_keystore.pkcs12
+                                </include> <!-- Add key store for wiremock server for testing. -->
                             </includes>
                             <excludes>
-                                <exclude>dummy-entry</exclude> <!-- override excludes inherited from parent plugin management with dummy entry -->
+                                <exclude>dummy-entry
+                                </exclude> <!-- override excludes inherited from parent plugin management with dummy entry -->
                             </excludes>
                         </configuration>
                     </execution>

--- a/sdl-core/src/test/scala/io/smartdatalake/app/AppUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/AppUtilTest.scala
@@ -23,9 +23,9 @@ import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformerConfig
 import io.smartdatalake.workflow.action.{Action, ActionMetadata, CopyAction, CustomDataFrameAction}
 import io.smartdatalake.workflow.dataobject.{CsvFileDataObject, DataObjectMetadata}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class AppUtilTest extends FunSuite {
+class AppUtilTest extends AnyFunSuite {
 
   test("mask secrets when logging spark conf") {
     val logTxt = AppUtil.createMaskedSecretsKVLog("secret.key", "+yQs4uO+taUi27+baM5D1/ishD8wDBuxj6+so0uk")
@@ -44,10 +44,10 @@ class AppUtilTest extends FunSuite {
   private val do4 = CsvFileDataObject("do4", "/dummy", metadata = Some(DataObjectMetadata(name = Some("dataObject4"), layer = Some("L1"))))
   private val do5 = CsvFileDataObject("do5", "/dummy", metadata = Some(DataObjectMetadata(name = Some("dataObject5"), layer = Some("L2"))))
   private val do6 = CsvFileDataObject("do6", "/dummy", metadata = Some(DataObjectMetadata(name = Some("dataObject6"), layer = Some("L3"))))
-  instanceRegistry.register(Seq(do1,do2,do3,do4,do5,do6))
+  instanceRegistry.register(Seq(do1, do2, do3, do4, do5, do6))
   private val actionA = CopyAction("a", "do1", "do2", metadata = Some(ActionMetadata(name = Some("actionA"), feed = Some("test1"))))
   private val actionB = CopyAction("b", "do1", "do3", metadata = Some(ActionMetadata(name = Some("actionB"), feed = Some("test2"))))
-  private val actionC = CustomDataFrameAction("c", Seq("do2","do3","do4"), Seq("do5"), transformer = Some(CustomDfsTransformerConfig(sqlCode = Some(Map(do5.id.id -> "select * from do2"))))
+  private val actionC = CustomDataFrameAction("c", Seq("do2", "do3", "do4"), Seq("do5"), transformer = Some(CustomDfsTransformerConfig(sqlCode = Some(Map(do5.id.id -> "select * from do2"))))
     , metadata = Some(ActionMetadata(name = Some("actionC"), feed = Some("test1")))
   )
   private val actionD = CopyAction("d", "do5", "do6", metadata = Some(ActionMetadata(name = Some("actionD"), feed = Some("test1"))))

--- a/sdl-core/src/test/scala/io/smartdatalake/app/GlobalConfigTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/GlobalConfigTest.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.app
 
 import io.smartdatalake.util.secrets.{SecretProvider, SecretProviderConfig, StringOrSecret}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class GlobalConfigTest extends FunSuite {
+class GlobalConfigTest extends AnyFunSuite {
   test("sparkOptions secrets are resolved in Hadoop config") {
     // prepare
     val providerConfig = SecretProviderConfig(classOf[TestSecretProvider].getName, Some(Map()))

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderAgentTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderAgentTest.scala
@@ -33,19 +33,20 @@ import io.smartdatalake.workflow.connection.Connection
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import io.smartdatalake.workflow.dataobject._
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-class SmartDataLakeBuilderAgentTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
+class SmartDataLakeBuilderAgentTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
   protected implicit val session: SparkSession = TestUtil.session
 
   import session.implicits._
 
-  val sdlb = DefaultSmartDataLakeBuilder
+  private val sdlb = DefaultSmartDataLakeBuilder
   implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
 
   before {
@@ -125,7 +126,7 @@ class SmartDataLakeBuilderAgentTest extends FunSuite with BeforeAndAfter with Sm
       }
     }.onComplete {
       case Success(_) => logger.info(s"pollForInstructions done")
-      case Failure(ex) => throw (ex)
+      case Failure(ex) => throw ex
     }
 
     // run SDLB Main Instance

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStatusInfoTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStatusInfoTest.scala
@@ -27,7 +27,8 @@ import io.smartdatalake.workflow.dataobject._
 import org.apache.spark.sql.SparkSession
 import org.eclipse.jetty.websocket.api.{Session, WebSocketAdapter}
 import org.eclipse.jetty.websocket.client.WebSocketClient
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
@@ -37,16 +38,16 @@ import scala.util.{Failure, Success}
 /**
  * This tests use configuration test/resources/configstatusinfo/application.conf
  */
-class SmartDataLakeBuilderStatusInfoTest extends FunSuite with BeforeAndAfter {
+class SmartDataLakeBuilderStatusInfoTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 
   import session.implicits._
 
-  val sdlb = DefaultSmartDataLakeBuilder
+  private val sdlb = DefaultSmartDataLakeBuilder
 
   before {
-    sdlb.instanceRegistry.clear
+    sdlb.instanceRegistry.clear()
   }
 
   // Note that this test produces a StackOverflowError in the Log with JDK11. The test succeeds nevertheless. Details see below.
@@ -67,12 +68,15 @@ class SmartDataLakeBuilderStatusInfoTest extends FunSuite with BeforeAndAfter {
     //Create Client Websocket that tries to establish connection with SDLB Job
     val receivedMessages: ListBuffer[String] = ListBuffer()
     // The socket that receives events
-    class UnitTestSocket() extends WebSocketAdapter with SmartDataLakeLogger {
+    class UnitTestSocket extends WebSocketAdapter with SmartDataLakeLogger {
       override def onWebSocketConnect(sess: Session): Unit = {}
+
       override def onWebSocketText(message: String): Unit = {
         receivedMessages += message
       }
+
       override def onWebSocketClose(statusCode: Int, reason: String): Unit = {}
+
       override def onWebSocketError(cause: Throwable): Unit = {}
     }
     val client = new WebSocketClient
@@ -111,6 +115,4 @@ class SmartDataLakeBuilderStatusInfoTest extends FunSuite with BeforeAndAfter {
     client.stop()
   }
 }
-
-
 

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStreamingTest.scala
@@ -38,13 +38,15 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.streaming.{StreamingQueryException, StreamingQueryListener}
 import org.apache.spark.sql.types.StructType
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogger with BeforeAndAfter {
+class SmartDataLakeBuilderStreamingTest extends AnyFunSuite with SmartDataLakeLogger with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("test")
@@ -54,7 +56,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
   val checkpointPath = "target/streamingCheckpointTest/"
   implicit val filesystem: FileSystem = HdfsUtil.getHadoopFsWithDefaultConf(new Path(statePath))
 
-  val sdlb = DefaultSmartDataLakeBuilder
+  private val sdlb = DefaultSmartDataLakeBuilder
   implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
 
   before {
@@ -74,55 +76,56 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-normal"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), doWarn = false)
     implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     val srcTable = Table(Some("default"), "ap_input")
     // source table has partitions columns dt and type
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), partitions = Seq("dt", "type"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgt1Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
+    val tgt1Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname", "firstname")))
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), partitions = Seq("dt", "type"), table = tgt1Table, numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
 
     // fill src table with first partition
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc1, Seq())
 
     // start streaming dag run
     // use only first partition col (dt) for partition diff mode
-    val action1 = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, udfAddX(rating) rating from src1"))))
     instanceRegistry.register(action1)
 
     // create state listener to control execution
     val stateListener = new StateListener with SmartDataLakeLogger {
       private var dfWritten = false
-      override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId : Option[ActionId]): Unit = {
+
+      override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId: Option[ActionId]): Unit = {
         assert(state.runId == context.executionId.runId && state.attemptId == context.executionId.attemptId)
         logger.info(s"Received metrics for runId=${state.runId} attemptId=${state.attemptId} final=${state.isFinal}")
         // check results after runId=1
-        if (state.isFinal && state.runId==1) {
+        if (state.isFinal && state.runId == 1) {
           // check results
           assert(tgt1DO.listPartitions.map(_.apply("dt")) == Seq("20180101"))
           assert(tgt1DO.getSparkDataFrame(Seq()).select($"lastname").as[String].collect().toSeq == Seq("doe"))
         }
         // add additional source partition in runId=2 for runId=3
-        if (state.isFinal && state.runId==2 && !dfWritten) {
+        if (state.isFinal && state.runId == 2 && !dfWritten) {
           dfWritten = true
           // add some more data
           logger.info("adding more data")
-          val dfSrc2 = Seq(("20180102", "company", "olmo","-",10)) // second partition 20190101
+          val dfSrc2 = Seq(("20180102", "company", "olmo", "-", 10)) // second partition 20190101
             .toDF("dt", "type", "lastname", "firstname", "rating")
           srcDO.writeSparkDataFrame(dfSrc2, Seq())
         }
         // stop after runId=3
-        if (state.isFinal && state.runId>=3) {
+        if (state.isFinal && state.runId >= 3) {
           Environment.stopStreamingGracefully = true
         }
       }
@@ -136,8 +139,8 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     Environment._additionalStateListeners = Seq()
 
     // check data after streaming is terminated
-    assert(tgt1DO.listPartitions.map(_.apply("dt")) == Seq("20180101","20180102"))
-    assert(tgt1DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6,11)) // +1 because of udfAddX
+    assert(tgt1DO.listPartitions.map(_.apply("dt")) == Seq("20180101", "20180102"))
+    assert(tgt1DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6, 11)) // +1 because of udfAddX
 
     // check state after streaming is terminated
     {
@@ -147,7 +150,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
       assert(runState.runId >= 3)
       assert(runState.attemptId == 1)
       val resultActionsState = runState.actionsState.mapValues(_.state).toMap
-      val expectedActionsState = Map((action1.id , RuntimeEventState.SKIPPED))
+      val expectedActionsState = Map((action1.id, RuntimeEventState.SKIPPED))
       assert(resultActionsState == expectedActionsState)
       assert(runState.actionsState.head._2.results.head.partitionValues.isEmpty)
     }
@@ -166,35 +169,38 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
     // setup DataObjects
     // source has partitions columns dt and type
-    val srcDO = CsvFileDataObject( "src1", tempPath+"/src1", partitions = Seq("dt","type")
-                                 , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
+    val srcDO = CsvFileDataObject("src1", tempPath + "/src1", partitions = Seq("dt", "type")
+      , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(srcDO)
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempPath+"/tgt1", partitions = Seq("dt","type")
+    val tgt1DO = CsvFileDataObject("tgt1", tempPath + "/tgt1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt1DO)
 
     // fill src with first files
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc1, Seq())
 
     // prepare streaming action
-    val action1 = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, udfAddX(rating) rating from src1"))))
     instanceRegistry.register(action1)
 
     // streaming event listener will add data and stop streaming after 3 micro-batches
     val testStreamingQueryListener = new StreamingQueryListener {
       private var dfWritten = false
-      private val actionRegex = (s"Action~(${SdlConfigObject.idRegexStr})").r.unanchored
+      private val actionRegex = s"Action~(${SdlConfigObject.idRegexStr})".r.unanchored
+
       override def onQueryIdle(event: StreamingQueryListener.QueryIdleEvent): Unit = {
         // Behaviour changed with Spark 3.5: no more progress if no data, but onQueryIdle is fired
         // stop streaming query
         logger.info("stopping streaming query after idle")
         session.streams.active.find(_.runId == event.runId).get.stop()
       }
+
       override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
+
       override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
         logger.info(s"progress ${event.progress.batchId} ${event.progress.name}")
         event.progress.name match {
@@ -215,6 +221,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
             }
         }
       }
+
       override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = ()
     }
     session.streams.addListener(testStreamingQueryListener)
@@ -227,8 +234,8 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     Environment.stopStreamingGracefully = false
 
     // check data after streaming is terminated
-    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Seq("20180101","20190101").toSet)
-    assert(tgt1DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6,11)) // +1 because of udfAddX
+    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Seq("20180101", "20190101").toSet)
+    assert(tgt1DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6, 11)) // +1 because of udfAddX
 
     val action1InfoSdl1 = action1.getRuntimeInfo(Some(SDLExecutionId(1))).get
     assert(action1InfoSdl1.state == RuntimeEventState.SUCCEEDED) // State for SDL execution 1 is reported as SUCCEEDED by streaming action
@@ -250,7 +257,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
       // only one SDL run executed (streaming action is asynchronous)
       assert(runState.runId == 1)
       assert(runState.attemptId == 1)
-      val resultActionsState = runState.actionsState.mapValues(s => (s.executionId,s.state)).toMap
+      val resultActionsState = runState.actionsState.mapValues(s => (s.executionId, s.state)).toMap
       val expectedActionsState = Map((action1.id, (SDLExecutionId(1), RuntimeEventState.SUCCEEDED))) // State for SDL execution 1 is reported as SUCCEEDED by streaming action
       assert(resultActionsState == expectedActionsState)
       assert(getFirstMetrics(runState.actionsState(action1.id))("records_written") == 1)
@@ -270,36 +277,38 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
     // setup DataObjects
     // source has partition columns dt and type
-    val srcDO = CsvFileDataObject( "src1", tempPath+"/src1", partitions = Seq("dt","type")
+    val srcDO = CsvFileDataObject("src1", tempPath + "/src1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(srcDO)
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempPath+"/tgt1", partitions = Seq("dt","type")
+    val tgt1DO = CsvFileDataObject("tgt1", tempPath + "/tgt1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt1DO)
     // second table has partitions columns dt and type (same as source)
-    val tgt2DO = CsvFileDataObject( "tgt2", tempPath+"/tgt2", partitions = Seq("dt","type")
+    val tgt2DO = CsvFileDataObject("tgt2", tempPath + "/tgt2", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt2DO)
 
     // fill src with first files
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc1, Seq())
 
     // prepare partition diff action
-    val actionA = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionA = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, rating from src1"))))
     // prepare streaming action
-    val actionB = CopyAction( "b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionB = CopyAction("b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, udfAddX(rating) rating from tgt1"))))
     instanceRegistry.register(Seq(actionA, actionB))
 
     // streaming event listener will add data and stop streaming after 3 micro-batches
     val testStreamingQueryListener = new StreamingQueryListener {
       private var dfWritten = false
-      private val actionRegex = (s"Action~(${SdlConfigObject.idRegexStr})").r.unanchored
+      private val actionRegex = s"Action~(${SdlConfigObject.idRegexStr})".r.unanchored
+
       override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
+
       override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
         logger.info(s"progress ${event.progress.batchId} ${event.progress.name}")
         event.progress.name match {
@@ -312,7 +321,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
                 val dfSrc2 = Seq(("20190101", "company", "olmo", "-", 10)) // second partition 20190101
                   .toDF("dt", "type", "lastname", "firstname", "rating")
                 srcDO.writeSparkDataFrame(dfSrc2, Seq())
-              case x if x>0 && event.progress.numInputRows > 0 =>
+              case x if x > 0 && event.progress.numInputRows > 0 =>
                 // stop streaming gracefully when second data partition was processed
                 logger.info("stopping streaming gracefully")
                 Environment.stopStreamingGracefully = true
@@ -320,6 +329,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
             }
         }
       }
+
       override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = ()
     }
     session.streams.addListener(testStreamingQueryListener)
@@ -332,8 +342,8 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     Environment.stopStreamingGracefully = false
 
     // check data after streaming is terminated
-    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101","20190101"))
-    assert(tgt2DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6,11)) // +1 because of udfAddX
+    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101", "20190101"))
+    assert(tgt2DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6, 11)) // +1 because of udfAddX
   }
 
   test("sdlb streaming recovery, synchronous action failing before asynchronously streaming action") {
@@ -349,50 +359,52 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
     // setup DataObjects
     // source has partition columns dt and type
-    val srcDO = CsvFileDataObject( "src1", tempPath+"/src1", partitions = Seq("dt","type")
+    val srcDO = CsvFileDataObject("src1", tempPath + "/src1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(srcDO)
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempPath+"/tgt1", partitions = Seq("dt","type")
+    val tgt1DO = CsvFileDataObject("tgt1", tempPath + "/tgt1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt1DO)
     // second table has partitions columns dt and type (same as source)
-    val tgt2DO = CsvFileDataObject( "tgt2", tempPath+"/tgt2", partitions = Seq("dt","type")
+    val tgt2DO = CsvFileDataObject("tgt2", tempPath + "/tgt2", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt2DO)
 
     // fill src with first files
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc1, Seq())
 
     // prepare partition diff action
-    val actionAFail = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionAFail = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(ScalaClassSparkDfTransformer(className = classOf[RuntimeFailTransformer].getName)))
-    val actionA = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionA = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, rating from src1"))))
     // prepare streaming action
-    val actionB = CopyAction( "b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionB = CopyAction("b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, udfAddX(rating) rating from tgt1"))))
 
     // streaming event listener will add data and stop streaming after 3 micro-batches
     val testStreamingQueryListener = new StreamingQueryListener {
       private var dfWritten = false
-      private val actionRegex = (s"Action~(${SdlConfigObject.idRegexStr})").r.unanchored
+      private val actionRegex = s"Action~(${SdlConfigObject.idRegexStr})".r.unanchored
+
       override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
+
       override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
         logger.info(s"progress ${event.progress.batchId} ${event.progress.name}")
         event.progress.name match {
           case actionRegex(actionId) =>
             event.progress.batchId match {
-              case 0 if !dfWritten=>
+              case 0 if !dfWritten =>
                 dfWritten = true
                 // add some more data
                 logger.info("adding more data")
                 val dfSrc2 = Seq(("20190101", "company", "olmo", "-", 10)) // second partition 20190101
                   .toDF("dt", "type", "lastname", "firstname", "rating")
                 srcDO.writeSparkDataFrame(dfSrc2, Seq())
-              case x if x>0 && event.progress.numInputRows > 0 =>
+              case x if x > 0 && event.progress.numInputRows > 0 =>
                 // stop streaming gracefully when second data partition was processed
                 logger.info("stopping streaming gracefully")
                 Environment.stopStreamingGracefully = true
@@ -400,6 +412,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
             }
         }
       }
+
       override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = ()
     }
     session.streams.addListener(testStreamingQueryListener)
@@ -423,8 +436,8 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     Environment.stopStreamingGracefully = false
 
     // check data after streaming is terminated
-    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101","20190101"))
-    assert(tgt2DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6,11)) // +1 because of udfAddX
+    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101", "20190101"))
+    assert(tgt2DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6, 11)) // +1 because of udfAddX
   }
 
   test("sdlb spark streaming failure, synchronous action before asynchronously streaming action, asynchronous action failing after first run") {
@@ -433,42 +446,44 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     val appName = "sdlb-streaming4"
     val feedName = "test"
 
-    HdfsUtil.deleteFiles(new Path(tempPath), false)
+    HdfsUtil.deleteFiles(new Path(tempPath), doWarn = false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(checkpointPath), false)
     implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partition columns dt and type
-    val srcDO = CsvFileDataObject( "src1", tempPath+"/src1", partitions = Seq("dt","type")
+    val srcDO = CsvFileDataObject("src1", tempPath + "/src1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(srcDO)
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempPath+"/tgt1", partitions = Seq("dt","type")
+    val tgt1DO = CsvFileDataObject("tgt1", tempPath + "/tgt1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt1DO)
     // second table has partitions columns dt and type (same as source)
-    val tgt2DO = CsvFileDataObject( "tgt2", tempPath+"/tgt2", partitions = Seq("dt","type")
+    val tgt2DO = CsvFileDataObject("tgt2", tempPath + "/tgt2", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt2DO)
 
     // fill src with first files
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc1, Seq())
 
     // prepare partition diff action
-    val actionA = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionA = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, rating from src1"))))
     // prepare streaming action
-    val actionB = CopyAction( "b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionB = CopyAction("b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, udfAddX(rating) rating from tgt1"))))
 
     // streaming event listener will add data and stop streaming after 3 micro-batches
     val testStreamingQueryListener = new StreamingQueryListener {
       private var dfWritten = false
-      private val actionRegex = (s"Action~(${SdlConfigObject.idRegexStr})").r.unanchored
+      private val actionRegex = s"Action~(${SdlConfigObject.idRegexStr})".r.unanchored
+
       override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
+
       override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
         logger.info(s"progress ${event.progress.batchId} ${event.progress.name}")
         event.progress.name match {
@@ -484,6 +499,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
             }
         }
       }
+
       override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = ()
     }
     session.streams.addListener(testStreamingQueryListener)
@@ -510,30 +526,30 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
     // setup DataObjects
     // source has partition columns dt and type
-    val srcDO = CsvFileDataObject( "src1", tempPath+"/src1", partitions = Seq("dt","type")
+    val srcDO = CsvFileDataObject("src1", tempPath + "/src1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(srcDO)
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempPath+"/tgt1", partitions = Seq("dt","type")
+    val tgt1DO = CsvFileDataObject("tgt1", tempPath + "/tgt1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt1DO)
     // second table has partitions columns dt and type (same as source)
-    val tgt2DO = CsvFileDataObject( "tgt2", tempPath+"/tgt2", partitions = Seq("dt","type")
+    val tgt2DO = CsvFileDataObject("tgt2", tempPath + "/tgt2", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt2DO)
 
     // fill src with first files
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc1, Seq())
 
     // prepare streaming action
-    val actionAFail = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionAFail = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(ScalaClassSparkDfTransformer(className = classOf[RuntimeFailTransformer].getName)))
-    val actionA = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionA = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, rating from src1"))))
     // prepare partition diff action
-    val actionB = CopyAction( "b", tgt1DO.id, tgt2DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionB = CopyAction("b", tgt1DO.id, tgt2DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, udfAddX(rating) rating from tgt1"))))
 
     // start run failing actionA
@@ -547,19 +563,20 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     // create state listener for controlling execution
     val stateListener: StateListener with SmartDataLakeLogger = new StateListener with SmartDataLakeLogger {
       var dfSrc2Written = false
-      override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId : Option[ActionId]): Unit = {
+
+      override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId: Option[ActionId]): Unit = {
         assert(state.runId == context.executionId.runId && state.attemptId == context.executionId.attemptId)
         logger.info(s"Received metrics for runId=${state.runId} attemptId=${state.attemptId} final=${state.isFinal}")
         // add additional source partition for runId=2
-        if (state.isFinal && state.runId==2 && !dfSrc2Written) {
+        if (state.isFinal && state.runId == 2 && !dfSrc2Written) {
           dfSrc2Written = true
           logger.info("adding more data")
-          val dfSrc2 = Seq(("20180102", "company", "olmo","-",10)) // second partition 20190101
+          val dfSrc2 = Seq(("20180102", "company", "olmo", "-", 10)) // second partition 20190101
             .toDF("dt", "type", "lastname", "firstname", "rating")
           srcDO.writeSparkDataFrame(dfSrc2, Seq())
         }
         // stop after runId=3
-        if (state.isFinal && state.runId>=3) {
+        if (state.isFinal && state.runId >= 3) {
           Environment.stopStreamingGracefully = true
         }
       }
@@ -579,8 +596,8 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     Environment._additionalStateListeners = Seq()
 
     // check data after streaming is terminated
-    assert(tgt2DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101","20180102"))
-    assert(tgt2DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6,11)) // +1 because of udfAddX
+    assert(tgt2DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101", "20180102"))
+    assert(tgt2DO.getSparkDataFrame(Seq()).select($"rating").as[Int].collect().toSeq == Seq(6, 11)) // +1 because of udfAddX
   }
 
   test("sdlb streaming restart, synchronous action skipped before asynchronously streaming action") {
@@ -591,40 +608,42 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     HdfsUtil.deleteFiles(new Path(statePath), false)
-    HdfsUtil.deleteFiles(new Path(checkpointPath), false)
+    HdfsUtil.deleteFiles(new Path(checkpointPath), doWarn = false)
     implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
     // setup DataObjects
     // source has partition columns dt and type
-    val srcDO = CsvFileDataObject( "src1", tempPath+"/src1", partitions = Seq("dt","type")
+    val srcDO = CsvFileDataObject("src1", tempPath + "/src1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(srcDO)
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempPath+"/tgt1", partitions = Seq("dt","type")
+    val tgt1DO = CsvFileDataObject("tgt1", tempPath + "/tgt1", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt1DO)
     // second table has partitions columns dt and type (same as source)
-    val tgt2DO = CsvFileDataObject( "tgt2", tempPath+"/tgt2", partitions = Seq("dt","type")
+    val tgt2DO = CsvFileDataObject("tgt2", tempPath + "/tgt2", partitions = Seq("dt", "type")
       , schema = Some(SparkSchema(StructType.fromDDL("dt string, type string, lastname string, firstname string, rating int"))))
     instanceRegistry.register(tgt2DO)
 
     // fill src with first files
-    val dfSrc1 = Seq(("20180101", "person", "doe","john",5)) // first partition 20180101
+    val dfSrc1 = Seq(("20180101", "person", "doe", "john", 5)) // first partition 20180101
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc1, Seq())
 
     // prepare partition diff action
-    val actionA = CopyAction( "a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionA = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(partitionColNb = Some(1))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, rating from src1"))))
     // prepare streaming action
-    val actionB = CopyAction( "b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val actionB = CopyAction("b", tgt1DO.id, tgt2DO.id, executionMode = Some(SparkStreamingMode(checkpointPath, "ProcessingTime", Some("1 seconds"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(SQLDfTransformer(code = Some("select dt, type, lastname, firstname, udfAddX(rating) rating from tgt1"))))
 
     // streaming event listener will add data and stop streaming after 3 micro-batches
     val testStreamingQueryListener: StreamingQueryListener = new StreamingQueryListener {
       var dfSrc2Written = false
-      private val actionRegex = (s"Action~(${SdlConfigObject.idRegexStr})").r.unanchored
+      private val actionRegex = s"Action~(${SdlConfigObject.idRegexStr})".r.unanchored
+
       override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = ()
+
       override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
         logger.info(s"progress ${event.progress.batchId} ${event.progress.name}")
         event.progress.name match {
@@ -637,7 +656,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
                 val dfSrc2 = Seq(("20190101", "company", "olmo", "-", 10)) // second partition 20190101
                   .toDF("dt", "type", "lastname", "firstname", "rating")
                 srcDO.writeSparkDataFrame(dfSrc2, Seq())
-              case x if x>0 && event.progress.numInputRows > 0 =>
+              case x if x > 0 && event.progress.numInputRows > 0 =>
                 // stop streaming gracefully when second data partition was processed
                 logger.info("stopping streaming gracefully")
                 Environment.stopStreamingGracefully = true
@@ -645,6 +664,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
             }
         }
       }
+
       override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = ()
     }
     session.streams.addListener(testStreamingQueryListener)
@@ -658,7 +678,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     Environment.stopStreamingGracefully = false
 
     // check data after streaming is terminated
-    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101","20190101"))
+    assert(tgt1DO.listPartitions.map(_.apply("dt")).toSet == Set("20180101", "20190101"))
 
     // restart run
     val currentRunId = actionA.runtimeData.currentExecutionId.get.asInstanceOf[SDLExecutionId].runId
@@ -666,7 +686,7 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
     actionA.reset
     actionB.reset
     // this listener adds more data after first skipped run
-    Environment._additionalStateListeners = Seq(new PartitionStreamingTestStateListener2(currentRunId+1))
+    Environment._additionalStateListeners = Seq(new PartitionStreamingTestStateListener2(currentRunId + 1))
     Environment.stopStreamingGracefully = false
     sdlb.run(sdlConfig)
     Environment.stopStreamingGracefully = false
@@ -681,25 +701,28 @@ class SmartDataLakeBuilderStreamingTest extends FunSuite with SmartDataLakeLogge
 
 /**
  * Add more data after given runId
+ *
  * @param nextRunId
  */
 class PartitionStreamingTestStateListener2(runIdToAddData: Int) extends StateListener with SmartDataLakeLogger {
   var srcDO: CsvFileDataObject = _
   private var dfWritten = false
+
   override def init(context: ActionPipelineContext): Unit = {
     srcDO = Environment.instanceRegistry.get[CsvFileDataObject](DataObjectId("src1"))
   }
-  override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId : Option[ActionId]): Unit = {
-    implicit val _context = context
-    implicit val _sparkSession = context.sparkSession
+
+  override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId: Option[ActionId]): Unit = {
+    implicit val _context: ActionPipelineContext = context
+    implicit val _sparkSession: SparkSession = context.sparkSession
     import _sparkSession.implicits._
     assert(state.runId == context.executionId.runId && state.attemptId == context.executionId.attemptId)
     logger.info(s"Received metrics for runId=${state.runId} attemptId=${state.attemptId} final=${state.isFinal}")
     // add additional source partition after runIdToAddData
-    if (state.isFinal && state.runId==runIdToAddData && !dfWritten) {
+    if (state.isFinal && state.runId == runIdToAddData && !dfWritten) {
       dfWritten = true
       logger.info("adding more data")
-      val dfSrc2 = Seq(("20180102", "company", "olmo","-",10)) // second partition 20190101
+      val dfSrc2 = Seq(("20180102", "company", "olmo", "-", 10)) // second partition 20190101
         .toDF("dt", "type", "lastname", "firstname", "rating")
       srcDO.writeSparkDataFrame(dfSrc2, Seq())
     }

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -42,16 +42,18 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{lit, raise_error, udf}
 import org.apache.spark.sql.{DataFrame, SparkSession, functions}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
 /**
  * This tests use configuration test/resources/application.conf
  */
-class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
+class SmartDataLakeBuilderTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:SmartDataLakeBuilderTest", "org.hsqldb.jdbcDriver")
@@ -59,7 +61,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
   private val tempDir = Files.createTempDirectory("test")
   private val tempPath = tempDir.toAbsolutePath.toString
 
-  val sdlb = DefaultSmartDataLakeBuilder
+  private val sdlb = DefaultSmartDataLakeBuilder
 
   val statePath = "target/stateTest/"
   implicit val filesystem: FileSystem = HdfsUtil.getHadoopFsWithDefaultConf(new Path(statePath))
@@ -98,27 +100,27 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     // configure SDLPlugin for testing
     Environment._sdlPlugins = Seq(new TestSDLPlugin)
 
-    HdfsUtil.deleteFiles(new Path(statePath), false)
+    HdfsUtil.deleteFiles(new Path(statePath), doWarn = false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
     // source table has partitions columns dt and type
-    val srcDO = MockDataObject( "src1", partitions = Seq("dt","type")).register
-    val tgt1Table = Table(Some("default"), "ap_copy1", None, Some(Seq("lastname","firstname")))
+    val srcDO = MockDataObject("src1", partitions = Seq("dt", "type")).register
+    val tgt1Table = Table(Some("default"), "ap_copy1", None, Some(Seq("lastname", "firstname")))
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), partitions = Seq("dt", "type"), table = tgt1Table, numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2Table = Table(Some("default"), "ap_copy2", None, Some(Seq("lastname","firstname")))
+    val tgt2Table = Table(Some("default"), "ap_copy2", None, Some(Seq("lastname", "firstname")))
     // second table has partition columns dt only (reduced)
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare data
-    val dfSrc = Seq(("20180101", "person", "doe","john",5) // partition 20180101 is included in partition values filter
-      ,("20190101", "company", "olmo","-",10)) // partition 20190101 is not included
+    val dfSrc = Seq(("20180101", "person", "doe", "john", 5) // partition 20180101 is included in partition values filter
+      , ("20190101", "company", "olmo", "-", 10)) // partition 20190101 is not included
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc, Seq())
 
@@ -129,7 +131,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     val action2fail = CopyAction("b", tgt1DO.id, tgt2DO.id, metadata = Some(ActionMetadata(feed = Some(feedName)))
       , transformers = Seq(ScalaClassSparkDfTransformer(className = classOf[RuntimeFailTransformer].getName)))
     instanceRegistry.register(action2fail.copy())
-    val selectedPartitions = Seq(PartitionValues(Map("dt"->"20180101")))
+    val selectedPartitions = Seq(PartitionValues(Map("dt" -> "20180101")))
     val sdlConfig = SmartDataLakeBuilderConfig(configuration = Seq("cp:/application.conf"), feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath)
       , partitionValues = Some(selectedPartitions))
     intercept[TaskFailedException](sdlb.run(sdlConfig))
@@ -176,8 +178,8 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 2)
-      val resultActionsState = runState.actionsState.mapValues(x=>(x.state, x.executionId)).toMap
-      val expectedActionsState = Map(action1.id -> (RuntimeEventState.SUCCEEDED,SDLExecutionId(1,1)), action2success.id -> (RuntimeEventState.SUCCEEDED,SDLExecutionId(1,2)))
+      val resultActionsState = runState.actionsState.mapValues(x => (x.state, x.executionId)).toMap
+      val expectedActionsState = Map(action1.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1, 1)), action2success.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1, 2)))
       assert(resultActionsState == expectedActionsState)
       assert(runState.actionsState.head._2.results.head.partitionValues == selectedPartitions)
       assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty)
@@ -198,24 +200,24 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
     // source table has partitions columns dt and type
-    val srcDO = MockDataObject( "src1", partitions = Seq("dt","type")).register
-    val tgt1Table = Table(Some("default"), "ap_copy1", None, Some(Seq("lastname","firstname")))
+    val srcDO = MockDataObject("src1", partitions = Seq("dt", "type")).register
+    val tgt1Table = Table(Some("default"), "ap_copy1", None, Some(Seq("lastname", "firstname")))
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), partitions = Seq("dt","type"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), partitions = Seq("dt", "type"), table = tgt1Table, numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2Table = Table(Some("default"), "ap_copy2", None, Some(Seq("lastname","firstname")))
+    val tgt2Table = Table(Some("default"), "ap_copy2", None, Some(Seq("lastname", "firstname")))
     // second table has partition columns dt only (reduced)
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare data
-    val dfSrc = Seq(("20180101", "person", "doe","john",5), ("20190101", "company", "olmo","-",10))
+    val dfSrc = Seq(("20180101", "person", "doe", "john", 5), ("20190101", "company", "olmo", "-", 10))
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc, Seq())
     tgt1DO.writeSparkDataFrame(dfSrc) // create table because it's needed but first action is skipped
@@ -225,7 +227,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionCondition = Some(Condition("false", Some("always skip this action"))), metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action1.copy())
     val action2fail = CopyAction("b", tgt1DO.id, tgt2DO.id, executionCondition = Some(Condition("true", Some("always execute this action"))), metadata = Some(ActionMetadata(feed = Some(feedName)))
-      , transformers = Seq(ScalaClassSparkDfTransformer(className = classOf[ExecFailTransformer].getName, runtimeOptions = Map("phase"-> "executionPhase"))))
+      , transformers = Seq(ScalaClassSparkDfTransformer(className = classOf[ExecFailTransformer].getName, runtimeOptions = Map("phase" -> "executionPhase"))))
     instanceRegistry.register(action2fail.copy())
     val sdlConfig = SmartDataLakeBuilderConfig(configuration = Seq("cp:/application.conf"), feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
     intercept[TaskFailedException](sdlb.run(sdlConfig))
@@ -249,7 +251,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(action1.copy())
 
     // start recovery dag run
-    val action2success = CopyAction("b", tgt1DO.id, tgt2DO.id, executionCondition = Some(Condition("true", Some("always execute this action"))),  metadata = Some(ActionMetadata(feed = Some(feedName))))
+    val action2success = CopyAction("b", tgt1DO.id, tgt2DO.id, executionCondition = Some(Condition("true", Some("always execute this action"))), metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action2success.copy())
     sdlb.run(sdlConfig)
 
@@ -260,8 +262,8 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 2)
-      val resultActionsState = runState.actionsState.mapValues(x=>(x.state, x.executionId)).toMap
-      val expectedActionsState = Map(action1.id -> (RuntimeEventState.SKIPPED,SDLExecutionId(1,1)), action2success.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1,2)))
+      val resultActionsState = runState.actionsState.mapValues(x => (x.state, x.executionId)).toMap
+      val expectedActionsState = Map(action1.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1, 1)), action2success.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1, 2)))
       assert(resultActionsState == expectedActionsState)
       assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty)
     }
@@ -276,18 +278,18 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
-    val srcDO = MockDataObject( "src1", partitions = Seq("dt")).register
-    val tgt1DO = MockDataObject( "tgt1", partitions = Seq("dt")).register
-    val tgt2DO = MockDataObject( "tgt2", partitions = Seq("dt")).register
-    val tgt3DO = MockDataObject( "tgt3", partitions = Seq("dt")).register
-    val tgt4DO = MockDataObject( "tgt4", partitions = Seq("dt")).register
-    val tgt5DO = MockDataObject( "tgt5", partitions = Seq("dt")).register
+    val srcDO = MockDataObject("src1", partitions = Seq("dt")).register
+    val tgt1DO = MockDataObject("tgt1", partitions = Seq("dt")).register
+    val tgt2DO = MockDataObject("tgt2", partitions = Seq("dt")).register
+    val tgt3DO = MockDataObject("tgt3", partitions = Seq("dt")).register
+    val tgt4DO = MockDataObject("tgt4", partitions = Seq("dt")).register
+    val tgt5DO = MockDataObject("tgt5", partitions = Seq("dt")).register
 
     // prepare data
-    val dfSrc = Seq(("20180101", "person", "doe","john",5), ("20190101", "company", "olmo","-",10))
+    val dfSrc = Seq(("20180101", "person", "doe", "john", 5), ("20190101", "company", "olmo", "-", 10))
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc, Seq())
 
@@ -349,13 +351,13 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 2)
-      val resultActionsState = runState.actionsState.mapValues(x=>(x.state, x.executionId)).toMap
+      val resultActionsState = runState.actionsState.mapValues(x => (x.state, x.executionId)).toMap
       val expectedActionsState = Map(
-        action1.id -> (RuntimeEventState.SKIPPED,SDLExecutionId(1,1)),
-        action2success.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1,2)),
-        action3.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1,2)),
-        action4.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1,2)),
-        action5.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1,1))
+        action1.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1, 1)),
+        action2success.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1, 2)),
+        action3.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1, 2)),
+        action4.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1, 2)),
+        action5.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1, 1))
       )
       assert(resultActionsState == expectedActionsState)
       assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty)
@@ -370,22 +372,22 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
-    val srcDO = MockDataObject( "src1", partitions = Seq("dt")).register
-    val tgt1DO = MockDataObject( "tgt1", partitions = Seq("dt")).register
-    val tgt2DO = MockDataObject( "tgt2", partitions = Seq("dt")).register
+    val srcDO = MockDataObject("src1", partitions = Seq("dt")).register
+    val tgt1DO = MockDataObject("tgt1", partitions = Seq("dt")).register
+    val tgt2DO = MockDataObject("tgt2", partitions = Seq("dt")).register
 
     // prepare data
-    val dfSrc = Seq(("20180101", "person", "doe","john",5), ("20190101", "company", "olmo","-",10))
+    val dfSrc = Seq(("20180101", "person", "doe", "john", 5), ("20190101", "company", "olmo", "-", 10))
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc, Seq())
 
     // start first dag run -> fail
     // action1 skipped (ExecNoDataTransformer)
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, metadata = Some(ActionMetadata(feed = Some(feedName)))
-      , transformers = Seq(ScalaClassSparkDfTransformer(className = classOf[ExecNoDataTransformer].getName, runtimeOptions = Map("phase"-> "executionPhase"))))
+      , transformers = Seq(ScalaClassSparkDfTransformer(className = classOf[ExecNoDataTransformer].getName, runtimeOptions = Map("phase" -> "executionPhase"))))
     instanceRegistry.register(action1.copy())
     // action2 is skipped because action1 is skipped
     val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id, metadata = Some(ActionMetadata(feed = Some(feedName))))
@@ -402,10 +404,10 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 1)
-      val resultActionsState = runState.actionsState.mapValues(x=>(x.state, x.executionId)).toMap
+      val resultActionsState = runState.actionsState.mapValues(x => (x.state, x.executionId)).toMap
       val expectedActionsState = Map(
-        action1.id -> (RuntimeEventState.SKIPPED,SDLExecutionId(1,1)),
-        action2.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1,1))
+        action1.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1, 1)),
+        action2.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1, 1))
       )
       assert(resultActionsState == expectedActionsState)
     }
@@ -420,15 +422,15 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
-    val srcDO = MockDataObject( "src1", partitions = Seq("dt")).register
-    val tgt1DO = MockDataObject( "tgt1", partitions = Seq("dt")).register
-    val tgt2DO = MockDataObject( "tgt2", partitions = Seq("dt")).register
+    val srcDO = MockDataObject("src1", partitions = Seq("dt")).register
+    val tgt1DO = MockDataObject("tgt1", partitions = Seq("dt")).register
+    val tgt2DO = MockDataObject("tgt2", partitions = Seq("dt")).register
 
     // prepare data
-    val dfSrc = Seq(("20180101", "person", "doe","john",5), ("20190101", "company", "olmo","-",10))
+    val dfSrc = Seq(("20180101", "person", "doe", "john", 5), ("20190101", "company", "olmo", "-", 10))
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc, Seq())
 
@@ -453,10 +455,10 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       val runState = stateStore.recoverRunState(stateFile)
       assert(runState.runId == 1)
       assert(runState.attemptId == 1)
-      val resultActionsState = runState.actionsState.mapValues(x=>(x.state, x.executionId)).toMap
+      val resultActionsState = runState.actionsState.mapValues(x => (x.state, x.executionId)).toMap
       val expectedActionsState = Map(
-        action1.id -> (RuntimeEventState.SUCCEEDED,SDLExecutionId(1,1)),
-        action2.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1,1))
+        action1.id -> (RuntimeEventState.SUCCEEDED, SDLExecutionId(1, 1)),
+        action2.id -> (RuntimeEventState.SKIPPED, SDLExecutionId(1, 1))
       )
       assert(resultActionsState == expectedActionsState)
       val action1Metrics = runState.actionsState(action1.id).results.head.metrics.get
@@ -474,7 +476,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
     val src1DO = MockDataObject("src1").register
@@ -485,17 +487,17 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     val tgt4DO = MockDataObject("tgt4").register
 
     // prepare data
-    val dfSrc1 = Seq((1,"20180101", "person", "doe","john",5), (2,"20190101", "company", "olmo","-",10))
+    val dfSrc1 = Seq((1, "20180101", "person", "doe", "john", 5), (2, "20190101", "company", "olmo", "-", 10))
       .toDF("id", "dt", "type", "lastname", "firstname", "rating")
     src1DO.writeSparkDataFrame(dfSrc1, Seq())
-    val dfSrc2 = Seq((1,"abc"))
+    val dfSrc2 = Seq((1, "abc"))
       .toDF("id", "comment")
     src2DO.writeSparkDataFrame(dfSrc2, Seq())
 
     // start first dag run -> fail
     // action1 has data
     val action1 = CopyAction("a", src1DO.id, tgt1DO.id, metadata = Some(ActionMetadata(feed = Some(feedName)))
-    , executionMode = Some(DataFrameIncrementalMode("id"))
+      , executionMode = Some(DataFrameIncrementalMode("id"))
     )
     instanceRegistry.register(action1.copy())
     // action2 is skipped in init phase as data is not yet there, but should execute in exec phase
@@ -509,7 +511,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     )
     instanceRegistry.register(action3.copy())
     // action4 is skipped in init phase as data is not yet there, but should execute in exec phase
-    val action4 = CustomDataFrameAction("d", Seq(tgt3DO.id,src2DO.id), Seq(tgt4DO.id), metadata = Some(ActionMetadata(feed = Some(feedName)))
+    val action4 = CustomDataFrameAction("d", Seq(tgt3DO.id, src2DO.id), Seq(tgt4DO.id), metadata = Some(ActionMetadata(feed = Some(feedName)))
       , executionMode = Some(DataFrameIncrementalMode("id"))
       , transformers = Seq(SQLDfsTransformer(code = Map("tgt4" -> "select dt, type, lastname, firstname, udfAddX(rating) rating from tgt3")))
     )
@@ -622,7 +624,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     HdfsUtil.deleteFiles(new Path(statePath), false)
     HdfsUtil.deleteFiles(new Path(tempPath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
     instanceRegistry.clear()
 
     // setup DataObjects
@@ -630,18 +632,18 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(srcDO1)
     val srcDO2 = TestIncrementalDataObject("src2", initVal = 5)
     instanceRegistry.register(srcDO2)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempPath+s"/tgt1", saveMode = SDLSaveMode.Append)
+    val tgt1DO = CsvFileDataObject("tgt1", tempPath + s"/tgt1", saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = CsvFileDataObject( "tgt2", tempPath+s"/tgt2", saveMode = SDLSaveMode.Append)
+    val tgt2DO = CsvFileDataObject("tgt2", tempPath + s"/tgt2", saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt2DO)
 
     // start first dag run
-    val action1 = CopyAction( "a", srcDO1.id, tgt1DO.id, executionMode = Some(DataObjectStateIncrementalMode())
-      , transformers = Seq(ColumnsTransformer(additionalColumns = Map("run_id"-> "runId")))
+    val action1 = CopyAction("a", srcDO1.id, tgt1DO.id, executionMode = Some(DataObjectStateIncrementalMode())
+      , transformers = Seq(ColumnsTransformer(additionalColumns = Map("run_id" -> "runId")))
       , metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action1)
-    val action2 = CopyAction( "b", srcDO2.id, tgt2DO.id, executionMode = Some(DataObjectStateIncrementalMode())
-      , transformers = Seq(ColumnsTransformer(additionalColumns = Map("run_id"-> "runId")))
+    val action2 = CopyAction("b", srcDO2.id, tgt2DO.id, executionMode = Some(DataObjectStateIncrementalMode())
+      , transformers = Seq(ColumnsTransformer(additionalColumns = Map("run_id" -> "runId")))
       , metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action2)
     val sdlConfig = SmartDataLakeBuilderConfig(configuration = Seq("cp:/application.conf"), feedSel = feedName, applicationName = Some(appName), statePath = Some(statePath))
@@ -649,7 +651,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check results
     val dfResult1 = tgt1DO.getSparkDataFrame(Seq())
-    assert(dfResult1.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int,Long)].head() == (10,10))
+    assert(dfResult1.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int, Long)].head() == (10, 10))
 
     // start second dag run
     action1.reset
@@ -658,7 +660,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check results
     val dfResult2 = tgt1DO.getSparkDataFrame(Seq())
-    assert(dfResult2.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int,Long)].head() == (20,20))
+    assert(dfResult2.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int, Long)].head() == (20, 20))
 
     // start 3rd dag run -> no data
     action1.reset
@@ -667,7 +669,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check results
     val dfResult3 = tgt1DO.getSparkDataFrame(Seq())
-    assert(dfResult3.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int,Long)].head() == (20,20))
+    assert(dfResult3.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int, Long)].head() == (20, 20))
 
     // start 4th dag run
     action1.reset
@@ -676,7 +678,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     // check results
     val dfResult4 = tgt1DO.getSparkDataFrame(Seq())
-    assert(dfResult4.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int,Long)].head() == (30,30))
+    assert(dfResult4.select(functions.max($"nb".cast("int")), functions.count("*")).as[(Int, Long)].head() == (30, 30))
   }
 
   test("sdlb simulation run") {
@@ -686,7 +688,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
     instanceRegistry.clear()
 
     // setup DataObjects
@@ -714,7 +716,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     // start first dag run
     val action1 = DeduplicateAction("a", srcDO.id, tgt1DO.id, metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action1)
-    val action2 = CopyAction( "b", tgt1DO.id, tgt2DO.id, metadata = Some(ActionMetadata(feed = Some(feedName))))
+    val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id, metadata = Some(ActionMetadata(feed = Some(feedName))))
     instanceRegistry.register(action2)
     val configStart = SmartDataLakeBuilderConfig(configuration = Seq("cp:/application.conf"), feedSel = feedName, applicationName = Some(appName))
     val (finalSubFeeds, stats) = sdlb.startSimulation(configStart, Seq(SparkSubFeed(Some(SparkDataFrame(dfSrc1)), srcDO.id, Seq())))
@@ -753,11 +755,11 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
         |""".stripMargin).resolve
 
     implicit val instanceRegistry: InstanceRegistry = ConfigParser.parse(config)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
     val sdlConfig = SmartDataLakeBuilderConfig(configuration = Seq("cp:/application.conf"), feedSel = "ids:act")
 
     val srcDO = instanceRegistry.get[CsvFileDataObject]("src")
-    val dfSrc = Seq(("testData", "Foo"),("bar", "Space")).toDF("testColumn", "c?olumnN[ä]me")
+    val dfSrc = Seq(("testData", "Foo"), ("bar", "Space")).toDF("testColumn", "c?olumnN[ä]me")
 
     // Run SDLB
     val (outputSubFeeds, _) = sdlb.startSimulation(sdlConfig, Seq(SparkSubFeed(Some(SparkDataFrame(dfSrc)), srcDO.id, Seq())))
@@ -800,11 +802,11 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
         |""".stripMargin).resolve
 
     implicit val instanceRegistry: InstanceRegistry = ConfigParser.parse(config)
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
     val sdlConfig = SmartDataLakeBuilderConfig(configuration = Seq("cp:/application.conf"), feedSel = "ids:act")
 
     val srcDO = instanceRegistry.get[CsvFileDataObject]("src")
-    val dfSrc = Seq(("testData", "Foo"),("bar", "Space")).toDF("FOO", "noCamel")
+    val dfSrc = Seq(("testData", "Foo"), ("bar", "Space")).toDF("FOO", "noCamel")
 
     // Run SDLB
     val (outputSubFeeds, _) = sdlb.startSimulation(sdlConfig, Seq(SparkSubFeed(Some(SparkDataFrame(dfSrc)), srcDO.id, Seq())))
@@ -825,7 +827,7 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     TestUtil.setupWebserviceStubs()
 
     val feedName = "test"
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext(sdlb.instanceRegistry)
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext(sdlb.instanceRegistry)
 
     // write csv data to target/src1, which is defined in "/configState/WithFinalStateWriter.conf"
     val dummySrcDO = CsvFileDataObject("dummysrc1", "target/src1")(sdlb.instanceRegistry)
@@ -853,9 +855,9 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
     assert(filesystem.exists(new Path(uploadStagePath)))
     assert(filesystem.listFiles(new Path(uploadStagePath), true).hasNext)
     val dfActionLog = sdlb.instanceRegistry.get[TransactionalTableDataObject](DataObjectId("actionLog")).getSparkDataFrame()
-    assert(dfActionLog.select($"run_id", $"action_id", $"attempt_id",$"state").as[(Long,String,Int,String)].collect().toSet == Set((1L,"act",1,"SUCCEEDED")))
+    assert(dfActionLog.select($"run_id", $"action_id", $"attempt_id", $"state").as[(Long, String, Int, String)].collect().toSet == Set((1L, "act", 1, "SUCCEEDED")))
     val dfMetricsLog = sdlb.instanceRegistry.get[TransactionalTableDataObject](DataObjectId("metricsLog")).getSparkDataFrame()
-    assert(dfMetricsLog.select($"run_id", $"action_id", $"data_object_id", $"records_written").as[(Long,String,String,Long)].collect().toSet == Set((1L,"act","tgt",1L)))
+    assert(dfMetricsLog.select($"run_id", $"action_id", $"data_object_id", $"records_written").as[(Long, String, String, Long)].collect().toSet == Set((1L, "act", "tgt", 1L)))
 
     // check StateUploader retry
     val uiBackend2 = Environment._globalConfig.uiBackend.get.copy(baseUrl = "https://localhost/good/post/no_auth?tenant=1&repo=abc")
@@ -874,17 +876,17 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
 
     HdfsUtil.deleteFiles(new Path(statePath), false)
     implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
-    implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
     // setup DataObjects
     // partition columns: dt, type
-    val srcDO = MockDataObject( "src1", partitions = Seq("dt","type")).register
+    val srcDO = MockDataObject("src1", partitions = Seq("dt", "type")).register
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = MockDataObject( "tgt1", partitions = Seq("dt","type"), primaryKey = Some(Seq("lastname","firstname"))).register
-    val tgt2DO = MockDataObject( "tgt2", partitions = Seq("dt","type"), primaryKey = Some(Seq("lastname","firstname"))).register
+    val tgt1DO = MockDataObject("tgt1", partitions = Seq("dt", "type"), primaryKey = Some(Seq("lastname", "firstname"))).register
+    val tgt2DO = MockDataObject("tgt2", partitions = Seq("dt", "type"), primaryKey = Some(Seq("lastname", "firstname"))).register
 
     // prepare data
-    val dfSrc = Seq(("20180101", "person", "doe","john",5), ("20190101", "company", "olmo","-",10))
+    val dfSrc = Seq(("20180101", "person", "doe", "john", 5), ("20190101", "company", "olmo", "-", 10))
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc, Seq())
 
@@ -912,8 +914,8 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       assert(runState.attemptId == 1)
       val resultActionsState = runState.actionsState.mapValues(s => (s.state, s.results.head.partitionValues)).toMap
       val expectedActionsState = Map(
-        (action1.id, (RuntimeEventState.SUCCEEDED, Seq(PartitionValues(Map("dt"->"20180101"))))),
-        (action2failRuntime.id, (RuntimeEventState.FAILED, Seq(PartitionValues(Map("dt"->"20180101")))))
+        (action1.id, (RuntimeEventState.SUCCEEDED, Seq(PartitionValues(Map("dt" -> "20180101"))))),
+        (action2failRuntime.id, (RuntimeEventState.FAILED, Seq(PartitionValues(Map("dt" -> "20180101")))))
       )
       assert(resultActionsState == expectedActionsState)
     }
@@ -965,8 +967,8 @@ class SmartDataLakeBuilderTest extends FunSuite with BeforeAndAfter {
       assert(runState.attemptId == 3)
       val resultActionsState = runState.actionsState.mapValues(s => (s.state, s.results.head.partitionValues)).toMap
       val expectedActionsState = Map(
-        (action1.id, (RuntimeEventState.SUCCEEDED, Seq(PartitionValues(Map("dt"->"20180101"))))),
-        (action2failRuntime.id, (RuntimeEventState.SUCCEEDED, Seq(PartitionValues(Map("dt"->"20180101")))))
+        (action1.id, (RuntimeEventState.SUCCEEDED, Seq(PartitionValues(Map("dt" -> "20180101"))))),
+        (action2failRuntime.id, (RuntimeEventState.SUCCEEDED, Seq(PartitionValues(Map("dt" -> "20180101")))))
       )
       assert(resultActionsState == expectedActionsState)
       assert(filesystem.listStatus(new Path(statePath, "current")).map(_.getPath).isEmpty)
@@ -1004,45 +1006,56 @@ class RuntimeFailTransformer extends CustomDfTransformer {
 
 class ExecFailTransformer extends CustomDfTransformer {
   def transform(session: SparkSession, options: Map[String, String], df: DataFrame, dataObjectId: String): DataFrame = {
-    if (options("phase")=="Exec") throw new IllegalStateException("aborted by ExecFailTransformer")
+    if (options("phase") == "Exec") throw new IllegalStateException("aborted by ExecFailTransformer")
     else df
   }
 }
 
 class ExecNoDataTransformer extends CustomDfTransformer {
   def transform(session: SparkSession, options: Map[String, String], df: DataFrame, dataObjectId: String): DataFrame = {
-    if (options("phase")=="Exec") throw NoDataToProcessWarning(dataObjectId, "skipped by ExecNoDataTransformer")
+    if (options("phase") == "Exec") throw NoDataToProcessWarning(dataObjectId, "skipped by ExecNoDataTransformer")
     else df
   }
 }
 
-class TestStateListener(options: Map[String,StringOrSecret]) extends StateListener {
+class TestStateListener(options: Map[String, StringOrSecret]) extends StateListener {
   var firstState: Option[ActionDAGRunState] = None
   var finalState: Option[ActionDAGRunState] = None
-  override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId : Option[ActionId]): Unit = {
+
+  override def notifyState(state: ActionDAGRunState, context: ActionPipelineContext, changedActionId: Option[ActionId]): Unit = {
     if (TestStateListener.context.isEmpty) TestStateListener.context = Some(context)
     if (firstState.isEmpty) firstState = Some(state)
     finalState = Some(state)
   }
 }
+
 object TestStateListener {
   var context: Option[ActionPipelineContext] = None
 }
 
-class TestUDFAddXCreator() extends SparkUDFCreator {
+class TestUDFAddXCreator extends SparkUDFCreator {
   override def get(options: Map[String, String]): UserDefinedFunction = {
     udf((v: Int) => {
-      if (v==999) throw new IllegalStateException("failing streaming query on input value 999 for testing purposes")
+      if (v == 999) throw new IllegalStateException("failing streaming query on input value 999 for testing purposes")
       else v + options("x").toInt
     })
   }
 }
 
 class TestSDLPlugin extends SDLPlugin {
-  override def startup(): Unit = { TestSDLPlugin.startupCalled = true }
-  override def configure(options: Map[String, StringOrSecret]): Unit = { TestSDLPlugin.configureCalled = true }
-  override def shutdown(): Unit = { TestSDLPlugin.shutdownCalled = true }
+  override def startup(): Unit = {
+    TestSDLPlugin.startupCalled = true
+  }
+
+  override def configure(options: Map[String, StringOrSecret]): Unit = {
+    TestSDLPlugin.configureCalled = true
+  }
+
+  override def shutdown(): Unit = {
+    TestSDLPlugin.shutdownCalled = true
+  }
 }
+
 object TestSDLPlugin {
   var startupCalled = false
   var configureCalled = false
@@ -1064,7 +1077,7 @@ case class TestIncrementalDataObject(override val id: DataObjectId, override val
     val session = context.sparkSession
     import session.implicits._
     // simulate no data for one request
-    if (previousState == 21 && !noDataCreated && context.phase==ExecutionPhase.Exec) {
+    if (previousState == 21 && !noDataCreated && context.phase == ExecutionPhase.Exec) {
       noDataCreated = true
       throw NoDataToProcessWarning(id.id, "test")
     }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ActionImplTests.scala
@@ -26,12 +26,13 @@ import io.smartdatalake.workflow.action.generic.transformer._
 import io.smartdatalake.workflow.action.script.CmdScript
 import io.smartdatalake.workflow.action.spark.customlogic.CustomFileTransformerConfig
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfTransformer
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.time.Duration
 
 
-private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
+private[smartdatalake] class ActionImplTests extends AnyFlatSpec with Matchers {
 
   val dataObjectConfig: Config = ConfigFactory.parseString(
     """
@@ -235,9 +236,9 @@ private[smartdatalake] class ActionImplTests extends FlatSpec with Matchers {
         |}
         |""".stripMargin).withFallback(dataObjectConfig).resolve
 
-    val thrown = the [ConfigurationException] thrownBy ConfigParser.parse(config)
+    val thrown = the[ConfigurationException] thrownBy ConfigParser.parse(config)
 
-    thrown.getMessage should include ("123")
-    thrown.getMessage should include ("tdo1")
+    thrown.getMessage should include("123")
+    thrown.getMessage should include("tdo1")
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigLoaderTest.scala
@@ -20,10 +20,10 @@ package io.smartdatalake.config
 
 import com.typesafe.config.ConfigException
 import org.apache.hadoop.conf.Configuration
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-
-class ConfigLoaderTest extends FlatSpec with Matchers {
+class ConfigLoaderTest extends AnyFlatSpec with Matchers {
 
   val defaultHadoopConf: Configuration = new Configuration()
 
@@ -59,7 +59,7 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
   }
 
   it must "fail parsing a non-existing location" in {
-    an [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("foo/bar"), defaultHadoopConf)
+    an[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("foo/bar"), defaultHadoopConf)
   }
 
   it must "fail if provided directory is empty" in {
@@ -67,21 +67,21 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
   }
 
   it must "fail if no configuration files are found for any location provided location in the Sequence" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/error.conf"), defaultHadoopConf)
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/empty"), defaultHadoopConf)
+    a[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/error.conf"), defaultHadoopConf)
+    a[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/config.conf").toString, getClass.getResource("/config").toURI.toString + "/empty"), defaultHadoopConf)
   }
 
   it must "fail parsing a non-existing classpath entry" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar.conf"), defaultHadoopConf)
+    a[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar.conf"), defaultHadoopConf)
   }
 
   it must "fail parsing a classpath entry with wrong extension" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar"), defaultHadoopConf)
+    a[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq("cp:/foo/bar"), defaultHadoopConf)
   }
 
   it must "not parse a file that is not a config file" in {
     val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString), defaultHadoopConf)
-    a [ConfigException] should be thrownBy config.getString("noconfig")
+    a[ConfigException] should be thrownBy config.getString("noconfig")
   }
 
   it must "ignore hidden files" in {
@@ -93,11 +93,11 @@ class ConfigLoaderTest extends FlatSpec with Matchers {
     val config = ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/config/subdirectory").toString), defaultHadoopConf)
     config.getString("foo") shouldBe "foo"
     config.getString("config2") shouldBe "config2"
-    a [ConfigException] should be thrownBy config.getString("noconfig")
+    a[ConfigException] should be thrownBy config.getString("noconfig")
   }
 
   it should "fail on duplicate configuration object IDs" in {
-    a [ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/configWithDuplicates").toString), defaultHadoopConf)
+    a[ConfigurationException] should be thrownBy ConfigLoader.loadConfigFromFilesystem(Seq(getClass.getResource("/configWithDuplicates").toString), defaultHadoopConf)
   }
 
   it must "should load configurations with templates" in {

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
@@ -27,9 +27,10 @@ import io.smartdatalake.workflow.action.executionMode.PartitionDiffMode
 import io.smartdatalake.workflow.action.{Action, FileTransferAction}
 import io.smartdatalake.workflow.dataobject.{CsvFileDataObject, DataObject, DataObjectMetadata, RawFileDataObject}
 import org.apache.spark.sql.types.StructType
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ConfigParsingTest extends FlatSpec with Matchers {
+class ConfigParsingTest extends AnyFlatSpec with Matchers {
 
   "SdlConfig" must "parse a configuration" in {
     val config = ConfigFactory.parseString(
@@ -137,8 +138,8 @@ class ConfigParsingTest extends FlatSpec with Matchers {
     implicit val registry: InstanceRegistry = ConfigParser.parse(config)
 
     registry.getDataObjects should have size 1
-    registry.getDataObjects.head shouldBe a [SdlConfigObject]
-    registry.getDataObjects.head shouldBe a [DataObject]
+    registry.getDataObjects.head shouldBe a[SdlConfigObject]
+    registry.getDataObjects.head shouldBe a[DataObject]
     registry.getDataObjects should contain only TestDataObject(id = "tdo", arg1 = "foo", args = List("bar", "!"), connectionId = Some("tcon"))
     registry.getConnections should contain only TestConnection(id = "tcon")
   }
@@ -212,18 +213,18 @@ class ConfigParsingTest extends FlatSpec with Matchers {
     val actions = registry.instances.values.filter(_.isInstanceOf[Action])
 
     actions should have size 1
-    actions.head shouldBe a [SdlConfigObject]
-    actions.head shouldBe a [Action]
+    actions.head shouldBe a[SdlConfigObject]
+    actions.head shouldBe a[Action]
 
     val expected = TestAction(
-        id = "ta1",
-        arg1 = None,
-        inputId = "tdo1",
-        outputId = "tdo2"
+      id = "ta1",
+      arg1 = None,
+      inputId = "tdo1",
+      outputId = "tdo2"
     )
     actions should contain only expected
-    expected.input shouldBe TestDataObject(id = "tdo1", arg1 = "foo", args=List.empty)
-    expected.output shouldBe TestDataObject(id = "tdo2", arg1 = "bar", args=List.empty)
+    expected.input shouldBe TestDataObject(id = "tdo1", arg1 = "foo", args = List.empty)
+    expected.output shouldBe TestDataObject(id = "tdo2", arg1 = "bar", args = List.empty)
   }
 
   it must "correctly parse an Action map with multiple elements" in {
@@ -659,7 +660,7 @@ class ConfigParsingTest extends FlatSpec with Matchers {
         |}""".stripMargin
     )
 
-    val refinedConfig = Environment.configPathsForLocalSubstitution.foldLeft(config){
+    val refinedConfig = Environment.configPathsForLocalSubstitution.foldLeft(config) {
       case (config, path) => localSubstitution(config, path)
     }
     refinedConfig.getString("path") shouldEqual "test10/abc"
@@ -670,10 +671,10 @@ class ConfigParsingTest extends FlatSpec with Matchers {
 }
 
 
-case class MyTestDataObject( id: DataObjectId,
-                             schemaMin: Option[StructType] = None,
-                           arg1: String,
-                           args: Seq[String],
-                           connectionId: Option[ConnectionId] = None,
-                           metadata: Option[DataObjectMetadata] = None)
-                         ( implicit val instanceRegistry: InstanceRegistry)
+case class MyTestDataObject(id: DataObjectId,
+                            schemaMin: Option[StructType] = None,
+                            arg1: String,
+                            args: Seq[String],
+                            connectionId: Option[ConnectionId] = None,
+                            metadata: Option[DataObjectMetadata] = None)
+                           (implicit val instanceRegistry: InstanceRegistry)

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigsMacroDebug.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigsMacroDebug.scala
@@ -43,7 +43,7 @@ object ConfigsMacroDebug extends App with ConfigImplicits {
       | }
       |""".stripMargin).resolve
 
-  implicit val instanceRegistry = new InstanceRegistry
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   import configs.syntax.RichConfig
   config.extract[CustomDfDataObject].value
   //CustomDfDataObject.fromConfig(config)(new InstanceRegistry)

--- a/sdl-core/src/test/scala/io/smartdatalake/config/DataObjectImplTests.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/DataObjectImplTests.scala
@@ -30,9 +30,10 @@ import io.smartdatalake.workflow.connection.jdbc.JdbcTableConnection
 import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.workflow.dataobject._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DataObjectImplTests extends FlatSpec with Matchers {
+class DataObjectImplTests extends AnyFlatSpec with Matchers {
 
   "AvroFileDataObject" should "be parsable" in {
 
@@ -130,7 +131,7 @@ class DataObjectImplTests extends FlatSpec with Matchers {
 
     implicit val registry: InstanceRegistry = ConfigParser.parse(config)
     val dos = registry.instances.values
-    dos should contain allOf (
+    dos should contain allOf(
       CsvFileDataObject(
         id = "123",
         path = "/path/to/foo",
@@ -202,7 +203,7 @@ class DataObjectImplTests extends FlatSpec with Matchers {
 
     implicit val registry: InstanceRegistry = ConfigParser.parse(config)
     val registry2: InstanceRegistry = new InstanceRegistry()
-    val jdbcCon = JdbcTableConnection( "jdbc1", url = "jdbc://example.test", driver = "com.example.Driver" )
+    val jdbcCon = JdbcTableConnection("jdbc1", url = "jdbc://example.test", driver = "com.example.Driver")
     registry2.register(jdbcCon)
     registry.instances(DataObjectId("123")) shouldBe JdbcTableDataObject(
       id = "123",
@@ -294,18 +295,18 @@ class DataObjectImplTests extends FlatSpec with Matchers {
 
     val config = ConfigFactory.parseString(
       """
-         |dataObjects = {
-         | 123 = {
-         |   type = CustomDfDataObject
-         |   creator {
-         |     class-name = io.smartdatalake.testutils.custom.TestCustomDfCreator
-         |     options = {
-         |       test = foo
-         |     }
-         |   }
-         | }
-         |}
-         |""".stripMargin).resolve
+        |dataObjects = {
+        | 123 = {
+        |   type = CustomDfDataObject
+        |   creator {
+        |     class-name = io.smartdatalake.testutils.custom.TestCustomDfCreator
+        |     options = {
+        |       test = foo
+        |     }
+        |   }
+        | }
+        |}
+        |""".stripMargin).resolve
 
     implicit val registry: InstanceRegistry = ConfigParser.parse(config)
     registry.instances.values.head shouldBe CustomDfDataObject(
@@ -317,18 +318,18 @@ class DataObjectImplTests extends FlatSpec with Matchers {
   "WebserviceFileDataObject" should "be parsable" in {
     val config = ConfigFactory.parseString(
       """
-         |dataObjects = {
-         | 123 = {
-         |  type = WebserviceFileDataObject
-         |  url = "http://test"
-         |  auth-mode = {
-         |    type = BasicAuthMode
-         |    user = "###CLEAR#test###"
-         |    password = "###CLEAR#test###"
-         |  }
-         | }
-         |}
-         |""".stripMargin).resolve
+        |dataObjects = {
+        | 123 = {
+        |  type = WebserviceFileDataObject
+        |  url = "http://test"
+        |  auth-mode = {
+        |    type = BasicAuthMode
+        |    user = "###CLEAR#test###"
+        |    password = "###CLEAR#test###"
+        |  }
+        | }
+        |}
+        |""".stripMargin).resolve
 
     implicit val registry: InstanceRegistry = ConfigParser.parse(config)
     registry.instances.values.head shouldBe WebserviceFileDataObject(
@@ -377,29 +378,29 @@ class DataObjectImplTests extends FlatSpec with Matchers {
   "DataObject" should "throw nice error when wrong Connection type" in {
 
     val config = ConfigFactory.parseString(
-    """
-      |connections = {
-      | con1 = {
-      |  type = HiveTableConnection
-      |   pathPrefix = "file://c:/temp"
-      |   db = default
-      | }
-      |}
-      |dataObjects = {
-      | 123 = {
-      |  type = CsvFileDataObject
-      |  path = foo
-      |  connectionId = con1
-      |  csv-options {
-      |   header = true
-      |  }
-      | }
-      |}
-      |""".stripMargin).resolve
+      """
+        |connections = {
+        | con1 = {
+        |  type = HiveTableConnection
+        |   pathPrefix = "file://c:/temp"
+        |   db = default
+        | }
+        |}
+        |dataObjects = {
+        | 123 = {
+        |  type = CsvFileDataObject
+        |  path = foo
+        |  connectionId = con1
+        |  csv-options {
+        |   header = true
+        |  }
+        | }
+        |}
+        |""".stripMargin).resolve
 
-    val thrown = the [ConfigurationException] thrownBy ConfigParser.parse(config)
+    val thrown = the[ConfigurationException] thrownBy ConfigParser.parse(config)
 
-    thrown.getMessage should include ("123")
-    thrown.getMessage should include ("con1")
+    thrown.getMessage should include("123")
+    thrown.getMessage should include("con1")
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/exporter/ExportWriterTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/exporter/ExportWriterTest.scala
@@ -23,11 +23,11 @@ import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.exporter.ExportWriter.{formatSchema, parseSchema}
 import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import org.apache.spark.sql.types._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class ExportWriterTest extends FunSuite {
+class ExportWriterTest extends AnyFunSuite {
 
   private val tempDir = Files.createTempDirectory("exportwritertest")
   private val dataObjectId = DataObjectId("testDO")

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/DataObjectTestSuite.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/DataObjectTestSuite.scala
@@ -23,12 +23,13 @@ import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql._
-import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 
-
-trait DataObjectTestSuite extends FunSuite with Matchers with BeforeAndAfter {
+trait DataObjectTestSuite extends AnyFunSuite with Matchers with BeforeAndAfter {
 
   protected implicit lazy val session: SparkSession = TestUtil.session
 
@@ -45,7 +46,7 @@ trait DataObjectTestSuite extends FunSuite with Matchers with BeforeAndAfter {
   implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
   val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
 
-  protected def createTempDir = Files.createTempDirectory("test")
+  protected def createTempDir: Path = Files.createTempDirectory("test")
 
   before {
     instanceRegistry.clear()

--- a/sdl-core/src/test/scala/io/smartdatalake/util/crypt/DatabricksCryptTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/crypt/DatabricksCryptTest.scala
@@ -21,13 +21,13 @@ package io.smartdatalake.util.crypt
 
 import io.smartdatalake.testutils.TestUtil
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /**
  * Unit tests for historization
  *
  */
-class DatabricksCryptTest extends FunSuite {
+class DatabricksCryptTest extends AnyFunSuite {
   implicit lazy val session: SparkSession = TestUtil.session
 
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/util/evolution/SchemaEvolutionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/evolution/SchemaEvolutionTest.scala
@@ -27,7 +27,7 @@ import io.smartdatalake.workflow.dataframe.spark._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.Checkers
 
 
@@ -35,7 +35,7 @@ import org.scalatestplus.scalacheck.Checkers
   * Unit tests for historization
   *
   */
-class SchemaEvolutionTest extends FunSuite with Checkers with SmartDataLakeLogger {
+class SchemaEvolutionTest extends AnyFunSuite with Checkers with SmartDataLakeLogger {
 
   implicit lazy val session: SparkSession = TestUtil.session
 

--- a/sdl-core/src/test/scala/io/smartdatalake/util/evolution/TypeEvolutionUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/evolution/TypeEvolutionUtilTest.scala
@@ -21,9 +21,9 @@ package io.smartdatalake.util.evolution
 import io.smartdatalake.util.spark.evolution.TypeEvolutionUtil
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class TypeEvolutionUtilTest extends FunSuite {
+class TypeEvolutionUtilTest extends AnyFunSuite {
   
   test("simple schema, no changes") {
     val srcSchema = StructType(Seq(StructField("a", IntegerType), StructField("b", StringType)))

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/HdfsUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/HdfsUtilTest.scala
@@ -21,11 +21,11 @@ package io.smartdatalake.util.hdfs
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileSystem, Path}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class HdfsUtilTest extends FunSuite {
+class HdfsUtilTest extends AnyFunSuite {
 
   test("touch file") {
     val file = new Path("target/touch.me")

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionLayoutTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionLayoutTest.scala
@@ -19,9 +19,9 @@
 package io.smartdatalake.util.hdfs
 
 import io.smartdatalake.definitions.Environment
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PartitionLayoutTest extends FunSuite {
+class PartitionLayoutTest extends AnyFunSuite {
 
   test("extracting tokens from partition layout") {
     val delimiter = PartitionLayout.delimiter

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionValuesTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hdfs/PartitionValuesTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.util.hdfs
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PartitionValuesTest extends FunSuite {
+class PartitionValuesTest extends AnyFunSuite {
 
   test("sorting of partition values: 1 column") {
     val orderingDt = PartitionValues.getOrdering(Seq("dt"))

--- a/sdl-core/src/test/scala/io/smartdatalake/util/historization/FullHistorizationTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/historization/FullHistorizationTest.scala
@@ -29,7 +29,8 @@ import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSimpleDat
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.Duration
 
@@ -37,9 +38,10 @@ import java.time.Duration
  * Unit tests for historization
  *
  */
-class FullHistorizationTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
+class FullHistorizationTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
   private implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(SparkSubFeed.subFeedType)
@@ -62,14 +64,14 @@ class FullHistorizationTest extends FunSuite with BeforeAndAfter with SmartDataL
     logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 
     //ID 123 has new value and so old record is closed with newcol1=null
-    val dfResultExistingRowNonNull = toHistorizedDf(baseColumnsOldHist.filter(_._1==123), HistorizationPhase.UpdatedOld)
+    val dfResultExistingRowNonNull = toHistorizedDf(baseColumnsOldHist.filter(_._1 == 123), HistorizationPhase.UpdatedOld)
       .withColumn("new_col1", lit(null).cast(SparkSimpleDataType(StringType)))
 
     //ID 123 has new value and so new record is created with newcol1="Test"
-    val dfResultNewRowNonNull = toHistorizedDf(baseColumnsNewFeed.filter(_._1==123), HistorizationPhase.UpdatedNew, colNames :+ "new_col1")
+    val dfResultNewRowNonNull = toHistorizedDf(baseColumnsNewFeed.filter(_._1 == 123), HistorizationPhase.UpdatedNew, colNames :+ "new_col1")
 
     //ID 124 has null new value and so old record is left unchanged but with additional column
-    val dfResultExistingRowNull = toHistorizedDf(baseColumnsOldHist.filter(_._1==124), HistorizationPhase.Existing)
+    val dfResultExistingRowNull = toHistorizedDf(baseColumnsOldHist.filter(_._1 == 124), HistorizationPhase.Existing)
       .withColumn("new_col1", lit(null).cast(SparkSimpleDataType(StringType)))
 
     val dfExpected = dfResultExistingRowNonNull
@@ -296,18 +298,20 @@ class FullHistorizationTest extends FunSuite with BeforeAndAfter with SmartDataL
     def rowsEqual(r1: Row, r2: Row): Boolean = {
       r1.hashCode() == r2.hashCode()
     }
-    assert(rowsEqual(Row.fromSeq(Seq(1, null, "value")),Row.fromSeq(Seq(1, null, "value"))))
-    assert(!rowsEqual(Row.fromSeq(Seq(1, null, "value")),Row.fromSeq(Seq(1, "value", null)))) // switched field content
-    assert(!rowsEqual(Row.fromSeq(Seq(1, null, "value")),Row.fromSeq(Seq(1, null, "value", "test")))) // additional field
-    assert(!rowsEqual(Row.fromSeq(Seq(1, null, "value")),Row.fromSeq(Seq(1, null, "value", null)))) // additional null field
+
+    assert(rowsEqual(Row.fromSeq(Seq(1, null, "value")), Row.fromSeq(Seq(1, null, "value"))))
+    assert(!rowsEqual(Row.fromSeq(Seq(1, null, "value")), Row.fromSeq(Seq(1, "value", null)))) // switched field content
+    assert(!rowsEqual(Row.fromSeq(Seq(1, null, "value")), Row.fromSeq(Seq(1, null, "value", "test")))) // additional field
+    assert(!rowsEqual(Row.fromSeq(Seq(1, null, "value")), Row.fromSeq(Seq(1, null, "value", null)))) // additional null field
 
     def internalRowsEqual(r1: InternalRow, r2: InternalRow): Boolean = {
       r1.hashCode() == r2.hashCode()
     }
-    assert(internalRowsEqual(InternalRow(1, null, "value"),InternalRow(1, null, "value")))
-    assert(!internalRowsEqual(InternalRow(1, null, "value"),InternalRow(1, "value", null))) // switched field content
-    assert(!internalRowsEqual(InternalRow(1, null, "value"),InternalRow(1, null, "value", "test"))) // additional field
-    assert(!internalRowsEqual(InternalRow(1, null, "value"),InternalRow(1, null, "value", null))) // additional null field
+
+    assert(internalRowsEqual(InternalRow(1, null, "value"), InternalRow(1, null, "value")))
+    assert(!internalRowsEqual(InternalRow(1, null, "value"), InternalRow(1, "value", null))) // switched field content
+    assert(!internalRowsEqual(InternalRow(1, null, "value"), InternalRow(1, null, "value", "test"))) // additional field
+    assert(!internalRowsEqual(InternalRow(1, null, "value"), InternalRow(1, null, "value", null))) // additional null field
   }
 
   test("When timeAxisUnit=0, history with half-open intervals should be created") {

--- a/sdl-core/src/test/scala/io/smartdatalake/util/historization/IncrementalCDCHistorizationTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/historization/IncrementalCDCHistorizationTest.scala
@@ -27,15 +27,17 @@ import io.smartdatalake.workflow.dataframe.DataFrameFunctions
 import io.smartdatalake.workflow.dataframe.spark.{SparkSimpleDataType, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.TimestampType
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 /**
  * Unit tests for historization with incrementalCDCHistorize.
  * incrementalCDCHistorize is much different from incrementalHistorize because it doesn't need an existing DataFrame
  */
-class IncrementalCDCHistorizationTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
+class IncrementalCDCHistorizationTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
   private implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(SparkSubFeed.subFeedType)

--- a/sdl-core/src/test/scala/io/smartdatalake/util/historization/IncrementalHistorizationTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/historization/IncrementalHistorizationTest.scala
@@ -26,7 +26,8 @@ import io.smartdatalake.workflow.DataFrameSubFeed
 import io.smartdatalake.workflow.dataframe.DataFrameFunctions
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.Duration
 
@@ -34,9 +35,10 @@ import java.time.Duration
  * Unit tests for historization
  *
  */
-class IncrementalHistorizationTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
+class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
   private implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(SparkSubFeed.subFeedType)

--- a/sdl-core/src/test/scala/io/smartdatalake/util/hive/HiveUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/hive/HiveUtilTest.scala
@@ -25,16 +25,18 @@ import io.smartdatalake.workflow.dataobject.Table
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.{Path => HadoopPath}
 import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path, Paths}
 
 /**
  * Unit tests for HiveUtil
  */
-class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
+class HiveUtilTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
   implicit lazy val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   private val hiveTable = Table(Some("default"), "unittesttable")
@@ -64,14 +66,14 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
     (1, "A", "X"),
     (2, "B", "X"),
     (3, "C", "Y"),
-    (4, "C", "Y"))).toDF( "id", "data1", "part" )
+    (4, "C", "Y"))).toDF("id", "data1", "part")
   val testDataB: DataFrame = session.createDataset(Seq(
     (1, "A", "C", "Z"),
     (2, "B", "B", "Z"),
     (3, "C", "A", "Y"),
-    (4, "C", "A", "Y"))).toDF( "id", "data1", "data2", "part" )
+    (4, "C", "A", "Y"))).toDF("id", "data1", "data2", "part")
 
-  def checkPartitionsExpected( table: Table, expectedPartitions:Seq[Map[String,String]] ) : Boolean = {
+  def checkPartitionsExpected(table: Table, expectedPartitions: Seq[Map[String, String]]): Boolean = {
     val tablePartitions = HiveUtil.getTablePartitions(table)
     tablePartitions.toSet.equals(expectedPartitions.toSet)
   }
@@ -81,11 +83,11 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
 
     logger.info("Creating table")
     HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
-    intercept[AnalysisException]{
+    intercept[AnalysisException] {
       // AnalysisException expected because table is not partitioned
       HiveUtil.getTablePartitions(hiveTable).isEmpty
     }
-    assert(session.table(hiveTable.fullName).isEqual(testDataA ))
+    assert(session.table(hiveTable.fullName).isEqual(testDataA))
 
     logger.info("Overwriting data in existing table")
     HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
@@ -101,11 +103,11 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
       // AnalysisException expected because table is not partitioned
       HiveUtil.getTablePartitions(hiveTable).isEmpty
     }
-    assert(session.table(hiveTable.fullName).isEqual(testDataA ))
+    assert(session.table(hiveTable.fullName).isEqual(testDataA))
 
     logger.info("Overwriting data in existing table with modified schema")
     HiveUtil.writeDfToHive(testDataB, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
-    assert(session.table(hiveTable.fullName).isEqual(testDataB ))
+    assert(session.table(hiveTable.fullName).isEqual(testDataB))
   }
 
   test("Create partitioned external table and overwrite data") {
@@ -113,13 +115,13 @@ class HiveUtilTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger
 
     logger.info("Creating table")
     HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
-    assert(checkPartitionsExpected(hiveTable, Seq(Map( "part" -> "X"), Map("part" -> "Y"))))
-    assert(session.table(hiveTable.fullName).isEqual(testDataA ))
+    assert(checkPartitionsExpected(hiveTable, Seq(Map("part" -> "X"), Map("part" -> "Y"))))
+    assert(session.table(hiveTable.fullName).isEqual(testDataA))
 
     logger.info("Overwriting data in existing table with modified schema")
     HiveUtil.writeDfToHive(testDataA, hdfsTablePath, hiveTable, partitions, SaveMode.Overwrite)
-    assert(checkPartitionsExpected(hiveTable, Seq(Map( "part" -> "X"), Map("part" -> "Y"))))
-    assert(session.table(hiveTable.fullName).isEqual(testDataA ))
+    assert(checkPartitionsExpected(hiveTable, Seq(Map("part" -> "X"), Map("part" -> "Y"))))
+    assert(session.table(hiveTable.fullName).isEqual(testDataA))
   }
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/json/JsonUtilsTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/json/JsonUtilsTest.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.util.json
 
 import org.json4s.jackson.JsonMethods
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class JsonUtilsTest extends FunSuite {
+class JsonUtilsTest extends AnyFunSuite {
 
   test("extract value") {
     val str = """{ "link": [ {"href": "abc", "rel": "last"}, {"href": "def", "rel": "next"}]}"""

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/AclUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/AclUtilTest.scala
@@ -18,16 +18,17 @@
  */
 package io.smartdatalake.util.misc
 
-import java.nio.file.{Files, Paths}
-
 import io.smartdatalake.definitions.Environment
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataOutputStream, FileSystem, Path}
+import org.scalatest.BeforeAndAfter
 import org.scalatest.OptionValues._
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
 
-class AclUtilTest extends FunSuite with BeforeAndAfter {
+import java.nio.file.{Files, Paths}
+
+class AclUtilTest extends AnyFunSuite with BeforeAndAfter {
 
   protected val fs: FileSystem = FileSystem.get(new Configuration())
 
@@ -99,7 +100,7 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
     assert(rootParentPath.isEmpty)
   }
 
-  def noOpAclSetter(p:Path): Unit = ()
+  def noOpAclSetter(p: Path): Unit = ()
 
   test("Traverse directoryUp some existing directory (user home)") {
     val path = new Path("/user/app_dir/integration/someapp")
@@ -246,10 +247,10 @@ class AclUtilTest extends FunSuite with BeforeAndAfter {
   }
 
   test("extract user home") {
-    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
-    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
-    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir/test/abc"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
-    intercept[IllegalArgumentException](AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/"),Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir"), Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir/"), Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    assert(AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/app_dir/test/abc"), Environment.hdfsAclsUserHomeLevel) == "app_dir")
+    intercept[IllegalArgumentException](AclUtil.extractPathLevel(new Path("hdfs://dfs.nameservices/user/"), Environment.hdfsAclsUserHomeLevel) == "app_dir")
   }
 
   test("check hdfsAclsLimitToBasedir") {

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/DataFrameUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/DataFrameUtilTest.scala
@@ -23,9 +23,10 @@ import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types._
-import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartDataLakeLogger {
+class DataFrameUtilTest extends AnyFunSuite with Matchers with SmartDataLakeLogger {
 
   import session.implicits._
 
@@ -48,20 +49,20 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
   test("symmetricDifference_with_difference") {
     val df_complex_2 = Seq(
-      (1,Seq(("a","A",Seq("a","A")))),
-      (2,Seq(("b","B",Seq("b","B")))),
-      (3,Seq(("c","C",Seq("c","X")))),
-      (4,Seq(("d","D",Seq("d","D")))),
-      (5,Seq(("e","E",Seq("e","E"))))
-    ).toDF("id","value")
-    val actual: DataFrame = dfComplex.symmetricDifference(df_complex_2,"df_complex")
+      (1, Seq(("a", "A", Seq("a", "A")))),
+      (2, Seq(("b", "B", Seq("b", "B")))),
+      (3, Seq(("c", "C", Seq("c", "X")))),
+      (4, Seq(("d", "D", Seq("d", "D")))),
+      (5, Seq(("e", "E", Seq("e", "E"))))
+    ).toDF("id", "value")
+    val actual: DataFrame = dfComplex.symmetricDifference(df_complex_2, "df_complex")
     val actualCount = actual.count()
     val expected = Seq(
-      (3,Seq(("c","C",Seq("c","C"))),true),
-      (3,Seq(("c","C",Seq("c","X"))),false)
-    ).toDF("id","value","_in_first_df")
+      (3, Seq(("c", "C", Seq("c", "C"))), true),
+      (3, Seq(("c", "C", Seq("c", "X"))), false)
+    ).toDF("id", "value", "_in_first_df")
     val resultat: Boolean = (actual.schema == dfComplex.schema.add("df_complex", BooleanType, nullable = false)) &&
-      (2 == actualCount) && (actual.takeAsList(2)===expected.takeAsList(2))
+      (2 == actualCount) && (actual.takeAsList(2) === expected.takeAsList(2))
     if (!resultat) {
       logger.error(s"df_complex.schema = ${dfComplex.schema.simpleString}")
       dfComplex.printSchema()
@@ -77,31 +78,31 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
       logger.error(s"expected.schema   = ${actual.schema.simpleString}")
       expected.printSchema()
       expected.show()
-      logger.error(s"  Do schemata equal? ${actual.schema==expected.schema}")
+      logger.error(s"  Do schemata equal? ${actual.schema == expected.schema}")
     }
     assert(resultat)
   }
 
   test("symmetricDifference_withNull") {
     val df_complex_withNull_2 = Seq(
-      (Some(1), Some(Seq(("a","A",Seq("a","A"))))),
-      (Some(2), Some(Seq(("b","B",Seq("b","B"))))),
-      (Some(3), Some(Seq(("c","C",null)))),
-      (Some(4), Some(Seq(("d","D",Seq("d","D"))))),
-      (Some(5), Some(Seq(("e","E",null))))
-    ).toDF("id","value")
-    val actual: DataFrame = dfComplexWithNull.symmetricDifference(df_complex_withNull_2,"df_complex_withNull")
+      (Some(1), Some(Seq(("a", "A", Seq("a", "A"))))),
+      (Some(2), Some(Seq(("b", "B", Seq("b", "B"))))),
+      (Some(3), Some(Seq(("c", "C", null)))),
+      (Some(4), Some(Seq(("d", "D", Seq("d", "D"))))),
+      (Some(5), Some(Seq(("e", "E", null))))
+    ).toDF("id", "value")
+    val actual: DataFrame = dfComplexWithNull.symmetricDifference(df_complex_withNull_2, "df_complex_withNull")
     val actualCount = actual.count().asInstanceOf[Int]
     val expected = Seq(
       (Some(5), None, true),
       (None, None, true),
-      (Some(5), Some(Seq(("e","E",null: Seq[String]))), false)
-    ).toDF("id","value","df_complex_withNull")
+      (Some(5), Some(Seq(("e", "E", null: Seq[String]))), false)
+    ).toDF("id", "value", "df_complex_withNull")
     val expectedCount = expected.count().asInstanceOf[Int]
 
     val resultat: Boolean = (actual.schema == expected.schema) &&
       (actualCount == expectedCount) &&
-      (actual.takeAsList(actualCount)===expected.takeAsList(expectedCount))
+      (actual.takeAsList(actualCount) === expected.takeAsList(expectedCount))
 
     if (!resultat) {
       logger.error(s"df_complex_withNull.schema = ${dfComplexWithNull.schema.simpleString}")
@@ -118,7 +119,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
       logger.error(s"expected.schema   = ${actual.schema.simpleString}")
       expected.printSchema()
       expected.show()
-      logger.error(s"  Do schemata equal? ${actual.schema==expected.schema}")
+      logger.error(s"  Do schemata equal? ${actual.schema == expected.schema}")
     }
     assert(resultat)
   }
@@ -147,12 +148,12 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
   test("isEqual_false_data") {
     val df_complex_2 = Seq(
-      (1,Seq(("a","A",Seq("a","A")))),
-      (2,Seq(("b","B",Seq("b","B")))),
-      (3,Seq(("c","C",Seq("c","X")))),
-      (4,Seq(("d","D",Seq("d","D")))),
-      (5,Seq(("e","E",Seq("e","E"))))
-    ).toDF("id","Value")
+      (1, Seq(("a", "A", Seq("a", "A")))),
+      (2, Seq(("b", "B", Seq("b", "B")))),
+      (3, Seq(("c", "C", Seq("c", "X")))),
+      (4, Seq(("d", "D", Seq("d", "D")))),
+      (5, Seq(("e", "E", Seq("e", "E"))))
+    ).toDF("id", "Value")
     val actual: Boolean = dfComplex.isEqual(df_complex_2)
     if (actual) {
       logger.error("   symmetric Difference ")
@@ -170,24 +171,24 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isSchemaEqual_complex_different_order") {
-    assert(dfComplex.isSchemaEqualIgnoreNullabilty(dfComplex.select(dfComplex.columns.reverseIterator.map(col).toSeq:_*)))
+    assert(dfComplex.isSchemaEqualIgnoreNullabilty(dfComplex.select(dfComplex.columns.reverseIterator.map(col).toSeq: _*)))
   }
 
   // other tests
 
   test("castAllDate2Timestamp") {
     val actual = dfManyTypes.castAllDate2Timestamp
-    val expected = actual.withColumn("_date",$"_date".cast(TimestampType))
+    val expected = actual.withColumn("_date", $"_date".cast(TimestampType))
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("castAllDate2Timestamp",Seq(dfManyTypes))(actual)(expected)
+    if (!resultat) printFailedTestResult("castAllDate2Timestamp", Seq(dfManyTypes))(actual)(expected)
     assert(resultat)
   }
 
   test("castAll2String") {
     val actual = dfManyTypes.castAll2String
-    val expected = actual.columns.foldLeft(actual)({ (df, s) => df.withColumn(s,col(s).cast(StringType)) })
+    val expected = actual.columns.foldLeft(actual)({ (df, s) => df.withColumn(s, col(s).cast(StringType)) })
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("castAll2String",Seq(dfManyTypes))(actual)(expected)
+    if (!resultat) printFailedTestResult("castAll2String", Seq(dfManyTypes))(actual)(expected)
     assert(resultat)
   }
 
@@ -201,7 +202,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
       .withColumn("_decimal_4_3", $"_decimal_4_3".cast(FloatType))
       .withColumn("_decimal_38_1", $"_decimal_38_1".cast(DoubleType))
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("castAllDecimal2IntegralFloat",Seq(dfManyTypes))(actual)(expected)
+    if (!resultat) printFailedTestResult("castAllDecimal2IntegralFloat", Seq(dfManyTypes))(actual)(expected)
     assert(resultat)
   }
 
@@ -227,17 +228,17 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
     val actual = dfHierarchy.getNonuniqueStats()
     val expected = dfHierarchy.where(lit(false)).withColumn("_cnt_", lit(0: Long))
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("getNonuniqueStats_No_nlets",Seq(dfHierarchy))(actual)(expected)
+    if (!resultat) printFailedTestResult("getNonuniqueStats_No_nlets", Seq(dfHierarchy))(actual)(expected)
     assert(resultat)
   }
 
   test("getNonuniqueStats_nlets_in_projected_data_frame") {
     val actual = dfHierarchy.getNonuniqueStats(Array("parent"))
-    val rows_expected: Seq[(String, Long)] = Seq(("a",2),("c",3),("ca",2))
-    val expected: DataFrame = rows_expected.toDF("parent","_cnt_")
+    val rows_expected: Seq[(String, Long)] = Seq(("a", 2), ("c", 3), ("ca", 2))
+    val expected: DataFrame = rows_expected.toDF("parent", "_cnt_")
 
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("getNonuniqueStats_nlets_in_projected_data_frame",Seq(dfHierarchy))(actual)(expected)
+    if (!resultat) printFailedTestResult("getNonuniqueStats_nlets_in_projected_data_frame", Seq(dfHierarchy))(actual)(expected)
     assert(resultat)
   }
 
@@ -246,24 +247,24 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
     val actual = argument.getNonuniqueStats()
     val expected = argument.where(lit(false)).withColumn("_cnt_", lit(0: Long))
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("getNonuniqueStats_DF_with_1_column",Seq(argument))(actual)(expected)
+    if (!resultat) printFailedTestResult("getNonuniqueStats_DF_with_1_column", Seq(argument))(actual)(expected)
     assert(resultat)
   }
 
   test("getNonuniqueStats_DF_with_nlets") {
     val actual = dfNonUnique.getNonuniqueStats()
-    val rows_expected: Seq[(String, String, Long)] = Seq(("2let","doublet",2),("3let","triplet",3),("4let","quatriplet",4))
-    val expected: DataFrame = rows_expected.toDF("id","value","_cnt_")
+    val rows_expected: Seq[(String, String, Long)] = Seq(("2let", "doublet", 2), ("3let", "triplet", 3), ("4let", "quatriplet", 4))
+    val expected: DataFrame = rows_expected.toDF("id", "value", "_cnt_")
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("getNonuniqueStats_DF_with_nlets",Seq(dfNonUnique))(actual)(expected)
+    if (!resultat) printFailedTestResult("getNonuniqueStats_DF_with_nlets", Seq(dfNonUnique))(actual)(expected)
     assert(resultat)
   }
 
   test("getNulls_df_complex") {
     val actual = dfComplex.getNulls()
-    val expected =  dfComplex.where(lit(false))
+    val expected = dfComplex.where(lit(false))
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("getNulls_df_complex",Seq(dfComplex))(actual)(expected)
+    if (!resultat) printFailedTestResult("getNulls_df_complex", Seq(dfComplex))(actual)(expected)
     assert(resultat)
   }
 
@@ -275,7 +276,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
     )
     val expected: DataFrame = rows_expected.toDF("id", "value")
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("getNulls_df_complex_withNull",Seq(dfNonUnique))(actual)(expected)
+    if (!resultat) printFailedTestResult("getNulls_df_complex_withNull", Seq(dfNonUnique))(actual)(expected)
     assert(resultat)
   }
 
@@ -289,7 +290,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isCandidateKey_df_TwoCandidateKeys_string12") {
-    val actual = dfTwoCandidateKeys.isCandidateKey(Array("string_id1","string_id2"))
+    val actual = dfTwoCandidateKeys.isCandidateKey(Array("string_id1", "string_id2"))
     if (!actual) {
       logger.error(s"actual = $actual")
       dfTwoCandidateKeys.show()
@@ -298,7 +299,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isCandidateKey_df_TwoCandidateKeys_int123") {
-    val actual = dfTwoCandidateKeys.isCandidateKey(Array("int_id1","int_id2","int_id3"))
+    val actual = dfTwoCandidateKeys.isCandidateKey(Array("int_id1", "int_id2", "int_id3"))
     if (!actual) {
       logger.error(s"actual = $actual")
       dfTwoCandidateKeys.show()
@@ -307,7 +308,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isCandidateKey_df_TwoCandidateKeys_string12int1") {
-    val actual = dfTwoCandidateKeys.isCandidateKey(Array("string_id1","string_id2","int_id1"))
+    val actual = dfTwoCandidateKeys.isCandidateKey(Array("string_id1", "string_id2", "int_id1"))
     if (actual) {
       logger.error(s"actual = $actual")
       dfTwoCandidateKeys.show()
@@ -316,7 +317,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isMinimalUnique_df_TwoCandidateKeys_string12") {
-    val actual = dfTwoCandidateKeys.isMinimalUnique(Array("string_id1","string_id2"))
+    val actual = dfTwoCandidateKeys.isMinimalUnique(Array("string_id1", "string_id2"))
     if (!actual) {
       logger.error(s"actual = $actual")
       dfTwoCandidateKeys.show()
@@ -325,7 +326,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isMinimalUnique_df_TwoCandidateKeys_int123") {
-    val actual = dfTwoCandidateKeys.isMinimalUnique(Array("int_id1","int_id2","int_id3"))
+    val actual = dfTwoCandidateKeys.isMinimalUnique(Array("int_id1", "int_id2", "int_id3"))
     if (!actual) {
       logger.error(s"actual = $actual")
       dfTwoCandidateKeys.show()
@@ -334,7 +335,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isMinimalUnique_df_TwoCandidateKeys_string12int1") {
-    val actual = dfTwoCandidateKeys.isMinimalUnique(Array("string_id1","string_id2","int_id1"))
+    val actual = dfTwoCandidateKeys.isMinimalUnique(Array("string_id1", "string_id2", "int_id1"))
     if (actual) {
       logger.error(s"actual = $actual")
       dfTwoCandidateKeys.show()
@@ -391,15 +392,15 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   test("project_df_complex") {
     val actual = dfComplex.project(Array("value"))
     val rows_expected: Seq[Seq[(String, String, Seq[String])]] = Seq(
-      Seq(("a","A",Seq("a","A"))),
-      Seq(("b","B",Seq("b","B"))),
-      Seq(("c","C",Seq("c","C"))),
-      Seq(("d","D",Seq("d","D"))),
-      Seq(("e","E",Seq("e","E")))
+      Seq(("a", "A", Seq("a", "A"))),
+      Seq(("b", "B", Seq("b", "B"))),
+      Seq(("c", "C", Seq("c", "C"))),
+      Seq(("d", "D", Seq("d", "D"))),
+      Seq(("e", "E", Seq("e", "E")))
     )
     val expected: DataFrame = rows_expected.toDF("value")
     val resultat: Boolean = actual.isEqual(expected)
-    if (!resultat) printFailedTestResult("project_df_complex",Seq(dfNonUnique))(actual)(expected)
+    if (!resultat) printFailedTestResult("project_df_complex", Seq(dfNonUnique))(actual)(expected)
     assert(resultat)
   }
 
@@ -422,7 +423,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isSuperschemaItself") {
-    val argExpMap: Map[DataFrame,Boolean] = Map(
+    val argExpMap: Map[DataFrame, Boolean] = Map(
       dfComplex -> true,
       dfComplexWithNull -> true,
       dfHierarchy -> true,
@@ -436,7 +437,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
   // reversed column order
   test("isSubschemaReversed") {
-    val argExpMap: Map[DataFrame,Boolean] = Map(
+    val argExpMap: Map[DataFrame, Boolean] = Map(
       dfComplex -> true,
       dfComplexWithNull -> true,
       dfHierarchy -> true,
@@ -449,7 +450,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isSuperschemaReversed") {
-    val argExpMap: Map[DataFrame,Boolean] = Map(
+    val argExpMap: Map[DataFrame, Boolean] = Map(
       dfComplex -> true,
       dfComplexWithNull -> true,
       dfHierarchy -> true,
@@ -463,7 +464,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
   /// first column dropped
   test("isSubschemaFirstColumnDropped") {
-    val argExpMap: Map[DataFrame,Boolean] = Map(
+    val argExpMap: Map[DataFrame, Boolean] = Map(
       dfComplex -> true,
       dfComplexWithNull -> true,
       dfHierarchy -> true,
@@ -477,7 +478,7 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
   }
 
   test("isSuperschemaFirstColumnDropped") {
-    val argExpMap: Map[DataFrame,Boolean] = Map(
+    val argExpMap: Map[DataFrame, Boolean] = Map(
       dfComplex -> false,
       dfComplexWithNull -> false,
       dfHierarchy -> false,
@@ -507,10 +508,10 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
     val intFieldNotnullable = StructField(notNullableStringField.name, IntegerType, nullable = false)
     val diffSchema = StructType(intFieldNotnullable :: intFieldNotnullable :: Nil)
-    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema, deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema, ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema, ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema, deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema, ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(diffSchema, ignoreNullable = true, deep = true).size should be(1)
 
     val schemaStruct = StructType(nullableStructField :: nullableStructField :: Nil)
     dfEmptyWithStructuredSchema.schemaDiffTo(schemaStruct) shouldBe empty
@@ -569,44 +570,44 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
     //nullability difference
     val fieldDiffNotnullable = nullableStringField.copy(nullable = false)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNotnullable :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNotnullable :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNotnullable :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNotnullable :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNotnullable :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
     val fieldDiffNullable = notNullableStringField.copy(nullable = true)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNullable :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNullable :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNullable :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNullable :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNullable :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(fieldDiffNullable :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
     //type difference
     val intFieldNotnullable = notNullableStringField.copy(dataType = IntegerType)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNotnullable :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     val intFieldNullable = nullableStringField.copy(dataType = IntegerType)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNullable :: Nil)) should not be empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNullable :: Nil), deep = true) should not be empty
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNullable :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNullable :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNullable :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(intFieldNullable :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     //name difference
     dfEmptyWithStructuredSchema.schemaDiffTo(
       StructType(nullableStringField.copy(name = "foo") :: notNullableStringField.copy(name = "foo2") :: Nil)
-    ).size should be (2)
+    ).size should be(2)
     dfEmptyWithStructuredSchema.schemaDiffTo(
       StructType(nullableStringField.copy(name = "foo") :: notNullableStringField.copy(name = "foo2") :: Nil),
-      deep = true).size should be (2)
+      deep = true).size should be(2)
     dfEmptyWithStructuredSchema.schemaDiffTo(
       StructType(nullableStringField.copy(name = "foo") :: notNullableStringField.copy(name = "foo2") :: Nil),
       ignoreNullable = true
-    ).size should be (2)
+    ).size should be(2)
     dfEmptyWithStructuredSchema.schemaDiffTo(
       StructType(nullableStringField.copy(name = "foo") :: notNullableStringField.copy(name = "foo2") :: Nil),
       ignoreNullable = true, deep = true
-    ).size should be (2)
+    ).size should be(2)
   }
 
   test("SchemaDiff to structured fields.") {
@@ -622,21 +623,21 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
     //name difference
     val diffNameStructField = nullableStructField.copy(name = "foo")
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameStructField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     //contains null difference
     val diffContainsNullStructField = nullableStructField.copy(name = notNullableStructField.name)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullStructField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullStructField :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullStructField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullStructField :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullStructField :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullStructField :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
     val diffContainsNoNullStructField = notNullableStructField.copy(name = nullableStructField.name)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullStructField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullStructField :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullStructField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullStructField :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullStructField :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullStructField :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
@@ -644,25 +645,25 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
     val missingFieldStructField = nullableStructField.copy(dataType = StructType(
       nullableStructField.dataType.asInstanceOf[StructType].fields.drop(1)
     ))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldStructField :: Nil)).size should be (1) // no deep partial matching.
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldStructField :: Nil)).size should be(1) // no deep partial matching.
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldStructField :: Nil), deep = true) shouldBe empty // deep partial match
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldStructField :: Nil), ignoreNullable = true).size should be (1) // no deep partial matching.
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldStructField :: Nil), ignoreNullable = true).size should be(1) // no deep partial matching.
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldStructField :: Nil), ignoreNullable = true, deep = true) shouldBe empty // deep partial match
 
     val additionalFieldStructField = nullableStructField.copy(dataType = StructType(
       nullableStructField.dataType.asInstanceOf[StructType].fields ++ Array(StructField("foo", StringType, nullable = true))
     ))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(additionalFieldStructField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     //field nullability can be ignored
     val switchedNullabilityInFields = nullableStructField.copy(
-        dataType = StructType(nullableStructField.dataType.asInstanceOf[StructType].fields.map(f => f.copy(nullable = !f.nullable)))
+      dataType = StructType(nullableStructField.dataType.asInstanceOf[StructType].fields.map(f => f.copy(nullable = !f.nullable)))
     )
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), ignoreNullable = true, deep = true) shouldBe empty
   }
@@ -680,48 +681,48 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
     //name difference
     val diffNameField = nullableArrayField.copy(name = "foo")
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     //contains null difference
     val diffContainsNullField = nullableArrayField.copy(name = notNullableArrayField.name)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
     val diffContainsNoNullField = notNullableArrayField.copy(name = nullableArrayField.name)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
     //elementType difference
     val diffElementTypeField = nullableArrayField.copy(dataType = ArrayType(IntegerType, containsNull = true))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     val missingFieldDeepDiffElementTypeField = nullableArrayField.copy(dataType = ArrayType(
       StructType(notNullableStringField :: Nil),
       containsNull = true
     ))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldDeepDiffElementTypeField :: Nil)).size should be (1) // no partial deep match
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldDeepDiffElementTypeField :: Nil)).size should be(1) // no partial deep match
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldDeepDiffElementTypeField :: Nil), deep = true) shouldBe empty // partial deep match
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be (1) // no partial deep match
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be(1) // no partial deep match
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(missingFieldDeepDiffElementTypeField :: Nil), ignoreNullable = true, deep = true) shouldBe empty // partial deep match
 
     val nameDifferenceDeepDiffElementTypeField = nullableArrayField.copy(dataType = ArrayType(
-        StructType(nullableStringField.copy(name = "foo") :: notNullableStringField :: Nil),
-        containsNull = true
+      StructType(nullableStringField.copy(name = "foo") :: notNullableStringField :: Nil),
+      containsNull = true
     ))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(nameDifferenceDeepDiffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     //element type nullability can be ignored
     val switchedNullabilityInFields = nullableArrayField.copy(
@@ -729,8 +730,8 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
         f => f.copy(nullable = !f.nullable)
       )), containsNull = true)
     )
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedNullabilityInFields :: Nil), ignoreNullable = true, deep = true) shouldBe empty
   }
@@ -748,47 +749,47 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
 
     //name difference
     val diffNameField = nullableMapField.copy(name = "foo")
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffNameField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     //contains null difference
     val diffContainsNullField = nullableMapField.copy(name = notNullableMapField.name)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNullField :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
     val diffContainsNoNullField = notNullableMapField.copy(name = nullableMapField.name)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffContainsNoNullField :: Nil), ignoreNullable = true, deep = true) shouldBe empty
 
     //elementType difference
     val diffElementTypeField = nullableMapField.copy(dataType = MapType(IntegerType, IntegerType, valueContainsNull = true))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(diffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     val keyTypeDeepDiffElementTypeField = nullableMapField.copy(dataType = MapType(
       StringType, StructType(nullableStringField :: notNullableStringField :: Nil),
       valueContainsNull = true
     ))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil), deep = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil), deep = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(keyTypeDeepDiffElementTypeField :: Nil), ignoreNullable = true, deep = true).size should be(1)
 
     val valueTypeOrderDeepDiffElementTypeField = nullableMapField.copy(dataType = MapType(
       IntegerType, StructType(notNullableStringField :: nullableStringField :: Nil),
       valueContainsNull = true
     ))
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(valueTypeOrderDeepDiffElementTypeField :: Nil)).size should be (1) // no partial deep match
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(valueTypeOrderDeepDiffElementTypeField :: Nil)).size should be(1) // no partial deep match
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(valueTypeOrderDeepDiffElementTypeField :: Nil), deep = true) shouldBe empty // partial deep match
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(valueTypeOrderDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be (1) // no partial deep match
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(valueTypeOrderDeepDiffElementTypeField :: Nil), ignoreNullable = true).size should be(1) // no partial deep match
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(valueTypeOrderDeepDiffElementTypeField :: Nil), ignoreNullable = true, deep = true) shouldBe empty // partial deep match
 
     //element type nullability can be ignored
@@ -798,8 +799,8 @@ class DataFrameUtilTest extends org.scalatest.FunSuite with Matchers with SmartD
       )), valueContainsNull = true)
     )
 
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedValueNullabilityInFields :: Nil)).size should be (1)
-    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedValueNullabilityInFields :: Nil), deep = true).size should be (1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedValueNullabilityInFields :: Nil)).size should be(1)
+    dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedValueNullabilityInFields :: Nil), deep = true).size should be(1)
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedValueNullabilityInFields :: Nil), ignoreNullable = true) shouldBe empty
     dfEmptyWithStructuredSchema.schemaDiffTo(StructType(switchedValueNullabilityInFields :: Nil), ignoreNullable = true, deep = true) shouldBe empty
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/DateUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/DateUtilTest.scala
@@ -19,12 +19,13 @@
 
 package io.smartdatalake.util.misc
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.time.temporal.ChronoUnit
 import java.time.{LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 
-class DateUtilTest extends FunSpec with Matchers {
+class DateUtilTest extends AnyFunSpec with Matchers {
 
   private val currentTime = LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS)
   private val currentTimeAtUtc = currentTime.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC)

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/EnvironmentUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/EnvironmentUtilTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.util.misc
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class EnvironmentUtilTest extends FunSuite {
+class EnvironmentUtilTest extends AnyFunSuite {
 
   test("camelCaseToUpper") {
     assert(EnvironmentUtil.camelCaseToUpper("camelCaseToUpper") == "CAMEL_CASE_TO_UPPER")

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/GraphUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/GraphUtilTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.util.misc
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class GraphUtilTest extends FunSuite {
+class GraphUtilTest extends AnyFunSuite {
 
   val graph1 = GraphUtil.Graph(Set(("A","B"),("A","C"),("B","D"),("C","D"),("D","E")))
   val allNodes = graph1.edges.flatMap(e => Set(e._1,e._2))

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/HoconUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/HoconUtilTest.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.util.misc
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class HoconUtilTest extends FunSuite {
+class HoconUtilTest extends AnyFunSuite {
 
   val config = ConfigFactory.parseString(
     """

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/NestedColumnUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/NestedColumnUtilTest.scala
@@ -24,12 +24,12 @@ import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSchema, S
 import io.smartdatalake.workflow.dataframe.{GenericColumn, GenericDataType}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
-class NestedColumnUtilTest extends FunSuite {
+class NestedColumnUtilTest extends AnyFunSuite {
 
   implicit val spark = session
   import spark.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/ProductUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/ProductUtilTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.util.misc
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ProductUtilTest extends FunSuite {
+class ProductUtilTest extends AnyFunSuite {
 
   test("get case class field value") {
     val p1 = XyzProduct("test", 1, true)

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/SchemaUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/SchemaUtilTest.scala
@@ -22,13 +22,13 @@ package io.smartdatalake.util.misc
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSchema}
 import io.smartdatalake.workflow.dataframe.{GenericArrayDataType, GenericStructDataType}
-import org.scalatest.FunSuite
-import org.scalatest.Matchers.{a, be}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers.{a, be}
 import org.apache.spark.sql.types._
 
 import java.nio.file.Files
 
-class SchemaUtilTest extends FunSuite {
+class SchemaUtilTest extends AnyFunSuite {
 
   private val tempDir = Files.createTempDirectory("schema-util-test")
 

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/SparkExpressionUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/SparkExpressionUtilTest.scala
@@ -26,9 +26,9 @@ import io.smartdatalake.util.spark.SparkExpressionUtil
 import io.smartdatalake.workflow.action.executionMode.DefaultExecutionModeExpressionData
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.{col, min, udf}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SparkExpressionUtilTest extends FunSuite {
+class SparkExpressionUtilTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
 

--- a/sdl-core/src/test/scala/io/smartdatalake/util/misc/URIUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/misc/URIUtilTest.scala
@@ -19,11 +19,11 @@
 
 package io.smartdatalake.util.misc
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.net.URI
 
-class URIUtilTest extends FunSuite {
+class URIUtilTest extends AnyFunSuite {
   test("add path should append path to existing URI path, without changing the rest of the URI") {
     {
       val uri = new URI("https://test.com/abc?name=123")

--- a/sdl-core/src/test/scala/io/smartdatalake/util/secrets/SecretsUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/secrets/SecretsUtilTest.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.util.secrets
 
 import io.smartdatalake.config.ConfigurationException
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SecretsUtilTest extends FunSuite {
+class SecretsUtilTest extends AnyFunSuite {
 
   test("register custom config provider and get secret") {
     val providerConfig = SecretProviderConfig(classOf[TestSecretProvider].getName, Some(Map("option1" -> "1")))

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/DataFrameUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/DataFrameUtilTest.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.util.spark
 
 import io.smartdatalake.util.spark.DataFrameUtil.{normalizeToAscii, removeNonStandardSQLNameChars, strCamelCase2LowerCaseWithUnderscores, strToLowerCamelCase}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class DataFrameUtilTest extends FunSuite {
+class DataFrameUtilTest extends AnyFunSuite {
 
   test("camelCase to lower_case_with_underscore") {
     assert(strCamelCase2LowerCaseWithUnderscores("abc0") == "abc0")

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/SDLSparkExtensionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/SDLSparkExtensionTest.scala
@@ -27,11 +27,11 @@ import io.smartdatalake.workflow.dataobject.Table
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 
-class SDLSparkExtensionTest extends FunSuite {
+class SDLSparkExtensionTest extends AnyFunSuite {
 
   private implicit val session: SparkSession = TestUtil.session
 

--- a/sdl-core/src/test/scala/io/smartdatalake/util/webservice/OpenApiUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/webservice/OpenApiUtilTest.scala
@@ -24,9 +24,9 @@ import io.smartdatalake.testutils.TestUtil
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.json4s.jackson.JsonMethods.parse
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class OpenApiUtilTest extends FunSuite {
+class OpenApiUtilTest extends AnyFunSuite {
 
   implicit val hadoopConf: Configuration = new Configuration()
 

--- a/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
@@ -25,13 +25,14 @@ import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.connection.authMode.{AuthHeaderMode, BasicAuthMode, CustomHttpAuthModeLogic}
 import io.smartdatalake.workflow.dataobject.WebserviceFileDataObject
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import sttp.client3.Response
 import sttp.model.StatusCode
 
 import scala.util.Try
 
-class WebserviceClientTest extends FunSuite with BeforeAndAfter with BeforeAndAfterAll  {
+class WebserviceClientTest extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
 
   val port = 8080 // for some reason, only the default port seems to work
   val httpsPort = 8443
@@ -40,7 +41,7 @@ class WebserviceClientTest extends FunSuite with BeforeAndAfter with BeforeAndAf
 
   // provide an empty instance registry
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
-  implicit val context : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
   override protected def beforeAll(): Unit = {
     wireMockServer = TestUtil.startWebservice(host, port, httpsPort)
@@ -107,9 +108,11 @@ class WebserviceClientTest extends FunSuite with BeforeAndAfter with BeforeAndAf
 
 private class MyCustomHttpAuthMode extends CustomHttpAuthModeLogic {
   var additionalHeaders: Map[String, StringOrSecret] = _
+
   override def prepare(options: Map[String, StringOrSecret]): Unit = {
     // add options as headers
     additionalHeaders = options
   }
-  override def getHeaders = additionalHeaders.mapValues(_.resolve()).toMap
+
+  override def getHeaders: Map[String, String] = additionalHeaders.mapValues(_.resolve()).toMap
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGRunTest.scala
@@ -28,13 +28,13 @@ import io.smartdatalake.util.misc.CustomCodeUtil
 import io.smartdatalake.workflow.action.{RuntimeEventState, RuntimeInfo, SDLExecutionId}
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import java.time.temporal.ChronoUnit
 import java.time.{Duration, LocalDateTime}
 
-class ActionDAGRunTest extends FunSuite {
+class ActionDAGRunTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -36,15 +36,17 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.{Instant, LocalDateTime}
 
-class ActionDAGTest extends FunSuite with BeforeAndAfter {
+class ActionDAGTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:ActionDAGTest", "org.hsqldb.jdbcDriver")
@@ -69,22 +71,22 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
-    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("lastname","firstname")))
+    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("lastname", "firstname")))
     val tgt1DO = JdbcTableDataObject("tgt1", table = tgt1Table, connectionId = "jdbcCon1")
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname", "firstname")))
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val statePath = tempPath+"stateTest/"
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val statePath = tempPath + "stateTest/"
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val action1 = DeduplicateAction("a", srcDO.id, tgt1DO.id, metricsFailCondition = Some(s"dataObjectId = '${tgt1DO.id.id}' and key = 'records_written' and value = 0"))
     val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id)
@@ -95,7 +97,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // exec dag
     dag.prepare(contextPrep)
     dag.init(contextInit)
-    assert(contextInit.dataFrameReuseStatistics((tgt1DO.id,Seq())).size == 1)
+    assert(contextInit.dataFrameReuseStatistics((tgt1DO.id, Seq())).size == 1)
     dag.exec(contextExec)
     assert(contextExec.dataFrameReuseStatistics.forall(_._2.isEmpty))
 
@@ -108,15 +110,15 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check metrics for HiveTableDataObject
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputId)
-    assert(action2MainMetrics("records_written")==1)
+    assert(action2MainMetrics("records_written") == 1)
     assert(action2MainMetrics.isDefinedAt("bytes_written"))
-    assert(action2MainMetrics("num_tasks")==1)
+    assert(action2MainMetrics("num_tasks") == 1)
 
     // check state: two actions succeeded
     val latestState = stateStore.getLatestStateId().get
     val previousRunState = stateStore.recoverRunState(latestState)
     val previousActionState = previousRunState.actionsState.mapValues(_.state).toMap
-    val resultActionState = actions.map( a => (a.id, RuntimeEventState.SUCCEEDED)).toMap
+    val resultActionState = actions.map(a => (a.id, RuntimeEventState.SUCCEEDED)).toMap
     assert(previousActionState == resultActionState)
   }
 
@@ -129,21 +131,21 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
-    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("lastname","firstname")))
+    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("lastname", "firstname")))
     val tgt1DO = JdbcTableDataObject("tgt1", table = tgt1Table, connectionId = "jdbcCon1")
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname", "firstname")))
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val action1 = DeduplicateAction("a", srcDO.id, tgt1DO.id)
     val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id, breakDataFrameLineage = true)
@@ -166,9 +168,9 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check metrics for HiveTableDataObject
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputId)
-    assert(action2MainMetrics("records_written")==1)
+    assert(action2MainMetrics("records_written") == 1)
     assert(action2MainMetrics.isDefinedAt("bytes_written"))
-    assert(action2MainMetrics("num_tasks")==1)
+    assert(action2MainMetrics("num_tasks") == 1)
   }
 
   test("action dag with 2 actions in sequence where 2nd action reads different schema than produced by last action") {
@@ -179,12 +181,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgt1DO = CsvFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), filenameColumn=Some("_filename"), csvOptions = Map("header" -> "true", "delimiter" -> ","))
+    val tgt1DO = CsvFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), filenameColumn = Some("_filename"), csvOptions = Map("header" -> "true", "delimiter" -> ","))
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = CsvFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
+    val tgt2DO = CsvFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
@@ -204,7 +206,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check result
     val dfR1 = tgt2DO.getSparkDataFrame()
-    assert(dfR1.columns.toSet == Set("_filename","rating"))
+    assert(dfR1.columns.toSet == Set("_filename", "rating"))
     val r1 = dfR1
       .select($"rating")
       .as[String].collect().toSeq
@@ -221,40 +223,40 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTableA = Table(Some("default"), "input_a")
-    val srcADO = HiveTableDataObject( "src_A", Some(tempPath+s"/${srcTableA.fullName}"), table = srcTableA, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    val srcADO = HiveTableDataObject("src_A", Some(tempPath + s"/${srcTableA.fullName}"), table = srcTableA, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     srcADO.dropTable
     instanceRegistry.register(srcADO)
 
     val srcTableB = Table(Some("default"), "input_b")
-    val srcBDO = HiveTableDataObject( "src_B", Some(tempPath+s"/${srcTableB.fullName}"), table = srcTableB, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    val srcBDO = HiveTableDataObject("src_B", Some(tempPath + s"/${srcTableB.fullName}"), table = srcTableB, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     srcBDO.dropTable
     instanceRegistry.register(srcBDO)
 
     instanceRegistry.register(jdbcConnection)
-    val tgtATable = Table(Some("public"), "tgt_a", None, Some(Seq("lastname","firstname")))
-    val tgtADO = JdbcTableDataObject("tgt_A", table = tgtATable, connectionId = "jdbcCon1", virtualPartitions = Seq("lastname"), jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255), rating INTEGER"))
+    val tgtATable = Table(Some("public"), "tgt_a", None, Some(Seq("lastname", "firstname")))
+    val tgtADO = JdbcTableDataObject("tgt_A", table = tgtATable, connectionId = "jdbcCon1", virtualPartitions = Seq("lastname"), jdbcOptions = Map("createTableColumnTypes" -> "lastname varchar(255), firstname varchar(255), rating INTEGER"))
     tgtADO.dropTable
     instanceRegistry.register(tgtADO)
 
-    val tgtBTable = Table(Some("default"), "tgt_b", None, Some(Seq("lastname","firstname")))
-    val tgtBDO = HiveTableDataObject( "tgt_B", Some(tempPath+s"/${tgtBTable.fullName}"), table = tgtBTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    val tgtBTable = Table(Some("default"), "tgt_b", None, Some(Seq("lastname", "firstname")))
+    val tgtBDO = HiveTableDataObject("tgt_B", Some(tempPath + s"/${tgtBTable.fullName}"), table = tgtBTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     tgtBDO.dropTable
     instanceRegistry.register(tgtBDO)
 
-    val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname","firstname")))
-    val tgtCDO = HiveTableDataObject( "tgt_C", Some(tempPath+s"/${tgtCTable.fullName}"), table = tgtCTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname", "firstname")))
+    val tgtCDO = HiveTableDataObject("tgt_C", Some(tempPath + s"/${tgtCTable.fullName}"), table = tgtCTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     tgtCDO.dropTable
     instanceRegistry.register(tgtCDO)
 
-    val tgtDTable = Table(Some("default"), "ap_copy3", None, Some(Seq("lastname","firstname")))
-    val tgtDDO = HiveTableDataObject( "tgt_D", Some(tempPath+s"/${tgtDTable.fullName}"), table = tgtDTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    val tgtDTable = Table(Some("default"), "ap_copy3", None, Some(Seq("lastname", "firstname")))
+    val tgtDDO = HiveTableDataObject("tgt_D", Some(tempPath + s"/${tgtDTable.fullName}"), table = tgtDTable, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     tgtDDO.dropTable
     instanceRegistry.register(tgtDDO)
 
     // prepare DAG
-    val dataA = Seq(("doe","john",5),("dau","bob",3)).toDF("lastname", "firstname", "rating")
-    val dfTgtA = dataA.where($"lastname"==="doe").withColumn("dl_ts_captured", current_timestamp())
-    val dataB = Seq(("doe","john",10),("dau","bob",6)).toDF("lastname", "firstname", "rating")
+    val dataA = Seq(("doe", "john", 5), ("dau", "bob", 3)).toDF("lastname", "firstname", "rating")
+    val dfTgtA = dataA.where($"lastname" === "doe").withColumn("dl_ts_captured", current_timestamp())
+    val dataB = Seq(("doe", "john", 10), ("dau", "bob", 6)).toDF("lastname", "firstname", "rating")
     srcADO.writeSparkDataFrame(dataA, Seq())
     srcBDO.writeSparkDataFrame(dataB, Seq())
     tgtADO.initSparkDataFrame(dfTgtA, Seq())
@@ -262,7 +264,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     tgtDDO.writeSparkDataFrame(dataA, Seq()) // populate tgtD so there should be no partitions left to process
     instanceRegistry.register(DeduplicateAction("a", srcADO.id, tgtADO.id, executionMode = Some(PartitionDiffMode()), metadata = Some(ActionMetadata(feed = Some(feed)))))
     // srcB should be filtered with partition values received from tgtA. Transformer selects records from srcB, so "doe, bob, 6" should be inserted in tgtB, but "doe, john, 3" should remain.
-    instanceRegistry.register(CustomDataFrameAction("b", Seq(tgtADO.id,srcBDO.id), Seq(tgtBDO.id), executionMode = Some(FailIfNoPartitionValuesMode()), metadata = Some(ActionMetadata(feed = Some(feed))),
+    instanceRegistry.register(CustomDataFrameAction("b", Seq(tgtADO.id, srcBDO.id), Seq(tgtBDO.id), executionMode = Some(FailIfNoPartitionValuesMode()), metadata = Some(ActionMetadata(feed = Some(feed))),
       transformers = Seq(SQLDfsTransformer(code = Map(tgtBDO.id.id -> "select * from src_B"))), mainInputId = Some(tgtADO.id)
     ))
 
@@ -287,37 +289,37 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val r3 = tgtDDO.getSparkDataFrame()
       .select($"rating")
       .as[Int].collect().toSeq
-    assert(r3.toSet == Set(3,5))
+    assert(r3.toSet == Set(3, 5))
   }
 
   test("action dag where first actions has multiple input subfeeds, one should ignore filters") {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable1 = Table(Some("default"), "input1")
-    val srcDO1 = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable1.fullName}"), table = srcTable1, numInitialHdfsPartitions = 1)
+    val srcDO1 = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable1.fullName}"), table = srcTable1, numInitialHdfsPartitions = 1)
     srcDO1.dropTable
     instanceRegistry.register(srcDO1)
     val srcTable2 = Table(Some("default"), "input2")
-    val srcDO2 = HiveTableDataObject( "src2", Some(tempPath+s"/${srcTable2.fullName}"), table = srcTable2, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    val srcDO2 = HiveTableDataObject("src2", Some(tempPath + s"/${srcTable2.fullName}"), table = srcTable2, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     srcDO2.dropTable
     instanceRegistry.register(srcDO2)
     val srcTable3 = Table(Some("default"), "input3")
-    val srcDO3 = HiveTableDataObject( "src3", Some(tempPath+s"/${srcTable3.fullName}"), table = srcTable3, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
+    val srcDO3 = HiveTableDataObject("src3", Some(tempPath + s"/${srcTable3.fullName}"), table = srcTable3, numInitialHdfsPartitions = 1, partitions = Seq("lastname"))
     srcDO3.dropTable
     instanceRegistry.register(srcDO3)
-    val tgtTable = Table(Some("default"), "output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare DAG
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    val l2 = Seq(("xyz","john",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    val l2 = Seq(("xyz", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO1.writeSparkDataFrame(l1, Seq())
     srcDO2.writeSparkDataFrame(l2.union(l1), Seq())
     srcDO3.writeSparkDataFrame(l2.union(l1), Seq())
-    val action1 = CustomDataFrameAction( "a", inputIds = Seq(srcDO1.id, srcDO2.id, srcDO3.id), inputIdsToIgnoreFilter = Seq(srcDO3.id), outputIds = Seq(tgtDO.id)
-                                    , transformers = Seq(ScalaClassSparkDfsTransformer(className=classOf[TestDfsUnionOfThree].getName)))
+    val action1 = CustomDataFrameAction("a", inputIds = Seq(srcDO1.id, srcDO2.id, srcDO3.id), inputIdsToIgnoreFilter = Seq(srcDO3.id), outputIds = Seq(tgtDO.id)
+      , transformers = Seq(ScalaClassSparkDfsTransformer(className = classOf[TestDfsUnionOfThree].getName)))
     // filter partition values lastname=xyz: src1 is not partitioned, src2 & src3 have 1 record with partition lastname=doe and 1 record with partition lastname=xyz
     val partitionValuesFilter = Seq(PartitionValues(Map("lastname" -> "doe")))
     val dag = ActionDAGRun(Seq(action1), partitionValues = partitionValuesFilter)
@@ -330,8 +332,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // as filters are ignored, we expect both records from src3, but only one record from src2
     val r1 = tgtDO.getSparkDataFrame(Seq())
       .select($"lastname", $"firstname", $"origin")
-      .as[(String,String,Int)].collect().toSet
-    assert(r1 == Set(("doe","john",1),("doe","john",2),("doe","john",3),("xyz","john",3)))
+      .as[(String, String, Int)].collect().toSet
+    assert(r1 == Set(("doe", "john", 1), ("doe", "john", 2), ("doe", "john", 3), ("xyz", "john", 3)))
   }
 
   test("action dag with four dependencies") {
@@ -341,40 +343,40 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "A", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("A", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
 
     instanceRegistry.register(jdbcConnection)
-    val tgtATable = Table(Some("public"), "tgt_a", None, Some(Seq("lastname","firstname")))
+    val tgtATable = Table(Some("public"), "tgt_a", None, Some(Seq("lastname", "firstname")))
     val tgtADO = JdbcTableDataObject("tgt_A", table = tgtATable, connectionId = "jdbcCon1")
     tgtADO.dropTable
     instanceRegistry.register(tgtADO)
 
-    val tgtBTable = Table(Some("default"), "tgt_b", None, Some(Seq("lastname","firstname")))
-    val tgtBDO = HiveTableDataObject( "tgt_B", Some(tempPath+s"/${tgtBTable.fullName}"), table = tgtBTable, numInitialHdfsPartitions = 1)
+    val tgtBTable = Table(Some("default"), "tgt_b", None, Some(Seq("lastname", "firstname")))
+    val tgtBDO = HiveTableDataObject("tgt_B", Some(tempPath + s"/${tgtBTable.fullName}"), table = tgtBTable, numInitialHdfsPartitions = 1)
     tgtBDO.dropTable
     instanceRegistry.register(tgtBDO)
 
-    val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname","firstname")))
-    val tgtCDO = HiveTableDataObject( "tgt_C", Some(tempPath+s"/${tgtCTable.fullName}"), table = tgtCTable, numInitialHdfsPartitions = 1)
+    val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname", "firstname")))
+    val tgtCDO = HiveTableDataObject("tgt_C", Some(tempPath + s"/${tgtCTable.fullName}"), table = tgtCTable, numInitialHdfsPartitions = 1)
     tgtCDO.dropTable
     instanceRegistry.register(tgtCDO)
 
-    val tgtDTable = Table(Some("default"), "tgt_d", None, Some(Seq("lastname","firstname")))
-    val tgtDDO = HiveTableDataObject( "tgt_D", Some(tempPath+s"/${tgtDTable.fullName}"), table = tgtDTable, numInitialHdfsPartitions = 1)
+    val tgtDTable = Table(Some("default"), "tgt_d", None, Some(Seq("lastname", "firstname")))
+    val tgtDDO = HiveTableDataObject("tgt_D", Some(tempPath + s"/${tgtDTable.fullName}"), table = tgtDTable, numInitialHdfsPartitions = 1)
     tgtDDO.dropTable
     instanceRegistry.register(tgtDDO)
 
     // prepare DAG
     val customTransfomer = ScalaClassSparkDfsTransformer(className = classOf[TestActionDagTransformer].getName)
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val actions = Seq(
       DeduplicateAction("A", srcDO.id, tgtADO.id),
       CopyAction("B", tgtADO.id, tgtBDO.id),
       CopyAction("C", tgtADO.id, tgtCDO.id),
-      CustomDataFrameAction("D", List(tgtBDO.id,tgtCDO.id), List(tgtDDO.id), transformers = Seq(customTransfomer))
+      CustomDataFrameAction("D", List(tgtBDO.id, tgtCDO.id), List(tgtDDO.id), transformers = Seq(customTransfomer))
     )
     val dag = ActionDAGRun(actions)
 
@@ -415,18 +417,18 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val srcD1 = MockDataObject("src1", partitions = Seq("lastname")).register
     val srcD2 = MockDataObject("src2", partitions = Seq("lastname")).register
-    val tgtATable = Table(Some("default"), "tgt_a", None, Some(Seq("lastname","firstname")))
-    val tgtADO = HiveTableDataObject("tgt_A", Some(tempPath+s"/${tgtATable.fullName}"), table = tgtATable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgtATable = Table(Some("default"), "tgt_a", None, Some(Seq("lastname", "firstname")))
+    val tgtADO = HiveTableDataObject("tgt_A", Some(tempPath + s"/${tgtATable.fullName}"), table = tgtATable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     tgtADO.dropTable
     instanceRegistry.register(tgtADO)
 
-    val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname","firstname")))
-    val tgtCDO = HiveTableDataObject( "tgt_C", Some(tempPath+s"/${tgtCTable.fullName}"), table = tgtCTable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgtCTable = Table(Some("default"), "tgt_c", None, Some(Seq("lastname", "firstname")))
+    val tgtCDO = HiveTableDataObject("tgt_C", Some(tempPath + s"/${tgtCTable.fullName}"), table = tgtCTable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     tgtCDO.dropTable
     instanceRegistry.register(tgtCDO)
 
     // prepare DAG
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcD1.writeSparkDataFrame(l1)
     val l2 = Seq(("peter", "pan", 3)).toDF("lastname", "firstname", "rating")
     srcD2.writeSparkDataFrame(l2)
@@ -473,32 +475,32 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actiondag"
     val srcTable = Table(Some("default"), "ap_input")
     // source table has partitions columns dt and type
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), partitions = Seq("dt","type"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), partitions = Seq("dt", "type"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
-    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("dt","type","lastname","firstname")))
+    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("dt", "type", "lastname", "firstname")))
     // first table has partitions columns dt and type (same as source)
-    val tgt1DO = JdbcTableDataObject("tgt1", table = tgt1Table, connectionId = "jdbcCon1", virtualPartitions = Seq("dt","type"), jdbcOptions = Map("createTableColumnTypes"->"dt varchar(255), type varchar(255), lastname varchar(255), firstname varchar(255), rating INTEGER"))
+    val tgt1DO = JdbcTableDataObject("tgt1", table = tgt1Table, connectionId = "jdbcCon1", virtualPartitions = Seq("dt", "type"), jdbcOptions = Map("createTableColumnTypes" -> "dt varchar(255), type varchar(255), lastname varchar(255), firstname varchar(255), rating INTEGER"))
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("dt","lastname","firstname")))
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("dt", "lastname", "firstname")))
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), partitions = Seq("dt"), table = tgt2Table, numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare data
-    val dfSrc = Seq(("20180101", "person", "doe","john",5) // partition 20180101 is included in partition values filter
-      ,("20190101", "company", "olmo","-",10)) // partition 20190101 is not included
+    val dfSrc = Seq(("20180101", "person", "doe", "john", 5) // partition 20180101 is included in partition values filter
+      , ("20190101", "company", "olmo", "-", 10)) // partition 20190101 is not included
       .toDF("dt", "type", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(dfSrc, Seq())
 
     // prepare DAG
     val actions = Seq(
-      DeduplicateAction("a", srcDO.id, tgt1DO.id, executionMode=Some(PartitionDiffMode())), // PartitionDiffMode is ignored because partition values are given below as parameter
+      DeduplicateAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode())), // PartitionDiffMode is ignored because partition values are given below as parameter
       CopyAction("b", tgt1DO.id, tgt2DO.id)
     )
-    val dag = ActionDAGRun(actions, partitionValues = Seq(PartitionValues(Map("dt"->"20180101"))))
+    val dag = ActionDAGRun(actions, partitionValues = Seq(PartitionValues(Map("dt" -> "20180101"))))
 
     // exec dag
     dag.prepare(contextPrep)
@@ -532,16 +534,16 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile).toFile)
 
     // setup src DataObject
-    val srcDO = new CsvFileDataObject( "src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
+    val srcDO = new CsvFileDataObject("src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
     instanceRegistry.register(srcDO)
 
     // setup tgt1 CSV DataObject
-    val tgt1DO = new CsvFileDataObject( "tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
+    val tgt1DO = new CsvFileDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
     instanceRegistry.register(tgt1DO)
 
     // setup tgt2 Hive DataObject
     val tgt2Table = Table(Some("default"), "ap_copy")
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), table = tgt2Table, numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
@@ -575,21 +577,21 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile).toFile)
 
     // setup src DataObject
-    val srcDO = new CsvFileDataObject( "src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
+    val srcDO = new CsvFileDataObject("src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
     instanceRegistry.register(srcDO)
 
     // setup tgt1 Hive DataObject
     val tgt1Table = Table(Some("default"), "ap_copy")
-    val tgt1DO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, numInitialHdfsPartitions = 1)
+    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), table = tgt1Table, numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
 
     // setup tgt2 CSV DataObject
-    val tgt2DO = new CsvFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
+    val tgt2DO = new CsvFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
     instanceRegistry.register(tgt2DO)
 
     // setup tgt3 CSV DataObject
-    val tgt3DO = new CsvFileDataObject( "tgt3", tempDir.resolve("tgt3").toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
+    val tgt3DO = new CsvFileDataObject("tgt3", tempDir.resolve("tgt3").toString.replace('\\', '/'), csvOptions = Map("header" -> "true", "delimiter" -> ","))
     instanceRegistry.register(tgt3DO)
 
     // prepare ActionPipeline
@@ -612,34 +614,34 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check metrics for CsvFileDataObject
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputId)
-    assert(action2MainMetrics("records_written")==40)
+    assert(action2MainMetrics("records_written") == 40)
     assert(action2MainMetrics.isDefinedAt("bytes_written"))
-    assert(action2MainMetrics("num_tasks")==1)
+    assert(action2MainMetrics("num_tasks") == 1)
 
     // check metrics for FileTransferAction
     val action3MainMetrics = TestUtil.getMetrics(action3.getRuntimeInfo().get, action3.outputId)
-    assert(action3MainMetrics("files_written")==1)
+    assert(action3MainMetrics("files_written") == 1)
   }
 
   test("action dag with 2 actions in sequence and executionMode=PartitionDiffMode and selectExpression") {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
-    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    val tgt1DO = JdbcTableDataObject("tgt1", table = tgt1Table, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255), rating INTEGER"), virtualPartitions = Seq("lastname"), expectedPartitionsCondition = Some("elements['lastname'] != 'xyz'"))
+    val tgt1Table = Table(Some("public"), "ap_dedup", None, Some(Seq("lastname", "firstname")))
+    val tgt1DO = JdbcTableDataObject("tgt1", table = tgt1Table, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes" -> "lastname varchar(255), firstname varchar(255), rating INTEGER"), virtualPartitions = Seq("lastname"), expectedPartitionsCondition = Some("elements['lastname'] != 'xyz'"))
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname", "firstname")))
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), table = tgt2Table, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5),("einstein","albert",2)).toDF("lastname", "firstname", "rating")
+    val df1 = Seq(("doe", "john", 5), ("einstein", "albert", 2)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df1, Seq())
     val partitionDiffMode = PartitionDiffMode(
       applyCondition = Some("isStartNode"),
@@ -662,7 +664,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
       .select($"rating")
       .as[Int].collect().toSeq
     assert(r1 == Seq(2))
-    assert(tgt2DO.listPartitions ==  Seq(PartitionValues(Map("lastname"->"einstein"))))
+    assert(tgt2DO.listPartitions == Seq(PartitionValues(Map("lastname" -> "einstein"))))
 
     // second dag run: partition lastname=doe
     dag.prepare(contextPrep)
@@ -673,8 +675,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val r2 = tgt2DO.getSparkDataFrame()
       .select($"rating")
       .as[Int].collect().toSet
-    assert(r2 == Set(2,5))
-    assert(tgt2DO.listPartitions ==  Seq(PartitionValues(Map("lastname"->"doe")), PartitionValues(Map("lastname"->"einstein"))))
+    assert(r2 == Set(2, 5))
+    assert(tgt2DO.listPartitions == Seq(PartitionValues(Map("lastname" -> "doe")), PartitionValues(Map("lastname" -> "einstein"))))
 
     // third dag run - skip action execution because there are no new partitions to process
     dag.prepare(contextPrep)
@@ -682,25 +684,25 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     subFeeds.forall(_.isSkipped)
   }
 
-  test( "validate expected partitions") {
+  test("validate expected partitions") {
 
     val srcTable = Table(Some("default"), "ap_input")
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1, expectedPartitionsCondition = Some("elements['lastname'] != 'xyz'"))
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1, expectedPartitionsCondition = Some("elements['lastname'] != 'xyz'"))
     srcDO.dropTable
 
     instanceRegistry.register(srcDO)
 
-    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    val tgt1Path = tempPath+s"/${tgt1Table.fullName}"
-    val tgt1DO = HiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname", "firstname")))
+    val tgt1Path = tempPath + s"/${tgt1Table.fullName}"
+    val tgt1DO = HiveTableDataObject("tgt1", Some(tgt1Path), table = tgt1Table, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
 
     val actions: Seq[DataFrameOneToOneActionImpl] = Seq(
       CopyAction("a", srcDO.id, tgt1DO.id)
     )
-    val df1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val df1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df1, Seq())
 
     // fail for not existing expected partition abc
@@ -719,22 +721,22 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname", "firstname")))
+    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), table = tgt1Table, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname","firstname")))
-    val tgt2DO = HiveTableDataObject( "tgt2", Some(tempPath+s"/${tgt2Table.fullName}"), table = tgt2Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt2Table = Table(Some("default"), "ap_copy", None, Some(Seq("lastname", "firstname")))
+    val tgt2DO = HiveTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), table = tgt2Table, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     tgt2DO.dropTable
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
     // prepare data in srcDO and tgt1DO. Because of alternativeOutputId in action~a it should be processed again.
-    val df1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    val expectedPartitions = Seq(PartitionValues(Map("lastname"->"doe")))
+    val df1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    val expectedPartitions = Seq(PartitionValues(Map("lastname" -> "doe")))
     srcDO.writeSparkDataFrame(df1, expectedPartitions)
     tgt1DO.writeSparkDataFrame(df1, expectedPartitions)
     val actions: Seq[DataFrameOneToOneActionImpl] = Seq(
@@ -768,15 +770,15 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int")
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(srcDO)
-    val tgt1DO = JsonFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
+    val tgt1DO = JsonFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = JsonFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
+    val tgt2DO = JsonFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val df1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df1, Seq())
 
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointLocation = tempDir.resolve("stateA").toUri.toString)))
@@ -808,7 +810,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     assert(r2.head == 5)
 
     // third dag run - new data to process
-    val df2 = Seq(("doe","john 2",10)).toDF("lastname", "firstname", "rating")
+    val df2 = Seq(("doe", "john 2", 10)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df2, Seq())
     dag.reset
     dag.prepare(contextPrep)
@@ -823,8 +825,8 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check metrics
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputId)
-    assert(action2MainMetrics("records_written")==1)
-    assert(outputSubFeeds.find(_.dataObjectId == action2.outputId).get.metrics.get("records_written")==1)
+    assert(action2MainMetrics("records_written") == 1)
+    assert(outputSubFeeds.find(_.dataObjectId == action2.outputId).get.metrics.get("records_written") == 1)
   }
 
   test("action dag with 2 actions in sequence, first is executionMode=SparkStreamingOnceMode, second is normal") {
@@ -832,15 +834,15 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int")
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(srcDO)
-    val tgt1DO = JsonFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
+    val tgt1DO = JsonFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = JsonFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), saveMode = SDLSaveMode.OverwriteOptimized, jsonOptions = Some(Map("multiLine" -> "false")))
+    val tgt2DO = JsonFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), saveMode = SDLSaveMode.OverwriteOptimized, jsonOptions = Some(Map("multiLine" -> "false")))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val df1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df1, Seq())
 
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(SparkStreamingMode(checkpointLocation = tempDir.resolve("stateA").toUri.toString)))
@@ -871,7 +873,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     assert(r2 == Seq(5))
 
     // third dag run - new data to process
-    val df2 = Seq(("doe","john 2",10)).toDF("lastname", "firstname", "rating")
+    val df2 = Seq(("doe", "john 2", 10)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(df2, Seq())
     dag.reset
     dag.prepare(contextPrep)
@@ -886,7 +888,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check metrics
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputId)
-    assert(action2MainMetrics("records_written")==2) // without execution mode always the whole table is processed
+    assert(action2MainMetrics("records_written") == 2) // without execution mode always the whole table is processed
   }
 
   test("action dag union 2 streams with executionMode=SparkStreamingOnceMode") {
@@ -894,23 +896,23 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int")
-    val src1DO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val src1DO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(src1DO)
-    val src2DO = JsonFileDataObject( "src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val src2DO = JsonFileDataObject("src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(src2DO)
-    val tgt1DO = JsonFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
+    val tgt1DO = JsonFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiLine" -> "false")))
     instanceRegistry.register(tgt1DO)
 
     // prepare DAG
-    val data1src1 = Seq(("doe","john",5))
-    val data1src2 = Seq(("einstein","albert",2))
+    val data1src1 = Seq(("doe", "john", 5))
+    val data1src2 = Seq(("einstein", "albert", 2))
     src1DO.writeSparkDataFrame(data1src1.toDF("lastname", "firstname", "rating"), Seq())
     src2DO.writeSparkDataFrame(data1src2.toDF("lastname", "firstname", "rating"), Seq())
 
-    val action1 = CustomDataFrameAction( "a", Seq(src1DO.id,src2DO.id), Seq(tgt1DO.id)
-                                   , executionMode = Some(SparkStreamingMode(checkpointLocation = tempDir.resolve("stateA").toUri.toString))
-                                   , transformers = Seq(ScalaClassSparkDfsTransformer(className = classOf[TestStreamingTransformer].getName))
-                                   )
+    val action1 = CustomDataFrameAction("a", Seq(src1DO.id, src2DO.id), Seq(tgt1DO.id)
+      , executionMode = Some(SparkStreamingMode(checkpointLocation = tempDir.resolve("stateA").toUri.toString))
+      , transformers = Seq(ScalaClassSparkDfsTransformer(className = classOf[TestStreamingTransformer].getName))
+    )
     val dag: ActionDAGRun = ActionDAGRun(Seq(action1))
 
     // first dag run, first file processed
@@ -919,7 +921,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.exec(contextExec)
 
     // check
-    val r1 = tgt1DO.getSparkDataFrame().select($"lastname",$"firstname",$"rating".cast("int")).as[(String,String,Int)].collect().toSet
+    val r1 = tgt1DO.getSparkDataFrame().select($"lastname", $"firstname", $"rating".cast("int")).as[(String, String, Int)].collect().toSet
     assert(r1 == (data1src1 ++ data1src2).toSet)
 
     // second dag run - no data to process
@@ -929,11 +931,11 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.exec(contextExec)
 
     // check
-    val r2 = tgt1DO.getSparkDataFrame().select($"lastname",$"firstname",$"rating".cast("int")).as[(String,String,Int)].collect().toSet
+    val r2 = tgt1DO.getSparkDataFrame().select($"lastname", $"firstname", $"rating".cast("int")).as[(String, String, Int)].collect().toSet
     assert(r2 == (data1src1 ++ data1src2).toSet)
 
     // third dag run - new data to process in src 2
-    val data2 = Seq(("doe","john 2",10))
+    val data2 = Seq(("doe", "john 2", 10))
     src2DO.writeSparkDataFrame(data2.toDF("lastname", "firstname", "rating"), Seq())
     dag.reset
     dag.prepare(contextPrep)
@@ -941,12 +943,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     dag.exec(contextExec)
 
     // check
-    val r3 = tgt1DO.getSparkDataFrame().select($"lastname",$"firstname",$"rating".cast("int")).as[(String,String,Int)].collect().toSet
+    val r3 = tgt1DO.getSparkDataFrame().select($"lastname", $"firstname", $"rating".cast("int")).as[(String, String, Int)].collect().toSet
     assert(r3 == (data1src1 ++ data1src2 ++ data2).toSet)
 
     // check metrics
     val action1MainMetrics = TestUtil.getMetrics(action1.getRuntimeInfo().get, action1.outputIds.head)
-    assert(action1MainMetrics("records_written")==1)
+    assert(action1MainMetrics("records_written") == 1)
   }
 
   test("action dag with 2 actions in sequence, first is executionMode=DataFrameIncrementalMode, second is normal") {
@@ -954,20 +956,20 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int, tstmp timestamp").asInstanceOf[StructType]
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(srcDO)
-    val tgt1DO = ParquetFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
+    val tgt1DO = ParquetFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = ParquetFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
+    val tgt2DO = ParquetFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    val df1 = Seq(("doe", "john", 5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
     srcDO.writeSparkDataFrame(df1, Seq())
 
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(DataFrameIncrementalMode(compareCol = "tstmp")))
     val action2 = CopyAction("b", tgt1DO.id, tgt2DO.id)
-    val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2))
+    val dag: ActionDAGRun = ActionDAGRun(Seq(action1, action2))
 
     // first dag run, first file processed
     dag.prepare(contextPrep)
@@ -993,7 +995,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     assert(r2 == Seq(5))
 
     // third dag run - new data to process
-    val df2 = Seq(("doe","john 2",10, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    val df2 = Seq(("doe", "john 2", 10, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
     srcDO.writeSparkDataFrame(df2, Seq())
     dag.reset
     dag.prepare(contextPrep)
@@ -1008,7 +1010,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check metrics
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputId)
-    assert(action2MainMetrics("records_written")==2) // without execution mode always the whole table is processed
+    assert(action2MainMetrics("records_written") == 2) // without execution mode always the whole table is processed
   }
 
   test("action dag with 2 actions in sequence, first is executionMode=DataFrameIncrementalMode, second with executionCondition=true und executionMode=ProcessAllMode") {
@@ -1016,29 +1018,29 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int, tstmp timestamp")
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(srcDO)
     val schema2 = StructType.fromDDL("lastname string, firstname string, address string")
-    val src2DO = JsonFileDataObject( "src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema2)))
+    val src2DO = JsonFileDataObject("src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema2)))
     instanceRegistry.register(src2DO)
-    val tgt1DO = ParquetFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
+    val tgt1DO = ParquetFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = ParquetFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
+    val tgt2DO = ParquetFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    val df1 = Seq(("doe", "john", 5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
     srcDO.writeSparkDataFrame(df1, Seq())
-    val df2 = Seq(("doe","john","waikiki beach")).toDF("lastname", "firstname", "address")
+    val df2 = Seq(("doe", "john", "waikiki beach")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df2, Seq())
 
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id
       , executionMode = Some(DataFrameIncrementalMode(compareCol = "tstmp")))
-    val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id)
+    val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id, src2DO.id), Seq(tgt2DO.id)
       , executionCondition = Some(Condition("true")), executionMode = Some(ProcessAllMode()) // process everything, also if predecessor skipped
       , transformers = Seq(SQLDfsTransformer(code = Map(tgt2DO.id.id -> "select * from src2 join tgt1 using (lastname, firstname)"))))
     instanceRegistry.register(Seq(action1, action2))
-    val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2))
+    val dag: ActionDAGRun = ActionDAGRun(Seq(action1, action2))
 
     // first dag run, first file processed
     dag.prepare(contextPrep)
@@ -1048,12 +1050,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // check
     val r1 = tgt2DO.getSparkDataFrame()
       .select($"rating", $"address")
-      .as[(Int,String)].collect().toSet
-    assert(r1 == Set((5,"waikiki beach")))
+      .as[(Int, String)].collect().toSet
+    assert(r1 == Set((5, "waikiki beach")))
 
     // second dag run - no data to process in action a
     // there should be no exception and action b should run with updated data of src2 and existing data of tgt1
-    val df3 = Seq(("doe","john","honolulu")).toDF("lastname", "firstname", "address")
+    val df3 = Seq(("doe", "john", "honolulu")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df3, Seq())
     dag.reset
     dag.prepare(contextPrep)
@@ -1063,12 +1065,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // check
     val r2 = tgt2DO.getSparkDataFrame()
       .select($"rating", $"address")
-      .as[(Int,String)].collect().toSet
-    assert(r2 == Set((5,"honolulu")))
+      .as[(Int, String)].collect().toSet
+    assert(r2 == Set((5, "honolulu")))
 
     // check metrics
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputIds.head)
-    assert(action2MainMetrics("records_written")==1)
+    assert(action2MainMetrics("records_written") == 1)
   }
 
   test("action dag with 2 actions in sequence, first is executionMode=DataFrameIncrementalMode, second with executionCondition=true") {
@@ -1076,28 +1078,28 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int, tstmp timestamp")
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(srcDO)
     val schema2 = StructType.fromDDL("lastname string, firstname string, address string")
-    val src2DO = JsonFileDataObject( "src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema2)))
+    val src2DO = JsonFileDataObject("src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema2)))
     instanceRegistry.register(src2DO)
-    val tgt1DO = ParquetFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
+    val tgt1DO = ParquetFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = ParquetFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
+    val tgt2DO = ParquetFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
     val refTimestamp1 = LocalDateTime.now()
-    val df1 = Seq(("doe","john",5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    val df1 = Seq(("doe", "john", 5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
     srcDO.writeSparkDataFrame(df1, Seq())
-    val df2 = Seq(("doe","john","waikiki beach")).toDF("lastname", "firstname", "address")
+    val df2 = Seq(("doe", "john", "waikiki beach")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df2, Seq())
 
     val sqlTransformer = SQLDfsTransformer(code = Map(tgt2DO.id.id -> "select * from src2 join tgt1 using (lastname, firstname)"))
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(DataFrameIncrementalMode(compareCol = "tstmp")))
-    val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id), transformers = Seq(sqlTransformer), executionCondition = Some(Condition("true")))
+    val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id, src2DO.id), Seq(tgt2DO.id), transformers = Seq(sqlTransformer), executionCondition = Some(Condition("true")))
     instanceRegistry.register(Seq(action1, action2))
-    val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2))
+    val dag: ActionDAGRun = ActionDAGRun(Seq(action1, action2))
 
     // first dag run, first file processed
     dag.prepare(contextPrep)
@@ -1107,12 +1109,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // check
     val r1 = tgt2DO.getSparkDataFrame()
       .select($"rating", $"address")
-      .as[(Int,String)].collect().toSet
-    assert(r1 == Set((5,"waikiki beach")))
+      .as[(Int, String)].collect().toSet
+    assert(r1 == Set((5, "waikiki beach")))
 
     // second dag run - no data to process in action a
     // there should be no exception and action b should run with updated data of src2 and all data of tgt1 (as skipped SubFeed is reset)
-    val df3 = Seq(("doe","john","honolulu")).toDF("lastname", "firstname", "address")
+    val df3 = Seq(("doe", "john", "honolulu")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df3, Seq())
     dag.reset
     dag.prepare(contextPrep)
@@ -1124,7 +1126,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // check metrics
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputIds.head)
-    assert(action2MainMetrics("records_written")==1)
+    assert(action2MainMetrics("records_written") == 1)
   }
 
   test("action dag with 2 actions in sequence, first is executionMode=DataFrameIncrementalMode, second with executionCondition=true and ProcessAll mode") {
@@ -1132,28 +1134,28 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int, tstmp timestamp").asInstanceOf[StructType]
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(srcDO)
     val schema2 = StructType.fromDDL("lastname string, firstname string, address string").asInstanceOf[StructType]
-    val src2DO = JsonFileDataObject( "src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema2)))
+    val src2DO = JsonFileDataObject("src2", tempDir.resolve("src2").toString.replace('\\', '/'), schema = Some(SparkSchema(schema2)))
     instanceRegistry.register(src2DO)
-    val tgt1DO = ParquetFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
+    val tgt1DO = ParquetFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = ParquetFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
+    val tgt2DO = ParquetFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'))
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
     val refTimestamp1 = LocalDateTime.now()
-    val df1 = Seq(("doe","john",5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    val df1 = Seq(("doe", "john", 5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
     srcDO.writeSparkDataFrame(df1, Seq())
-    val df2 = Seq(("doe","john","waikiki beach")).toDF("lastname", "firstname", "address")
+    val df2 = Seq(("doe", "john", "waikiki beach")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df2, Seq())
 
     val sqlTransformer = SQLDfsTransformer(code = Map(tgt2DO.id.id -> "select * from src2 join tgt1 using (lastname, firstname)"))
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(DataFrameIncrementalMode(compareCol = "tstmp")))
-    val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id,src2DO.id), Seq(tgt2DO.id), transformers = Seq(sqlTransformer), executionCondition = Some(Condition("true")), executionMode = Some(ProcessAllMode()))
+    val action2 = CustomDataFrameAction("b", Seq(tgt1DO.id, src2DO.id), Seq(tgt2DO.id), transformers = Seq(sqlTransformer), executionCondition = Some(Condition("true")), executionMode = Some(ProcessAllMode()))
     instanceRegistry.register(Seq(action1, action2))
-    val dag: ActionDAGRun = ActionDAGRun(Seq(action1,action2))
+    val dag: ActionDAGRun = ActionDAGRun(Seq(action1, action2))
 
     // first dag run, first file processed
     dag.prepare(contextPrep)
@@ -1163,12 +1165,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // check
     val r1 = tgt2DO.getSparkDataFrame()
       .select($"rating", $"address")
-      .as[(Int,String)].collect().toSet
-    assert(r1 == Set((5,"waikiki beach")))
+      .as[(Int, String)].collect().toSet
+    assert(r1 == Set((5, "waikiki beach")))
 
     // second dag run - no data to process in action a
     // there should be no exception and action b should run with updated data of src2 and existing data of tgt1 due to ProcessAllMode
-    val df3 = Seq(("doe","john","honolulu")).toDF("lastname", "firstname", "address")
+    val df3 = Seq(("doe", "john", "honolulu")).toDF("lastname", "firstname", "address")
     src2DO.writeSparkDataFrame(df3, Seq())
     dag.reset
     dag.prepare(contextPrep)
@@ -1178,12 +1180,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // check
     val r2 = tgt2DO.getSparkDataFrame()
       .select($"rating", $"address")
-      .as[(Int,String)].collect().toSet
-    assert(r2 == Set((5,"honolulu")))
+      .as[(Int, String)].collect().toSet
+    assert(r2 == Set((5, "honolulu")))
 
     // check metrics
     val action2MainMetrics = TestUtil.getMetrics(action2.getRuntimeInfo().get, action2.outputIds.head)
-    assert(action2MainMetrics("records_written")==1)
+    assert(action2MainMetrics("records_written") == 1)
   }
 
   test("action dag fails because of metricsFailCondition") {
@@ -1191,13 +1193,13 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int, tstmp timestamp").asInstanceOf[StructType]
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)))
     instanceRegistry.register(srcDO)
-    val tgt1DO = ParquetFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
+    val tgt1DO = ParquetFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt1DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    val df1 = Seq(("doe", "john", 5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
     srcDO.writeSparkDataFrame(df1, Seq())
 
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, metricsFailCondition = Some(s"dataObjectId = '${tgt1DO.id.id}' and value > 0"))
@@ -1234,19 +1236,19 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     val feed = "actionpipeline"
     val tempDir = Files.createTempDirectory(feed)
     val schema = StructType.fromDDL("lastname string, firstname string, rating int, tstmp timestamp").asInstanceOf[StructType]
-    val srcDO = JsonFileDataObject( "src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)), partitions = Seq("lastname"))
+    val srcDO = JsonFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'), schema = Some(SparkSchema(schema)), partitions = Seq("lastname"))
     instanceRegistry.register(srcDO)
-    val tgt1DO = ParquetFileDataObject( "tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), partitions = Seq("lastname"), saveMode = SDLSaveMode.Append)
+    val tgt1DO = ParquetFileDataObject("tgt1", tempDir.resolve("tgt1").toString.replace('\\', '/'), partitions = Seq("lastname"), saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = ParquetFileDataObject( "tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), partitions = Seq("lastname"), saveMode = SDLSaveMode.Append)
+    val tgt2DO = ParquetFileDataObject("tgt2", tempDir.resolve("tgt2").toString.replace('\\', '/'), partitions = Seq("lastname"), saveMode = SDLSaveMode.Append)
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
+    val df1 = Seq(("doe", "john", 5, Timestamp.from(Instant.now))).toDF("lastname", "firstname", "rating", "tstmp")
     srcDO.writeSparkDataFrame(df1, Seq())
 
     // dag1 run fails in init-phase because action1 fails and there is no other action to execute
-    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode=Some(PartitionDiffMode(failConditions = Seq(Condition(expression = "year(runStartTime) > 2000", Some("testing"))))))
+    val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode(failConditions = Seq(Condition(expression = "year(runStartTime) > 2000", Some("testing"))))))
     val dag1: ActionDAGRun = ActionDAGRun(Seq(action1))
     dag1.prepare(contextPrep)
     dag1.init(contextInit)
@@ -1256,7 +1258,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 
     // dag2 run fails in exec-phase because action1 fails but there is another action to execute
     val action2 = CopyAction("b", srcDO.id, tgt2DO.id)
-    val dag2: ActionDAGRun = ActionDAGRun(Seq(action1,action2))
+    val dag2: ActionDAGRun = ActionDAGRun(Seq(action1, action2))
     dag2.reset
     dag2.prepare(contextPrep)
     dag2.init(contextInit)
@@ -1276,15 +1278,15 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgt1DO = UnpartitionedTestDataObject( "tgt1")
+    val tgt1DO = UnpartitionedTestDataObject("tgt1")
     instanceRegistry.register(tgt1DO)
 
     // prepare DAG
-    val df1 = Seq[(String,String,Int)]().toDF("lastname", "firstname", "rating")
-    val expectedPartitions = Seq(PartitionValues(Map("lastname"->"doe")))
+    val df1 = Seq[(String, String, Int)]().toDF("lastname", "firstname", "rating")
+    val expectedPartitions = Seq(PartitionValues(Map("lastname" -> "doe")))
     Environment._enableSparkPlanNoDataCheck = Some(false)
     srcDO.writeSparkDataFrame(df1, expectedPartitions)
     Environment._enableSparkPlanNoDataCheck = Some(true)
@@ -1303,19 +1305,19 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "actionpipeline"
     val srcTable = Table(Some("default"), "ap_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname","firstname")))
-    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath+s"/${tgt1Table.fullName}"), table = tgt1Table, partitions=Seq("lastname"), numInitialHdfsPartitions = 1)
+    val tgt1Table = Table(Some("default"), "ap_dedup", None, Some(Seq("lastname", "firstname")))
+    val tgt1DO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), table = tgt1Table, partitions = Seq("lastname"), numInitialHdfsPartitions = 1)
     tgt1DO.dropTable
     instanceRegistry.register(tgt1DO)
-    val tgt2DO = UnpartitionedTestDataObject( "tgt2")
+    val tgt2DO = UnpartitionedTestDataObject("tgt2")
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-    val expectedPartitions = Seq(PartitionValues(Map("lastname"->"doe")))
+    val df1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    val expectedPartitions = Seq(PartitionValues(Map("lastname" -> "doe")))
     srcDO.writeSparkDataFrame(df1, expectedPartitions)
     val actions: Seq[DataFrameOneToOneActionImpl] = Seq(
       CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(PartitionDiffMode()))
@@ -1339,7 +1341,7 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val srcDO1 = MockDataObject("src1")
     instanceRegistry.register(srcDO1)
-    val recDO = MockDataObject("rec1", schemaMin = Some(SparkSchema(StructType(Seq(StructField("lastname",StringType), StructField("role",StringType))))))
+    val recDO = MockDataObject("rec1", schemaMin = Some(SparkSchema(StructType(Seq(StructField("lastname", StringType), StructField("role", StringType))))))
     recDO.dropTable
     instanceRegistry.register(recDO)
     val tgt1DO = MockDataObject("tgt1")
@@ -1391,12 +1393,12 @@ class ActionDAGTest extends FunSuite with BeforeAndAfter {
 }
 
 class TestActionDagTransformer extends CustomDfsTransformer {
-  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String,DataFrame]): Map[String,DataFrame] = {
+  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String, DataFrame]): Map[String, DataFrame] = {
     import session.implicits._
     val dfTransformed = dfs("tgt_B")
-    .union(dfs("tgt_C"))
-    .groupBy($"lastname",$"firstname")
-    .agg(sum($"rating").as("rating"))
+      .union(dfs("tgt_C"))
+      .groupBy($"lastname", $"firstname")
+      .agg(sum($"rating").as("rating"))
 
     Map("tgt_D" -> dfTransformed)
   }
@@ -1410,11 +1412,11 @@ class TestStreamingTransformer extends CustomDfsTransformer {
 }
 
 class TestDfsUnionOfThree extends CustomDfsTransformer {
-  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String,DataFrame]): Map[String,DataFrame] = {
+  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String, DataFrame]): Map[String, DataFrame] = {
     import session.implicits._
     val dfTgt = dfs("src1").select($"lastname", $"firstname", $"rating").withColumn("origin", lit(1))
-    .union(dfs("src2").select($"lastname", $"firstname", $"rating").withColumn("origin", lit(2)))
-    .union(dfs("src3").select($"lastname", $"firstname", $"rating").withColumn("origin", lit(3)))
+      .union(dfs("src2").select($"lastname", $"firstname", $"rating").withColumn("origin", lit(2)))
+      .union(dfs("src3").select($"lastname", $"firstname", $"rating").withColumn("origin", lit(3)))
     Map("tgt1" -> dfTgt)
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/DAGTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/DAGTest.scala
@@ -18,15 +18,16 @@
  */
 package io.smartdatalake.workflow
 
-import java.util.concurrent.atomic.AtomicInteger
+import io.smartdatalake.util.dag.DAGHelper.NodeId
+import io.smartdatalake.util.dag._
 import io.smartdatalake.util.misc.PerformanceUtils.measureTime
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.util.dag.DAGHelper.NodeId
-import io.smartdatalake.util.dag.{DAG, DAGEdge, DAGEventListener, DAGNode, DAGResult, TaskPredecessorFailureWarning}
 import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -38,6 +39,7 @@ case class TestNode(override val nodeId: NodeId) extends DAGNode {
 }
 
 case class TestEgde(override val nodeIdFrom: NodeId, override val nodeIdTo: NodeId, override val resultId: String = TestEdge.defaultResultId) extends DAGEdge
+
 object TestEdge {
   val defaultResultId = "-"
 }
@@ -49,17 +51,26 @@ class TestEventListener extends DAGEventListener[TestNode] with SmartDataLakeLog
   val maxConcurrentRuns: AtomicInteger = new AtomicInteger(0)
   // record node start order
   val nodeStarts: mutable.Buffer[NodeId] = mutable.Buffer()
+
   override def onNodeStart(node: TestNode): Unit = {
     concurrentRuns.incrementAndGet
-    maxConcurrentRuns.set(Math.max(concurrentRuns.get,maxConcurrentRuns.get))
+    maxConcurrentRuns.set(Math.max(concurrentRuns.get, maxConcurrentRuns.get))
     nodeStarts.append(node.nodeId)
-    logger.info(s"${node.nodeId} started (" + concurrentRuns.get +" job(s) running currently)") }
-  override def onNodeFailure(exception: Throwable, partialResults: Seq[DAGResult] = Seq())(node: TestNode): Unit = { logger.error(s"${node.nodeId} failed with ${exception.getClass.getSimpleName}"); concurrentRuns.decrementAndGet }
+    logger.info(s"${node.nodeId} started (" + concurrentRuns.get + " job(s) running currently)")
+  }
+
+  override def onNodeFailure(exception: Throwable, partialResults: Seq[DAGResult] = Seq())(node: TestNode): Unit = {
+    logger.error(s"${node.nodeId} failed with ${exception.getClass.getSimpleName}"); concurrentRuns.decrementAndGet
+  }
+
   override def onNodeSkipped(exception: Throwable)(node: TestNode): Unit = logger.warn(s"${node.nodeId} skipped because ${exception.getClass.getSimpleName}")
-  override def onNodeSuccess(result: Seq[DAGResult])(node: TestNode): Unit = { logger.info(s"${node.nodeId} succeeded"); concurrentRuns.decrementAndGet }
+
+  override def onNodeSuccess(result: Seq[DAGResult])(node: TestNode): Unit = {
+    logger.info(s"${node.nodeId} succeeded"); concurrentRuns.decrementAndGet
+  }
 }
 
-class DAGTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
+class DAGTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
   before {
     execCntPerNode.clear()
@@ -68,65 +79,71 @@ class DAGTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
   test("create and run dag: linear unordered") {
     val dag = DAG.create[TestNode](
       Seq(TestNode("A"), TestNode("C"), TestNode("B")),
-      Seq(TestEgde("A", "B"),TestEgde("B", "C"))
+      Seq(TestEgde("A", "B"), TestEgde("B", "C"))
     )
     println(dag.toString)
-    val task = dag.buildTaskGraph[TestResult](new TestEventListener){ defaultOp(300) }
+    val task = dag.buildTaskGraph[TestResult](new TestEventListener) {
+      defaultOp(300)
+    }
     val resultFuture = task.runToFuture
     val result = Await.result(resultFuture, 5.seconds)
       .map(_.get)
     println(result)
-    assert(result.size==1)
-    assert(result.head.path=="A-B-C")
+    assert(result.size == 1)
+    assert(result.head.path == "A-B-C")
   }
 
   test("create and run dag: split and join with parallel execution") {
     val nodes = Seq(TestNode("A"), TestNode("B"), TestNode("C"), TestNode("D"))
-    val edges = Seq(TestEgde("A", "B"),TestEgde("B", "D"),TestEgde("A", "C"),TestEgde("C", "D"))
+    val edges = Seq(TestEgde("A", "B"), TestEgde("B", "D"), TestEgde("A", "C"), TestEgde("C", "D"))
     val dag = DAG.create[TestNode](nodes, edges)
     println(dag.toString)
     val testEventListener: TestEventListener = new TestEventListener
-    val task =  dag.buildTaskGraph[TestResult](testEventListener){ defaultOp() }
+    val task = dag.buildTaskGraph[TestResult](testEventListener) {
+      defaultOp()
+    }
     val resultFuture = task.runToFuture
     val (result, tResult) = measureTime(
       Await.result(resultFuture, 10.seconds)
         .map(_.get)
     )
     println(result)
-    assert(result.size==1)
+    assert(result.size == 1)
     assert(result.head.path.endsWith("-D"))
     // check nodes are executed only once
-    val nodesExecutedMoreThanOnce = execCntPerNode.filter{ case (_,cnt) => cnt.get > 1}
+    val nodesExecutedMoreThanOnce = execCntPerNode.filter { case (_, cnt) => cnt.get > 1 }
     assert(nodesExecutedMoreThanOnce.isEmpty, s"Nodes $nodesExecutedMoreThanOnce have been executed more than once")
     // check all nodes are executed
     val nodesNotExecuted = nodes.map(_.nodeId).toSet -- execCntPerNode.keySet
     assert(nodesNotExecuted.isEmpty, s"Nodes $nodesNotExecuted have not been executed")
     // check parallel execution, in this case it is not possible for more than 2 jobs to run concurrently
-    logger.info("Maximum number of parallel executions was " +testEventListener.maxConcurrentRuns.get)
+    logger.info("Maximum number of parallel executions was " + testEventListener.maxConcurrentRuns.get)
     assert(testEventListener.maxConcurrentRuns.get() == 2)
   }
 
   test("create and run dag: split and join with serialized execution") {
     val singleScheduler = Scheduler.fixedPool("fixed", 1) // scheduler with 1 thread serializes execution (only one task at the time)
     val nodes = Seq(TestNode("A"), TestNode("B"), TestNode("C"), TestNode("D"))
-    val edges = Seq(TestEgde("A", "B"),TestEgde("B", "D"),TestEgde("A", "C"),TestEgde("C", "D"))
+    val edges = Seq(TestEgde("A", "B"), TestEgde("B", "D"), TestEgde("A", "C"), TestEgde("C", "D"))
     val dag = DAG.create[TestNode](nodes, edges)
     println(dag.toString)
     val testEventListener: TestEventListener = new TestEventListener
-    val task =  dag.buildTaskGraph[TestResult](testEventListener) { defaultOp(300) }
+    val task = dag.buildTaskGraph[TestResult](testEventListener) {
+      defaultOp(300)
+    }
     val resultFuture = task.runToFuture(singleScheduler)
-    val (result, tResult) = measureTime( Await.result(resultFuture, 10.seconds).map(_.get))
+    val (result, tResult) = measureTime(Await.result(resultFuture, 10.seconds).map(_.get))
     println(result)
-    assert(result.size==1)
+    assert(result.size == 1)
     assert(result.head.path.endsWith("-D"))
     // check nodes are executed only once
-    val nodesExecutedMoreThanOnce = execCntPerNode.filter{ case (_,cnt) => cnt.get > 1}
+    val nodesExecutedMoreThanOnce = execCntPerNode.filter { case (_, cnt) => cnt.get > 1 }
     assert(nodesExecutedMoreThanOnce.isEmpty, s"Nodes $nodesExecutedMoreThanOnce have been executed more than once")
     // check all nodes are executed
     val nodesNotExecuted = nodes.map(_.nodeId).toSet -- execCntPerNode.keySet
     assert(nodesNotExecuted.isEmpty, s"Nodes $nodesNotExecuted have not been executed")
     // parallel execution is not permitted in this case, as serialization is forced
-    logger.info("Maximum number of parallel executions was " +testEventListener.maxConcurrentRuns.get)
+    logger.info("Maximum number of parallel executions was " + testEventListener.maxConcurrentRuns.get)
     assert(testEventListener.maxConcurrentRuns.get() == 1)
   }
 
@@ -137,7 +154,9 @@ class DAGTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
     val dag = DAG.create[TestNode](nodes, edges)
     println(dag.toString)
     val testEventListener: TestEventListener = new TestEventListener
-    val task =  dag.buildTaskGraph[TestResult](testEventListener) { defaultOp(300) }
+    val task = dag.buildTaskGraph[TestResult](testEventListener) {
+      defaultOp(300)
+    }
     val resultFuture = task.runToFuture(singleScheduler)
     val result = Await.result(resultFuture, 10.seconds).map(_.get)
     assert(testEventListener.nodeStarts == testEventListener.nodeStarts.sorted)
@@ -147,10 +166,12 @@ class DAGTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
   test("cancel running dag: stop pending tasks") {
     val dag = DAG.create[TestNode](
       Seq(TestNode("A"), TestNode("C"), TestNode("B")),
-      Seq(TestEgde("A", "B"),TestEgde("B", "C"))
+      Seq(TestEgde("A", "B"), TestEgde("B", "C"))
     )
     println(dag.toString)
-    val task = dag.buildTaskGraph[TestResult](new TestEventListener) { defaultOp(500) }
+    val task = dag.buildTaskGraph[TestResult](new TestEventListener) {
+      defaultOp(500)
+    }
     val resultFuture = task.runToFuture
     Thread.sleep(100)
     resultFuture.cancel()
@@ -163,66 +184,68 @@ class DAGTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
     val edges = Seq(TestEgde("A", "B"), TestEgde("B", "C"), TestEgde("A", "D"), TestEgde("D", "E"))
     val dag = DAG.create[TestNode](nodes, edges)
     println(dag.toString)
-    val opWithException = (node:DAGNode, inResults:Seq[TestResult]) => {
+    val opWithException = (node: DAGNode, inResults: Seq[TestResult]) => {
       node.nodeId match {
         case "B" => throw new RuntimeException("test exception on node B")
-        case _ => defaultOp(500)(node,inResults)
+        case _ => defaultOp(500)(node, inResults)
       }
     }
-    val task =  dag.buildTaskGraph[TestResult](new TestEventListener) ( opWithException )
+    val task = dag.buildTaskGraph[TestResult](new TestEventListener)(opWithException)
     val resultFuture = task.runToFuture
     val resultTry = Await.result(resultFuture, 10.seconds)
     println(resultTry)
-    assert(resultTry.size==2)
+    assert(resultTry.size == 2)
     // check failed task
     intercept[TaskPredecessorFailureWarning](resultTry.filter(_.isFailure).map(_.get))
     // check succeeded tasks
     val resultSucceeded = resultTry.filter(_.isSuccess).map(_.get)
     assert(resultSucceeded.head.path.endsWith("-E"))
     // check nodes are executed only once
-    val nodesExecutedMoreThanOnce = execCntPerNode.filter{ case (_,cnt) => cnt.get > 1}
+    val nodesExecutedMoreThanOnce = execCntPerNode.filter { case (_, cnt) => cnt.get > 1 }
     assert(nodesExecutedMoreThanOnce.isEmpty, s"Nodes $nodesExecutedMoreThanOnce have been executed more than once")
     // check all nodes except node B and C are executed
     val nodesNotExecuted = nodes.map(_.nodeId).toSet -- execCntPerNode.keySet
-    assert(nodesNotExecuted == Set("B","C"), s"Nodes $nodesNotExecuted have not been executed")
+    assert(nodesNotExecuted == Set("B", "C"), s"Nodes $nodesNotExecuted have not been executed")
   }
 
   test("create dag: detect loop") {
     intercept[AssertionError](DAG.create(
       Seq(TestNode("A"), TestNode("C"), TestNode("B")),
-      Seq(TestEgde("C", "A"),TestEgde("A", "B"),TestEgde("B", "C"))
+      Seq(TestEgde("C", "A"), TestEgde("A", "B"), TestEgde("B", "C"))
     ))
   }
 
   test("create and run dag: unconnected subgraphs with parallel execution") {
     val nodes = Seq(TestNode("A"), TestNode("C"), TestNode("B"), TestNode("D"), TestNode("E"), TestNode("F"))
-    val edges = Seq(TestEgde("A", "B"),TestEgde("B", "C"), TestEgde("D", "E"),TestEgde("D", "F"))
+    val edges = Seq(TestEgde("A", "B"), TestEgde("B", "C"), TestEgde("D", "E"), TestEgde("D", "F"))
     val dag = DAG.create[TestNode](nodes, edges)
     println(dag.toString)
     val testEventListener: TestEventListener = new TestEventListener
-    val task =  dag.buildTaskGraph[TestResult](testEventListener){ defaultOp() }
+    val task = dag.buildTaskGraph[TestResult](testEventListener) {
+      defaultOp()
+    }
     val resultFuture = task.runToFuture
-    val (result, tResult) = measureTime( Await.result(resultFuture, 10.seconds).map(_.get))
+    val (result, tResult) = measureTime(Await.result(resultFuture, 10.seconds).map(_.get))
     println(result)
-    assert(result.size==3)
-    assert(result.exists( _.path.endsWith("-C")))
-    assert(result.exists( _.path.endsWith("-E")))
-    assert(result.exists( _.path.endsWith("-F")))
+    assert(result.size == 3)
+    assert(result.exists(_.path.endsWith("-C")))
+    assert(result.exists(_.path.endsWith("-E")))
+    assert(result.exists(_.path.endsWith("-F")))
     // check nodes are executed only once
-    val nodesExecutedMoreThanOnce = execCntPerNode.filter{ case (_,cnt) => cnt.get > 1}
+    val nodesExecutedMoreThanOnce = execCntPerNode.filter { case (_, cnt) => cnt.get > 1 }
     assert(nodesExecutedMoreThanOnce.isEmpty, s"Nodes $nodesExecutedMoreThanOnce have been executed more than once")
     // check all nodes are executed
     val nodesNotExecuted = nodes.map(_.nodeId).toSet -- execCntPerNode.keySet
     assert(nodesNotExecuted.isEmpty, s"Nodes $nodesNotExecuted have not been executed")
     // check parallel execution
-    logger.info("Maximum number of parallel executions was " +testEventListener.maxConcurrentRuns.get)
+    logger.info("Maximum number of parallel executions was " + testEventListener.maxConcurrentRuns.get)
     assert(testEventListener.maxConcurrentRuns.get() >= 2)
   }
 
 
-  val defaultResultId = TestEdge.defaultResultId
+  private val defaultResultId = TestEdge.defaultResultId
 
-  def defaultOp(sleepMs: Int = 1000): ((DAGNode, Seq[TestResult]) => Seq[TestResult]) = {
+  def defaultOp(sleepMs: Int = 1000): (DAGNode, Seq[TestResult]) => Seq[TestResult] = {
     (node: DAGNode, inResults: Seq[TestResult]) => {
       // execute something
       logger.debug(s"start ${node.nodeId}")
@@ -232,13 +255,13 @@ class DAGTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
       execCntPerNode.getOrElseUpdate(node.nodeId, new AtomicInteger()).getAndIncrement()
       // prepare path for this result
       val path = if (inResults.isEmpty) node.nodeId
-      else if (inResults.size==1) inResults.head.path + "-" + node.nodeId
-      else inResults.map( r => s"(${r.path})").mkString("&") + "-" + node.nodeId
+      else if (inResults.size == 1) inResults.head.path + "-" + node.nodeId
+      else inResults.map(r => s"(${r.path})").mkString("&") + "-" + node.nodeId
       // return
       Seq(TestResult(defaultResultId, path))
     }
   }
 
-  val execCntPerNode: mutable.Map[NodeId,AtomicInteger] = scala.collection.concurrent.TrieMap[String,AtomicInteger]()
+  val execCntPerNode: mutable.Map[NodeId, AtomicInteger] = scala.collection.concurrent.TrieMap[String, AtomicInteger]()
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/SubFeedTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/SubFeedTest.scala
@@ -24,9 +24,9 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.dataobject.FileRef
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SubFeedTest extends FunSuite {
+class SubFeedTest extends AnyFunSuite {
 
   implicit val session: SparkSession = TestUtil.session
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ActionHelperTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ActionHelperTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.workflow.action
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ActionHelperTest extends FunSuite {
+class ActionHelperTest extends AnyFunSuite {
 
   test("replaceSpecialCharactersWithUnderscore") {
     assert(ActionHelper.replaceSpecialCharactersWithUnderscore("1-x.y+z!9") == "1_x_y_z_9")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyActionTest.scala
@@ -37,13 +37,15 @@ import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, InitSub
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.functions.{lit, substring}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path => NioPath}
 
-class CopyActionTest extends FunSuite with BeforeAndAfter {
+class CopyActionTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
@@ -67,30 +69,30 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val feed = "copy"
-    val srcDO = ParquetFileDataObject( "src1", tempPath+s"/src1", filenameColumn = Some("_filename"))
+    val srcDO = ParquetFileDataObject("src1", tempPath + s"/src1", filenameColumn = Some("_filename"))
     srcDO.deleteAll
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite = true, table = tgtTable, numInitialHdfsPartitions = 1)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
     val customTransformerConfig = ScalaClassSparkDfTransformer(className = classOf[TestDfTransformer].getName)
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformers = Seq(customTransformerConfig), executionMode = Some(FileIncrementalMoveMode()))
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     assert(srcDO.getFileRefs(Seq()).nonEmpty)
-    val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")),PartitionValues(Map("lastname" -> "jonson"))))
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")), PartitionValues(Map("lastname" -> "jonson"))))
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
-    action1.postExec(Seq(srcSubFeed),Seq(tgtSubFeed))
+    action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed))
     assert(tgtSubFeed.dataObjectId == tgtDO.id)
 
     // check output
     val r1 = session.table(s"${tgtTable.fullName}")
       .select($"rating")
       .as[Int].collect().toSet
-    assert(r1 == Set(4,6)) // should be increased by 1 through TestDfTransformer
+    assert(r1 == Set(4, 6)) // should be increased by 1 through TestDfTransformer
 
     // check input deleted by incremental move mode
     assert(srcDO.getFileRefs(Seq()).isEmpty)
@@ -99,7 +101,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
   test("copy load with custom transformation from code string, incremental move mode (archive) and schema file test") {
 
     // define custom transformation
-    val codeStr = """
+    val codeStr =
+      """
       import org.apache.spark.sql.{DataFrame, SparkSession}
       def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
         import session.implicits._
@@ -112,18 +115,18 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val feed = "copy"
-    val srcDO = ParquetFileDataObject( "src1", tempPath+s"/src1")
+    val srcDO = ParquetFileDataObject("src1", tempPath + s"/src1")
     srcDO.deleteAll
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), analyzeTableAfterWrite = true, table = tgtTable, numInitialHdfsPartitions = 1)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare data
     val executionMode = FileIncrementalMoveMode(archivePath = Some("archive"))
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformers = Seq(customTransformerConfig), executionMode = Some(executionMode))
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
 
     // start load
@@ -131,7 +134,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     assert(srcFiles.nonEmpty)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
-    action1.postExec(Seq(srcSubFeed),Seq(tgtSubFeed))
+    action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed))
 
     // check result
     val r1 = session.table(s"${tgtTable.fullName}")
@@ -141,7 +144,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     assert(r1.head == 6) // should be increased by 1 through TestDfTransformer
     // check input archived by incremental move mode
     assert(srcDO.getFileRefs(Seq()).isEmpty)
-    val srcDOArchived = ParquetFileDataObject( "src1", tempPath+s"/src1/archive")
+    val srcDOArchived = ParquetFileDataObject("src1", tempPath + s"/src1/archive")
     assert(srcDOArchived.getFileRefs(Seq()).nonEmpty)
 
     // start second load without new files - schema should be present because of schema file
@@ -199,8 +202,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
         CountExpectation(name = "countAll", expectation = Some("= 2"), scope = ExpectationScope.All),
       )
     ).register
-    val tgtTable = Table(Some("default"), "copy_output", None, primaryKey = Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1,
+    val tgtTable = Table(Some("default"), "copy_output", None, primaryKey = Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite = true, table = tgtTable, numInitialHdfsPartitions = 1,
       constraints = Seq(Constraint("firstnameNotNull", Some("firstname should be non empty"), "firstname is not null")),
       expectations = Seq(
         CountExpectation(expectation = Some(">= 1")),
@@ -210,7 +213,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
         CountExpectation(name = "countAll", expectation = Some(">= 1"), scope = ExpectationScope.All),
         SQLQueryExpectation(name = "countOfPartitionsWith1Record", code = "select count(*) from (select lastname from %{inputViewName} group by lastname having count(*) = 1)", scope = ExpectationScope.All),
         SQLExpectation("resultNull", Some("dont fail if result is null"), "null", Some("> 1")),
-        UniqueKeyExpectation("primaryKey", approximate=approximateUniqueConstraint)
+        UniqueKeyExpectation("primaryKey", approximate = approximateUniqueConstraint)
       )
     )
     tgtDO.dropTable
@@ -223,7 +226,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
       transformers = Seq(customTransformerConfig1, customTransformerConfig2),
       expectations = Seq(TransferRateExpectation(), CompletenessExpectation(expectation = None))
     )
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed1 = action1.exec(Seq(srcSubFeed))(contextExec).head
@@ -250,7 +253,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     assert(metrics2 == Map("count" -> 2, "avgRatingGt1" -> 5.0, "pctBob" -> 0.0, "countPerPartition#dau" -> 2, "count#src1" -> 2, "count#mainInput" -> 2, "pctTransfer" -> 1.0, "countAll" -> 3, "countAll#src1" -> 2, "countAll#mainInput" -> 2, "pctComplete" -> 1.5, "countOfPartitionsWith1Record" -> 1, "resultNull" -> None, "primaryKey" -> 1.0))
 
     // fail tgt constraint evaluation
-    val tgtDOConstraintFail = HiveTableDataObject( "tgt1constraintFail", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), table = tgtTable,
+    val tgtDOConstraintFail = HiveTableDataObject("tgt1constraintFail", Some(tempPath + s"/${tgtTable.fullName}"), Seq("lastname"), table = tgtTable,
       constraints = Seq(Constraint("firstnameNull", Some("firstname should be empty"), "firstname is null")),
     )
     instanceRegistry.register(tgtDOConstraintFail)
@@ -267,7 +270,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     assert(getRootCause(ex2).isInstanceOf[RuntimeException])
 
     // fail tgt expectation evaluation
-    val tgtDOExpectationFail = HiveTableDataObject( "tgt1expectationFail", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), table = tgtTable,
+    val tgtDOExpectationFail = HiveTableDataObject("tgt1expectationFail", Some(tempPath + s"/${tgtTable.fullName}"), Seq("lastname"), table = tgtTable,
       expectations = Seq(SQLExpectation("avgRatingEq1", Some("avg rating should be 1"), "avg(rating)", Some("= 1")))
     )
     instanceRegistry.register(tgtDOExpectationFail)
@@ -292,17 +295,17 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "notransform"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, numInitialHdfsPartitions = 1)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
     val action1 = CopyAction("a1", srcDO.id, tgtDO.id, transformer = None)
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
@@ -320,11 +323,11 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "partitiondiff"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("type","lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("type", "lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     instanceRegistry.register(tgtDO)
     tgtDO.dropTable
 
@@ -333,8 +336,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test executionMode!
 
     // prepare & start first load
-    val l1 = Seq(("A","doe","john",5)).toDF("type", "lastname", "firstname", "rating")
-    val l1PartitionValues = Seq(PartitionValues(Map("type"->"A")))
+    val l1 = Seq(("A", "doe", "john", 5)).toDF("type", "lastname", "firstname", "rating")
+    val l1PartitionValues = Seq(PartitionValues(Map("type" -> "A")))
     srcDO.writeSparkDataFrame(l1, l1PartitionValues) // prepare testdata
     action.preInit(Seq(srcSubFeed), Seq())
     val initOutputSubFeeds = action.init(Seq(srcSubFeed))
@@ -351,8 +354,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 2nd load
     action.reset
-    val l2 = Seq(("B","pan","peter",11)).toDF("type", "lastname", "firstname", "rating")
-    val l2PartitionValues = Seq(PartitionValues(Map("type"->"B")))
+    val l2 = Seq(("B", "pan", "peter", 11)).toDF("type", "lastname", "firstname", "rating")
+    val l2PartitionValues = Seq(PartitionValues(Map("type" -> "B")))
     srcDO.writeSparkDataFrame(l2, l2PartitionValues) // prepare testdata
     assert(srcDO.getSparkDataFrame().count() == 2) // note: this needs spark.sql.sources.partitionOverwriteMode=dynamic, otherwise the whole table is overwritten
     action.init(Seq(srcSubFeed))
@@ -370,11 +373,11 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "partitiondiff"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("type","lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("type", "lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("type"), numInitialHdfsPartitions = 1)
     instanceRegistry.register(tgtDO)
     tgtDO.dropTable
 
@@ -383,8 +386,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val srcSubFeed = InitSubFeed("src1", Seq()) // InitSubFeed needed to test executionMode!
 
     // prepare & start first load
-    val l1 = Seq(("A","doe","john",5)).toDF("type", "lastname", "firstname", "rating")
-    val l1PartitionValues = Seq(PartitionValues(Map("type"->"A")))
+    val l1 = Seq(("A", "doe", "john", 5)).toDF("type", "lastname", "firstname", "rating")
+    val l1PartitionValues = Seq(PartitionValues(Map("type" -> "A")))
     srcDO.writeSparkDataFrame(l1, l1PartitionValues) // prepare testdata
     action.preInit(Seq(srcSubFeed), Seq())
     val initOutputSubFeeds = action.init(Seq(srcSubFeed))
@@ -401,8 +404,8 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
 
     // prepare & start 2nd load
     action.reset
-    val l2 = Seq(("B","pan","peter",11)).toDF("type", "lastname", "firstname", "rating")
-    val l2PartitionValues = Seq(PartitionValues(Map("type"->"B")))
+    val l2 = Seq(("B", "pan", "peter", 11)).toDF("type", "lastname", "firstname", "rating")
+    val l2PartitionValues = Seq(PartitionValues(Map("type" -> "B")))
     srcDO.writeSparkDataFrame(l2, l2PartitionValues) // prepare testdata
     assert(srcDO.getSparkDataFrame().count() == 2) // note: this needs spark.sql.sources.partitionOverwriteMode=dynamic, otherwise the whole table is overwritten
     action.init(Seq(srcSubFeed))
@@ -420,11 +423,11 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), Seq("lastname"), analyzeTableAfterWrite = true, table = tgtTable, numInitialHdfsPartitions = 1)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
@@ -436,7 +439,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
         ColumnsTransformer(additionalColumns = Map("run_id" -> "runId"))
       )
     )
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
@@ -444,7 +447,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
 
     val r1 = tgtDO.getSparkDataFrame()
       .select($"rating", $"test", $"run_id")
-      .as[(Int,String,Int)].collect().toSeq
+      .as[(Int, String, Int)].collect().toSeq
     assert(r1 == Seq((6, "test-appTest", 1)))
   }
 
@@ -453,22 +456,22 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("dt"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("dt"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("mt"), analyzeTableAfterWrite=true, table = tgtTable, numInitialHdfsPartitions = 1)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), Seq("mt"), analyzeTableAfterWrite = true, table = tgtTable, numInitialHdfsPartitions = 1)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare, simulate
     val contextExec = contextInit.copy(phase = ExecutionPhase.Exec)
     val customTransformerConfig = ScalaClassSparkDfTransformer(className = classOf[TestAggDfTransformer].getName)
-    val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformers = Seq(customTransformerConfig), executionMode = Some(PartitionDiffMode(applyPartitionValuesTransform=true)))
-    val l1 = Seq(("20100101","jonson","rob",5),("20100103","doe","bob",3)).toDF("dt", "lastname", "firstname", "rating")
+    val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformers = Seq(customTransformerConfig), executionMode = Some(PartitionDiffMode(applyPartitionValuesTransform = true)))
+    val l1 = Seq(("20100101", "jonson", "rob", 5), ("20100103", "doe", "bob", 3)).toDF("dt", "lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-    val srcSubFeedWithPartitions = srcSubFeed.copy(partitionValues = Seq(PartitionValues(Map("dt"->"20100101")), PartitionValues(Map("dt"->"20100103"))))
+    val srcSubFeedWithPartitions = srcSubFeed.copy(partitionValues = Seq(PartitionValues(Map("dt" -> "20100101")), PartitionValues(Map("dt" -> "20100103"))))
     action1.preInit(Seq(srcSubFeedWithPartitions), Seq())
     val tgtSubFeed = action1.init(Seq(srcSubFeedWithPartitions)).head.asInstanceOf[SparkSubFeed]
 
@@ -482,7 +485,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     action1.preExec(Seq(srcSubFeed))(contextExec)
     val resultSubFeeds = action1.exec(Seq(srcSubFeed))(contextExec)
     assert(tgtDO.getSparkDataFrame().count() == 2)
-    action1.postExec(Seq(srcSubFeed),resultSubFeeds)(contextExec)
+    action1.postExec(Seq(srcSubFeed), resultSubFeeds)(contextExec)
 
     // next run with no data
     action1.reset
@@ -498,25 +501,25 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), Seq("lastname"), table = tgtTable, numInitialHdfsPartitions = 1, saveMode = SDLSaveMode.Append)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), Seq("lastname"), table = tgtTable, numInitialHdfsPartitions = 1, saveMode = SDLSaveMode.Append)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load - force SaveMode.Overwrite instead of Append
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, saveModeOptions = Some(SaveModeGenericOptions(SDLSaveMode.Overwrite)))
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
-    val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")),PartitionValues(Map("lastname" -> "jonson"))))
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq(PartitionValues(Map("lastname" -> "doe")), PartitionValues(Map("lastname" -> "jonson"))))
     action1.exec(Seq(srcSubFeed))(contextExec).head
 
     val r1 = tgtDO.getSparkDataFrame()
       .select($"rating")
       .as[Int].collect().toSeq
-    assert(r1.toSet == Set(5,3))
+    assert(r1.toSet == Set(5, 3))
 
     // start 2nd load - data should be overwritten
     action1.exec(Seq(srcSubFeed))(contextExec).head
@@ -524,7 +527,7 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     val r2 = tgtDO.getSparkDataFrame()
       .select($"rating")
       .as[Int].collect().toSeq
-    assert(r2.toSet == Set(5,3))
+    assert(r2.toSet == Set(5, 3))
   }
 
   test("fail on reading missing partition") {
@@ -532,17 +535,17 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("lastname", "firstname"), numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, partitions = Seq("lastname", "firstname"), numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = HiveTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("lastname", "firstname"), numInitialHdfsPartitions = 1, saveMode = SDLSaveMode.Append)
+    val tgtTable = Table(Some("default"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = HiveTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, partitions = Seq("lastname", "firstname"), numInitialHdfsPartitions = 1, saveMode = SDLSaveMode.Append)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id)
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
 
     // dont fail if partition exists
@@ -593,15 +596,15 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val feed = "copy"
-    val srcDO = ParquetFileDataObject( "src1", tempPath+s"/src1")
+    val srcDO = ParquetFileDataObject("src1", tempPath + s"/src1")
     srcDO.deleteAll
     instanceRegistry.register(srcDO)
-    val tgtDO = ParquetFileDataObject( "tgt1", tempPath+s"/tgt1")
+    val tgtDO = ParquetFileDataObject("tgt1", tempPath + s"/tgt1")
     instanceRegistry.register(tgtDO)
 
     // prepare empty Parquet file & start load
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id, transformers = Seq(SparkRepartitionTransformer(numberOfTasksPerPartition = 10)))
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
       .where(lit(false)) // write empty DataFrame
     Environment._enableSparkPlanNoDataCheck = Some(false)
     srcDO.writeSparkDataFrame(l1, Seq())
@@ -617,26 +620,27 @@ class CopyActionTest extends FunSuite with BeforeAndAfter {
 }
 
 class TestDfTransformer extends CustomDfTransformer {
-  def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
+  def transform(session: SparkSession, options: Map[String, String], df: DataFrame, dataObjectId: String): DataFrame = {
     import session.implicits._
     df.withColumn("rating", $"rating" + 1)
   }
 }
 
 class TestOptionsDfTransformer extends CustomDfTransformer {
-  def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
+  def transform(session: SparkSession, options: Map[String, String], df: DataFrame, dataObjectId: String): DataFrame = {
     import session.implicits._
     df.withColumn("rating", $"rating" + 1)
-      .withColumn("test", lit(options("test")+"-"+options("appName")))
+      .withColumn("test", lit(options("test") + "-" + options("appName")))
   }
 }
 
 class TestAggDfTransformer extends CustomDfTransformer {
-  def transform(session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) : DataFrame = {
+  def transform(session: SparkSession, options: Map[String, String], df: DataFrame, dataObjectId: String): DataFrame = {
     import session.implicits._
-    df.withColumn("mt", substring($"dt",1,6))
+    df.withColumn("mt", substring($"dt", 1, 6))
   }
-  override def transformPartitionValues(options: Map[String, String], partitionValues: Seq[PartitionValues]): Option[Map[PartitionValues,PartitionValues]] = {
-    Some(partitionValues.map(pv => (pv,PartitionValues(Map("mt" -> pv("dt").toString.take(6))))).toMap)
+
+  override def transformPartitionValues(options: Map[String, String], partitionValues: Seq[PartitionValues]): Option[Map[PartitionValues, PartitionValues]] = {
+    Some(partitionValues.map(pv => (pv, PartitionValues(Map("mt" -> pv("dt").toString.take(6))))).toMap)
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CopyWithMergeActionTest.scala
@@ -27,13 +27,15 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, JdbcTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class CopyWithMergeActionTest extends FunSuite with BeforeAndAfter {
+class CopyWithMergeActionTest extends AnyFunSuite with BeforeAndAfter {
 
-  protected implicit val session : SparkSession = TestUtil.session
+  protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("test")
@@ -54,19 +56,19 @@ class CopyWithMergeActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val feed = "copy"
     val srcTable = Table(Some("default"), "copy_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"),  table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
-    val tgtTable = Table(Some("public"), "copy_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255)"), allowSchemaEvolution = true)
+    val tgtTable = Table(Some("public"), "copy_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes" -> "lastname varchar(255), firstname varchar(255)"), allowSchemaEvolution = true)
     tgtDO.dropTable
-    tgtDO.connection.dropTable(tgtTable.fullName+"_sdltmp")
+    tgtDO.connection.dropTable(tgtTable.fullName + "_sdltmp")
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
     val action1 = CopyAction("dda", srcDO.id, tgtDO.id, saveModeOptions = Some(SaveModeMergeOptions()))
-    val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5), ("pan", "peter", 5), ("hans", "muster", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.init(Seq(srcSubFeed))
@@ -82,7 +84,7 @@ class CopyWithMergeActionTest extends FunSuite with BeforeAndAfter {
     }
 
     // prepare & start 2nd load - schema evolution: column rating -> rating2!
-    val l2 = Seq(("doe","john",10),("pan","peter",5),("pan","peter2",5)).toDF("lastname", "firstname", "rating2")
+    val l2 = Seq(("doe", "john", 10), ("pan", "peter", 5), ("pan", "peter2", 5)).toDF("lastname", "firstname", "rating2")
     srcDO.writeSparkDataFrame(l2, Seq())
     action1.init(Seq(srcSubFeed))
     action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(contextExec)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDataFrameActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDataFrameActionTest.scala
@@ -36,11 +36,12 @@ import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, InitSub
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path => NioPath}
 
-class CustomDataFrameActionTest extends FunSuite with BeforeAndAfter {
+class CustomDataFrameActionTest extends AnyFunSuite with BeforeAndAfter {
   protected implicit val session: SparkSession = TestUtil.session
 
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDfToHiveTableTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomDfToHiveTableTest.scala
@@ -18,28 +18,28 @@
  */
 package io.smartdatalake.workflow.action
 
-import java.nio.file.{Files, Path => NioPath}
-import java.time.LocalDateTime
-import io.smartdatalake.app.SmartDataLakeBuilderConfig
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.testutils.TestUtil._
 import io.smartdatalake.testutils.custom.{TestCustomDfCreator, TestCustomDfManyTypes}
-import io.smartdatalake.util.hive.HiveUtil
 import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfCreatorConfig
 import io.smartdatalake.workflow.action.spark.transformer.StandardizeSparkDatatypesTransformer
+import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.{CustomDfDataObject, HiveTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
-class CustomDfToHiveTableTest extends FunSuite with BeforeAndAfter {
+import java.nio.file.{Files, Path => NioPath}
+
+class CustomDfToHiveTableTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
@@ -62,9 +62,9 @@ class CustomDfToHiveTableTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val feed = "customDf2Hive"
-    val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
+    val sourceDO = CustomDfDataObject(id = "source", creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
     val targetTable = Table(db = Some("default"), name = "custom_df_copy", query = None, primaryKey = Some(Seq("line")))
-    val targetDO = HiveTableDataObject(id="target", Some(tempPath+s"/${targetTable.fullName}"), table = targetTable, numInitialHdfsPartitions = 1)
+    val targetDO = HiveTableDataObject(id = "target", Some(tempPath + s"/${targetTable.fullName}"), table = targetTable, numInitialHdfsPartitions = 1)
     targetDO.dropTable
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
@@ -77,7 +77,7 @@ class CustomDfToHiveTableTest extends FunSuite with BeforeAndAfter {
     val expected = sourceDO.getSparkDataFrame()
     val actual = targetDO.getSparkDataFrame()
     val resultat: Boolean = expected.isEqual(actual)
-    if (!resultat) printFailedTestResult("Df2HiveTable",Seq())(actual)(expected)
+    if (!resultat) printFailedTestResult("Df2HiveTable", Seq())(actual)(expected)
     assert(resultat)
   }
 
@@ -86,9 +86,9 @@ class CustomDfToHiveTableTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val feed = "customDf2Hive_dfManyTypes"
-    val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfManyTypes].getName)))
+    val sourceDO = CustomDfDataObject(id = "source", creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfManyTypes].getName)))
     val targetTable = Table(db = Some("default"), name = "custom_dfManyTypes_copy")
-    val targetDO = HiveTableDataObject(id="target", Some(tempPath+s"/${targetTable.fullName}"), table = targetTable, numInitialHdfsPartitions = 1)
+    val targetDO = HiveTableDataObject(id = "target", Some(tempPath + s"/${targetTable.fullName}"), table = targetTable, numInitialHdfsPartitions = 1)
     targetDO.dropTable
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
@@ -107,7 +107,7 @@ class CustomDfToHiveTableTest extends FunSuite with BeforeAndAfter {
       .withColumn("_decimal_4_3", $"_decimal_4_3".cast(FloatType))
       .withColumn("_decimal_38_1", $"_decimal_38_1".cast(DoubleType))
     val resultat: Boolean = expected.isEqual(actual)
-    if (!resultat) printFailedTestResult("Df2HiveTable_Decimal2IntegralFloat",Seq())(actual)(expected)
+    if (!resultat) printFailedTestResult("Df2HiveTable_Decimal2IntegralFloat", Seq())(actual)(expected)
     assert(resultat)
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomFileActionTest.scala
@@ -28,14 +28,15 @@ import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, FileSub
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.PrintWriter
 import java.nio.file.{Files, Path => NioPath}
 import scala.io.Source
 import scala.util.Using
 
-class CustomFileActionTest extends FunSuite with BeforeAndAfter {
+class CustomFileActionTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 
@@ -74,7 +75,7 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Some(Map("test"->"true")))
+    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Some(Map("test" -> "true")))
     val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, 1)
     val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq())
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
@@ -106,7 +107,7 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
     val tempDir = Files.createTempDirectory(feed)
 
     // copy data file to ftp
-    val srcPartitionValues = Seq(PartitionValues(Map("p"->"test")))
+    val srcPartitionValues = Seq(PartitionValues(Map("p" -> "test")))
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve("p=test/" + resourceFile).toFile)
 
     // setup DataObjects
@@ -116,7 +117,7 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(tgtDO)
 
     // prepare & start load
-    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Some(Map("test"->"true")))
+    val fileTransformerConfig = CustomFileTransformerConfig(className = Some("io.smartdatalake.workflow.action.TestFileTransformer"), options = Some(Map("test" -> "true")))
     val action1 = CustomFileAction(id = "cfa", srcDO.id, tgtDO.id, fileTransformerConfig, 1, executionMode = Some(PartitionDiffMode()))
     val srcSubFeed = InitSubFeed("src1", srcPartitionValues) // InitSubFeed needed to test initExecutionMode!
     val tgtSubFeed = action1.exec(Seq(srcSubFeed))(contextExec).head
@@ -135,13 +136,14 @@ class CustomFileActionTest extends FunSuite with BeforeAndAfter {
   }
 
 }
+
 object CustomFileActionTest {
   val delimiter = ","
 }
 
 class TestFileTransformer extends CustomFileTransformer {
-  override def transform(options: Map[String,String], input: FSDataInputStream, output: FSDataOutputStream): Option[Exception] = {
-    assert(options("test")=="true")
+  override def transform(options: Map[String, String], input: FSDataInputStream, output: FSDataOutputStream): Option[Exception] = {
+    assert(options("test") == "true")
     Using.resource(Source.fromInputStream(input)) { src =>
       Using.resource(new PrintWriter(output)) { os =>
         src.getLines().foreach { l =>

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomScriptActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/CustomScriptActionTest.scala
@@ -20,19 +20,20 @@ package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
-import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.script.CmdScript
+import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.{CanReceiveScriptNotification, CsvFileDataObject, DataObject, DataObjectMetadata}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, FileSubFeed}
 import org.apache.commons.lang.NotImplementedException
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class CustomScriptActionTest extends FunSuite with BeforeAndAfter {
+class CustomScriptActionTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 
@@ -51,6 +52,7 @@ class CustomScriptActionTest extends FunSuite with BeforeAndAfter {
 
     // notify test variable & function
     var testVar: Option[String] = None
+
     def notify(v: String): Unit = {
       testVar = Some(v)
     }
@@ -58,7 +60,7 @@ class CustomScriptActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val src1DO = CsvFileDataObject("src1", tempDir.resolve("src1").toString.replace('\\', '/'))
     val src2DO = CsvFileDataObject("src2", tempDir.resolve("src2").toString.replace('\\', '/'))
-    val tgtDO = TestScriptNotificationDataObject("tgt", notify )
+    val tgtDO = TestScriptNotificationDataObject("tgt", notify)
     instanceRegistry.register(src1DO)
     instanceRegistry.register(src2DO)
     instanceRegistry.register(tgtDO)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DataValidationTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DataValidationTransformerTest.scala
@@ -25,9 +25,9 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.generic.transformer.{DataValidationTransformer, RowLevelValidationRule}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class DataValidationTransformerTest extends FunSuite {
+class DataValidationTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateActionTest.scala
@@ -30,13 +30,14 @@ import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, JdbcTableDataO
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path => NioPath}
 import java.sql.Timestamp
 import java.time.{LocalDateTime, Month}
 
-class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
+class DeduplicateActionTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 
@@ -63,12 +64,12 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
   test("deduplicate 1st 2nd load") {
     // setup DataObjects
     val srcTable = Table(Some("default"), "deduplicate_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"),  table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
-    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1")
+    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1")
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
@@ -76,7 +77,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     val refTimestamp1 = LocalDateTime.now()
     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id)
-    val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5), ("pan", "peter", 5), ("hans", "muster", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.init(Seq(srcSubFeed))
@@ -96,7 +97,7 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-    val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
+    val l2 = Seq(("doe", "john", 10), ("pan", "peter", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l2, Seq())(context1)
     action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)
 
@@ -115,33 +116,35 @@ class DeduplicateActionTest extends FunSuite with BeforeAndAfter {
     instanceRegistry.register(jdbcConnection)
     // setup DataObjects
     val srcTable = Table(Some("default"), "deduplicate_input")
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
     instanceRegistry.register(srcDO)
     val tgtTable = Table(Some("public"), "deduplicate_output")
-    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1")
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1")
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
-    intercept[IllegalArgumentException]{DeduplicateAction("dda", srcDO.id, tgtDO.id)}
+    intercept[IllegalArgumentException] {
+      DeduplicateAction("dda", srcDO.id, tgtDO.id)
+    }
   }
 
   test("deduplicate with filter clause") {
     instanceRegistry.register(jdbcConnection)
     // setup DataObjects
     val srcTable = Table(Some("default"), "deduplicate_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1")
+    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1")
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(LocalDateTime.now), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, transformers = Seq(FilterTransformer(filterClause = "lastname='jonson'")))
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.init(Seq(srcSubFeed))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/DeduplicateWithMergeActionTest.scala
@@ -28,15 +28,17 @@ import io.smartdatalake.workflow.dataobject.{JdbcTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path => NioPath}
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
-class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
+class DeduplicateWithMergeActionTest extends AnyFunSuite with BeforeAndAfter {
 
-  protected implicit val session : SparkSession = TestUtil.session
+  protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
@@ -63,7 +65,7 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
     val srcDO = MockDataObject("src1").register
     instanceRegistry.register(jdbcConnection)
     val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname")))
-    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255)"), allowSchemaEvolution = true)
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes" -> "lastname varchar(255), firstname varchar(255)"), allowSchemaEvolution = true)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
@@ -71,7 +73,7 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
     val refTimestamp1 = LocalDateTime.now()
     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true)
-    val l1 = Seq(("doe","john",5),("pan","peter",5),("hans","muster",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5), ("pan", "peter", 5), ("hans", "muster", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
@@ -89,7 +91,7 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-    val l2 = Seq(("doe","john",10),("pan","peter",5)).toDF("lastname", "firstname", "rating")
+    val l2 = Seq(("doe", "john", 10), ("pan", "peter", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l2, Seq())(context2)
     action1.init(Seq(srcSubFeed))(context2.copy(phase = ExecutionPhase.Init)).head
     action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)
@@ -127,17 +129,17 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
     instanceRegistry.register(jdbcConnection)
-    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes"->"lastname varchar(255), firstname varchar(255)"), allowSchemaEvolution = true)
+    val tgtTable = Table(Some("public"), "deduplicate_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", jdbcOptions = Map("createTableColumnTypes" -> "lastname varchar(255), firstname varchar(255)"), allowSchemaEvolution = true)
     tgtDO.dropTable
-    tgtDO.connection.dropTable(tgtTable.fullName+"_sdltmp") // drop temp table if not properly cleaned up...
+    tgtDO.connection.dropTable(tgtTable.fullName + "_sdltmp") // drop temp table if not properly cleaned up...
     instanceRegistry.register(tgtDO)
 
     // prepare & start 1st load
     val refTimestamp1 = LocalDateTime.now()
     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = DeduplicateAction("dda", srcDO.id, tgtDO.id, mergeModeEnable = true, updateCapturedColumnOnlyWhenChanged = true)
-    val l1 = Seq(("doe","john",Some(5)),("pan","peter",Some(5)),("pan","peter2",None),("pan","peter3",None),("hans","muster",Some(5))).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", Some(5)), ("pan", "peter", Some(5)), ("pan", "peter2", None), ("pan", "peter3", None), ("hans", "muster", Some(5))).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
@@ -155,7 +157,7 @@ class DeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
     // prepare & start 2nd load
     val refTimestamp2 = LocalDateTime.now()
     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-    val l2 = Seq(("doe","john",Some(10)),("pan","peter",Some(5)),("pan","peter2",Some(3)),("pan","peter3",None)).toDF("lastname", "firstname", "rating")
+    val l2 = Seq(("doe", "john", Some(10)), ("pan", "peter", Some(5)), ("pan", "peter2", Some(3)), ("pan", "peter3", None)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l2, Seq())(context2)
     action1.init(Seq(srcSubFeed))(context2.copy(phase = ExecutionPhase.Init))
     action1.exec(Seq(SparkSubFeed(None, "src1", Seq())))(context2)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionIdTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionIdTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.workflow.action
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ExecutionIdTest extends FunSuite {
+class ExecutionIdTest extends AnyFunSuite {
 
   test("SDLExecutionId Ordering") {
     assert(SDLExecutionId(1,1) < SDLExecutionId(1,2))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ExecutionModeTest.scala
@@ -34,12 +34,13 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.io.FileNotFoundException
 import java.nio.file.Files
 
-class ExecutionModeTest extends FunSuite with BeforeAndAfter with BeforeAndAfterAll {
+class ExecutionModeTest extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
 
   protected implicit val session: SparkSession = TestUtil.session
 
@@ -206,7 +207,7 @@ class ExecutionModeTest extends FunSuite with BeforeAndAfter with BeforeAndAfter
     val result = executionMode.apply(ActionId("test"), srcDO, tgt3DO, subFeed, PartitionValues.oneToOneMapping).get
     assert(result.filter.nonEmpty)
   }
-    test("DataFrameIncrementalMode comparison column has different case than OutputDataObject Column") {
+  test("DataFrameIncrementalMode comparison column has different case than OutputDataObject Column") {
     val executionMode = DataFrameIncrementalMode(compareCol = "rating")
     executionMode.prepare(ActionId("test"))
     val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/FileTransferActionTest.scala
@@ -32,11 +32,12 @@ import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, FileSubFeed}
 import org.apache.spark.sql.SparkSession
 import org.apache.sshd.server.SshServer
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.nio.file.Files
 
-class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAndAfterAll {
+class FileTransferActionTest extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
 
   protected implicit val session: SparkSession = TestUtil.session
 
@@ -65,7 +66,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
 
   before {
     instanceRegistry.clear()
-    instanceRegistry.register(SFtpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshUser))), ignoreHostKeyVerification = true))
+    instanceRegistry.register(SFtpFileRefConnection("con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshUser))), ignoreHostKeyVerification = true))
     wireMockServer.resetAll()
     TestUtil.setupWebserviceStubs()
   }
@@ -82,8 +83,8 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(resourceFile).toFile)
 
     // setup DataObjects
-    val srcDO = SFtpFileRefDataObject( "src1", tempDir.resolve(ftpDir).toString.replace('\\', '/'), "con1")
-    val tgtDO = CsvFileDataObject( "tgt1", tempDir.resolve(hadoopDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"))
+    val srcDO = SFtpFileRefDataObject("src1", tempDir.resolve(ftpDir).toString.replace('\\', '/'), "con1")
+    val tgtDO = CsvFileDataObject("tgt1", tempDir.resolve(hadoopDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"))
     instanceRegistry.register(srcDO)
     instanceRegistry.register(tgtDO)
 
@@ -141,7 +142,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(datePartitionVal).resolve(resourceFile).toFile)
 
     // setup DataObjects
-    val srcDO = SFtpFileRefDataObject( "src1"
+    val srcDO = SFtpFileRefDataObject("src1"
       , tempDir.resolve(ftpDir).toString.replace('\\', '/')
       , connectionId = "con1"
       , partitions = Seq("date", "town", "year")
@@ -177,7 +178,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(datePartitionVal).resolve(resourceFile).toFile)
 
     // setup DataObjects
-    val srcDO = SFtpFileRefDataObject( "src1"
+    val srcDO = SFtpFileRefDataObject("src1"
       , tempDir.resolve(ftpDir).toString.replace('\\', '/')
       , connectionId = "con1"
       , partitions = Seq("date", "town", "year")
@@ -193,11 +194,11 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id)
 
     // fail if partition values dont exist
-    val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date"->"00010101", "town"->"NYC", "year"->"2020"))))
+    val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date" -> "00010101", "town" -> "NYC", "year" -> "2020"))))
     intercept[AssertionError](action1.exec(Seq(srcSubFeed)))
 
     // fail if partition values dont exist, also if only the first partition value is defined
-    val srcSubFeedValidInit = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date"->"00010101"))))
+    val srcSubFeedValidInit = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date" -> "00010101"))))
     intercept[AssertionError](action1.exec(Seq(srcSubFeedValidInit)))
   }
 
@@ -228,7 +229,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
 
     // prepare & start load
     val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id)
-    val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date"->datePartitionVal))))
+    val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq(PartitionValues(Map("date" -> datePartitionVal))))
     action1.exec(Seq(srcSubFeed))
 
     val r1 = tgtDO.getFileRefs(Seq())
@@ -250,7 +251,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(datePartitionVal).resolve(resourceFile).toFile)
 
     // setup DataObjects
-    val srcDO = SFtpFileRefDataObject( "src1"
+    val srcDO = SFtpFileRefDataObject("src1"
       , tempDir.resolve(ftpDir).toString.replace('\\', '/')
       , connectionId = "con1"
       , partitions = Seq("date", "town", "year")
@@ -264,7 +265,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
 
     // prepare & start load
     val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id)
-    val partitionValuesFilter = PartitionValues(Map("date"->datePartitionVal, "town"->"NYC", "year"->"2019"))
+    val partitionValuesFilter = PartitionValues(Map("date" -> datePartitionVal, "town" -> "NYC", "year" -> "2019"))
     val srcSubFeed = FileSubFeed(None, "src1", partitionValues = Seq(partitionValuesFilter))
     action1.exec(Seq(srcSubFeed))
 
@@ -287,13 +288,13 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(datePartitionVal).resolve(resourceFile).toFile)
 
     // setup DataObjects
-    val srcDO = SFtpFileRefDataObject( "src1"
+    val srcDO = SFtpFileRefDataObject("src1"
       , tempDir.resolve(ftpDir).toString.replace('\\', '/')
       , connectionId = "con1"
       , partitions = Seq("date", "town", "year")
       , partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%")
     )
-    val srcDOdontExpectPartitions = SFtpFileRefDataObject( "src1a"
+    val srcDOdontExpectPartitions = SFtpFileRefDataObject("src1a"
       , tempDir.resolve(ftpDir).toString.replace('\\', '/')
       , connectionId = "con1"
       , partitions = Seq("date", "town", "year")
@@ -310,7 +311,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     // prepare & start load
     val action1 = FileTransferAction("fta", srcDO.id, tgtDO.id)
     val action1dontExpectPartitions = FileTransferAction("fta", srcDOdontExpectPartitions.id, tgtDO.id)
-    val partitionValuesFilter = PartitionValues(Map("date"->datePartitionVal, "town"->"NYC", "year"->"0001"))
+    val partitionValuesFilter = PartitionValues(Map("date" -> datePartitionVal, "town" -> "NYC", "year" -> "0001"))
     val srcSubFeed1 = FileSubFeed(None, "src1", partitionValues = Seq(partitionValuesFilter))
     intercept[AssertionError](action1.exec(Seq(srcSubFeed1)))
     val srcSubFeed1a = FileSubFeed(None, "src1a", partitionValues = Seq(partitionValuesFilter))
@@ -357,7 +358,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     val tempDir = Files.createTempDirectory(feed)
 
     // copy data 1 file to hadoop
-    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"1").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile + "1").toFile)
 
     // setup DataObjects
     val srcDO = CsvFileDataObject("src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"))
@@ -376,11 +377,11 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
 
     // check 1
     val r1 = tgtDO.getFileRefs(Seq())
-    assert(r1.map(_.fileName) == Seq(resourceFile+"1"))
+    assert(r1.map(_.fileName) == Seq(resourceFile + "1"))
     assert(srcDO.getFileRefs(Seq()).isEmpty)
 
     // copy data 2 file to hadoop
-    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"2").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile + "2").toFile)
 
     // start load 2
     action1.init(Seq(srcSubFeed))
@@ -390,7 +391,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
 
     // check 2
     val r2 = tgtDO.getFileRefs(Seq())
-    assert(r2.map(_.fileName) == Seq(resourceFile+"2"))
+    assert(r2.map(_.fileName) == Seq(resourceFile + "2"))
     assert(srcDO.getFileRefs(Seq()).isEmpty)
   }
 
@@ -403,7 +404,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     val tempDir = Files.createTempDirectory(feed)
 
     // copy data 1 file to hadoop
-    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"1").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile + "1").toFile)
 
     // setup DataObjects
     val srcDO = CsvFileDataObject("src1", tempDir.resolve(srcDir).toString.replace('\\', '/'), csvOptions = Map("header" -> "true"))
@@ -422,11 +423,11 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
 
     // check 1
     val r1 = tgtDO.getFileRefs(Seq())
-    assert(r1.map(_.fileName) == Seq(resourceFile+"1"))
+    assert(r1.map(_.fileName) == Seq(resourceFile + "1"))
     assert(srcDO.getFileRefs(Seq()).isEmpty)
 
     // copy data 2 file to hadoop
-    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile+"2").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir).resolve(resourceFile + "2").toFile)
 
     // start load 2
     action1.init(Seq(srcSubFeed))
@@ -471,7 +472,7 @@ class FileTransferActionTest extends FunSuite with BeforeAndAfter with BeforeAnd
     // setup DataObjects
     // For testing we will read something from Spark UI API...
     val srcDO = WebserviceFileDataObject("src1", url = session.sparkContext.uiWebUrl.get + "/api/v1"
-      , partitionDefs = Seq(WebservicePartitionDefinition("subject", Seq("applications","version"))), partitionLayout = Some("/%subject%?test")) // "?test" is added to test cleaning of filenames created. It has no meaning in the Spark API.
+      , partitionDefs = Seq(WebservicePartitionDefinition("subject", Seq("applications", "version"))), partitionLayout = Some("/%subject%?test")) // "?test" is added to test cleaning of filenames created. It has no meaning in the Spark API.
     val tgtDO = JsonFileDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), partitions = Seq("subject"))
     instanceRegistry.register(srcDO)
     instanceRegistry.register(tgtDO)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeActionTest.scala
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
- package io.smartdatalake.workflow.action
+package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions
@@ -26,21 +26,22 @@ import io.smartdatalake.util.historization.Historization
 import io.smartdatalake.util.historization.HistorizationTestUtils.defaultTimeAxisUnit
 import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
 import io.smartdatalake.workflow.ExecutionPhase
- import io.smartdatalake.workflow.connection.jdbc.JdbcTableConnection
- import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
-import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table, JdbcTableDataObject}
+import io.smartdatalake.workflow.connection.jdbc.JdbcTableConnection
+import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
+import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, JdbcTableDataObject, Table}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
- import org.scalatest.Assertions.withClue
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path => NioPath}
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
-class HistorizeActionTest extends FunSuite with BeforeAndAfter {
+class HistorizeActionTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:HistorizeActionTest", "org.hsqldb.jdbcDriver")
@@ -65,11 +66,11 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
 
     // setup DataObjects
     val srcTable = Table(Some("default"), "historize_input")
-    val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
     srcDO.dropTable(context)
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
-    val tgtTable = Table(Some("public"), "historize_output", None, Some(Seq("lastname","firstname")))
+    val tgtTable = Table(Some("public"), "historize_output", None, Some(Seq("lastname", "firstname")))
     val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", allowSchemaEvolution = true)
     tgtDO.dropTable(context)
     instanceRegistry.register(tgtDO)
@@ -78,7 +79,7 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
     val refTimestamp1 = LocalDateTime.now()
     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id)
-    val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())(context1)
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
@@ -102,7 +103,7 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
     val refTimestamp2 = LocalDateTime.now()
     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id)
-    val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
+    val l2 = Seq(("doe", "john", 10)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l2, Seq())(context1)
     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
@@ -126,7 +127,7 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
     val refTimestamp3 = LocalDateTime.now()
     val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
     val action3 = HistorizeAction("ha3", srcDO.id, tgtDO.id)
-    val l3 = Seq(("doe","john",10,"test")).toDF("lastname", "firstname", "rating", "test")
+    val l3 = Seq(("doe", "john", 10, "test")).toDF("lastname", "firstname", "rating", "test")
     srcDO.writeSparkDataFrame(l3, Seq())(context3)
     val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
     action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
@@ -150,16 +151,18 @@ class HistorizeActionTest extends FunSuite with BeforeAndAfter {
   test("early validation that output primary key exists") {
     // setup DataObjects
     val srcTable = Table(Some("default"), "historize_input")
-    val srcPath = tempPath+s"/${srcTable.fullName}"
-    val srcDO = HiveTableDataObject( "src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
     instanceRegistry.register(srcDO)
     instanceRegistry.register(jdbcConnection)
     val tgtTable = Table(Some("public"), "historize_output")
-    val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1")
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1")
     instanceRegistry.register(tgtDO)
 
     // check primary key missing
-    val exception = intercept[IllegalArgumentException]{HistorizeAction("hist1", srcDO.id, tgtDO.id)}
+    val exception = intercept[IllegalArgumentException] {
+      HistorizeAction("hist1", srcDO.id, tgtDO.id)
+    }
     withClue(exception.getMessage) {
       assert(exception.getMessage.contains("Primary key must be defined for output DataObject"))
     }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeWithMergeActionTest.scala
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
- package io.smartdatalake.workflow.action
+package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions
@@ -29,325 +29,327 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, JdbcTableDataObject, Table}
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Path => NioPath}
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
- class HistorizeWithMergeActionTest extends FunSuite with BeforeAndAfter {
+class HistorizeWithMergeActionTest extends AnyFunSuite with BeforeAndAfter {
 
-   protected implicit val session: SparkSession = TestUtil.session
-   import session.implicits._
+  protected implicit val session: SparkSession = TestUtil.session
 
-   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  import session.implicits._
 
-   private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:HistorizeWithMergeActionTest", "org.hsqldb.jdbcDriver")
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
 
-   private var tempDir: NioPath = _
-   private var tempPath: String = _
+  private val jdbcConnection = JdbcTableConnection("jdbcCon1", "jdbc:hsqldb:mem:HistorizeWithMergeActionTest", "org.hsqldb.jdbcDriver")
 
-   before {
-     instanceRegistry.clear()
-     tempDir = Files.createTempDirectory("test")
-     tempPath = tempDir.toAbsolutePath.toString
-   }
+  private var tempDir: NioPath = _
+  private var tempPath: String = _
 
-   after {
-     FileUtils.deleteDirectory(tempDir.toFile)
-   }
+  before {
+    instanceRegistry.clear()
+    tempDir = Files.createTempDirectory("test")
+    tempPath = tempDir.toAbsolutePath.toString
+  }
 
-   test("historize load mergeModeEnable") {
+  after {
+    FileUtils.deleteDirectory(tempDir.toFile)
+  }
 
-     val context = TestUtil.getDefaultActionPipelineContext
+  test("historize load mergeModeEnable") {
 
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input")
-     val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
-     srcDO.dropTable(context)
-     instanceRegistry.register(srcDO)
-     instanceRegistry.register(jdbcConnection)
-     val tgtTable = Table(Some("public"), "historize_output", None, Some(Seq("lastname","firstname")))
-     val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1")//, jdbcOptions = Map("createTableColumnTypes"->"lastname varchar, firstname varchar"))
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    val context = TestUtil.getDefaultActionPipelineContext
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
-     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1, Seq())(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input")
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable(context)
+    instanceRegistry.register(srcDO)
+    instanceRegistry.register(jdbcConnection)
+    val tgtTable = Table(Some("public"), "historize_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1") //, jdbcOptions = Map("createTableColumnTypes"->"lastname varchar, firstname varchar"))
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     {
-       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp))
-         .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1, Seq())(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2nd load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
-     val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2, Seq())(context2)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed2), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    {
+      val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp))
+        .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context2)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
+    val l2 = Seq(("doe", "john", 10)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2, Seq())(context2)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed2), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // prepare & start 3rd load with schema evolution
-     val refTimestamp3 = LocalDateTime.now()
-     val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
-     val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
-     instanceRegistry.register(tgtDOwithSchemaEvolution)
-     val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true)
-     val l3 = Seq(("doe","john",10,"test")).toDF("lastname", "firstname", "rating", "test")
-     srcDO.writeSparkDataFrame(l3, Seq())(context3)
-     val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
-     action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
-     action3.preInit(Seq(srcSubFeed3), Seq())(context3.copy(phase = ExecutionPhase.Init))
-     action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
-     action3.exec(Seq(srcSubFeed3))(context3)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context2)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
-         ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context3)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
-       assert(resultat)
-     }
-   }
+    // prepare & start 3rd load with schema evolution
+    val refTimestamp3 = LocalDateTime.now()
+    val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
+    val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
+    instanceRegistry.register(tgtDOwithSchemaEvolution)
+    val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true)
+    val l3 = Seq(("doe", "john", 10, "test")).toDF("lastname", "firstname", "rating", "test")
+    srcDO.writeSparkDataFrame(l3, Seq())(context3)
+    val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
+    action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
+    action3.preInit(Seq(srcSubFeed3), Seq())(context3.copy(phase = ExecutionPhase.Init))
+    action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
+    action3.exec(Seq(srcSubFeed3))(context3)
 
-   test("historize load mergeModeEnable CDC") {
+    {
+      val expected = Seq(
+        ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
+        ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context3)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
+      assert(resultat)
+    }
+  }
 
-     val context = TestUtil.getDefaultActionPipelineContext
+  test("historize load mergeModeEnable CDC") {
 
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input")
-     val srcDO = HiveTableDataObject( "src1", Some(tempPath+s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
-     srcDO.dropTable(context)
-     instanceRegistry.register(srcDO)
-     instanceRegistry.register(jdbcConnection)
-     val tgtTable = Table(Some("public"), "historize_output", None, Some(Seq("lastname","firstname")))
-     val tgtDO = JdbcTableDataObject( "tgt1", table = tgtTable, connectionId = "jdbcCon1")//, jdbcOptions = Map("createTableColumnTypes"->"lastname varchar, firstname varchar"))
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    val context = TestUtil.getDefaultActionPipelineContext
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l1 = Seq(("doe","john",5,"new"), ("pan","peter",5,"new")).toDF("lastname", "firstname", "rating", "operation")
-     srcDO.writeSparkDataFrame(l1, Seq())(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input")
+    val srcDO = HiveTableDataObject("src1", Some(tempPath + s"/${srcTable.fullName}"), table = srcTable, numInitialHdfsPartitions = 1)
+    srcDO.dropTable(context)
+    instanceRegistry.register(srcDO)
+    instanceRegistry.register(jdbcConnection)
+    val tgtTable = Table(Some("public"), "historize_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1") //, jdbcOptions = Map("createTableColumnTypes"->"lastname varchar, firstname varchar"))
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l1 = Seq(("doe", "john", 5, "new"), ("pan", "peter", 5, "new")).toDF("lastname", "firstname", "rating", "operation")
+    srcDO.writeSparkDataFrame(l1, Seq())(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2nd load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l2 = Seq(("doe","john",10,"updated"), ("pan","peter",5,"deleted")).toDF("lastname", "firstname", "rating", "operation")
-     srcDO.writeSparkDataFrame(l2, Seq())(context1)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed2), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan","peter", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l2 = Seq(("doe", "john", 10, "updated"), ("pan", "peter", 5, "deleted")).toDF("lastname", "firstname", "rating", "operation")
+    srcDO.writeSparkDataFrame(l2, Seq())(context1)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed2), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // prepare & start 3rd load with schema evolution
-     val refTimestamp3 = LocalDateTime.now()
-     val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
-     val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
-     instanceRegistry.register(tgtDOwithSchemaEvolution)
-     val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l3 = Seq(("doe","john",10,"test","updated")).toDF("lastname", "firstname", "rating", "test", "operation")
-     srcDO.writeSparkDataFrame(l3, Seq())(context3)
-     val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
-     action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
-     action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
-     action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
-     action3.exec(Seq(srcSubFeed3))(context3)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
-         ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan","peter", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L)))
-       ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context3)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
-       assert(resultat)
-     }
-   }
+    // prepare & start 3rd load with schema evolution
+    val refTimestamp3 = LocalDateTime.now()
+    val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
+    val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
+    instanceRegistry.register(tgtDOwithSchemaEvolution)
+    val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l3 = Seq(("doe", "john", 10, "test", "updated")).toDF("lastname", "firstname", "rating", "test", "operation")
+    srcDO.writeSparkDataFrame(l3, Seq())(context3)
+    val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
+    action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
+    action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
+    action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
+    action3.exec(Seq(srcSubFeed3))(context3)
 
-   test("activate merge mode on existing dataframe no null dl_hash") {
+    {
+      val expected = Seq(
+        ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
+        ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L)))
+      ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context3)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
+      assert(resultat)
+    }
+  }
 
-     instanceRegistry.register(jdbcConnection)
+  test("activate merge mode on existing dataframe no null dl_hash") {
 
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input")
-     val srcPath = tempPath + s"/${srcTable.fullName}"
-     val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-     instanceRegistry.register(srcDO)
-     val tgtTable = Table(Some("public"), "historize_output", primaryKey = Some(Seq("id")))
+    instanceRegistry.register(jdbcConnection)
 
-     val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", allowSchemaEvolution = true)
-     val context = TestUtil.getDefaultActionPipelineContext
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input")
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgtTable = Table(Some("public"), "historize_output", primaryKey = Some(Seq("id")))
 
-     // prepare & start 1st load without merge mode
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id
-     )
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", allowSchemaEvolution = true)
+    val context = TestUtil.getDefaultActionPipelineContext
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1)(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // prepare & start 1st load without merge mode
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id
+    )
 
-     // 1. expectation schema should not have dl_hash column
-     assert(!tgtDO.getSparkDataFrame()(context1).columns.contains("dl_hash"))
+    val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1)(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2st load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id,
-       mergeModeEnable = true
-     )
+    // 1. expectation schema should not have dl_hash column
+    assert(!tgtDO.getSparkDataFrame()(context1).columns.contains("dl_hash"))
 
-     val l2 = Seq((1, "doe", "john", 4)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2)(context2)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    // prepare & start 2st load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id,
+      mergeModeEnable = true
+    )
 
-     // expectation dl_hash should not have null values
-     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
+    val l2 = Seq((1, "doe", "john", 4)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2)(context2)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-
-   }
-
-   test("update hash on existing non updated rows") {
-
-     instanceRegistry.register(jdbcConnection)
-
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input")
-     val srcPath = tempPath + s"/${srcTable.fullName}"
-     val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-     instanceRegistry.register(srcDO)
-     val tgtTable = Table(Some("public"), "historize_output", primaryKey = Some(Seq("id")))
-
-     val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", allowSchemaEvolution = true)
-     val context = TestUtil.getDefaultActionPipelineContext
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
-
-     // prepare & start 1st load with merge mode
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id)
-
-     val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1)(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
-
-     // prepare & start 2st load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id,
-       mergeModeEnable = true
-     )
-
-     val l2 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2)(context2)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
-
-     // expectation dl_hash should not have null values
-     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
+    // expectation dl_hash should not have null values
+    assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
 
 
-   }
- }
+  }
+
+  test("update hash on existing non updated rows") {
+
+    instanceRegistry.register(jdbcConnection)
+
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input")
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgtTable = Table(Some("public"), "historize_output", primaryKey = Some(Seq("id")))
+
+    val tgtDO = JdbcTableDataObject("tgt1", table = tgtTable, connectionId = "jdbcCon1", allowSchemaEvolution = true)
+    val context = TestUtil.getDefaultActionPipelineContext
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
+
+    // prepare & start 1st load with merge mode
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id)
+
+    val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1)(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
+
+    // prepare & start 2st load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id,
+      mergeModeEnable = true
+    )
+
+    val l2 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2)(context2)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
+
+    // expectation dl_hash should not have null values
+    assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
+
+
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/OfflineCopyActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/OfflineCopyActionTest.scala
@@ -29,11 +29,11 @@ import io.smartdatalake.workflow.dataframe.spark.{SparkSchema, SparkSubFeed}
 import io.smartdatalake.workflow.dataobject.ParquetFileDataObject
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class OfflineCopyActionTest extends FunSuite {
+class OfflineCopyActionTest extends AnyFunSuite {
 
   private val tempDir = Files.createTempDirectory("test")
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/RuntimeDataTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/RuntimeDataTest.scala
@@ -22,11 +22,11 @@ package io.smartdatalake.workflow.action
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.{ExecutionPhase, GenericMetrics}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.LocalDateTime
 
-class RuntimeDataTest extends FunSuite {
+class RuntimeDataTest extends AnyFunSuite {
 
   test("store and get synchronous events") {
     val runtimeData = SynchronousRuntimeData(10)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ScalaClassSparkDsNTo1TransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ScalaClassSparkDsNTo1TransformerTest.scala
@@ -34,8 +34,8 @@ import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Dataset, SparkSession}
-import org.scalatest.Matchers.{a, thrownBy}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 import java.nio.file.Files
@@ -102,7 +102,7 @@ class BadSignatureTransformDsNTo1Transformer extends CustomDsNto1Transformer {
   }
 }
 
-class ScalaClassSparkDsNTo1TransformerTest extends FunSuite with BeforeAndAfter {
+class ScalaClassSparkDsNTo1TransformerTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 
@@ -111,7 +111,7 @@ class ScalaClassSparkDsNTo1TransformerTest extends FunSuite with BeforeAndAfter 
   private val tempDir = Files.createTempDirectory("testScalaClassSparkDs2To1TransformerTest")
   private val tempPath = tempDir.toAbsolutePath.toString
 
-  val sdlb = DefaultSmartDataLakeBuilder
+  private val sdlb = DefaultSmartDataLakeBuilder
   implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
   implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 
@@ -178,7 +178,9 @@ class ScalaClassSparkDsNTo1TransformerTest extends FunSuite with BeforeAndAfter 
 
     val srcSubFeed1 = SparkSubFeed(None, "src1Ds", partitionValues = Seq())
     val srcSubFeed2 = SparkSubFeed(None, "src2Ds", partitionValues = Seq())
-    a[AssertionError] shouldBe thrownBy(testAction.exec(Seq(srcSubFeed1, srcSubFeed2)))
+    assertThrows[AssertionError] {
+      testAction.exec(Seq(srcSubFeed1, srcSubFeed2))
+    }
   }
 
   test("Transform method with bad signature defined (direct call to exec)") {
@@ -290,9 +292,9 @@ class ScalaClassSparkDsNTo1TransformerTest extends FunSuite with BeforeAndAfter 
 
     // setup DataObjects
     val partitionValues = Seq(PartitionValues(
-      Map(("year" -> "1992"),
-        ("month" -> "04"),
-        ("day" -> "25"))))
+      Map("year" -> "1992",
+        "month" -> "04",
+        "day" -> "25")))
     // fill src with first files
     val srcDO1 = SparkSubFeed(SparkDataFrame(
       Seq(("john", 5, "1992", "04", "25"))
@@ -307,9 +309,9 @@ class ScalaClassSparkDsNTo1TransformerTest extends FunSuite with BeforeAndAfter 
     val sdlConfig = SmartDataLakeBuilderConfig(feedSel = "test_feed_name", configuration = Seq("cp:/configScalaClassSparkDsNto1Transformer/usingDataObjectIdWithPartitionAutoSelect.conf"),
       partitionValues =
         Some(Seq(PartitionValues(
-          Map(("year" -> "1992"),
-            ("month" -> "04"),
-            ("day" -> "25")
+          Map("year" -> "1992",
+            "month" -> "04",
+            "day" -> "25"
           ))))
     )
     //Run SDLB
@@ -421,6 +423,8 @@ class ScalaClassSparkDsNTo1TransformerTest extends FunSuite with BeforeAndAfter 
     val sdlConfig = SmartDataLakeBuilderConfig(feedSel = "test_feed_name", configuration = Seq("cp:/configScalaClassSparkDsNto1Transformer/usingDataObjectOrdering9InputsWrongTransformer.conf"))
     //Run SDLB
 
-    a[TaskFailedException] shouldBe thrownBy(sdlb.run(sdlConfig))
+    assertThrows[TaskFailedException] {
+      sdlb.run(sdlConfig)
+    }
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ScalaClassSparkDsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/ScalaClassSparkDsTransformerTest.scala
@@ -28,7 +28,8 @@ import io.smartdatalake.workflow.dataobject.CsvFileDataObject
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Dataset, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
@@ -43,7 +44,7 @@ class TestDSTransformer extends CustomDsTransformer[InputDataSet, OutputDataSet]
   }
 }
 
-class ScalaClassSparkDsTransformerTest extends FunSuite with BeforeAndAfter {
+class ScalaClassSparkDsTransformerTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/BlacklistTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/BlacklistTransformerTest.scala
@@ -27,9 +27,9 @@ import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class BlacklistTransformerTest extends FunSuite {
+class BlacklistTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/ColumnTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/ColumnTransformerTest.scala
@@ -18,30 +18,17 @@
  */
 package io.smartdatalake.workflow.action.generic.transformer
 
-import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, SmartDataLakeBuilderConfig}
+import io.smartdatalake.app.DefaultSmartDataLakeBuilder
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.testutils.TestUtil
-import io.smartdatalake.util.dag.TaskFailedException
-import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.workflow.action.RuntimeEventState.RuntimeEventState
-import io.smartdatalake.workflow.action.spark.customlogic.CustomDsNto1Transformer
-import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDsNTo1Transformer
-import io.smartdatalake.workflow.dataframe.spark.{SparkColumn, SparkDataFrame, SparkSchema, SparkSubFeed}
-import io.smartdatalake.workflow.dataobject.CsvFileDataObject
-import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, SubFeed}
-import org.apache.spark.sql.expressions.Window
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.{Dataset, SparkSession}
-import org.scalatest.Matchers.{a, thrownBy}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
+import org.apache.spark.sql.SparkSession
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
-import java.io.File
-import java.nio.file.Files
-import scala.reflect.io.Directory
-
-class ColumnTransformerTest extends FunSuite with BeforeAndAfter {
+class ColumnTransformerTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 
@@ -63,7 +50,7 @@ class ColumnTransformerTest extends FunSuite with BeforeAndAfter {
       additionalColumns = Map("run_id" -> "runId"),
       additionalDerivedColumns = Map(
         "col_1_plus_col2" -> """col_1 + col_2"""
-        ,"sum_col_1" -> """sum(col_1) over (partition by 'whatever')"""
+        , "sum_col_1" -> """sum(col_1) over (partition by 'whatever')"""
       ),
       renamedColumns = Map("col_1" -> "new_col_1"),
       droppedColumns = Seq("col_2")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/ConvertNullValuesTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/ConvertNullValuesTransformerTest.scala
@@ -27,9 +27,9 @@ import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ConvertNullValuesTransformerTest extends FunSuite {
+class ConvertNullValuesTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/DebugTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/DebugTransformerTest.scala
@@ -25,9 +25,9 @@ import io.smartdatalake.workflow.action.CustomDataFrameAction
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class DebugTransformerTest extends FunSuite {
+class DebugTransformerTest extends AnyFunSuite {
   protected implicit val session: SparkSession = TestUtil.session
 
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/DeduplicateTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/DeduplicateTransformerTest.scala
@@ -30,10 +30,12 @@ import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionDAGRun, ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.TimestampType
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
-class DeduplicateTransformerTest extends FunSuite with BeforeAndAfter {
+
+class DeduplicateTransformerTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{SaveMode, SparkSession}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import java.time.LocalDateTime
@@ -49,7 +49,7 @@ case class Test_Record(
                         lo: Long
                       )
 
-class EncryptColumnsTransformerTest extends FunSuite {
+class EncryptColumnsTransformerTest extends AnyFunSuite {
   implicit val session: SparkSession = TestUtil.session
   import session.implicits._
   private val tempDir = Files.createTempDirectory("test")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformerTest.scala
@@ -27,9 +27,9 @@ import io.smartdatalake.workflow.connection.jdbc.JdbcTableConnection
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import io.smartdatalake.workflow.dataobject.{JdbcTableDataObject, Table}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SQLDfTransformerTest extends FunSuite {
+class SQLDfTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformerTest.scala
@@ -27,9 +27,9 @@ import io.smartdatalake.workflow.connection.jdbc.JdbcTableConnection
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import io.smartdatalake.workflow.dataobject.{JdbcTableDataObject, Table}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SQLDfsTransformerTest extends FunSuite {
+class SQLDfsTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformerTest.scala
@@ -25,9 +25,9 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import org.apache.spark.sql.SparkSession
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class StandardizeColNamesTransformerTest extends FunSuite {
+class StandardizeColNamesTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/WhitelistTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/WhitelistTransformerTest.scala
@@ -27,9 +27,9 @@ import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class WhitelistTransformerTest extends FunSuite {
+class WhitelistTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/script/CmdScriptTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/script/CmdScriptTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.workflow.action.script
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class CmdScriptTest extends FunSuite {
+class CmdScriptTest extends AnyFunSuite {
 
   test("split cmd with quotes") {
     val actual = CmdScript.splitCmdParameters("""my test "is splitted" correctly 'or not' """)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/CustomDfsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/CustomDfsTransformerTest.scala
@@ -29,11 +29,11 @@ import io.smartdatalake.workflow.action.CustomDataFrameAction
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformer
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, InitSubFeed}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.reflect.runtime.universe.typeOf
 
-class CustomDfsTransformerTest extends FunSuite {
+class CustomDfsTransformerTest extends AnyFunSuite {
   protected implicit val session: SparkSession = TestUtil.session
 
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeDfTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeDfTransformerTest.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.workflow.action.spark.transformer
 
 import io.smartdatalake.workflow.action.spark.transformer.PythonCodeDfTransformer.dedent
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class PythonCodeDfTransformerTest extends FunSuite {
+class PythonCodeDfTransformerTest extends AnyFunSuite {
 
 	// To ensure consistent comparisons across different environments, we normalize line endings.
 	def normalizeLineEndings(text: String): String =

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaNotebookSparkDfTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaNotebookSparkDfTransformerTest.scala
@@ -21,9 +21,9 @@ package io.smartdatalake.workflow.action.spark.transformer
 
 import com.fasterxml.jackson.core.JsonParseException
 import io.smartdatalake.workflow.action.spark.transformer.ScalaNotebookSparkDfTransformer.{compileCode, parseNotebook, prepareFunction}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ScalaNotebookSparkDfTransformerTest extends FunSuite {
+class ScalaNotebookSparkDfTransformerTest extends AnyFunSuite {
 
   val testNotebookContent = """
     {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDFTransformerTest.scala
@@ -25,13 +25,13 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.config.SdlConfigObject.ActionId
 import org.apache.spark.sql.{SparkSession, Row}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import org.apache.spark.sql.types.{StructType, IntegerType, StringType, ArrayType}
 import java.util.ArrayList
 
 
 
-class SparkFlattenDFTransformerTest extends FunSuite {
+class SparkFlattenDFTransformerTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/authMode/OAuthModeIT.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/authMode/OAuthModeIT.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.workflow.connection.authMode
 
 import io.smartdatalake.util.secrets.StringOrSecret
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class OAuthModeIT extends FunSuite {
+class OAuthModeIT extends AnyFunSuite {
 
   // Check request to open OAuth2 server: https://oauth.tools/collection/1599045253169-GHF
   test("sample client_credentials flow") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnectionTest.scala
@@ -26,14 +26,14 @@ import org.apache.logging.log4j.core.{LogEvent, LoggerContext}
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.LoggerConfig
 import org.hsqldb.Server
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.net.ConnectException
 import java.sql.{SQLException, SQLTransientConnectionException}
 import java.util.Properties
 import scala.collection.mutable
 
-class JdbcTableConnectionTest extends FunSuite with SmartDataLakeLogger {
+class JdbcTableConnectionTest extends AnyFunSuite with SmartDataLakeLogger {
 
   test("autocommit is disabled by default") {
     // prepare

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/MariaDbDialectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/jdbc/MariaDbDialectTest.scala
@@ -20,9 +20,9 @@
 package io.smartdatalake.workflow.connection.jdbc
 
 import org.apache.spark.sql.types.{FloatType, IntegerType}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class MariaDbDialectTest extends FunSuite {
+class MariaDbDialectTest extends AnyFunSuite {
 
   test("can handle MariaDB url") {
     assert(MariaDbDialect.canHandle("jdbc:mariadb://localhost:3306"))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomDfDataObjectTest.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.testutils.custom.{TestCustomDfCreator, TestCustomDfCreat
 import io.smartdatalake.testutils.{DataObjectTestSuite, TestUtil}
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfCreatorConfig
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 class CustomDfDataObjectTest extends DataObjectTestSuite with Matchers {
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CustomFileDataObjectTest.scala
@@ -22,7 +22,7 @@ package io.smartdatalake.workflow.dataobject
 import io.smartdatalake.testutils.DataObjectTestSuite
 import io.smartdatalake.testutils.custom.TestCustomFileCreator
 import io.smartdatalake.workflow.action.spark.customlogic.CustomFileCreatorConfig
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source.fromInputStream
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableSchemaViolationTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HiveTableSchemaViolationTest.scala
@@ -22,21 +22,23 @@ import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.testutils.TestUtil._
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.util.spark.DataFrameUtil
 import io.smartdatalake.workflow.{ActionPipelineContext, SchemaViolationException}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.Files
 
-class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAndAfter with SmartDataLakeLogger {
+class HiveTableSchemaViolationTest extends AnyFunSuite with Matchers with BeforeAndAfter with SmartDataLakeLogger {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
-  implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
   private val tempDir = Files.createTempDirectory("test")
   private val tempPath = tempDir.toAbsolutePath.toString
@@ -98,7 +100,7 @@ class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAnd
       primaryKeyColumns = Some(Seq("id"))
     )
 
-    val thrown = the [SchemaViolationException] thrownBy sourceDo.getSparkDataFrame()
+    val thrown = the[SchemaViolationException] thrownBy sourceDo.getSparkDataFrame()
     println(thrown.getMessage)
   }
 
@@ -115,7 +117,7 @@ class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAnd
       primaryKeyColumns = Some(Seq("id"))
     )
 
-    val thrown = the [SchemaViolationException] thrownBy sourceDo.getSparkDataFrame()
+    val thrown = the[SchemaViolationException] thrownBy sourceDo.getSparkDataFrame()
     println(thrown.getMessage)
   }
 
@@ -126,13 +128,13 @@ class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAnd
       schemaMin = Some(schemaMin),
       tableName = "source_table",
       dirPath = tempPath,
-      df = TestUtil.arbitraryDataFrame(schema,1),
+      df = TestUtil.arbitraryDataFrame(schema, 1),
       primaryKeyColumns = Some(Seq("id"))
     )
 
     noException should be thrownBy sourceDo.writeSparkDataFrame(Seq(
       ("foo", "bar")
-    ).toDF(schema.names:_*), Seq.empty)
+    ).toDF(schema.names: _*), Seq.empty)
   }
 
   test("Write: SchemaMin equals Schema is valid (ignoring nullable)") {
@@ -142,13 +144,13 @@ class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAnd
       schemaMin = Some(schemaMin),
       tableName = "source_table",
       dirPath = tempPath,
-      df = TestUtil.arbitraryDataFrame(schema,1),
+      df = TestUtil.arbitraryDataFrame(schema, 1),
       primaryKeyColumns = Some(Seq("id"))
     )
 
     noException should be thrownBy sourceDo.writeSparkDataFrame(Seq(
       ("foo", "bar")
-    ).toDF(schema.names:_*), Seq.empty)
+    ).toDF(schema.names: _*), Seq.empty)
   }
 
   test("Write: SchemaMin is valid subset of Schema") {
@@ -158,13 +160,13 @@ class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAnd
       schemaMin = Some(schemaMin),
       tableName = "source_table",
       dirPath = tempPath,
-      df = TestUtil.arbitraryDataFrame(schema,1),
+      df = TestUtil.arbitraryDataFrame(schema, 1),
       primaryKeyColumns = Some(Seq("id"))
     )
 
     noException should be thrownBy sourceDo.writeSparkDataFrame(Seq(
       ("foo", "bar")
-    ).toDF(schema.names:_*), Seq.empty)
+    ).toDF(schema.names: _*), Seq.empty)
   }
 
   test("Write: Invalid schema - missing column") {
@@ -178,13 +180,13 @@ class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAnd
       schemaMin = Some(schemaMin),
       tableName = "source_table",
       dirPath = tempPath,
-      df = TestUtil.arbitraryDataFrame(schema,1),
+      df = TestUtil.arbitraryDataFrame(schema, 1),
       primaryKeyColumns = Some(Seq("id"))
     )
 
-    val thrown = the [SchemaViolationException] thrownBy sourceDo.writeSparkDataFrame(Seq(
+    val thrown = the[SchemaViolationException] thrownBy sourceDo.writeSparkDataFrame(Seq(
       ("foo", "bar")
-    ).toDF(schema.names:_*), Seq.empty)
+    ).toDF(schema.names: _*), Seq.empty)
     println(thrown.getMessage)
   }
 
@@ -198,13 +200,13 @@ class HiveTableSchemaViolationTest extends FunSuite with Matchers with BeforeAnd
       schemaMin = Some(schemaMin),
       tableName = "source_table",
       dirPath = tempPath,
-      df = TestUtil.arbitraryDataFrame(schema,1),
+      df = TestUtil.arbitraryDataFrame(schema, 1),
       primaryKeyColumns = Some(Seq("id"))
     )
 
-    val thrown = the [SchemaViolationException] thrownBy sourceDo.writeSparkDataFrame(Seq(
+    val thrown = the[SchemaViolationException] thrownBy sourceDo.writeSparkDataFrame(Seq(
       ("foo", "bar")
-    ).toDF(schema.names:_*), Seq.empty)
+    ).toDF(schema.names: _*), Seq.empty)
     println(thrown.getMessage)
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HousekeepingModeTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/HousekeepingModeTest.scala
@@ -29,13 +29,15 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.lit
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
+class HousekeepingModeTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("test")
@@ -44,7 +46,7 @@ class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
-  val df1 = Seq(("doe","john",5,"20201101"),("einstein","albert",2,"20201201"))
+  private val df1 = Seq(("doe", "john", 5, "20201101"), ("einstein", "albert", 2, "20201201"))
     .toDF("lastname", "firstname", "rating", "dt")
 
   before {
@@ -52,8 +54,8 @@ class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
   }
 
   test("PartitionRetentionMode") {
-    val srcDO = CsvFileDataObject("srcDO", tempPath+s"/src0", partitions=Seq("dt"))
-    val tgtDO = CsvFileDataObject("tgtDO", tempPath+s"/tgt1", partitions=Seq("dt")
+    val srcDO = CsvFileDataObject("srcDO", tempPath + s"/src0", partitions = Seq("dt"))
+    val tgtDO = CsvFileDataObject("tgtDO", tempPath + s"/tgt1", partitions = Seq("dt")
       , housekeepingMode = Some(PartitionRetentionMode("elements.dt >= 20201201"))
     )
     instanceRegistry.register(srcDO)
@@ -63,7 +65,7 @@ class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
     val srcSubFeed = SparkSubFeed(None, "srcDO", Seq())
     val tgtSubFeed = SparkSubFeed(None, "tgtDO", Seq())
     action1.prepare
-    assert(tgtDO.listPartitions.map(_.apply("dt").toString).sorted == Seq("20201101","20201201"))
+    assert(tgtDO.listPartitions.map(_.apply("dt").toString).sorted == Seq("20201101", "20201201"))
     action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed)) // exec housekeeping
 
     // check partition dt=20201101 is deleted
@@ -71,8 +73,8 @@ class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
   }
 
   test("PartitionArchiveCompactionMode with SparkFileDataObject") {
-    val srcDO = CsvFileDataObject("srcDO", tempPath+s"/src0", partitions=Seq("dt"))
-    val tgtDO = CsvFileDataObject("tgtDO", tempPath+s"/tgt1", partitions=Seq("dt")
+    val srcDO = CsvFileDataObject("srcDO", tempPath + s"/src0", partitions = Seq("dt"))
+    val tgtDO = CsvFileDataObject("tgtDO", tempPath + s"/tgt1", partitions = Seq("dt")
       , housekeepingMode = Some(PartitionArchiveCompactionMode(
         archivePartitionExpression = Some("map('dt','20201101')"), // always archive to 20201101
         compactPartitionExpression = Some("true") // compact all partitions...
@@ -85,7 +87,7 @@ class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
     val srcSubFeed = SparkSubFeed(None, "srcDO", Seq())
     val tgtSubFeed = SparkSubFeed(None, "tgtDO", Seq())
     action1.prepare
-    assert(tgtDO.listPartitions.map(_.apply("dt").toString).sorted == Seq("20201101","20201201"))
+    assert(tgtDO.listPartitions.map(_.apply("dt").toString).sorted == Seq("20201101", "20201201"))
     action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed)) // exec housekeeping
 
     // check partition dt=20201201 is archived and dt=20201101 is compacted
@@ -99,8 +101,8 @@ class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
   }
 
   test("PartitionArchiveCompactionMode with HiveTableDataObject") {
-    val srcDO = CsvFileDataObject("srcDO", tempPath+s"/src0", partitions=Seq("dt"))
-    val tgtDO = HiveTableDataObject("tgtDO", Some(tempPath+s"/tgt1"), partitions=Seq("dt"), table = Table(Some("default"), "tgtDO")
+    val srcDO = CsvFileDataObject("srcDO", tempPath + s"/src0", partitions = Seq("dt"))
+    val tgtDO = HiveTableDataObject("tgtDO", Some(tempPath + s"/tgt1"), partitions = Seq("dt"), table = Table(Some("default"), "tgtDO")
       , housekeepingMode = Some(PartitionArchiveCompactionMode(
         archivePartitionExpression = Some("map('dt','20201101')"), // always archive to 20201101
         compactPartitionExpression = Some("true") // compact all partitions...
@@ -114,7 +116,7 @@ class HousekeepingModeTest extends FunSuite with BeforeAndAfter {
     val srcSubFeed = SparkSubFeed(None, "srcDO", Seq())
     val tgtSubFeed = SparkSubFeed(None, "tgtDO", Seq())
     action1.prepare
-    assert(tgtDO.listPartitions.map(_.apply("dt").toString).sorted == Seq("20201101","20201201"))
+    assert(tgtDO.listPartitions.map(_.apply("dt").toString).sorted == Seq("20201101", "20201201"))
     action1.postExec(Seq(srcSubFeed), Seq(tgtSubFeed)) // exec housekeeping
 
     // check partition dt=20201201 is archived and dt=20201101 is compacted

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectIT.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectIT.scala
@@ -24,9 +24,9 @@ import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.explode
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class OpenApiDataObjectIT extends FunSuite {
+class OpenApiDataObjectIT extends AnyFunSuite {
   protected implicit lazy val session: SparkSession = TestUtil.session
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectTest.scala
@@ -27,9 +27,9 @@ import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.{DataType, StructType}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class OpenApiDataObjectTest extends FunSuite {
+class OpenApiDataObjectTest extends AnyFunSuite {
   protected implicit lazy val session: SparkSession = TestUtil.session
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObjectTest.scala
@@ -27,19 +27,23 @@ import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfCreatorConfig
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSubFeed}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.reflect.runtime.universe.typeOf
 
-class PKViolatorsDataObjectTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger{
+class PKViolatorsDataObjectTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
-  implicit val actionPipelineContext : ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
-  before { instanceRegistry.clear() }
+  before {
+    instanceRegistry.clear()
+  }
 
   test("normal pk violations") {
     val src = MockDataObject("source_tableDO", tableName = "source_table", primaryKey = Some(Seq("id"))).register
@@ -51,27 +55,27 @@ class PKViolatorsDataObjectTest extends FunSuite with BeforeAndAfter with SmartD
 
     // creating expected
     val rows_expected = Seq(
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","2let")),Seq(TestKV("value","doublet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","2let")),Seq(TestKV("value","doublet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","3let")),Seq(TestKV("value","triplet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","3let")),Seq(TestKV("value","triplet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","3let")),Seq(TestKV("value","triplet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet"))),
-      TestData("source_tableDO","mock","source_table","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet")))
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "2let")), Seq(TestKV("value", "doublet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "2let")), Seq(TestKV("value", "doublet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "3let")), Seq(TestKV("value", "triplet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "3let")), Seq(TestKV("value", "triplet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "3let")), Seq(TestKV("value", "triplet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet"))),
+      TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet")))
     )
     val expected = SparkDataFrame(rows_expected.toDF)
 
     // Comparing actual with expected
     val resultat: Boolean = expected.isEqual(actual)
-    if (!resultat) printFailedTestResult("normal pk violations",Seq(src.getSparkDataFrame()))(actual.inner)(expected.inner)
+    if (!resultat) printFailedTestResult("normal pk violations", Seq(src.getSparkDataFrame()))(actual.inner)(expected.inner)
     assert(resultat)
   }
 
   test("pk violations with null values") {
     // creating and registering data object //
-    val src = MockDataObject("hive_table_pk_id_ValueDO", tableName = "hive_table_pk_id_Value", primaryKey = Some(Seq("id","value"))).register
+    val src = MockDataObject("hive_table_pk_id_ValueDO", tableName = "hive_table_pk_id_Value", primaryKey = Some(Seq("id", "value"))).register
     src.writeSparkDataFrame(dfNonUniqueWithNull)
 
     // actual: reading the table containing the PK violators
@@ -79,16 +83,16 @@ class PKViolatorsDataObjectTest extends FunSuite with BeforeAndAfter with SmartD
 
     // creating expected
     val rows_expected = Seq(
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","0let"),TestKV("value",null))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","2let"),TestKV("value","doublet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","2let"),TestKV("value","doublet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","3let"),TestKV("value","triplet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","3let"),TestKV("value","triplet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","3let"),TestKV("value","triplet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_id_ValueDO","mock","hive_table_pk_id_Value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet")))
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "0let"), TestKV("value", null))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "2let"), TestKV("value", "doublet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "2let"), TestKV("value", "doublet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "3let"), TestKV("value", "triplet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "3let"), TestKV("value", "triplet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "3let"), TestKV("value", "triplet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet")))
     )
     val expected = SparkDataFrame(rows_expected.toDF)
 
@@ -103,7 +107,7 @@ class PKViolatorsDataObjectTest extends FunSuite with BeforeAndAfter with SmartD
     // creating and registering data objects //
 
     // a custom data object
-    val customDO = CustomDfDataObject(id="custom_do",
+    val customDO = CustomDfDataObject(id = "custom_do",
       creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfNonUniqueWithNullCreator].getName)))
     instanceRegistry.register(customDO)
 
@@ -113,7 +117,7 @@ class PKViolatorsDataObjectTest extends FunSuite with BeforeAndAfter with SmartD
     val hiveTableNoPKDO = MockDataObject("hive_table_no_pkDO", tableName = "hive_table_no_pk").register
     hiveTableNoPKDO.writeSparkDataFrame(dfTwoCandidateKeys)
 
-    val hiveTablePKidValueDO = MockDataObject("hive_table_pk_id_valueDO", tableName = "hive_table_pk_id_value", primaryKey = Some(Seq("id","value"))).register
+    val hiveTablePKidValueDO = MockDataObject("hive_table_pk_id_valueDO", tableName = "hive_table_pk_id_value", primaryKey = Some(Seq("id", "value"))).register
     hiveTablePKidValueDO.writeSparkDataFrame(dfNonUniqueWithNull)
 
     // actual: reading the table containing the PK violators
@@ -122,29 +126,29 @@ class PKViolatorsDataObjectTest extends FunSuite with BeforeAndAfter with SmartD
     // creating expected
     val rows_expectedWithData = Seq(
       // PKviolators of hiveTablePKidDO
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","2let")),Seq(TestKV("value","doublet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","2let")),Seq(TestKV("value","doublet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","3let")),Seq(TestKV("value","triplet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","3let")),Seq(TestKV("value","triplet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","3let")),Seq(TestKV("value","triplet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_idDO","mock","hive_table_pk_id","id STRING,value STRING",Seq(TestKV("id","4let")),Seq(TestKV("value","quatriplet")))
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "2let")), Seq(TestKV("value", "doublet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "2let")), Seq(TestKV("value", "doublet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "3let")), Seq(TestKV("value", "triplet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "3let")), Seq(TestKV("value", "triplet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "3let")), Seq(TestKV("value", "triplet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_idDO", "mock", "hive_table_pk_id", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet")))
     )
 
     // PKviolators of hiveTablePKidValueDO
     val rows_expectedWithOutData = Seq(
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","0let"),TestKV("value",null))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","2let"),TestKV("value","doublet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","2let"),TestKV("value","doublet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","3let"),TestKV("value","triplet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","3let"),TestKV("value","triplet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","3let"),TestKV("value","triplet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet"))),
-      TestData("hive_table_pk_id_valueDO","mock","hive_table_pk_id_value","id STRING,value STRING",Seq(TestKV("id","4let"),TestKV("value","quatriplet")))
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "0let"), TestKV("value", null))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "2let"), TestKV("value", "doublet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "2let"), TestKV("value", "doublet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "3let"), TestKV("value", "triplet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "3let"), TestKV("value", "triplet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "3let"), TestKV("value", "triplet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet"))),
+      TestData("hive_table_pk_id_valueDO", "mock", "hive_table_pk_id_value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet")))
     )
 
     val expected = SparkDataFrame(
@@ -153,14 +157,14 @@ class PKViolatorsDataObjectTest extends FunSuite with BeforeAndAfter with SmartD
 
     val resultat: Boolean = expected.isEqual(actual)
     if (!resultat) printFailedTestResult("pk violations for multiple sources",
-      Seq(customDO.getSparkDataFrame(),hiveTablePKidDO.getSparkDataFrame(),hiveTableNoPKDO.getSparkDataFrame(),hiveTablePKidValueDO.getSparkDataFrame()))(actual.inner)(expected.inner)
+      Seq(customDO.getSparkDataFrame(), hiveTablePKidDO.getSparkDataFrame(), hiveTableNoPKDO.getSparkDataFrame(), hiveTablePKidValueDO.getSparkDataFrame()))(actual.inner)(expected.inner)
     assert(resultat)
   }
-
 
 
 }
 
 case class TestKV(column_name: String, column_value: String)
+
 case class TestData(data_object_id: String, db: String, table: String, schema: String, key: Seq[TestKV], data: Seq[TestKV] = null)
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
@@ -29,11 +29,13 @@ import io.smartdatalake.workflow.connection.authMode.BasicAuthMode
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.sshd.server.SshServer
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import java.nio.file.{Files, Path}
 
-class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
+class SFtpFileRefDataObjectTest extends AnyFunSuite with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
 
   implicit val session: SparkSession = TestUtil.session
   implicit val registry: InstanceRegistry = new InstanceRegistry
@@ -49,7 +51,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
 
   override protected def beforeAll(): Unit = {
     sshd = TestUtil.setupSSHServer(sshPort, sshUser, sshPwd)
-    con = SFtpFileRefConnection( "con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshPwd))), ignoreHostKeyVerification = true, maxParallelConnections = 10)
+    con = SFtpFileRefConnection("con1", "localhost", sshPort, BasicAuthMode(Some(StringOrSecret(sshUser)), Some(StringOrSecret(sshPwd))), ignoreHostKeyVerification = true, maxParallelConnections = 10)
   }
 
   override protected def afterAll(): Unit = {
@@ -69,22 +71,22 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
 
   test("initialize") {
     // no partition
-    SFtpFileRefDataObject( "src1", "test", connectionId = "con1")
+    SFtpFileRefDataObject("src1", "test", connectionId = "con1")
 
     // partitions without layout
-    intercept[IllegalArgumentException](SFtpFileRefDataObject( "src1", "test", connectionId = "con1", partitions = Seq("test")))
+    intercept[IllegalArgumentException](SFtpFileRefDataObject("src1", "test", connectionId = "con1", partitions = Seq("test")))
 
     // layout without partitions
-    intercept[IllegalArgumentException](SFtpFileRefDataObject( "src1", "test", connectionId = "con1", partitionLayout = Some("%test%")))
+    intercept[IllegalArgumentException](SFtpFileRefDataObject("src1", "test", connectionId = "con1", partitionLayout = Some("%test%")))
 
     // layout with incomplete partitions
-    intercept[IllegalArgumentException](SFtpFileRefDataObject( "src1", "test", connectionId = "con1", partitions = Seq("test1"), partitionLayout = Some("%test%")))
+    intercept[IllegalArgumentException](SFtpFileRefDataObject("src1", "test", connectionId = "con1", partitions = Seq("test1"), partitionLayout = Some("%test%")))
 
     // with partitions
-    SFtpFileRefDataObject( "src1", "test", connectionId = "con1", partitions = Seq("test"), partitionLayout = Some("%test%"))
+    SFtpFileRefDataObject("src1", "test", connectionId = "con1", partitions = Seq("test"), partitionLayout = Some("%test%"))
 
     // with multiple partitions
-    SFtpFileRefDataObject( "src1", "test", connectionId = "con1", partitions = Seq("test1", "test2"), partitionLayout = Some("%test1%/abc/%test2%/def"))
+    SFtpFileRefDataObject("src1", "test", connectionId = "con1", partitions = Seq("test1", "test2"), partitionLayout = Some("%test1%/abc/%test2%/def"))
   }
 
   test("get FileRef's without partitions") {
@@ -96,7 +98,7 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(resourceFile).toFile)
 
     // setup DataObject
-    val sftpDO = SFtpFileRefDataObject( "src1", tempDir.resolve(ftpDir).toString.replace('\\','/'), connectionId = "con1")
+    val sftpDO = SFtpFileRefDataObject("src1", tempDir.resolve(ftpDir).toString.replace('\\', '/'), connectionId = "con1")
 
     // list files
     val fileRefs = sftpDO.getFileRefs(Seq())
@@ -114,11 +116,11 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(resourceFile).toFile)
 
     // setup DataObject
-    val sftpDO = SFtpFileRefDataObject( "src1"
-      , tempDir.resolve(ftpDir).toString.replace('\\','/')
+    val sftpDO = SFtpFileRefDataObject("src1"
+      , tempDir.resolve(ftpDir).toString.replace('\\', '/')
       , connectionId = "con1"
       , partitions = Seq("town", "year")
-      , partitionLayout = Some("AB_%town%_%year:[0-9]+%" ))
+      , partitionLayout = Some("AB_%town%_%year:[0-9]+%"))
     val partitionValuesExpected = Seq(PartitionValues(Map("town" -> "NYC", "year" -> "2019")))
 
     // list all files and extract partitions
@@ -151,11 +153,11 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(partitionDir).resolve(resourceFile).toFile)
 
     // setup DataObject
-    val sftpDO = SFtpFileRefDataObject( "src1"
-      , tempDir.resolve(ftpDir).toString.replace('\\','/')
+    val sftpDO = SFtpFileRefDataObject("src1"
+      , tempDir.resolve(ftpDir).toString.replace('\\', '/')
       , connectionId = "con1"
       , partitions = Seq("date", "town", "year")
-      , partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%" ))
+      , partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%"))
     val partitionValuesExpected = Seq(PartitionValues(Map("date" -> "20190101", "town" -> "NYC", "year" -> "2019")))
 
     // list all files and extract partitions
@@ -187,25 +189,25 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(resourceFile).toFile)
 
     // setup DataObject
-    val sftpDO = SFtpFileRefDataObject( "src1", tempDir.resolve(ftpDir).toString.replace('\\','/'), connectionId = "con1")
+    val sftpDO = SFtpFileRefDataObject("src1", tempDir.resolve(ftpDir).toString.replace('\\', '/'), connectionId = "con1")
     val fileRefs = sftpDO.getFileRefs(Seq())
     assert(fileRefs.map(_.fileName) == Seq(resourceFile))
 
     // rename 1
     sftpDO.renameFileHandleAlreadyExisting(
-      tempDir.resolve(ftpDir).resolve(resourceFile).toString.replace('\\','/'),
-      tempDir.resolve(ftpDir).resolve(resourceFile+".temp").toString.replace('\\','/')
+      tempDir.resolve(ftpDir).resolve(resourceFile).toString.replace('\\', '/'),
+      tempDir.resolve(ftpDir).resolve(resourceFile + ".temp").toString.replace('\\', '/')
     )
     val fileRefs1 = sftpDO.getFileRefs(Seq())
-    assert(fileRefs1.map(_.fileName) == Seq(resourceFile+".temp"))
+    assert(fileRefs1.map(_.fileName) == Seq(resourceFile + ".temp"))
 
     // copy data file again to ftp
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(ftpDir).resolve(resourceFile).toFile)
 
     // rename 2 -> handle already existing
     sftpDO.renameFileHandleAlreadyExisting(
-      tempDir.resolve(ftpDir).resolve(resourceFile).toString.replace('\\','/'),
-      tempDir.resolve(ftpDir).resolve(resourceFile+".temp").toString.replace('\\','/')
+      tempDir.resolve(ftpDir).resolve(resourceFile).toString.replace('\\', '/'),
+      tempDir.resolve(ftpDir).resolve(resourceFile + ".temp").toString.replace('\\', '/')
     )
     val fileRefs2 = sftpDO.getFileRefs(Seq())
     assert(fileRefs2.size == 2 && fileRefs2.map(_.fileName).forall(_.startsWith(resourceFile)))
@@ -257,8 +259,8 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     val resourceFile = "AB_NYC_2019.csv"
 
     // copy data file to ftp
-    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir1).resolve("2022").resolve(resourceFile+"1").toFile)
-    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir2).resolve("2022").resolve(resourceFile+"2").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir1).resolve("2022").resolve(resourceFile + "1").toFile)
+    TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(srcDir2).resolve("2022").resolve(resourceFile + "2").toFile)
 
     // setup DataObject
     val srcDO1 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir1).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("year"), partitionLayout = Some("%year%/"))
@@ -299,21 +301,21 @@ class SFtpFileRefDataObjectTest extends FunSuite with Matchers with BeforeAndAft
     TestUtil.copyResourceToFile(resourceFile, tempDir.resolve(tgtDir).resolve("20220201").resolve(resourceFile).toFile)
 
     // setup DataObject
-    val srcDO1 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir1).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("date","town","year"), partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%"))
-    val tgtDO = SFtpFileRefDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("date","town","year"), partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%"))
+    val srcDO1 = SFtpFileRefDataObject("src1", tempDir.resolve(srcDir1).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("date", "town", "year"), partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%"))
+    val tgtDO = SFtpFileRefDataObject("tgt1", tempDir.resolve(tgtDir).toString.replace('\\', '/'), connectionId = "con1", partitions = Seq("date", "town", "year"), partitionLayout = Some("%date%/AB_%town%_%year:[0-9]+%"))
 
     // src1 file transfer
     val filetransfer1 = new StreamFileTransfer(srcDO1, tgtDO)
     val srcFileRefs1 = srcDO1.getFileRefs(Seq())
-    assert(srcFileRefs1.map(f => srcDO1.relativizePath(f.fullPath)).toSet==Set("20220101/AB_NYC_2019.csv2"))
+    assert(srcFileRefs1.map(f => srcDO1.relativizePath(f.fullPath)).toSet == Set("20220101/AB_NYC_2019.csv2"))
     val tgtFileRefs1 = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefs1.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_BN_2019.csv","20220101/AB_NYC_2019.csv1","20220201/AB_NYC_2019.csv"))
+    assert(tgtFileRefs1.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_BN_2019.csv", "20220101/AB_NYC_2019.csv1", "20220201/AB_NYC_2019.csv"))
     val fileRefPairs1 = tgtDO.translateFileRefs(srcFileRefs1, Some("\\.csv.*".r)) // keep only filetype from source filename, the rest is handled as partition values...
     tgtDO.startWritingOutputStreams(fileRefPairs1.map(_.tgt.partitionValues))
     filetransfer1.exec(fileRefPairs1)
-    val tgtFileRefs1after = tgtDO.getFileRefs(Seq(PartitionValues(Map("date"->"20220101","town"->"NYC","year"->"2019"))))
+    val tgtFileRefs1after = tgtDO.getFileRefs(Seq(PartitionValues(Map("date" -> "20220101", "town" -> "NYC", "year" -> "2019"))))
     assert(tgtFileRefs1after.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_NYC_2019.csv2"))
     val tgtFileRefsFinal = tgtDO.getFileRefs(Seq())
-    assert(tgtFileRefsFinal.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_BN_2019.csv","20220101/AB_NYC_2019.csv2","20220201/AB_NYC_2019.csv"))
+    assert(tgtFileRefsFinal.map(f => tgtDO.relativizePath(f.fullPath)).toSet == Set("20220101/AB_BN_2019.csv", "20220101/AB_NYC_2019.csv2", "20220201/AB_NYC_2019.csv"))
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectSchemaBehavior.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectSchemaBehavior.scala
@@ -25,21 +25,23 @@ import io.smartdatalake.workflow.{ActionPipelineContext, SchemaViolationExceptio
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import java.io.File
 import java.nio.file.Files
 
-trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
+trait SparkFileDataObjectSchemaBehavior {
+  this: AnyFunSuite with Matchers =>
 
   def readNonExistingSources(createDataObject: (String, Option[StructType]) => DataObject with CanCreateDataFrame with CanCreateSparkDataFrame with UserDefinedSchema,
-                                     fileExtension: String = null)
-                                         (implicit context: ActionPipelineContext): Unit = {
+                             fileExtension: String = null)
+                            (implicit context: ActionPipelineContext): Unit = {
 
     test("It is not possible to read from an non-existing file without user-defined-schema.") {
       val path = tempFilePath(fileExtension)
       val dataObj = createDataObject(path, None)
-      an [IllegalArgumentException] should be thrownBy dataObj.getSparkDataFrame()
+      an[IllegalArgumentException] should be thrownBy dataObj.getSparkDataFrame()
     }
   }
 
@@ -49,8 +51,8 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
     test("Reading from an empty file with user-defined schema results in an empty data frame.") {
       val schema = Seq(
-          StructField("header1", StringType, nullable = true),
-          StructField("header2", IntegerType, nullable = true)
+        StructField("header1", StringType, nullable = true),
+        StructField("header2", IntegerType, nullable = true)
       )
 
       val path = tempFilePath(fileExtension)
@@ -72,8 +74,8 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
   }
 
   def readEmptySourcesWithEmbeddedSchema(createDataObject: (String, Option[StructType]) => DataObject with CanCreateDataFrame with CanCreateSparkDataFrame with UserDefinedSchema,
-                       fileExtension: String = null)
-                      (implicit context: ActionPipelineContext): Unit = {
+                                         fileExtension: String = null)
+                                        (implicit context: ActionPipelineContext): Unit = {
 
     test("Reading an empty file creates an empty data frame with the user-defined schema.") {
       val userSchema = Seq(
@@ -121,7 +123,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
   def validateSchemaMinOnWrite(createDataObject: (String, Option[StructType], Option[StructType]) => DataObject with CanWriteSparkDataFrame,
                                fileExtension: String = null)
-                              (implicit context: ActionPipelineContext) : Unit = {
+                              (implicit context: ActionPipelineContext): Unit = {
 
     implicit val session: SparkSession = context.sparkSession
     import session.implicits._
@@ -146,7 +148,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -166,7 +168,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -180,14 +182,14 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         ).toDF("foo", "value")
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           dataObj.writeSparkDataFrame(df, partitionValues = Seq.empty)
         }
         println(thrown.getMessage)
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -201,14 +203,14 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         ).toDF("id", "value")
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           dataObj.writeSparkDataFrame(df, partitionValues = Seq.empty)
         }
         println(thrown.getMessage)
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -222,14 +224,14 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         ).toDF("id")
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           dataObj.writeSparkDataFrame(df, partitionValues = Seq.empty)
         }
         println(thrown.getMessage)
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -240,7 +242,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         val df = session.emptyDataFrame
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           try {
             dataObj.writeSparkDataFrame(df, partitionValues = Seq.empty)
           } catch {
@@ -251,15 +253,15 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
   }
 
   def validateSchemaMinOnRead(createDataObject: (String, Option[StructType], Option[StructType]) => DataObject with CanCreateDataFrame with CanCreateSparkDataFrame,
-                               fileExtension: String = null)
-                              (implicit context: ActionPipelineContext) : Unit = {
+                              fileExtension: String = null)
+                             (implicit context: ActionPipelineContext): Unit = {
 
     implicit val session: SparkSession = context.sparkSession
     import session.implicits._
@@ -285,7 +287,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -306,7 +308,7 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -321,14 +323,14 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         createFile(path, data = df)
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           dataObj.getSparkDataFrame()
         }
         println(thrown.getMessage)
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -343,14 +345,14 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         createFile(path, data = df)
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           dataObj.getSparkDataFrame()
         }
         println(thrown.getMessage)
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -365,14 +367,14 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         createFile(path, data = df)
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           dataObj.getSparkDataFrame()
         }
         println(thrown.getMessage)
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }
@@ -384,18 +386,18 @@ trait SparkFileDataObjectSchemaBehavior { this: FunSuite with Matchers =>
         try {
           createFile(path, data = df)
         } catch {
-          case _: AnalysisException => succeed //data frame writer does not support empty schemata
+          case _: AnalysisException => //data frame writer does not support empty schemata
         }
         val dataObj = createDataObject(path, Some(df.schema), Some(StructType(schemaMin)))
 
-        val thrown = the [SchemaViolationException] thrownBy {
+        val thrown = the[SchemaViolationException] thrownBy {
           dataObj.getSparkDataFrame()
         }
         println(thrown.getMessage)
 
       } finally {
         val f = new File(path)
-        if(f.exists())
+        if (f.exists())
           FileUtils.forceDelete(f)
       }
     }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/expectations/UniqueKeyExpectationTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/expectations/UniqueKeyExpectationTest.scala
@@ -29,11 +29,13 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.expectation.{ExpectationScope, ExpectationValidationException, UniqueKeyExpectation}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
-class UniqueKeyExpectationTest extends FunSuite with BeforeAndAfter {
+class UniqueKeyExpectationTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
@@ -48,14 +50,14 @@ class UniqueKeyExpectationTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
     val tgtDO = MockDataObject("tgt1", primaryKey = Some(Seq("lastname")), saveMode = SDLSaveMode.Append,
-      expectations = Seq(UniqueKeyExpectation("primaryKeyTest", approximate=false))
+      expectations = Seq(UniqueKeyExpectation("primaryKeyTest", approximate = false))
     ).register
 
     // prepare
-      val action1 = CopyAction("ca", srcDO.id, tgtDO.id)
-      val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
-      srcDO.writeSparkDataFrame(l1, Seq())
-      val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    val action1 = CopyAction("ca", srcDO.id, tgtDO.id)
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1, Seq())
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
 
     // start first load -> should succeed
     {
@@ -70,7 +72,7 @@ class UniqueKeyExpectationTest extends FunSuite with BeforeAndAfter {
     }
 
     // prepare source with duplicate record
-    val l2 = Seq(("jonson","rob",5),("jonson","bob",3)).toDF("lastname", "firstname", "rating")
+    val l2 = Seq(("jonson", "rob", 5), ("jonson", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l2, Seq())
 
     // start 3nd load -> should fail because of duplicate records processed in job
@@ -83,13 +85,13 @@ class UniqueKeyExpectationTest extends FunSuite with BeforeAndAfter {
   test("succeed and fail primary key validation with scope=All") {
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
-    val tgtDO = MockDataObject("tgt1", primaryKey=Some(Seq("lastname")), saveMode=SDLSaveMode.Append,
-      expectations = Seq(UniqueKeyExpectation("primaryKeyTest", approximate=false, scope=ExpectationScope.All))
+    val tgtDO = MockDataObject("tgt1", primaryKey = Some(Seq("lastname")), saveMode = SDLSaveMode.Append,
+      expectations = Seq(UniqueKeyExpectation("primaryKeyTest", approximate = false, scope = ExpectationScope.All))
     ).register
 
     // prepare
     val action1 = CopyAction("ca", srcDO.id, tgtDO.id)
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
     srcDO.writeSparkDataFrame(l1, Seq())
     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/expectations/ValidateOnReadTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/expectations/ValidateOnReadTest.scala
@@ -29,11 +29,13 @@ import io.smartdatalake.workflow.dataobject.expectation.ExpectationScope.Expecta
 import io.smartdatalake.workflow.dataobject.expectation.{ExpectationScope, ExpectationValidationException, SQLExpectation}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
-class ValidateOnReadTest extends FunSuite with BeforeAndAfter {
+class ValidateOnReadTest extends AnyFunSuite with BeforeAndAfter {
 
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
@@ -56,7 +58,7 @@ class ValidateOnReadTest extends FunSuite with BeforeAndAfter {
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
     val tgt1DO = MockDataObject("tgt1",
-      expectations = Seq(SQLExpectation("countTest", scope=scope, aggExpression = "count(lastname)", expectation = Some("> 5")))
+      expectations = Seq(SQLExpectation("countTest", scope = scope, aggExpression = "count(lastname)", expectation = Some("> 5")))
     ).register
     val tgt2DO = MockDataObject("tgt2").register
 
@@ -71,7 +73,7 @@ class ValidateOnReadTest extends FunSuite with BeforeAndAfter {
     assert(instanceRegistry.shouldValidateDataObjectOnRead(srcDO.id))
     assert(!instanceRegistry.shouldValidateDataObjectOnRead(tgt1DO.id))
 
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
 
     // action2 should succeed, because tgt1 expectations is not validated on read
     tgt1DO.writeSparkDataFrame(l1)
@@ -90,7 +92,7 @@ class ValidateOnReadTest extends FunSuite with BeforeAndAfter {
   def testValidateExpectationsOnReadIfThereIsNoDataFrameActionHavingThisDataObjectAsOutput(scope: ExpectationScope): Unit = {
     // setup DataObjects
     val srcDO = MockDataObject("src1",
-      expectations = Seq(SQLExpectation("countTest", scope=scope, aggExpression = "count(lastname)", expectation = Some("> 5")))
+      expectations = Seq(SQLExpectation("countTest", scope = scope, aggExpression = "count(lastname)", expectation = Some("> 5")))
     ).register
     val tgt1DO = MockDataObject("tgt1").register
 
@@ -103,7 +105,7 @@ class ValidateOnReadTest extends FunSuite with BeforeAndAfter {
     assert(instanceRegistry.shouldValidateDataObjectOnRead(srcDO.id))
     assert(!instanceRegistry.shouldValidateDataObjectOnRead(tgt1DO.id))
 
-    val l1 = Seq(("jonson","rob",5),("doe","bob",3)).toDF("lastname", "firstname", "rating")
+    val l1 = Seq(("jonson", "rob", 5), ("doe", "bob", 3)).toDF("lastname", "firstname", "rating")
 
     // action1 will fail, because src1 expectations is validated on read
     srcDO.writeSparkDataFrame(l1)

--- a/sdl-debezium/pom.xml
+++ b/sdl-debezium/pom.xml
@@ -175,8 +175,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.scalacheck</groupId>
-      <artifactId>scalacheck_${scala.minor.version}</artifactId>
+      <groupId>org.scalatestplus</groupId>
+      <artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/sdl-deltalake/pom.xml
+++ b/sdl-deltalake/pom.xml
@@ -122,8 +122,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scalacheck</groupId>
-			<artifactId>scalacheck_${scala.minor.version}</artifactId>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- sdl-core test utils -->

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
@@ -27,16 +27,18 @@ import io.smartdatalake.workflow.dataobject.DeltaLakeTestUtils.deltaDb
 import io.smartdatalake.workflow.dataobject.{DeltaLakeTableDataObject, DeltaLakeTestUtils, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
-class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
+class DeltaLakeDeduplicateWithMergeActionTest extends AnyFunSuite with BeforeAndAfter {
 
   // set additional spark options for delta lake
-  protected implicit val session : SparkSession = DeltaLakeTestUtils.session
+  protected implicit val session: SparkSession = DeltaLakeTestUtils.session
+
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("test")
@@ -53,8 +55,8 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
-    val tgtTable = Table(Some(deltaDb), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = DeltaLakeTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, allowSchemaEvolution = true)
+    val tgtTable = Table(Some(deltaDb), "deduplicate_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, allowSchemaEvolution = true)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
@@ -117,8 +119,8 @@ class DeltaLakeDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAft
 
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
-    val tgtTable = Table(Some(deltaDb), "deduplicate_output", None, Some(Seq("lastname","firstname")))
-    val tgtDO = DeltaLakeTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable, allowSchemaEvolution = true)
+    val tgtTable = Table(Some(deltaDb), "deduplicate_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, allowSchemaEvolution = true)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeHistorizeWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeHistorizeWithMergeActionTest.scala
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
- package io.smartdatalake.workflow.action
+package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions
@@ -28,412 +28,414 @@ import io.smartdatalake.workflow.dataobject.DeltaLakeTestUtils.deltaDb
 import io.smartdatalake.workflow.dataobject.{DeltaLakeTableDataObject, DeltaLakeTestUtils, HiveTableDataObject, Table}
 import io.smartdatalake.workflow.{ActionDAGRun, ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
- class DeltaLakeHistorizeWithMergeActionTest extends FunSuite with BeforeAndAfter {
+class DeltaLakeHistorizeWithMergeActionTest extends AnyFunSuite with BeforeAndAfter {
 
-   // set additional spark options for delta lake
-   protected implicit val session: SparkSession = DeltaLakeTestUtils.session
-   import session.implicits._
+  // set additional spark options for delta lake
+  protected implicit val session: SparkSession = DeltaLakeTestUtils.session
 
-   private val tempDir = Files.createTempDirectory("test")
-   private val tempPath = tempDir.toAbsolutePath.toString
+  import session.implicits._
 
-   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  private val tempDir = Files.createTempDirectory("test")
+  private val tempPath = tempDir.toAbsolutePath.toString
 
-   before {
-     instanceRegistry.clear()
-   }
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
 
-   test("historize load mergeModeEnable") {
+  before {
+    instanceRegistry.clear()
+  }
 
-     val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  test("historize load mergeModeEnable") {
 
-     // setup DataObjects
-     val srcDO = MockDataObject("src1").register
-     val tgtTable = Table(Some(deltaDb), "historize_output", None, Some(Seq("lastname","firstname")))
-     val tgtDO = DeltaLakeTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
-     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1, Seq())(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // setup DataObjects
+    val srcDO = MockDataObject("src1").register
+    val tgtTable = Table(Some(deltaDb), "historize_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable)
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     {
-       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp))
-         .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1, Seq())(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2nd load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
-     val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2, Seq())(context1)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    {
+      val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp))
+        .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
+    val l2 = Seq(("doe", "john", 10)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2, Seq())(context1)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // prepare & start 3rd load with schema evolution
-     val refTimestamp3 = LocalDateTime.now()
-     val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
-     val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
-     instanceRegistry.register(tgtDOwithSchemaEvolution)
-     val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true)
-     val l3 = Seq(("doe","john",10,"test")).toDF("lastname", "firstname", "rating", "test")
-     srcDO.writeSparkDataFrame(l3, Seq())(context3)
-     val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
-     action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
-     action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
-     action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
-     action3.exec(Seq(srcSubFeed3))(context3)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
-         ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context3)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
-       assert(resultat)
-     }
-   }
+    // prepare & start 3rd load with schema evolution
+    val refTimestamp3 = LocalDateTime.now()
+    val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
+    val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
+    instanceRegistry.register(tgtDOwithSchemaEvolution)
+    val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true)
+    val l3 = Seq(("doe", "john", 10, "test")).toDF("lastname", "firstname", "rating", "test")
+    srcDO.writeSparkDataFrame(l3, Seq())(context3)
+    val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
+    action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
+    action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
+    action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
+    action3.exec(Seq(srcSubFeed3))(context3)
 
-   test("historize load mergeModeEnable CDC") {
+    {
+      val expected = Seq(
+        ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
+        ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context3)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
+      assert(resultat)
+    }
+  }
 
-     val context = TestUtil.getDefaultActionPipelineContext
+  test("historize load mergeModeEnable CDC") {
 
-     // setup DataObjects
-     val srcDO = MockDataObject("src1").register
-     val tgtTable = Table(Some(deltaDb), "historize_output", None, Some(Seq("lastname","firstname")))
-     val tgtDO = DeltaLakeTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    val context = TestUtil.getDefaultActionPipelineContext
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l1 = Seq(("doe","john",5,"new"), ("pan","peter",5,"new")).toDF("lastname", "firstname", "rating", "operation")
-     srcDO.writeSparkDataFrame(l1, Seq())(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // setup DataObjects
+    val srcDO = MockDataObject("src1").register
+    val tgtTable = Table(Some(deltaDb), "historize_output", None, Some(Seq("lastname", "firstname")))
+    val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable)
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l1 = Seq(("doe", "john", 5, "new"), ("pan", "peter", 5, "new")).toDF("lastname", "firstname", "rating", "operation")
+    srcDO.writeSparkDataFrame(l1, Seq())(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2nd load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l2 = Seq(("doe","john",10,"updated"), ("pan","peter",5,"deleted")).toDF("lastname", "firstname", "rating", "operation")
-     srcDO.writeSparkDataFrame(l2, Seq())(context1)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan","peter", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l2 = Seq(("doe", "john", 10, "updated"), ("pan", "peter", 5, "deleted")).toDF("lastname", "firstname", "rating", "operation")
+    srcDO.writeSparkDataFrame(l2, Seq())(context1)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // prepare & start 3rd load with schema evolution
-     val refTimestamp3 = LocalDateTime.now()
-     val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
-     val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
-     instanceRegistry.register(tgtDOwithSchemaEvolution)
-     val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l3 = Seq(("doe","john",10,"test","updated")).toDF("lastname", "firstname", "rating", "test", "operation")
-     srcDO.writeSparkDataFrame(l3, Seq())(context3)
-     val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
-     action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
-     action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
-     action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
-     action3.exec(Seq(srcSubFeed3))(context3)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
-         ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan","peter", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L)))
-       ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context3)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
-       assert(resultat)
-     }
-   }
+    // prepare & start 3rd load with schema evolution
+    val refTimestamp3 = LocalDateTime.now()
+    val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
+    val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
+    instanceRegistry.register(tgtDOwithSchemaEvolution)
+    val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l3 = Seq(("doe", "john", 10, "test", "updated")).toDF("lastname", "firstname", "rating", "test", "operation")
+    srcDO.writeSparkDataFrame(l3, Seq())(context3)
+    val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
+    action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
+    action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
+    action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
+    action3.exec(Seq(srcSubFeed3))(context3)
 
-   test("switch from incremental cdc historization to incremental historization on existing dataframe") {
-     // setup DataObjects
-     val srcTable = Table(Some(deltaDb), "historize_input")
-     val srcPath = tempPath + s"/${srcTable.fullName}"
-     val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-     instanceRegistry.register(srcDO)
-     val tgtTable = Table(Some(deltaDb), "historize_output", primaryKey = Some(Seq("id")))
-     val tgtPath = tempPath + s"/${tgtTable.fullName}"
-     val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
-     val context = TestUtil.getDefaultActionPipelineContext
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
+        ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L)))
+      ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context3)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
+      assert(resultat)
+    }
+  }
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id,
-       mergeModeEnable = true,
-       mergeModeCDCColumn = Some("operation"),
-       mergeModeCDCDeletedValue = Some("deleted"),
-     )
+  test("switch from incremental cdc historization to incremental historization on existing dataframe") {
+    // setup DataObjects
+    val srcTable = Table(Some(deltaDb), "historize_input")
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgtTable = Table(Some(deltaDb), "historize_output", primaryKey = Some(Seq("id")))
+    val tgtPath = tempPath + s"/${tgtTable.fullName}"
+    val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
+    val context = TestUtil.getDefaultActionPipelineContext
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     val l1 = Seq((1, "doe", "john", 5, "new")).toDF("id", "lastname", "firstname", "rating", "operation")
-     srcDO.writeSparkDataFrame(l1)(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id,
+      mergeModeEnable = true,
+      mergeModeCDCColumn = Some("operation"),
+      mergeModeCDCDeletedValue = Some("deleted"),
+    )
 
-     // 1. expectation schema should not have dl_hash column
-     assert(!session.table(s"${tgtTable.fullName}").columns.contains("dl_hash"))
+    val l1 = Seq((1, "doe", "john", 5, "new")).toDF("id", "lastname", "firstname", "rating", "operation")
+    srcDO.writeSparkDataFrame(l1)(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2st load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id,
-       mergeModeEnable = true
-     )
+    // 1. expectation schema should not have dl_hash column
+    assert(!session.table(s"${tgtTable.fullName}").columns.contains("dl_hash"))
 
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed))(context2)
+    // prepare & start 2st load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id,
+      mergeModeEnable = true
+    )
 
-     // 2. expectation schema should have dl_hash column
-     assert(session.table(s"${tgtTable.fullName}").columns.contains("dl_hash"))
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed))(context2)
 
-   }
+    // 2. expectation schema should have dl_hash column
+    assert(session.table(s"${tgtTable.fullName}").columns.contains("dl_hash"))
 
-   test("activate merge mode on existing dataframe no null dl_hash") {
+  }
 
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input")
-     val srcPath = tempPath + s"/${srcTable.fullName}"
-     val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-     instanceRegistry.register(srcDO)
-     val tgtTable = Table(Some("default"), "historize_output", primaryKey = Some(Seq("id")))
-     val tgtPath = tempPath + s"/${tgtTable.fullName}"
-     val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
-     val context = TestUtil.getDefaultActionPipelineContext
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+  test("activate merge mode on existing dataframe no null dl_hash") {
 
-     // prepare & start 1st load without merge mode
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id
-     )
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input")
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgtTable = Table(Some("default"), "historize_output", primaryKey = Some(Seq("id")))
+    val tgtPath = tempPath + s"/${tgtTable.fullName}"
+    val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
+    val context = TestUtil.getDefaultActionPipelineContext
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1)(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // prepare & start 1st load without merge mode
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id
+    )
 
-     // 1. expectation schema should not have dl_hash column
-     assert(!tgtDO.getSparkDataFrame()(context1).columns.contains("dl_hash"))
+    val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1)(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2st load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id,
-       mergeModeEnable = true
-     )
+    // 1. expectation schema should not have dl_hash column
+    assert(!tgtDO.getSparkDataFrame()(context1).columns.contains("dl_hash"))
 
-     val l2 = Seq((1, "doe", "john", 4)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2)(context2)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    // prepare & start 2st load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id,
+      mergeModeEnable = true
+    )
 
-     // expectation dl_hash should not have null values
-     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
+    val l2 = Seq((1, "doe", "john", 4)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2)(context2)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-
-   }
-
-   test("update hash on existing non updated rows") {
-
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input")
-     val srcPath = tempPath + s"/${srcTable.fullName}"
-     val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-     instanceRegistry.register(srcDO)
-     val tgtTable = Table(Some("default"), "historize_output", primaryKey = Some(Seq("id")))
-     val tgtPath = tempPath + s"/${tgtTable.fullName}"
-     val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
-     val context = TestUtil.getDefaultActionPipelineContext
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
-
-     // prepare & start 1st load with merge mode
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id)
-
-     val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1)(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
-
-     // prepare & start 2st load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id,
-       mergeModeEnable = true
-     )
-
-     val l2 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2)(context2)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
-
-     // expectation dl_hash should not have null values
-     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
+    // expectation dl_hash should not have null values
+    assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
 
 
-   }
+  }
 
-   test("historize load mergeModeEnable and copy action") {
+  test("update hash on existing non updated rows") {
 
-     val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input")
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgtTable = Table(Some("default"), "historize_output", primaryKey = Some(Seq("id")))
+    val tgtPath = tempPath + s"/${tgtTable.fullName}"
+    val tgtDO = DeltaLakeTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
+    val context = TestUtil.getDefaultActionPipelineContext
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     // setup DataObjects
-     val srcDO = MockDataObject("src1").register
-     val tgt1Table = Table(Some(deltaDb), "historize_output1", None, Some(Seq("lastname", "firstname")))
-     val tgt1DO = DeltaLakeTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), table = tgt1Table)
-     tgt1DO.dropTable(context)
-     instanceRegistry.register(tgt1DO)
-     val tgt2Table = Table(Some(deltaDb), "copy_output2", None, Some(Seq("lastname", "firstname")))
-     val tgt2DO = DeltaLakeTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), table = tgt2Table)
-     tgt2DO.dropTable(context)
-     instanceRegistry.register(tgt2DO)
+    // prepare & start 1st load with merge mode
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id)
 
-     // define DAG
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", srcDO.id, tgt1DO.id, mergeModeEnable = true)
-     instanceRegistry.register(action1)
-     val action2 = CopyAction("cb", tgt1DO.id, tgt2DO.id)
-     instanceRegistry.register(action2)
-     val dag = ActionDAGRun(Seq(action1, action2))(context1)
+    val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1)(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // start first load
-     val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1, Seq())(context1)
-     dag.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     dag.init(context1.copy(phase = ExecutionPhase.Init))
-     val r1 = dag.exec(context1)
+    // prepare & start 2st load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id,
+      mergeModeEnable = true
+    )
 
-     assert(!tgt1DO.getSparkDataFrame()(context1).schema.fieldNames.contains("dl_operation"))
-     assert(!r1.head.isSkipped)
+    val l2 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2)(context2)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // start second load -> no data
-     dag.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     dag.init(context1.copy(phase = ExecutionPhase.Init))
-     val r2 = dag.exec(context1)
+    // expectation dl_hash should not have null values
+    assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
 
-     assert(r2.head.isSkipped)
 
-     // start third load
-     val l2 = Seq(("papa", "john", 5)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2, Seq())(context1)
-     dag.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     dag.init(context1.copy(phase = ExecutionPhase.Init))
-     val r3 = dag.exec(context1)
+  }
 
-     assert(!r3.head.isSkipped)
-   }
- }
+  test("historize load mergeModeEnable and copy action") {
+
+    val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+
+    // setup DataObjects
+    val srcDO = MockDataObject("src1").register
+    val tgt1Table = Table(Some(deltaDb), "historize_output1", None, Some(Seq("lastname", "firstname")))
+    val tgt1DO = DeltaLakeTableDataObject("tgt1", Some(tempPath + s"/${tgt1Table.fullName}"), table = tgt1Table)
+    tgt1DO.dropTable(context)
+    instanceRegistry.register(tgt1DO)
+    val tgt2Table = Table(Some(deltaDb), "copy_output2", None, Some(Seq("lastname", "firstname")))
+    val tgt2DO = DeltaLakeTableDataObject("tgt2", Some(tempPath + s"/${tgt2Table.fullName}"), table = tgt2Table)
+    tgt2DO.dropTable(context)
+    instanceRegistry.register(tgt2DO)
+
+    // define DAG
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", srcDO.id, tgt1DO.id, mergeModeEnable = true)
+    instanceRegistry.register(action1)
+    val action2 = CopyAction("cb", tgt1DO.id, tgt2DO.id)
+    instanceRegistry.register(action2)
+    val dag = ActionDAGRun(Seq(action1, action2))(context1)
+
+    // start first load
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1, Seq())(context1)
+    dag.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    dag.init(context1.copy(phase = ExecutionPhase.Init))
+    val r1 = dag.exec(context1)
+
+    assert(!tgt1DO.getSparkDataFrame()(context1).schema.fieldNames.contains("dl_operation"))
+    assert(!r1.head.isSkipped)
+
+    // start second load -> no data
+    dag.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    dag.init(context1.copy(phase = ExecutionPhase.Init))
+    val r2 = dag.exec(context1)
+
+    assert(r2.head.isSkipped)
+
+    // start third load
+    val l2 = Seq(("papa", "john", 5)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2, Seq())(context1)
+    dag.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    dag.init(context1.copy(phase = ExecutionPhase.Init))
+    val r3 = dag.exec(context1)
+
+    assert(!r3.head.isSkipped)
+  }
+}

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObjectTest.scala
@@ -34,12 +34,13 @@ import io.smartdatalake.workflow.dataobject.expectation.SQLExpectation
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, ProcessingLogicException}
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.scalatest.Matchers.convertToAnyShouldWrapper
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class DeltaLakeTableDataObjectTest extends FunSuite with BeforeAndAfter with BeforeAndAfterAll {
+class DeltaLakeTableDataObjectTest extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
 
   // set additional spark options for delta lake
   protected implicit val session : SparkSession = DeltaLakeTestUtils.session

--- a/sdl-iceberg/pom.xml
+++ b/sdl-iceberg/pom.xml
@@ -145,8 +145,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scalacheck</groupId>
-			<artifactId>scalacheck_${scala.minor.version}</artifactId>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- sdl-core test utils -->

--- a/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/action/IcebergCustomDataFrameTest.scala
+++ b/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/action/IcebergCustomDataFrameTest.scala
@@ -28,11 +28,12 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.workflow.dataobject.{IcebergTableDataObject, IcebergTestUtils, Table}
 import io.smartdatalake.workflow.{ActionDAGRun, ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class IcebergCustomDataFrameTest extends FunSuite with BeforeAndAfter {
+class IcebergCustomDataFrameTest extends AnyFunSuite with BeforeAndAfter {
 
   // set additional spark options for delta lake
   protected implicit val session: SparkSession = IcebergTestUtils.session
@@ -44,8 +45,8 @@ class IcebergCustomDataFrameTest extends FunSuite with BeforeAndAfter {
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   implicit val contextInit: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
-  val contextPrep = contextInit.copy(phase = ExecutionPhase.Prepare)
-  val contextExec = contextInit.copy(phase = ExecutionPhase.Exec) // note that mutable Map dataFrameReuseStatistics is shared between contextInit & contextExec like this!
+  private val contextPrep = contextInit.copy(phase = ExecutionPhase.Prepare)
+  private val contextExec = contextInit.copy(phase = ExecutionPhase.Exec) // note that mutable Map dataFrameReuseStatistics is shared between contextInit & contextExec like this!
   Environment._globalConfig = GlobalConfig()
 
   before {

--- a/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/action/IcebergDeduplicateWithMergeActionTest.scala
+++ b/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/action/IcebergDeduplicateWithMergeActionTest.scala
@@ -25,16 +25,18 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.{IcebergTableDataObject, IcebergTestUtils, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
-class IcebergDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter {
+class IcebergDeduplicateWithMergeActionTest extends AnyFunSuite with BeforeAndAfter {
 
   // set additional spark options for delta lake
-  protected implicit val session : SparkSession = IcebergTestUtils.session
+  protected implicit val session: SparkSession = IcebergTestUtils.session
+
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("test")
@@ -51,8 +53,8 @@ class IcebergDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter
 
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
-    val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "deduplicate_output", primaryKey = Some(Seq("lastname","firstname")))
-    val tgtDO = IcebergTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
+    val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "deduplicate_output", primaryKey = Some(Seq("lastname", "firstname")))
+    val tgtDO = IcebergTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 
@@ -121,8 +123,8 @@ class IcebergDeduplicateWithMergeActionTest extends FunSuite with BeforeAndAfter
     // setup DataObjects
     val srcDO = MockDataObject("src1").register
     instanceRegistry.register(srcDO)
-    val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "deduplicate_output", primaryKey = Some(Seq("lastname","firstname")))
-    val tgtDO = IcebergTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
+    val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "deduplicate_output", primaryKey = Some(Seq("lastname", "firstname")))
+    val tgtDO = IcebergTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable)
     tgtDO.dropTable
     instanceRegistry.register(tgtDO)
 

--- a/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/action/IcebergHistorizeWithMergeActionTest.scala
+++ b/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/action/IcebergHistorizeWithMergeActionTest.scala
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
- package io.smartdatalake.workflow.action
+package io.smartdatalake.workflow.action
 
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions
@@ -27,304 +27,306 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.{HiveTableDataObject, IcebergTableDataObject, IcebergTestUtils, Table}
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
- class IcebergHistorizeWithMergeActionTest extends FunSuite with BeforeAndAfter {
+class IcebergHistorizeWithMergeActionTest extends AnyFunSuite with BeforeAndAfter {
 
-   // set additional spark options for delta lake
-   protected implicit val session: SparkSession = IcebergTestUtils.session
-   import session.implicits._
+  // set additional spark options for delta lake
+  protected implicit val session: SparkSession = IcebergTestUtils.session
 
-   private val tempDir = Files.createTempDirectory("test")
-   private val tempPath = tempDir.toAbsolutePath.toString
+  import session.implicits._
 
-   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  private val tempDir = Files.createTempDirectory("test")
+  private val tempPath = tempDir.toAbsolutePath.toString
 
-   session.sql("CREATE DATABASE IF NOT EXISTS iceberg1.default")
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
 
-   before {
-     instanceRegistry.clear()
-   }
+  session.sql("CREATE DATABASE IF NOT EXISTS iceberg1.default")
 
-   test("historize load mergeModeEnable") {
+  before {
+    instanceRegistry.clear()
+  }
 
-     val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
+  test("historize load mergeModeEnable") {
 
-     // setup DataObjects
-     val srcDO = MockDataObject("src1").register
-     val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "historize_output", primaryKey = Some(Seq("lastname","firstname")))
-     val tgtDO = IcebergTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
-     val l1 = Seq(("doe","john",5)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1, Seq())(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // setup DataObjects
+    val srcDO = MockDataObject("src1").register
+    val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "historize_output", primaryKey = Some(Seq("lastname", "firstname")))
+    val tgtDO = IcebergTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable)
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     {
-       val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp))
-         .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true)
+    val l1 = Seq(("doe", "john", 5)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1, Seq())(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2nd load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
-     val l2 = Seq(("doe","john",10)).toDF("lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2, Seq())(context1)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    {
+      val expected = Seq(("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp))
+        .toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context2)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true)
+    val l2 = Seq(("doe", "john", 10)).toDF("lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2, Seq())(context1)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // prepare & start 3rd load with schema evolution
-     // Note that this is not possible with DeltaLake 1.x, as schema evolution with mergeStmt.insertExpr is not properly supported.
-     // See also last two tests in IcebergTableDataObjectTest.
-     val refTimestamp3 = LocalDateTime.now()
-     val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
-     val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
-     instanceRegistry.register(tgtDOwithSchemaEvolution)
-     val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true)
-     val l3 = Seq(("doe","john",10,"test")).toDF("lastname", "firstname", "rating", "test")
-     srcDO.writeSparkDataFrame(l3, Seq())(context3)
-     val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
-     action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
-     action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
-     action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
-     action3.exec(Seq(srcSubFeed3))(context3)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context2)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
-         ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context3)
-         .drop(Historization.historizeHashColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
-       assert(resultat)
-     }
-   }
+    // prepare & start 3rd load with schema evolution
+    // Note that this is not possible with DeltaLake 1.x, as schema evolution with mergeStmt.insertExpr is not properly supported.
+    // See also last two tests in IcebergTableDataObjectTest.
+    val refTimestamp3 = LocalDateTime.now()
+    val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
+    val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
+    instanceRegistry.register(tgtDOwithSchemaEvolution)
+    val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true)
+    val l3 = Seq(("doe", "john", 10, "test")).toDF("lastname", "firstname", "rating", "test")
+    srcDO.writeSparkDataFrame(l3, Seq())(context3)
+    val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
+    action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
+    action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
+    action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
+    action3.exec(Seq(srcSubFeed3))(context3)
 
-   test("historize load mergeModeEnable CDC") {
+    {
+      val expected = Seq(
+        ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
+        ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context3)
+        .drop(Historization.historizeHashColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
+      assert(resultat)
+    }
+  }
 
-     val context = TestUtil.getDefaultActionPipelineContext
+  test("historize load mergeModeEnable CDC") {
 
-     // setup DataObjects
-     val srcDO = MockDataObject("src1").register
-     val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "historize_output", primaryKey = Some(Seq("lastname","firstname")))
-     val tgtDO = IcebergTableDataObject( "tgt1", Some(tempPath+s"/${tgtTable.fullName}"), table = tgtTable)
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    val context = TestUtil.getDefaultActionPipelineContext
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l1 = Seq(("doe","john",5,"new"), ("pan","peter",5,"new")).toDF("lastname", "firstname", "rating", "operation")
-     srcDO.writeSparkDataFrame(l1, Seq())(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // setup DataObjects
+    val srcDO = MockDataObject("src1").register
+    val tgtTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "historize_output", primaryKey = Some(Seq("lastname", "firstname")))
+    val tgtDO = IcebergTableDataObject("tgt1", Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable)
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp)
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l1 = Seq(("doe", "john", 5, "new"), ("pan", "peter", 5, "new")).toDF("lastname", "firstname", "rating", "operation")
+    srcDO.writeSparkDataFrame(l1, Seq())(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2nd load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l2 = Seq(("doe","john",10,"updated"), ("pan","peter",5,"deleted")).toDF("lastname", "firstname", "rating", "operation")
-     srcDO.writeSparkDataFrame(l2, Seq())(context1)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), definitions.Environment.historizationUpperHorizonTimestamp)
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 1st load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan","peter", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-       ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context1)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
-       assert(resultat)
-     }
+    // prepare & start 2nd load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha2", srcDO.id, tgtDO.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l2 = Seq(("doe", "john", 10, "updated"), ("pan", "peter", 5, "deleted")).toDF("lastname", "firstname", "rating", "operation")
+    srcDO.writeSparkDataFrame(l2, Seq())(context1)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // prepare & start 3rd load with schema evolution
-     // Note that this is not possible with DeltaLake 1.x, as schema evolution with mergeStmt.insertExpr is not properly supported.
-     // See also last two tests in IcebergTableDataObjectTest.
-     val refTimestamp3 = LocalDateTime.now()
-     val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
-     val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
-     instanceRegistry.register(tgtDOwithSchemaEvolution)
-     val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
-     val l3 = Seq(("doe","john",10,"test","updated")).toDF("lastname", "firstname", "rating", "test", "operation")
-     srcDO.writeSparkDataFrame(l3, Seq())(context3)
-     val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
-     action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
-     action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
-     action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
-     action3.exec(Seq(srcSubFeed3))(context3)
+    {
+      val expected = Seq(
+        ("doe", "john", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, Timestamp.valueOf(refTimestamp2), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+      ).toDF("lastname", "firstname", "rating", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context1)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 2nd load mergeModeEnable", Seq())(actual)(expected)
+      assert(resultat)
+    }
 
-     {
-       val expected = Seq(
-         ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
-         ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
-         ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp),
-         ("pan","peter", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L)))
-       ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
-       val actual = tgtDO.getSparkDataFrame()(context3)
-         .drop(Historization.historizeDummyColName)
-       val resultat = expected.isEqual(actual)
-       if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
-       assert(resultat)
-     }
-   }
+    // prepare & start 3rd load with schema evolution
+    // Note that this is not possible with DeltaLake 1.x, as schema evolution with mergeStmt.insertExpr is not properly supported.
+    // See also last two tests in IcebergTableDataObjectTest.
+    val refTimestamp3 = LocalDateTime.now()
+    val context3 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp3), phase = ExecutionPhase.Exec)
+    val tgtDOwithSchemaEvolution = tgtDO.copy(id = "tgt3", allowSchemaEvolution = true) // table remains the same...
+    instanceRegistry.register(tgtDOwithSchemaEvolution)
+    val action3 = HistorizeAction("ha3", srcDO.id, tgtDOwithSchemaEvolution.id, mergeModeEnable = true, mergeModeCDCColumn = Some("operation"), mergeModeCDCDeletedValue = Some("deleted"))
+    val l3 = Seq(("doe", "john", 10, "test", "updated")).toDF("lastname", "firstname", "rating", "test", "operation")
+    srcDO.writeSparkDataFrame(l3, Seq())(context3)
+    val srcSubFeed3 = SparkSubFeed(None, "src1", Seq())
+    action3.prepare(context3.copy(phase = ExecutionPhase.Prepare))
+    action3.preInit(Seq(srcSubFeed), Seq())(context3.copy(phase = ExecutionPhase.Init))
+    action3.init(Seq(srcSubFeed3))(context3.copy(phase = ExecutionPhase.Init))
+    action3.exec(Seq(srcSubFeed3))(context3)
 
-   test("activate merge mode on existing dataframe no null dl_hash") {
+    {
+      val expected = Seq(
+        ("doe", "john", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L))),
+        ("doe", "john", 10, null, Timestamp.valueOf(refTimestamp2), Timestamp.valueOf(refTimestamp3.minusNanos(1000000L))),
+        ("doe", "john", 10, "test", Timestamp.valueOf(refTimestamp3), definitions.Environment.historizationUpperHorizonTimestamp),
+        ("pan", "peter", 5, null, Timestamp.valueOf(refTimestamp1), Timestamp.valueOf(refTimestamp2.minusNanos(1000000L)))
+      ).toDF("lastname", "firstname", "rating", "test", "dl_ts_captured", "dl_ts_delimited")
+      val actual = tgtDO.getSparkDataFrame()(context3)
+        .drop(Historization.historizeDummyColName)
+      val resultat = expected.isEqual(actual)
+      if (!resultat) TestUtil.printFailedTestResult("historize 3rd load mergeModeEnable with schema evolution", Seq())(actual)(expected)
+      assert(resultat)
+    }
+  }
 
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input", catalog = Some("iceberg1"))
-     val srcPath = tempPath + s"/${srcTable.fullName}"
-     val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-     instanceRegistry.register(srcDO)
-     val tgtTable = Table(Some("default"), "historize_output", catalog = Some("iceberg1"), primaryKey = Some(Seq("id")))
-     val tgtPath = tempPath + s"/${tgtTable.fullName}"
-     val tgtDO = IcebergTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
-     val context = TestUtil.getDefaultActionPipelineContext
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+  test("activate merge mode on existing dataframe no null dl_hash") {
 
-     // prepare & start 1st load without merge mode
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id
-     )
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input", catalog = Some("iceberg1"))
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgtTable = Table(Some("default"), "historize_output", catalog = Some("iceberg1"), primaryKey = Some(Seq("id")))
+    val tgtPath = tempPath + s"/${tgtTable.fullName}"
+    val tgtDO = IcebergTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
+    val context = TestUtil.getDefaultActionPipelineContext
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1)(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    // prepare & start 1st load without merge mode
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id
+    )
 
-     // 1. expectation schema should not have dl_hash column
-     assert(!tgtDO.getSparkDataFrame()(context1).columns.contains("dl_hash"))
+    val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1)(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2st load
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha",
-       inputId = srcDO.id,
-       outputId = tgtDO.id,
-       mergeModeEnable = true
-     )
+    // 1. expectation schema should not have dl_hash column
+    assert(!tgtDO.getSparkDataFrame()(context1).columns.contains("dl_hash"))
 
-     val l2 = Seq((1, "doe", "john", 4)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2)(context2)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    // prepare & start 2st load
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha",
+      inputId = srcDO.id,
+      outputId = tgtDO.id,
+      mergeModeEnable = true
+    )
 
-     // expectation dl_hash should not have null values
-     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
+    val l2 = Seq((1, "doe", "john", 4)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2)(context2)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
+
+    // expectation dl_hash should not have null values
+    assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
 
 
-   }
+  }
 
-   test("update hash on existing non updated rows") {
+  test("update hash on existing non updated rows") {
 
-     // setup DataObjects
-     val srcTable = Table(Some("default"), "historize_input", catalog = Some("iceberg1"))
-     val srcPath = tempPath + s"/${srcTable.fullName}"
-     val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
-     instanceRegistry.register(srcDO)
-     val tgtTable = Table(Some("default"), "historize_output", catalog = Some("iceberg1"), primaryKey = Some(Seq("id")))
-     val tgtPath = tempPath + s"/${tgtTable.fullName}"
-     val tgtDO = IcebergTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
-     val context = TestUtil.getDefaultActionPipelineContext
-     tgtDO.dropTable(context)
-     instanceRegistry.register(tgtDO)
+    // setup DataObjects
+    val srcTable = Table(Some("default"), "historize_input", catalog = Some("iceberg1"))
+    val srcPath = tempPath + s"/${srcTable.fullName}"
+    val srcDO = HiveTableDataObject("src1", Some(srcPath), table = srcTable, numInitialHdfsPartitions = 1)
+    instanceRegistry.register(srcDO)
+    val tgtTable = Table(Some("default"), "historize_output", catalog = Some("iceberg1"), primaryKey = Some(Seq("id")))
+    val tgtPath = tempPath + s"/${tgtTable.fullName}"
+    val tgtDO = IcebergTableDataObject("tgt1", Some(tgtPath), table = tgtTable, allowSchemaEvolution = true)
+    val context = TestUtil.getDefaultActionPipelineContext
+    tgtDO.dropTable(context)
+    instanceRegistry.register(tgtDO)
 
-     // prepare & start 1st load
-     val refTimestamp1 = LocalDateTime.now()
-     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-     val action1 = HistorizeAction("ha", inputId = srcDO.id, outputId = tgtDO.id)
+    // prepare & start 1st load
+    val refTimestamp1 = LocalDateTime.now()
+    val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
+    val action1 = HistorizeAction("ha", inputId = srcDO.id, outputId = tgtDO.id)
 
-     val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l1)(context1)
-     val srcSubFeed = SparkSubFeed(None, "src1", Seq())
-     action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
-     action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
-     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
-     action1.exec(Seq(srcSubFeed))(context1)
+    val l1 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l1)(context1)
+    val srcSubFeed = SparkSubFeed(None, "src1", Seq())
+    action1.prepare(context1.copy(phase = ExecutionPhase.Prepare))
+    action1.preInit(Seq(srcSubFeed), Seq())(context1.copy(phase = ExecutionPhase.Init))
+    action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
+    action1.exec(Seq(srcSubFeed))(context1)
 
-     // prepare & start 2st load with merge mode
-     val refTimestamp2 = LocalDateTime.now()
-     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-     val action2 = HistorizeAction("ha", inputId = srcDO.id, outputId = tgtDO.id, mergeModeEnable = true)
+    // prepare & start 2st load with merge mode
+    val refTimestamp2 = LocalDateTime.now()
+    val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
+    val action2 = HistorizeAction("ha", inputId = srcDO.id, outputId = tgtDO.id, mergeModeEnable = true)
 
-     val l2 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
-     srcDO.writeSparkDataFrame(l2)(context2)
-     val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
-     action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
-     action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
-     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
-     action2.exec(Seq(srcSubFeed2))(context2)
+    val l2 = Seq((1, "doe", "john", 5)).toDF("id", "lastname", "firstname", "rating")
+    srcDO.writeSparkDataFrame(l2)(context2)
+    val srcSubFeed2 = SparkSubFeed(None, "src1", Seq())
+    action2.prepare(context2.copy(phase = ExecutionPhase.Prepare))
+    action2.preInit(Seq(srcSubFeed), Seq())(context2.copy(phase = ExecutionPhase.Init))
+    action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
+    action2.exec(Seq(srcSubFeed2))(context2)
 
-     // expectation dl_hash should not have null values
-     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
-   }
- }
+    // expectation dl_hash should not have null values
+    assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
+  }
+}

--- a/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
+++ b/sdl-iceberg/src/test/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObjectTest.scala
@@ -33,13 +33,15 @@ import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, Process
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.Files
 
-class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with SmartDataLakeLogger {
+class IcebergTableDataObjectTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger {
 
-  protected implicit val session : SparkSession = IcebergTestUtils.session
+  protected implicit val session: SparkSession = IcebergTestUtils.session
+
   import session.implicits._
 
   private val tempDir = Files.createTempDirectory("tempHadoopDO")
@@ -56,10 +58,10 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   test("Write data") {
 
     // setup DataObjects
-    val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
+    val sourceDO = CustomDfDataObject(id = "source", creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "custom_df_copy", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable)
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
     targetDO.prepare
@@ -72,7 +74,7 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
     val expected = sourceDO.getSparkDataFrame()
     val actual = targetDO.getSparkDataFrame()
     val resultat = expected.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable",Seq())(actual)(expected)
+    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable", Seq())(actual)(expected)
     assert(resultat)
 
     // check statistics
@@ -85,10 +87,10 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   test("Write data partitioned") {
 
     // setup DataObjects
-    val sourceDO = CustomDfDataObject(id="source",creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
+    val sourceDO = CustomDfDataObject(id = "source", creator = CustomDfCreatorConfig(className = Some(classOf[TestCustomDfCreator].getName)))
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "custom_df_copy_partitioned", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", partitions=Seq("num"), path=Some(targetTablePath), table=targetTable)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", partitions = Seq("num"), path = Some(targetTablePath), table = targetTable)
     targetDO.dropTable
     instanceRegistry.register(sourceDO)
     instanceRegistry.register(targetDO)
@@ -101,172 +103,172 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
     val expected = sourceDO.getSparkDataFrame()
     val actual = targetDO.getSparkDataFrame()
     val resultat: Boolean = expected.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable_partitioned",Seq())(actual)(expected)
+    if (!resultat) TestUtil.printFailedTestResult("CustomDf2DeltaTable_partitioned", Seq())(actual)(expected)
     assert(resultat)
     assert(targetDO.listPartitions.map(_.elements).toSet == Set(Map("num" -> "0"), Map("num" -> "1")))
   }
 
   test("SaveMode overwrite with different schema") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_overwrite", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Overwrite, allowSchemaEvolution = true)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Overwrite, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val resultat: Boolean = df1.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(resultat)
 
     // 2nd load: overwrite all with different schema
-    val df2 = Seq(("ext","doe","john",10,"test"),("ext","smith","peter",1,"test"))
+    val df2 = Seq(("ext", "doe", "john", 10, "test"), ("ext", "smith", "peter", 1, "test"))
       .toDF("type", "lastname", "firstname", "rating2", "test")
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
     val resultat2: Boolean = df2.isEqual(actual2)
-    if (!resultat2) TestUtil.printFailedTestResult("SaveMode overwrite",Seq())(actual2)(df2)
+    if (!resultat2) TestUtil.printFailedTestResult("SaveMode overwrite", Seq())(actual2)(df2)
     assert(resultat2)
   }
 
   test("SaveMode append with different schema") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_append", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Append, allowSchemaEvolution = true)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Append, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: append all with different schema
-    val df2 = Seq(("ext","doe","john",10,"test"),("ext","smith","peter",1,"test"))
+    val df2 = Seq(("ext", "doe", "john", 10, "test"), ("ext", "smith", "peter", 1, "test"))
       .toDF("type", "lastname", "firstname", "rating2", "test")
     targetDO.initSparkDataFrame(df2, Seq()) // for applying schema evolution
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame().filter($"lastname" === "doe")
     val result2 = actual2.count() == 2 && (df1.columns ++ df2.columns).toSet == actual2.columns.toSet
-    if (!result2) TestUtil.printFailedTestResult("SaveMode append with different schema",Seq())(actual2)(df2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode append with different schema", Seq())(actual2)(df2)
     assert(result2)
   }
 
   test("SaveMode overwrite and delete partition") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_overwrite", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, partitions = Seq("type")
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, partitions = Seq("type")
       , saveMode = SDLSaveMode.Overwrite, options = Map("partitionOverwriteMode" -> "static")
     )
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
-    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type"->"ext")), PartitionValues(Map("type"->"int"))))
+    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type" -> "ext")), PartitionValues(Map("type" -> "int"))))
 
     // 2nd load: overwrite partition type=ext
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     intercept[ProcessingLogicException](targetDO.writeSparkDataFrame(df2)) // not allowed to overwrite all partitions
-    targetDO.writeSparkDataFrame(df2, partitionValues = Seq(PartitionValues(Map("type"->"ext"))))
-    val expected2 = df2.union(df1.where($"type"=!="ext"))
+    targetDO.writeSparkDataFrame(df2, partitionValues = Seq(PartitionValues(Map("type" -> "ext"))))
+    val expected2 = df2.union(df1.where($"type" =!= "ext"))
     val actual2 = targetDO.getSparkDataFrame()
     val resul2 = expected2.isEqual(actual2)
-    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite and delete partition",Seq())(actual2)(expected2)
+    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite and delete partition", Seq())(actual2)(expected2)
     assert(resul2)
 
     // delete partition
-    targetDO.deletePartitions(Seq(PartitionValues(Map("type"->"int"))))
-    assert(targetDO.listPartitions == Seq(PartitionValues(Map("type"->"ext"))))
+    targetDO.deletePartitions(Seq(PartitionValues(Map("type" -> "int"))))
+    assert(targetDO.listPartitions == Seq(PartitionValues(Map("type" -> "ext"))))
   }
 
   test("SaveMode overwrite partitions dynamically") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_overwrite_dynamic", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, partitions = Seq("type")
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, partitions = Seq("type")
       , saveMode = SDLSaveMode.Overwrite, options = Map("partitionOverwriteMode" -> "dynamic")
     )
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
-    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type"->"ext")), PartitionValues(Map("type"->"int"))))
+    assert(targetDO.listPartitions.toSet == Set(PartitionValues(Map("type" -> "ext")), PartitionValues(Map("type" -> "int"))))
 
     // 2nd load: dynamically overwrite partition type=ext
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2) // allowed overwriting partitions because of partitionOverwriteMode=dynamic
-    val expected2 = df2.union(df1.where($"type"=!="ext"))
+    val expected2 = df2.union(df1.where($"type" =!= "ext"))
     val actual2 = targetDO.getSparkDataFrame()
     val resul2 = expected2.isEqual(actual2)
-    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite partitions dynamically",Seq())(actual2)(expected2)
+    if (!resul2) TestUtil.printFailedTestResult("SaveMode overwrite partitions dynamically", Seq())(actual2)(expected2)
     assert(resul2)
   }
 
   test("SaveMode append") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_append", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Append)
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Append)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: append data
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
     val expected2 = df2.union(df1)
     val resultat2: Boolean = expected2.isEqual(actual2)
-    if (!resultat2) TestUtil.printFailedTestResult("SaveMode append",Seq())(actual2)(expected2)
+    if (!resultat2) TestUtil.printFailedTestResult("SaveMode append", Seq())(actual2)(expected2)
     assert(resultat2)
   }
 
 
   test("throw NoDataToProcessWarning if no new snapshot created (no data)") {
     val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_nodata", query = None)
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
     // Iceberg doesnt create a new snapshot if no data is written with dynamic partition mode
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, partitions = Seq("type"))
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, partitions = Seq("type"))
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3),("int","emma","brown",7))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: no data -> NoDataToProcessWarning
-    val df2 = Seq(("ext","doe","john",10),("ext","smith","peter",1))
+    val df2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 1))
       .toDF("type", "lastname", "firstname", "rating")
     Environment._enableSparkPlanNoDataCheck = Some(false) // disable triggering SparkPlanNoDataWarning, as this test is about another case
     intercept[NoDataToProcessWarning](targetDO.writeSparkDataFrame(df2.where(lit(false))))
@@ -278,57 +280,57 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
 
 
   test("SaveMode merge") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: merge data by primary key
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
-    val expected2 = Seq(("ext","doe","john",10),("ext","smith","peter",3),("int","emma","brown",7))
+    val expected2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     val result2 = expected2.isEqual(actual2)
-    if (!result2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode merge", Seq())(actual2)(expected2)
     assert(result2)
   }
 
 
   test("SaveMode merge with updateCols") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("type", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: merge data by primary key
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df2, saveModeOptions = Some(SaveModeMergeOptions(updateColumns = Seq("rating"))))
     val actual2 = targetDO.getSparkDataFrame()
-    val expected2 = Seq(("ext","doe","john",10),("ext","smith","peter",3),("int","emma","brown",7))
+    val expected2 = Seq(("ext", "doe", "john", 10), ("ext", "smith", "peter", 3), ("int", "emma", "brown", 7))
       .toDF("type", "lastname", "firstname", "rating")
     val result2 = expected2.isEqual(actual2)
-    if (!result2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode merge", Seq())(actual2)(expected2)
     assert(result2)
   }
 
@@ -336,32 +338,32 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   // We test for failure to be notified once it is working...
   // Once this works again, also enable 3rd load in IcebergHistorizeWithMergeActionTest and IcebergDeduplicateWithMergeActionTest test cases again
   test("SaveMode merge with schema evolution") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("tpe", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val result = df1.isEqual(actual)
-    if (!result) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!result) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(result)
 
     // 2nd load: merge data by primary key with different schema
     // - column 'rating' deleted -> existing records will keep column rating untouched (values are preserved and not set to null), new records will get new column rating set to null.
     // - column 'rating2' added -> existing records will get new column rating2 set to null
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("tpe", "lastname", "firstname", "rating2")
     targetDO.initSparkDataFrame(df2, Seq())
     targetDO.writeSparkDataFrame(df2)
     val actual2 = targetDO.getSparkDataFrame()
-    val expected2 = Seq(("ext","doe","john",Some(5),Some(10)),("ext","smith","peter",Some(3),None),("int","emma","brown",None,Some(7)))
+    val expected2 = Seq(("ext", "doe", "john", Some(5), Some(10)), ("ext", "smith", "peter", Some(3), None), ("int", "emma", "brown", None, Some(7)))
       .toDF("tpe", "lastname", "firstname", "rating", "rating2")
     val result2 = expected2.isEqual(actual2)
-    if (!result2) TestUtil.printFailedTestResult("SaveMode merge",Seq())(actual2)(expected2)
+    if (!result2) TestUtil.printFailedTestResult("SaveMode merge", Seq())(actual2)(expected2)
     assert(result2)
   }
 
@@ -369,24 +371,24 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   // We test for failure to be notified once it is working...
   // Once this works again, also enable 3rd load in IcebergHistorizeWithMergeActionTest and IcebergDeduplicateWithMergeActionTest test cases again
   test("SaveMode merge with updateCols and schema evolution - fails in deltalake 1.x") {
-    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe","lastname","firstname")))
-    val targetTablePath = tempPath+s"/${targetTable.fullName}"
-    val targetDO = IcebergTableDataObject(id="target", path=Some(targetTablePath), table=targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_merge", query = None, primaryKey = Some(Seq("tpe", "lastname", "firstname")))
+    val targetTablePath = tempPath + s"/${targetTable.fullName}"
+    val targetDO = IcebergTableDataObject(id = "target", path = Some(targetTablePath), table = targetTable, saveMode = SDLSaveMode.Merge, allowSchemaEvolution = true)
     targetDO.dropTable
 
     // first load
-    val df1 = Seq(("ext","doe","john",5),("ext","smith","peter",3))
+    val df1 = Seq(("ext", "doe", "john", 5), ("ext", "smith", "peter", 3))
       .toDF("tpe", "lastname", "firstname", "rating")
     targetDO.writeSparkDataFrame(df1)
     val actual = targetDO.getSparkDataFrame()
     val resultat = df1.isEqual(actual)
-    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable",Seq())(actual)(df1)
+    if (!resultat) TestUtil.printFailedTestResult("Df2HiveTable", Seq())(actual)(df1)
     assert(resultat)
 
     // 2nd load: merge data by primary key with different schema
     // - column 'rating' deleted -> existing records will keep column rating untouched (values are preserved and not set to null), new records will get new column rating set to null.
     // - column 'rating2' added -> existing records will get new column rating2 set to null
-    val df2 = Seq(("ext","doe","john",10),("int","emma","brown",7))
+    val df2 = Seq(("ext", "doe", "john", 10), ("int", "emma", "brown", 7))
       .toDF("tpe", "lastname", "firstname", "rating2")
     intercept[AnalysisException](targetDO.writeSparkDataFrame(df2, saveModeOptions = Some(SaveModeMergeOptions(updateColumns = Seq("lastname", "firstname", "rating", "rating2")))))
   }
@@ -394,7 +396,7 @@ class IcebergTableDataObjectTest extends FunSuite with BeforeAndAfter with Smart
   test("incremental output mode with inserts") {
 
     // create data object
-    val targetTable = Table(catalog =  Some("iceberg1"), db = Some("default"), name = "test_inc", primaryKey = Some(Seq("id")))
+    val targetTable = Table(catalog = Some("iceberg1"), db = Some("default"), name = "test_inc", primaryKey = Some(Seq("id")))
     val targetTablePath = tempPath + s"/${targetTable.fullName}"
     val targetDO = IcebergTableDataObject("icebergDO1", table = targetTable, path = Some(targetTablePath), saveMode = SDLSaveMode.Append)
     targetDO.dropTable

--- a/sdl-jms/pom.xml
+++ b/sdl-jms/pom.xml
@@ -115,8 +115,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scalacheck</groupId>
-			<artifactId>scalacheck_${scala.minor.version}</artifactId>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- sdl-core test utils -->

--- a/sdl-kafka/pom.xml
+++ b/sdl-kafka/pom.xml
@@ -178,8 +178,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scalacheck</groupId>
-			<artifactId>scalacheck_${scala.minor.version}</artifactId>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- sdl-core test utils -->

--- a/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
+++ b/sdl-kafka/src/test/scala/io/smartdatalake/workflow/ActionDAGKafkaTest.scala
@@ -31,9 +31,8 @@ import io.smartdatalake.workflow.dataobject._
 import io.smartdatalake.workflow.executionMode.KafkaStateIncrementalMode
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
-
-import java.nio.file.Files
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 /**
  * Note about EmbeddedKafka compatibility:
@@ -42,8 +41,9 @@ import java.nio.file.Files
  * "java.nio.channels.UnresolvedAddressException: Session 0x0 for server localhost/<unresolved>:6001, unexpected error, closing socket connection and attempting reconnect"
  * see also https://www.oracle.com/java/technologies/javase/14all-relnotes.html#JDK-8225499
  */
-class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndAfter with EmbeddedKafka with SmartDataLakeLogger {
+class ActionDAGKafkaTest extends AnyFunSuite with BeforeAndAfterAll with BeforeAndAfter with EmbeddedKafka with SmartDataLakeLogger {
   protected implicit val session: SparkSession = TestUtil.session
+
   import session.implicits._
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
@@ -65,7 +65,7 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     val feed = "actionpipeline"
     val kafkaConnection = KafkaConnection("kafkaCon1", "localhost:6001")
     instanceRegistry.register(kafkaConnection)
-    val srcDO = MockDataObject( "src1").register
+    val srcDO = MockDataObject("src1").register
     createCustomTopic("topic1", Map(), 1, 1)
     val tgt1DO = KafkaTopicDataObject("kafka1", topicName = "topic1", connectionId = "kafkaCon1", valueType = KafkaColumnType.String, selectCols = Seq("value", "timestamp"))
     instanceRegistry.register(tgt1DO)
@@ -87,7 +87,7 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
 
     // check result
     val dfR1 = tgt2DO.getSparkDataFrame(Seq())
-    assert(dfR1.columns.toSet == Set("value","timestamp"))
+    assert(dfR1.columns.toSet == Set("value", "timestamp"))
     val r1 = dfR1
       .select($"value")
       .as[String].collect().toSeq
@@ -117,7 +117,7 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     instanceRegistry.register(tgt2DO)
 
     // prepare DAG
-    val df1 = Seq(("r1",TestPerson("doe", "john", 5))).toDF("key", "value")
+    val df1 = Seq(("r1", TestPerson("doe", "john", 5))).toDF("key", "value")
     srcDO.writeSparkDataFrame(df1, Seq())
 
     val action1 = CopyAction("a", srcDO.id, tgt1DO.id, executionMode = Some(KafkaStateIncrementalMode()))
@@ -206,7 +206,7 @@ class ActionDAGKafkaTest extends FunSuite with BeforeAndAfterAll with BeforeAndA
     // second dag run
     {
       val delaySecs = 1
-      Thread.sleep(delaySecs*1000 + 1000) // make sure to wait some time
+      Thread.sleep(delaySecs * 1000 + 1000) // make sure to wait some time
       val action1Delay1s = action1Delay10s.copy(
         executionMode = Some(KafkaStateIncrementalMode(delayedMaxTimestampExpr = Some(s"timestamp_seconds(unix_seconds(now()) - $delaySecs)"))))
       val dag: ActionDAGRun = ActionDAGRun(Seq(action1Delay1s))

--- a/sdl-kafka/src/test/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObjectTest.scala
+++ b/sdl-kafka/src/test/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObjectTest.scala
@@ -29,7 +29,8 @@ import org.apache.kafka.common.serialization.StringSerializer
 import org.apache.spark.sql.confluent.IncompatibleSchemaException
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.streaming.Trigger
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import java.nio.file.Files
 import java.sql.Timestamp
@@ -37,7 +38,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 
-class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with BeforeAndAfter with EmbeddedKafkaWithSchemaRegistry with DataObjectTestSuite with SmartDataLakeLogger {
+class KafkaTopicDataObjectTest extends AnyFunSuite with BeforeAndAfterAll with BeforeAndAfter with EmbeddedKafkaWithSchemaRegistry with DataObjectTestSuite with SmartDataLakeLogger {
 
   import io.smartdatalake.util.spark.DataFrameUtil.DfSDL
   import session.implicits._
@@ -49,7 +50,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
   test("Can read and write from Kafka") {
     createCustomTopic("topic", Map(), 1, 1)
     publishStringMessageToKafka("topic", "message")
-    assert(consumeFirstStringMessageFrom("topic")=="message", "Whoops - couldn't read message")
+    assert(consumeFirstStringMessageFrom("topic") == "message", "Whoops - couldn't read message")
   }
 
   test("DataObject can write and read kafka topic") {
@@ -78,7 +79,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     dataObject1.writeSparkDataFrame(df1, Seq())
 
     // stream
-    val dfStream1 = dataObject1.getStreamingDataFrame(Map("startingOffsets"->"earliest"), None)
+    val dfStream1 = dataObject1.getStreamingDataFrame(Map("startingOffsets" -> "earliest"), None)
     val query = dataObject2.writeStreamingDataFrame(SparkDataFrame(dfStream1), Trigger.Once, Map(), checkpointLocation = tempDir.resolve("state").toString, "test")
     query.awaitTermination()
     logger.info(s"streaming query finished, rows processed = ${query.lastProgress.numInputRows}")
@@ -94,7 +95,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     logger.info("topic created")
 
     // publish several messages with some delay between to have different timestamps
-    implicit val stringSerializer = new StringSerializer
+    implicit val stringSerializer: StringSerializer = new StringSerializer
     publishToKafka(topic1, "A", "1")
     Thread.sleep(1000)
     publishToKafka(topic1, "B", "2")
@@ -105,17 +106,17 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     // configure DataObject with partition column defined as seconds
     instanceRegistry.register(kafkaConnection)
     val dataObject1 = KafkaTopicDataObject("kafka1", topicName = topic1, connectionId = "kafkaCon1"
-      , datePartitionCol = Some(DatePartitionColumnDef( colName = "sec", timeUnit = ChronoUnit.SECONDS.toString, timeFormat ="yyyyMMddHHmmss")))
+      , datePartitionCol = Some(DatePartitionColumnDef(colName = "sec", timeUnit = ChronoUnit.SECONDS.toString, timeFormat = "yyyyMMddHHmmss")))
 
     // list and check partitions
     val partitions = dataObject1.listPartitions
     assert(partitions.size >= 3) // as we have written messages over a timestamp of 3secs
 
     // check query first partitions data
-    val dfP1 = dataObject1.getSparkDataFrame(Seq(partitions.minBy( p => p("sec").toString.toLong))).cache()
+    val dfP1 = dataObject1.getSparkDataFrame(Seq(partitions.minBy(p => p("sec").toString.toLong))).cache()
     assert(dfP1.columns.contains("sec"))
-    val dataP1 = dfP1.select($"key",$"value").as[(String,String)].collect().toSeq
-    assert(dataP1 == Seq(("A","1")))
+    val dataP1 = dfP1.select($"key", $"value").as[(String, String)].collect().toSeq
+    assert(dataP1 == Seq(("A", "1")))
   }
 
   test("Exclude or include current date partition in list partitions") {
@@ -124,13 +125,13 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     logger.info("topic created")
 
     // publish one messages
-    implicit val stringSerializer = new StringSerializer
+    implicit val stringSerializer: StringSerializer = new StringSerializer
     publishToKafka(topic1, "A", "1")
 
     // configure DataObject with partition column defined as day and excluding current partition
     instanceRegistry.register(kafkaConnection)
     val dataObject1 = KafkaTopicDataObject("kafka1", topicName = topic1, connectionId = "kafkaCon1"
-      , datePartitionCol = Some(DatePartitionColumnDef( colName = "dt", timeUnit = ChronoUnit.DAYS.toString, timeFormat ="yyyyMMdd")))
+      , datePartitionCol = Some(DatePartitionColumnDef(colName = "dt", timeUnit = ChronoUnit.DAYS.toString, timeFormat = "yyyyMMdd")))
 
     // list and check partitions
     val partitions1 = dataObject1.listPartitions
@@ -138,7 +139,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
 
     // configure DataObject with partition column defined as day and including current partition
     val dataObject2 = KafkaTopicDataObject("kafka2", topicName = topic1, connectionId = "kafkaCon1"
-      , datePartitionCol = Some(DatePartitionColumnDef( colName = "dt", timeUnit = ChronoUnit.DAYS.toString, timeFormat ="yyyyMMdd", includeCurrentPartition = true)))
+      , datePartitionCol = Some(DatePartitionColumnDef(colName = "dt", timeUnit = ChronoUnit.DAYS.toString, timeFormat = "yyyyMMdd", includeCurrentPartition = true)))
 
     // list and check partitions
     val partitions2 = dataObject2.listPartitions
@@ -149,16 +150,16 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     createCustomTopic("topic", Map(), 1, 1)
 
     // write json record using KafkaJsonSerializer
-    implicit val jsonSerializer = new KafkaJsonSerializer[User]
-    jsonSerializer.configure(new java.util.HashMap[String,String](), false)
+    implicit val jsonSerializer: KafkaJsonSerializer[User] = new KafkaJsonSerializer[User]
+    jsonSerializer.configure(new java.util.HashMap[String, String](), false)
     val test = new User
     test.setUserId(1)
     test.setLastName("hello")
     publishToKafka("topic", test)
 
     // read json record using KafkaJsonDeserializer
-    implicit val jsonDeserializer = new KafkaJsonDeserializer[User]
-    val deserializerConfig = new java.util.HashMap[String,Any]
+    implicit val jsonDeserializer: KafkaJsonDeserializer[User] = new KafkaJsonDeserializer[User]
+    val deserializerConfig = new java.util.HashMap[String, Any]
     deserializerConfig.put(KafkaJsonDeserializerConfig.JSON_VALUE_TYPE, classOf[User])
     jsonDeserializer.configure(deserializerConfig, false)
     val t = consumeFirstMessageFrom("topic")
@@ -170,7 +171,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
 
     // write json record using KafkaJsonSerializer
     implicit val jsonSerializer: KafkaJsonSerializer[User] = new KafkaJsonSerializer[User]
-    jsonSerializer.configure(new java.util.HashMap[String,String](), false)
+    jsonSerializer.configure(new java.util.HashMap[String, String](), false)
     val expected = new User
     expected.setUserId(1)
     expected.setLastName("hello")
@@ -182,7 +183,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     val dataObject = KafkaTopicDataObject("kafka1", topicName = "topicJsonRead", connectionId = "kafkaCon1", valueType = KafkaColumnType.Json, valueSchema = Some(SparkSchema(userSchema)))
     val df = dataObject.getSparkDataFrame()
       .select($"value.*")
-    val (actFirstName, actLastName, actUserId) = df.as[(String,String,Long)].head()
+    val (actFirstName, actLastName, actUserId) = df.as[(String, String, Long)].head()
     assert(actFirstName == expected.getFirstName && actLastName == expected.getLastName && actUserId == expected.getUserId)
   }
 
@@ -194,7 +195,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     val expected = Seq(("hello", 1L))
 
     // write json message incl. schema
-    val dfExp = expected.toDF("txt","num")
+    val dfExp = expected.toDF("txt", "num")
       .select(lit(1).as("key"), struct("*").as("value"))
     dataObject.writeSparkDataFrame(dfExp)
 
@@ -202,7 +203,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     val dfAct = dataObject.getSparkDataFrame()
       .select($"value.*")
 
-    val actual = dfAct.as[(String,Long)].collect()
+    val actual = dfAct.as[(String, Long)].collect()
     assert(actual.toSeq == expected)
   }
 
@@ -214,7 +215,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     val expected = Seq(("hello", 1L))
 
     // write json message incl. schema
-    val dfExp = expected.toDF("txt","num")
+    val dfExp = expected.toDF("txt", "num")
       .select(lit(1).as("key"), struct("*").as("value"))
     dataObject.writeSparkDataFrame(dfExp)
 
@@ -222,7 +223,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
     val dfAct = dataObject.getSparkDataFrame()
       .select($"value.*")
 
-    val actual = dfAct.as[(String,Long)].collect()
+    val actual = dfAct.as[(String, Long)].collect()
     assert(actual.toSeq == expected)
   }
 
@@ -341,7 +342,7 @@ class KafkaTopicDataObjectTest extends FunSuite with BeforeAndAfterAll with Befo
       .select(lit(1).as("key"), struct("*").as("value"))
 
     // check schema evolution disabled
-    intercept[IncompatibleSchemaException](dataObject.initSparkDataFrame(dfExp1,Seq()))
+    intercept[IncompatibleSchemaException](dataObject.initSparkDataFrame(dfExp1, Seq()))
     intercept[IncompatibleSchemaException](dataObject.writeSparkDataFrame(dfExp1))
 
     dataObjectAllowSchemaEvo.initSparkDataFrame(dfExp1, Seq())

--- a/sdl-lang/src/test/scala/io/smartdatalake/lab/LabCatalogGeneratorTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/lab/LabCatalogGeneratorTest.scala
@@ -20,13 +20,13 @@
 package io.smartdatalake.lab
 
 import io.smartdatalake.util.misc.{CustomCodeUtil, ScalaUtil}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Paths}
 import scala.io.Source
 import scala.util.Using
 
-class LabCatalogGeneratorTest extends FunSuite {
+class LabCatalogGeneratorTest extends AnyFunSuite {
   test("generate catalog") {
     val srcDir = "target/generatedSrc"
     val packageName = "ch.smartdatalake.generated"

--- a/sdl-lang/src/test/scala/io/smartdatalake/lab/LabSparkActionWrapperTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/lab/LabSparkActionWrapperTest.scala
@@ -28,9 +28,9 @@ import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformer
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfsTransformer
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class LabSparkActionWrapperTest extends FunSuite {
+class LabSparkActionWrapperTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-lang/src/test/scala/io/smartdatalake/lab/LabSparkDataObjectWrapperTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/lab/LabSparkDataObjectWrapperTest.scala
@@ -26,9 +26,9 @@ import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformer
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfsTransformer
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class LabSparkDataObjectWrapperTest extends FunSuite {
+class LabSparkDataObjectWrapperTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-lang/src/test/scala/io/smartdatalake/lab/SmartDataLakeBuilderLabTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/lab/SmartDataLakeBuilderLabTest.scala
@@ -27,9 +27,9 @@ import io.smartdatalake.workflow.action.spark.customlogic.CustomDfsTransformer
 import io.smartdatalake.workflow.dataobject.ParquetFileDataObject
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SmartDataLakeBuilderLabTest extends FunSuite {
+class SmartDataLakeBuilderLabTest extends AnyFunSuite {
 
   protected implicit val session: SparkSession = TestUtil.session
   import session.implicits._

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/GenericTypeUtilTest.scala
@@ -19,11 +19,11 @@
 
 package io.smartdatalake.meta
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.reflect.runtime.universe.typeOf
 
-class GenericTypeUtilTest extends FunSuite {
+class GenericTypeUtilTest extends AnyFunSuite {
 
   test ("handle attributes - required, deprecated, override") {
     val testObjectTypeDef = GenericTypeUtil.typeDefForClass(typeOf[TestObject])

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -24,11 +24,11 @@ import io.smartdatalake.testutils.TestUtil
 import org.apache.hadoop.conf.Configuration
 import org.json4s.jackson.JsonMethods
 import org.json4s.{StringInput, _}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.File
 
-class ConfigJsonExporterTest extends FunSuite {
+class ConfigJsonExporterTest extends AnyFunSuite {
   private val descriptionPath = getClass.getResource("/dagexporter/description").getPath
 
   test("export config") {

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporterTest.scala
@@ -34,15 +34,16 @@ import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.json4s.jackson.{JsonMethods, Serialization}
 import org.json4s.{Formats, NoTypeHints, StringInput}
-import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
 
 import java.nio.file.{Files, Paths}
 
-class DataObjectSchemaExporterTest extends FunSuite with BeforeAndAfter {
+class DataObjectSchemaExporterTest extends AnyFunSuite with BeforeAndAfter {
 
-  val configPath = getClass.getResource("/dagexporter/dagexporterTest.conf").getPath
+  private val configPath = getClass.getResource("/dagexporter/dagexporterTest.conf").getPath
   val target = "localfile:./target/schema"
-  val exportPath = Paths.get(target.stripPrefix("localfile:"))
+  private val exportPath = Paths.get(target.stripPrefix("localfile:"))
 
   before {
     FileUtils.deleteDirectory(exportPath.toFile)
@@ -144,7 +145,7 @@ class DataObjectSchemaExporterTest extends FunSuite with BeforeAndAfter {
     // first write
     val schema1 = SparkSchema(StructType(Seq(StructField("a", StringType))))
     writer.writeSchema(formatSchema(Some(schema1), None), DataObjectId("test"), getCurrentVersion)
-    assert(writer.readIndex(dataObjectId, "schema").length==1)
+    assert(writer.readIndex(dataObjectId, "schema").length == 1)
     Thread.sleep(1000) // timestamp in filename has seconds resolution, make sure we dont overwrite previous file.
     // second write -> no update
     writer.writeSchema(formatSchema(Some(schema1), None), DataObjectId("test"), getCurrentVersion)
@@ -175,8 +176,8 @@ class DataObjectSchemaExporterTest extends FunSuite with BeforeAndAfter {
     val writer = FileExportWriter(exportPath)
     val latestStats = writer.getLatestData(hiveDO.id, "stats")
       .map(Serialization.read[Map[String, Any]]).get
-    assert(latestStats.apply("columns").asInstanceOf[Map[String,Any]]
-      .apply("lastname").asInstanceOf[Map[String,Any]]
+    assert(latestStats.apply("columns").asInstanceOf[Map[String, Any]]
+      .apply("lastname").asInstanceOf[Map[String, Any]]
       .apply(ColumnStatsType.DistinctCount.toString) == 3)
   }
 }

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/dagexporter/DagExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/dagexporter/DagExporterTest.scala
@@ -19,9 +19,9 @@
 
 package io.smartdatalake.meta.dagexporter
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class DagExporterTest extends FunSuite {
+class DagExporterTest extends AnyFunSuite {
 
   test("testMain") {
     val expectedOutput =

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/jsonschema/JsonTypeConverterTest.scala
@@ -28,11 +28,11 @@ import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.connection.{Connection, ConnectionMetadata}
 import io.smartdatalake.workflow.dataobject.{DataObject, DataObjectMetadata}
 import org.reflections.Reflections
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.reflect.runtime.universe.{Type, typeOf}
 
-class JsonTypeConverterTest extends FunSuite {
+class JsonTypeConverterTest extends AnyFunSuite {
   private val registry = new DefinitionRegistry
   private val reflections = new Reflections
   private val jsonTypeConverter = new JsonSchemaUtil.JsonTypeConverter(reflections, registry)

--- a/sdl-snowflake/pom.xml
+++ b/sdl-snowflake/pom.xml
@@ -127,8 +127,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scalacheck</groupId>
-			<artifactId>scalacheck_${scala.minor.version}</artifactId>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
 <!--		 sdl-core test utils-->

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeDataObjectIT.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeDataObjectIT.scala
@@ -33,7 +33,7 @@ import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.workflow.dataobject.{SnowflakeTableDataObject, Table}
 import org.apache.spark
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.Matchers.intercept
+import org.scalatest.matchers.should.Matchers.intercept
 
 
 /**

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeSubFeedTest.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowflakeSubFeedTest.scala
@@ -21,9 +21,9 @@ package io.smartdatalake.workflow.snowflake
 
 import io.smartdatalake.workflow.dataframe.snowflake.SnowparkDataFrame
 import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class SnowflakeSubFeedTest extends FunSuite {
+class SnowflakeSubFeedTest extends AnyFunSuite {
 
   test("unsupported subFeedType exception message contains proper function name") {
     val ex = intercept[IllegalStateException](SnowparkDataFrame(null).unionByName(SparkDataFrame(null)))

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowparkIT.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowparkIT.scala
@@ -23,7 +23,7 @@ import com.snowflake.snowpark.types._
 import io.smartdatalake.config.{ConfigToolbox, InstanceRegistry}
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.workflow.dataobject.{SnowflakeTableDataObject, Table}
-import org.scalatest.Matchers.intercept
+import org.scalatest.matchers.should.Matchers.intercept
 
 
 /**

--- a/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowparkSchemaConverterTest.scala
+++ b/sdl-snowflake/src/test/scala/io/smartdatalake/workflow/snowflake/SnowparkSchemaConverterTest.scala
@@ -23,11 +23,11 @@ import com.snowflake.snowpark.{types => snowpark}
 import io.smartdatalake.workflow.dataframe.snowflake.{SnowparkSchema, SnowparkSimpleDataType, SnowparkSubFeed}
 import io.smartdatalake.workflow.dataframe.spark.{SparkSchema, SparkSubFeed}
 import org.apache.spark.sql.{types => spark}
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.reflect.runtime.universe.typeOf
 
-class SnowparkSchemaConverterTest extends FunSuite {
+class SnowparkSchemaConverterTest extends AnyFunSuite {
 
   test("converting simple schema from Spark to Snowflake") {
     val sparkSchema = SparkSchema(

--- a/sdl-splunk/pom.xml
+++ b/sdl-splunk/pom.xml
@@ -124,8 +124,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.scalacheck</groupId>
-			<artifactId>scalacheck_${scala.minor.version}</artifactId>
+			<groupId>org.scalatestplus</groupId>
+			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- sdl-core test utils -->


### PR DESCRIPTION
### What changes are included in the pull request?
- update of scala test 3.0.8 -> 3.2.19
- replacing `org.scalacheck_scalacheck_` by `org.scalatestplus.scalacheck-1-18_`

### Why are the changes needed?
This PR prepares the of SDLB TestTools, cf. issue https://github.com/smart-data-lake/smart-data-lake/issues/1034
The functions there are tested using property-based testing, cf. https://www.scalatest.org/user_guide/property_based_testing