### PR TITLE
Switch `schema-viewer` to github npm registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
   # allow for manual releases
   workflow_dispatch:
     branches: [documentation]
-      
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages
@@ -21,6 +21,8 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn build
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,3 +17,5 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn build
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+smart-data-lake:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-smart-data-lake:registry=https://npm.pkg.github.com/
+@smart-data-lake:registry=https://npm.pkg.github.com/
 //npm.pkg.github.com/:_authToken=${TOKEN}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This website is built using [Docusaurus 3](https://docusaurus.io/), a modern sta
 ### Installation
 Because the dependency `@smart-data-lake/sdlb-schema-viewer` is hosted on the Github npm registry (https://npm.pkg.github.com/) one needs to [authenticate against Github](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages) to pull the package.
 The `.npmrc` of the project sets the token to the environment variable `TOKEN` for the github action.
-To install the project locally, set the environment variable `export TOKEN=...` once or in your shell config (e.g. `.zshrc.`, `.bashrc`).
 To install the project locally, define the environment variable by running `export TOKEN=...` or add that line to your shell config (e.g., `.zshrc`, `.bashrc`) to make it persistent.
 
 How to generate the token:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
 ### Installation
+Because the dependency `@smart-data-lake/sdlb-schema-viewer` is hosted on the Github npm registry (https://npm.pkg.github.com/) one needs to [authenticate against Github](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages) to pull the package.
+The `.npmrc` of the project sets the token to the environment variable `TOKEN` for the github action.
+To install the project locally, set the environment variable `export TOKEN=...` once or in your shell config (e.g. `.zshrc.`, `.bashrc`).
+To install the project locally, define the environment variable by running `export TOKEN=...` or add that line to your shell config (e.g., `.zshrc`, `.bashrc`) to make it persistent.
+
+How to generate the token:
+- Settings -> Developer settings -> Personal access token
+    - Tokens (classic): create on with the permission `read:packages`
+
+And then the following command can be run.
 
 ```
 $ yarn

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "sdlb-schema-viewer": "2.0.0"
+    "@smart-data-lake/sdlb-schema-viewer": "2.0.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.8.1",

--- a/src/schema-viewer/SchemaViewerComponent.js
+++ b/src/schema-viewer/SchemaViewerComponent.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SchemaViewer, defaultTheme } from 'sdlb-schema-viewer';
+import { SchemaViewer, defaultTheme } from '@smart-data-lake/sdlb-schema-viewer';
 import { CssVarsProvider } from "@mui/joy";
 import UseColorMode from "./UseColorMode";
 import useBaseUrl from '@docusaurus/useBaseUrl';


### PR DESCRIPTION
According to https://github.com/smart-data-lake/schema-viewer/issues/31 add the necessary changes and update the `README.md`.

Contains:
- Add `.npmrc`: specify authtoken env variable + npm registry for `schema-viewer`
- Update action definitions: add github secret as env variable
- Update `package.json` to respect the new package name + update version
- Update `README.md` with instructions on how to create PAT and set the env variable
