### PR TITLE
RelaxedCsvFileDataObject: improve including filename in error msg

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
@@ -89,6 +89,7 @@ case class RelaxedCsvFileDataObject(override val id: DataObjectId,
   override val format = "csv"
   override val readFormat = "text"// read with Spark as text and then parse csv with custom logic
   override val ignoreSchemaForReader = true // schema will be applied in customizeContent and not by SparkFileDataObject
+  override val customizeBeforeFilename = false // filename column should be added by SparkFileDataObject before calling customizeContent
 
   override val readOptions: Map[String, String] = Map("wholetext" -> "true") // options for Spark text DataSource
 
@@ -125,33 +126,54 @@ case class RelaxedCsvFileDataObject(override val id: DataObjectId,
     df
       .flatMap { csvContentRow =>
         if (csvContentRow.isNullAt(0)) Iterator[Row]()
-        else parseCsvContent(csvContentRow.getString(0), parserOptions)
-          .map { parsedRow =>
-            val values = parsedRow.toSeq ++ csvContentRow.toSeq.drop(1) // add partition column values
-            Row(values: _*)
+        else {
+          val content = csvContentRow.getAs[String]("value")
+          val filename = filenameColumn.map(csvContentRow.getAs[String])
+          if (filename.isDefined) logger.debug(s"($id) Parsing file $filename, size=${content.length}")
+          try {
+            parseCsvContent(content, parserOptions, filename)
+              .map { parsedRow =>
+                val values = parsedRow.toSeq ++ csvContentRow.toSeq.drop(1) // value column is at pos 0, partition columns (if any) and filename column are after that
+                Row(values: _*)
+              }
           }
-      }(ExpressionEncoder.apply(StructType(sparkParserSchema ++ df.schema.drop(1)))) // add partition cols
+        }
+      }(ExpressionEncoder.apply(StructType(sparkParserSchema ++ df.schema.drop(1)))) // value column is at pos 0, partition columns (if any) and filename column are after that
   }
 
-  private def parseCsvContent(csvContent: String, parserOptions: CSVOptions)(implicit session: SparkSession): Iterator[Row] = {
+  private def parseCsvContent(csvContent: String, parserOptions: CSVOptions, filename: Option[String])(implicit session: SparkSession): Iterator[Row] = {
 
     // parse header
-    val (headerLine, dataIterator) = getHeaderLine(csvContent, parserOptions) match {
-      case (Some(headerLine), dataIterator) => (headerLine, dataIterator)
-      case _ => throw new SparkException("No header line found")
-    }
-    val caseSensitive = SQLConf.get.getConf(SQLConf.CASE_SENSITIVE)
-    val csvParser = new CsvParser(parserOptions.asParserSettings)
-    val header = CSVUtils.makeSafeHeader(csvParser.parseLine(headerLine), caseSensitive, parserOptions)
-      .map(_.trim) // remove spaces from all column names and potential CR from last column name
-    val headerNormalized = if (caseSensitive) header else header.map(_.toLowerCase)
-    val schemaNormalizedMap = sparkParserSchema.map(field => (if (caseSensitive) field.name else field.name.toLowerCase, field)).toMap
-    assert(headerNormalized.intersect(schemaNormalizedMap.keys.toSeq).nonEmpty, s"No column names match between header and schema. Please check CSV has header (header line: ${headerLine.trim})")
+    enrichException(filename) {
+      val (headerLine, dataIterator) = getHeaderLine(csvContent, parserOptions) match {
+        case (Some(headerLine), dataIterator) => (headerLine, dataIterator)
+        case _ => throw new SparkException("No header line found")
+      }
+      val caseSensitive = SQLConf.get.getConf(SQLConf.CASE_SENSITIVE)
+      val csvParser = new CsvParser(parserOptions.asParserSettings)
+      val header = CSVUtils.makeSafeHeader(csvParser.parseLine(headerLine), caseSensitive, parserOptions)
+        .map(_.trim) // remove spaces from all column names and potential CR from last column name
+      val headerNormalized = if (caseSensitive) header else header.map(_.toLowerCase)
+      val schemaNormalizedMap = sparkParserSchema.map(field => (if (caseSensitive) field.name else field.name.toLowerCase, field)).toMap
+      assert(headerNormalized.intersect(schemaNormalizedMap.keys.toSeq).nonEmpty, s"No column names match between header and schema. Please check CSV has header (header line: ${headerLine.trim})")
 
-    // parse to row with file schema
-    val fileSchema = StructType(headerNormalized.map(name => schemaNormalizedMap.getOrElse(name, StructField(name, StringType))))
-    val parser = new RelaxedParser(fileSchema, sparkParserSchema, parserOptions, treatMissingColumnsAsCorrupt, treatSuperfluousColumnsAsCorrupt)
-    dataIterator.flatMap( line => parser.parse(line.trim)) // remove potential CR from last column value
+      // parse to row with file schema
+      val fileSchema = StructType(headerNormalized.map(name => schemaNormalizedMap.getOrElse(name, StructField(name, StringType))))
+      val parser = new RelaxedParser(fileSchema, sparkParserSchema, parserOptions, treatMissingColumnsAsCorrupt, treatSuperfluousColumnsAsCorrupt)
+      dataIterator.flatMap( line => enrichException(filename)(parser.parse(line.trim))) // remove potential CR from last column value
+    }
+  }
+
+  def enrichException[A](filename: Option[String])(code: => A): A = {
+    try {
+      code
+    } catch {
+      case e: Throwable =>
+        val msg = if (filename.isDefined) s"($id) Error parsing file $filename: ${e.getMessage}"
+        else s"($id) Error parsing CSV-file: ${e.getMessage}"
+        logger.error(msg)
+        throw CsvParserException(msg, e)
+    }
   }
 
   private def getHeaderLine(csvContent: String, parserOptions: CSVOptions): (Option[String], Iterator[String]) = {
@@ -215,7 +237,7 @@ class RelaxedParser( fileSchema:StructType, tgtSchema: StructType, parserOptions
     case e: BadRecordException => parserOptions.parseMode match {
       case PermissiveMode => Some(createResultRow(e.partialResults().map(fnRowConverter).headOption, Option(e.record()).map(_.toString), Option(e.cause).map(_.getMessage)))
       case DropMalformedMode => None
-      case FailFastMode => throw new SparkException(s"Malformed records are detected in record parsing, failing because of FailFastMode. inputRecord=${input.take(100)}", e)
+      case FailFastMode => throw new SparkException(s"Malformed records are detected in record parsing, failing because of FailFastMode. inputRecord=${input.take(1000)}", e)
     }
   }
 
@@ -234,3 +256,5 @@ class RelaxedParser( fileSchema:StructType, tgtSchema: StructType, parserOptions
     resultRow
   }
 }
+
+case class CsvParserException(message: String, cause: Throwable) extends Exception(message, cause)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
@@ -91,8 +91,6 @@ case class RelaxedCsvFileDataObject(override val id: DataObjectId,
   override val ignoreSchemaForReader = true // schema will be applied in customizeContent and not by SparkFileDataObject
   override val customizeBeforeFilename = false // filename column should be added by SparkFileDataObject before calling customizeContent
 
-  override val readOptions: Map[String, String] = Map("wholetext" -> "true") // options for Spark text DataSource
-
   // this is only needed for FileRef actions
   override val fileName: String = "*.csv*"
 
@@ -108,6 +106,8 @@ case class RelaxedCsvFileDataObject(override val id: DataObjectId,
   )
 
   override val options: Map[String, String] = formatOptionsDefault ++ csvOptions ++ formatOptionsOverride
+
+  override val readOptions: Map[String, String] = options ++ Map("wholetext" -> "true") // read whole files using Spark text DataSource!
 
   // validate parser options
   private val defaultNameOfCorruptRecord = SQLConf.get.getConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -191,6 +191,12 @@ trait SparkFileDataObject extends HadoopFileDataObject
   protected def recursiveFileLookup: Boolean = options.get("recursiveFileLookup").contains("true")
 
   /**
+   * Hook for subclasses to customize if filename column should be added to DataFrame in getSparkDataFrame before calling customizeContent
+   * Default is true.
+   */
+  protected def customizeBeforeFilename: Boolean = true
+
+  /**
    * Hook to use different options for reading
    */
   protected def readOptions: Map[String, String] = options // hook to use different provider for reading
@@ -231,7 +237,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
     else if (handleFilesOneByOne) getContentFilesOneByOne(partitionValues, schemaOpt.filter(_ => !ignoreSchemaForReader), incrementalOutputOptions)
     else if (isV2ReadDataSource) getContentV2(partitionValues, schemaOpt.filter(_ => !ignoreSchemaForReader), incrementalOutputOptions)
     else getContentV1(partitionValues, schemaOpt.filter(_ => !ignoreSchemaForReader), incrementalOutputOptions)
-    df = customizeContent(df)
+    if (customizeBeforeFilename) df = customizeContent(df)
 
     // early check for no data to process.
     // This also prevents an error on Databricks when using filesObserver if there are no files to process. See also [[CollectSetDeterministic]].
@@ -240,6 +246,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
 
     // add filename column
     df = df.withOptionalColumn(filenameColumn, if (!doCreateEmptyDataFrame) input_file_name() else lit(""))
+    if (!customizeBeforeFilename) df = customizeContent(df)
 
     // configure observer to get files processed for incremental execution mode
     if (filesObservers.nonEmpty && context.isExecPhase) {
@@ -249,6 +256,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
     // finalize & return DataFrame
     afterRead(df)
   }
+
 
   private[smartdatalake] def createEmptyDataFrame(schema: GenericSchema)(implicit session: SparkSession): DataFrame = {
     val sparkSchema = schema.convert(typeOf[SparkSubFeed]).asInstanceOf[SparkSchema]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObject.scala
@@ -199,7 +199,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
   /**
    * Hook to use different options for reading
    */
-  protected def readOptions: Map[String, String] = options // hook to use different provider for reading
+  protected def readOptions: Map[String, String] = options // hook to use by different provider for reading
 
   override def checkFilesExisting(recursive: Boolean = recursiveFileLookup)(implicit context: ActionPipelineContext): Boolean = {
     super.checkFilesExisting(recursive)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObjectTest.scala
@@ -1,16 +1,17 @@
 package io.smartdatalake.workflow.dataobject
 
-import io.smartdatalake.definitions.Environment
+import io.smartdatalake.definitions.{Environment, SDLSaveMode}
 import io.smartdatalake.workflow.dataframe.spark.SparkSchema
-import io.smartdatalake.testutils.DataObjectTestSuite
+import io.smartdatalake.testutils.{DataObjectTestSuite, TestTool}
 import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import org.apache.spark.SparkException
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.types.{StringType, StructType}
 
-import java.nio.file.Files
+import java.nio.file.{Files, Path}
 
-class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite {
+class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
 
   import session.implicits._
 
@@ -235,4 +236,23 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite {
     assert(dfResult.columns.toSeq == Seq("h1", "h2", "h3"))
     assert(dfResult.count == 0)
   }
+
+  private val testDf = Seq(
+    ("string1",1),
+    ("string2",2),
+    ("string3",3)
+  ).toDF("str","number")
+
+  test("read parquet files mixed with other files in same directory") {
+    val tempDir = Files.createTempDirectory("csv")
+    val srcDO = RelaxedCsvFileDataObject(id = "src1", path = tempDir.toString, filenameColumn = Some("_filename"), schema=Some(SparkSchema(testDf.schema)))
+    val jsonDO = JsonFileDataObject(id = "src2", path = tempDir.toString, filenameColumn = Some("_filename"), saveMode = SDLSaveMode.Append, jsonOptions = Some(Map("multiline" -> "false")))
+    srcDO.writeSparkDataFrame(testDf, Seq())
+    jsonDO.writeSparkDataFrame(testDf, Seq())
+    val resultParquet = srcDO.getSparkDataFrame()(contextExec)
+    assert(resultParquet.select($"_filename").as[String].collect.map(_.split('.').last).toSeq == Seq("csv", "csv", "csv"))
+    val resultJson = jsonDO.getSparkDataFrame()(contextExec)
+    assert(resultJson.select($"_filename").as[String].collect.map(_.split('.').last).toSeq == Seq("json", "json", "json"))
+  }
+
 }


### PR DESCRIPTION
### What changes are included in the pull request?
add filename to parsing exceptions in RelaxedCsvFileDataObject

### Why are the changes needed?
In the current behaviour It's difficult to know which file an error happens.