### PR TITLE
fix incremental historize null aware hashing

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/historization/Historization.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/historization/Historization.scala
@@ -198,7 +198,7 @@ object Historization extends SmartDataLakeLogger {
     val hashColEqualsExpr = existingHashCol === newHashCol
     // add hash column
     val dfNewHashed = addHashCol(dfNew, historizeWhitelist, historizeBlacklist, useHash = true)
-    val dfExistingHashed = if (addExistingDfHashColumn) {
+    val dfExistingHashed = if (!addExistingDfHashColumn) {
       dfExisting
     } else {
       addHashCol(dfExisting, historizeWhitelist, historizeBlacklist, useHash = true, colsToIgnore = Seq(Environment.capturedColumnName, Environment.delimitedColumnName))
@@ -383,6 +383,7 @@ object Historization extends SmartDataLakeLogger {
   }
 
   private[smartdatalake] def addHashCol(df: GenericDataFrame, historizeWhitelist: Option[Seq[String]], historizeBlacklist: Option[Seq[String]], useHash: Boolean, colsToIgnore: Seq[String] = Seq()): GenericDataFrame = {
+    assert(!df.columns.contains(historizeHashColName), s"DataFrame must not contain column with name $historizeHashColName if addHashCol is called")
     implicit val functions: DataFrameFunctions = DataFrameSubFeed.getFunctions(df.subFeedType)
     val colsToCompare = getCompareColumns(df.columns.diff(colsToIgnore), historizeWhitelist, historizeBlacklist)
     df.withColumn(historizeHashColName, colsComparisionExpr(colsToCompare, useHash))

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/NullAwareMurmur3HashExpr.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/NullAwareMurmur3HashExpr.scala
@@ -1,0 +1,71 @@
+/*
+ * Smart Data Lake - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.smartdatalake.util.spark
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, HashExpression, InterpretedHashFunction, Murmur3HashFunction}
+import org.apache.spark.sql.types.{DataType, IntegerType}
+import org.apache.spark.unsafe.hash.Murmur3_x86_32
+
+
+/**
+ * A null aware MurMur3 Hash expression.
+ * Copied from org.apache.spark.sql.catalyst.expressions.Murmur3Hash, but with the following changes:
+ * - It is null aware, i.e. it treat null values as regular values, which influence hash value of the row.
+ *   The original Murmur3Hash ignores null values, e.g. a row with an additional null column has the same hash as without.
+ */
+case class NullAwareMurmur3HashExpr(children: Seq[Expression], seed: Int) extends HashExpression[Int] {
+  def this(arguments: Seq[Expression]) = this(arguments, 42)
+
+  override def dataType: DataType = IntegerType
+
+  override def prettyName: String = "null_aware_hash"
+
+  override protected def hasherClassName: String = classOf[Murmur3_x86_32].getName
+
+  override protected def computeHash(value: Any, dataType: DataType, seed: Int): Int = {
+    NullAwareMurmur3HashExpr.hash(value, dataType, seed).toInt
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): NullAwareMurmur3HashExpr =
+    copy(children = newChildren)
+}
+
+object NullAwareMurmur3HashExpr extends InterpretedHashFunction {
+
+  override def hash(value: Any, dataType: DataType, seed: Long): Long = {
+    value match {
+      /** here comes the change for treating null */
+      case null => seed + 1 // add a constant value
+      case _ => super.hash(value, dataType, seed)
+    }
+  }
+
+  override protected def hashInt(i: Int, seed: Long): Long = {
+    Murmur3_x86_32.hashInt(i, seed.toInt)
+  }
+
+  override protected def hashLong(l: Long, seed: Long): Long = {
+    Murmur3_x86_32.hashLong(l, seed.toInt)
+  }
+
+  override protected def hashUnsafeBytes(base: AnyRef, offset: Long, len: Int, seed: Long): Long = {
+    Murmur3_x86_32.hashUnsafeBytes(base, offset, len, seed.toInt)
+  }
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
@@ -315,7 +315,7 @@ case class HistorizeAction(
 
     // if context is init check if column needs to be added -> save in needsHashColumn
     if (!context.isExecPhase) existingDfNeedsHashColumn = existingDf match {
-      case Some(df) => Some(df.columns.contains(Historization.historizeHashColName))
+      case Some(df) => Some(!df.columns.map(_.toLowerCase).contains(Historization.historizeHashColName))
       case _ => Some(false)
     }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
@@ -22,7 +22,7 @@ package io.smartdatalake.workflow.dataframe.spark
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.spark.evolution.TypeEvolutionUtil
-import io.smartdatalake.util.spark.{dataset, DummyStreamProvider}
+import io.smartdatalake.util.spark.{DummyStreamProvider, NullAwareMurmur3HashExpr, dataset}
 import io.smartdatalake.workflow._
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
@@ -270,9 +270,18 @@ object SparkSubFeed extends DataFrameSubFeedCompanion {
     }
   }
 
+  /**
+   * Spark Hash Functions ignores null values, e.g. adding a null column to a row does not change the hash value of the row.
+   * This method will treat null values as regular values, which influence hash value of the row.
+   */
+  def nullAwareHash(cols: Column*): Column = {
+    val expr = new NullAwareMurmur3HashExpr(cols.map(_.expr))
+    new Column(expr)
+  }
+
   override def hash(column: GenericColumn): GenericColumn = {
     column match {
-      case sparkColumn: SparkColumn => SparkColumn(functions.hash(sparkColumn.inner))
+      case sparkColumn: SparkColumn => SparkColumn(nullAwareHash(sparkColumn.inner))
       case _ => DataFrameSubFeed.throwIllegalSubFeedTypeException(column)
     }
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/historization/IncrementalHistorizationTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/historization/IncrementalHistorizationTest.scala
@@ -34,7 +34,6 @@ import java.time.Duration
 
 /**
  * Unit tests for historization
- *
  */
 class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with SmartDataLakeLogger
   with io.smartdatalake.testutils.spark.dataset.TestToolDataset {
@@ -85,7 +84,7 @@ class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with 
     val dfNewFeed = toDataDf(baseColumnsNewFeed)
     if (logger.isDebugEnabled) logger.debug(s"New feed:\n${dfNewFeed.showString()}")
 
-    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = true)
+    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = false)
     if (logger.isDebugEnabled) logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 
     // nothing to do if unchanged
@@ -101,7 +100,7 @@ class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with 
     val dfNewFeed = toDataDf(baseColumnsNewFeed).select(Seq(col("age"), col("health_state"), col("id"), col("name")))
     if (logger.isDebugEnabled) logger.debug(s"New feed:\n${dfNewFeed.showString()}")
 
-    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = true)
+    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = false)
     if (logger.isDebugEnabled) logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 
     // nothing to do if unchanged
@@ -118,7 +117,7 @@ class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with 
     val dfNewFeed = toDataDf(baseColumnsNewFeed)
     if (logger.isDebugEnabled) logger.debug(s"New feed:\n${dfNewFeed.showString()}")
 
-    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = true)
+    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = false)
       .drop("dl_hash")
     if (logger.isDebugEnabled) logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 
@@ -142,7 +141,7 @@ class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with 
     val dfNewFeed = toDataDf(baseColumnsNewFeed)
     if (logger.isDebugEnabled) logger.debug(s"New feed:\n${dfNewFeed.showString()}")
 
-    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = true)
+    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = false)
       .drop("dl_hash")
     if (logger.isDebugEnabled) logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 
@@ -163,7 +162,7 @@ class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with 
     val dfNewFeed = toDataDf(baseColumnsNewFeed)
     if (logger.isDebugEnabled) logger.debug(s"New feed:\n${dfNewFeed.showString()}")
 
-    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = true)
+    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = false)
       .drop("dl_hash")
     if (logger.isDebugEnabled) logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 
@@ -189,7 +188,7 @@ class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with 
     val dfNewFeed = toDataDf(baseColumnsNewFeed)
     if (logger.isDebugEnabled) logger.debug(s"New feed:\n${dfNewFeed.showString()}")
 
-    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = true)
+    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, defaultTimeAxisUnit, None, None, addExistingDfHashColumn = false)
       .drop("dl_hash")
     if (logger.isDebugEnabled) logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 
@@ -231,7 +230,7 @@ class IncrementalHistorizationTest extends AnyFunSuite with BeforeAndAfter with 
     val dfNewFeed = toDataDf(baseColumnsNewFeed)
     if (logger.isDebugEnabled) logger.debug(s"New feed:\n${dfNewFeed.showString()}")
 
-    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, timeAxisUnitNone, None, None, addExistingDfHashColumn = true)
+    val dfHistorized = Historization.incrementalHistorize(dfOldHist, dfNewFeed, primaryKeyColumns, referenceTimestampNewTs, timeAxisUnitNone, None, None, addExistingDfHashColumn = false)
       .drop("dl_hash")
     if (logger.isDebugEnabled) logger.debug(s"Historization result:\n${dfHistorized.showString()}")
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeWithMergeActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/HistorizeWithMergeActionTest.scala
@@ -263,7 +263,7 @@ class HistorizeWithMergeActionTest extends AnyFunSuite with BeforeAndAfter
     // prepare & start 1st load without merge mode
     val refTimestamp1 = LocalDateTime.now()
     val context1 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp1), phase = ExecutionPhase.Exec)
-    val action1 = HistorizeAction("ha",
+    val action1 = HistorizeAction("ha1",
       inputId = srcDO.id,
       outputId = tgtDO.id
     )
@@ -276,13 +276,13 @@ class HistorizeWithMergeActionTest extends AnyFunSuite with BeforeAndAfter
     action1.init(Seq(srcSubFeed))(context1.copy(phase = ExecutionPhase.Init))
     action1.exec(Seq(srcSubFeed))(context1)
 
-    // 1. expectation schema should not have dl_hash column
+    // 1. expectation: schema should not have dl_hash column
     assert(!tgtDO.getSparkDataFrame()(context1).columns.contains("dl_hash"))
 
     // prepare & start 2st load
     val refTimestamp2 = LocalDateTime.now()
     val context2 = TestUtil.getDefaultActionPipelineContext.copy(referenceTimestamp = Some(refTimestamp2), phase = ExecutionPhase.Exec)
-    val action2 = HistorizeAction("ha",
+    val action2 = HistorizeAction("ha2",
       inputId = srcDO.id,
       outputId = tgtDO.id,
       mergeModeEnable = true
@@ -296,10 +296,8 @@ class HistorizeWithMergeActionTest extends AnyFunSuite with BeforeAndAfter
     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
     action2.exec(Seq(srcSubFeed2))(context2)
 
-    // expectation dl_hash should not have null values
+    // 2. expectation: dl_hash should not have null values
     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
-
-
   }
 
   test("update hash on existing non updated rows") {
@@ -350,9 +348,7 @@ class HistorizeWithMergeActionTest extends AnyFunSuite with BeforeAndAfter
     action2.init(Seq(srcSubFeed2))(context2.copy(phase = ExecutionPhase.Init))
     action2.exec(Seq(srcSubFeed2))(context2)
 
-    // expectation dl_hash should not have null values
+    // 2. expectation: dl_hash should not have null values
     assert(tgtDO.getSparkDataFrame()(context2).where($"dl_hash".isNull).count() == 0)
-
-
   }
 }


### PR DESCRIPTION
### What changes are included in the pull request?
Implement incremental historize with null aware hashing, and fix condition to add dl_hash column when starting with incremental historize on a traditionally historized table.

### Why are the changes needed?
This didn't popup in unit tests up to now because initial dl_hash column was "accidentially" overwritten, and so the test succeeded, but was actionally not testing properly what happens with "null" values. Spark hash function is ignoring null values. If a column with null values is added to a DataFrame, these records have the same hash value as the record without null value. This is intended by spark as it somehow is the ternary logic of SQL. See also https://stackoverflow.com/questions/72026028/how-to-create-unique-hash-for-each-row-having-null-value-in-column-in-spark-scal for an documented example

When implementing #972 i came across some strange behavior of unit tests, investigated it and found that the current behaviour is not correct... 
