### PR TITLE
Compiler Warning removed.

### DIFF
--- a/.idea/scala_settings.xml
+++ b/.idea/scala_settings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ScalaProjectSettings">
-    <option name="incrementalHighlighting" value="true" />
     <option name="intInjectionMapping">
       <map>
         <entry key="xml" value="XML" />

--- a/sdl-core/src/main/scala/io/smartdatalake/app/UIBackendConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/UIBackendConfig.scala
@@ -107,7 +107,7 @@ case class UIBackendConfig(
           .readTimeout(FiniteDuration(timeouts.readTimeoutMs, TimeUnit.MILLISECONDS))
           .followRedirects(true)
         body.foreach(b => request = request.body(b))
-        multipartBody.foreach(mp => request = request.multipartBody(mp.head, mp.tail: _*))
+        multipartBody.foreach(mp => request = request.multipartBody(mp.head, mp.tail.toIndexedSeq: _*))
         val response = request.send(httpBackend)
         Option(getContent(response, s"$method $operation")).filter(_.nonEmpty)
       }

--- a/sdl-core/src/main/scala/io/smartdatalake/config/exporter/ExportWriter.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/exporter/ExportWriter.scala
@@ -72,7 +72,7 @@ object ExportWriter {
       info.toSeq.map("info" -> JString(_)),
       schema.toSeq.map("schema" -> _.toJson),
       schema.toSeq.map(s => "subFeedType" -> JString(s.subFeedType.typeSymbol.name.toString))
-    ).flatten: _*)
+    ).flatten.toIndexedSeq: _*)
     pretty(contentJson)
   }
 
@@ -83,7 +83,7 @@ object ExportWriter {
     }
     val schema = json \ "schema" match {
       case jsonSchema: JArray =>
-        val subFeedType = (json \ "subFeedType") match {
+        val subFeedType = json \ "subFeedType" match {
           case JString(tpe) =>
             DataFrameSubFeed.getKnownSubFeedTypes.find(_.typeSymbol.name.toString.endsWith(tpe))
               .getOrElse(throw new IllegalStateException(s"Could not find SubFeedType $tpe"))
@@ -92,7 +92,7 @@ object ExportWriter {
         GenericSchema.fromJson(jsonSchema, subFeedType)
       case _ => throw new IllegalStateException(s"Attribute 'schema' not found")
     }
-    val info = (json \ "info") match {
+    val info = json \ "info" match {
       case JString(s) => Some(s)
       case _ => None
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/CompatParColls.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/CompatParColls.scala
@@ -18,12 +18,14 @@
  */
 package io.smartdatalake.util.misc
 
+import scala.collection.parallel.CollectionConverters
+
 /**
- * Workaround to use scala.collection.parallel.CollectionConverters in Scala 2.12 and Scala 2.13,
+ * Workaround to use scala.collection.parallel.collectionConverters in Scala 2.12 and Scala 2.13,
  * see also https://github.com/scala/scala-parallel-collections/issues/22
  */
 object CompatParColls {
-  val Converters = {
+  val Converters: CollectionConverters.type = {
     import Compat._
     {
       import scala.collection.parallel._

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/NestedColumnUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/NestedColumnUtil.scala
@@ -46,7 +46,7 @@ object NestedColumnUtil extends SmartDataLakeLogger {
             if (logger.isDebugEnabled) logger.debug(s"selecting column ${f.name}: currentDataType=${currentFieldTypes(f.name)} tgtDataType=${f.dataType}")
             selectColumn(column(f.name), currentFieldTypes(f.name), f.dataType).as(f.name)
           }
-          functions.struct(columns: _*)
+          functions.struct(columns.toIndexedSeq: _*)
         } else column
       case (ct: GenericArrayDataType, tt: GenericArrayDataType) =>
         functions.transform(column, c => selectColumn(c, ct.elementDataType, tt.elementDataType))
@@ -107,7 +107,7 @@ object NestedColumnUtil extends SmartDataLakeLogger {
                 case (f, t: TransformColumn) => Some(t.newColumn.as(f.name))
                 case (_, RemoveColumn)       => None
               }
-              TransformColumn(functions.struct(selFields: _*))
+              TransformColumn(functions.struct(selFields.toIndexedSeq: _*))
             } else KeepColumn
           case t: GenericArrayDataType =>
             val arrayTransformed = functions.transform(column, c => transformColumn(t.elementDataType, c, path, visitorFunc).getOrElse(c))
@@ -129,7 +129,7 @@ object NestedColumnUtil extends SmartDataLakeLogger {
  */
 sealed trait TransformColumnCmd {
   def changeRequested = true
-  def getOrElse(originalColumn: GenericColumn) = originalColumn
+  def getOrElse(originalColumn: GenericColumn): GenericColumn = originalColumn
 }
 case class TransformColumn(newColumn: GenericColumn) extends TransformColumnCmd {
   override def getOrElse(originalColumn: GenericColumn): GenericColumn = newColumn

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ProductUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ProductUtil.scala
@@ -205,16 +205,16 @@ object ProductUtil {
   /**
    * Extract case class attributes with values through reflection
    */
-  def attributesWithValuesForCaseClass(obj: Any): Seq[(String, Any)] = {
+  def attributesWithValuesForCaseClass(obj: Any): List[(String, Any)] = {
     val clsSym = currentMirror.classSymbol(obj.getClass)
     val inst = currentMirror.reflect(obj)
 
-    val attributes = classAccessors(clsSym.toType)
+    val attributes: List[MethodSymbol] = classAccessors(clsSym.toType)
     attributes.map { m =>
       val key = m.name.toString
       val value = inst.reflectMethod(m).apply()
       (key, value)
-    }.toSeq
+    }
   }
 
   /**
@@ -226,12 +226,12 @@ object ProductUtil {
     val inst = currentMirror.reflect(obj)
     val copyConstructor = inst.symbol.toType.decls.find(_.name.toString == "copy")
       .getOrElse(throw new IllegalStateException(s"copy constructor method not found in object of type ${obj.getClass.getSimpleName}"))
-    val attributes = classAccessors(clsSym.toType)
+    val attributes: List[(String, Any)] = classAccessors(clsSym.toType)
       .map { m =>
         val key = m.name.toString
         val value = if (key == fieldName) newValue else inst.reflectMethod(m).apply()
         (key, value)
-      }.toSeq
-    inst.reflectMethod(copyConstructor.asMethod).apply(attributes.map(_._2): _*).asInstanceOf[T]
+      }
+    inst.reflectMethod(copyConstructor.asMethod).apply(attributes.map(_._2).toIndexedSeq: _*).asInstanceOf[T]
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ScaladocUtil.scala
@@ -19,9 +19,10 @@
 package io.smartdatalake.util.misc
 
 import com.github.takezoe.scaladoc.{Scaladoc => ScaladocAnnotation}
-import scaladoc.Markup._ // https://github.com/andyglow/scaladoc
+import scaladoc.Markup._
 import scaladoc.{Markup, Scaladoc, Tag}
 
+import scala.annotation.tailrec
 import scala.reflect.runtime.universe.Annotation
 
 private[smartdatalake] object ScaladocUtil {
@@ -74,12 +75,13 @@ private[smartdatalake] object ScaladocUtil {
     })
   }
 
+  @tailrec
   def removeSpacesAndTabs(line: String, spacesTabs: (Int, Int)): String = {
     require(spacesTabs._1 >= 0 && spacesTabs._2 >= 0, "Indentation error. The line has either too many spaces or too many tabs")
     if (line.isEmpty) ""
     else if (List("{{{","}}}").contains(line.trim)) line.trim
     else line.head match {
-      case c if ((0, 0) == spacesTabs) => line
+      case _ if (0, 0) == spacesTabs => line
       case ' ' => removeSpacesAndTabs(line.tail, (spacesTabs._1 - 1, spacesTabs._2))
       case '\t' => removeSpacesAndTabs(line.tail, (spacesTabs._1, spacesTabs._2 - 1))
       case _ => throw new Exception("The line doesn't have enough indentation characters to remove the entire common indentation")
@@ -99,16 +101,16 @@ private[smartdatalake] object ScaladocUtil {
         parsedLink = captureGroup1
       }
     } else {
-      parsedLink = s"`${captureGroup1}`"
+      parsedLink = s"`$captureGroup1`"
     }
 
-    s"${parsedLink}${if (captureGroup2 != null) captureGroup2 else " "}"
+    s"$parsedLink${if (captureGroup2 != null) captureGroup2 else " "}"
   }
 
   def formatScaladocString(str: String): String = {
     // Remove link square brackets (including plural s handling)
     // If the link is followed by a single s, remove the space
-    val bracketRemovalPattern = raw"\[\[(.+?)\]\] (\.|s|,)?".r
+    val bracketRemovalPattern = raw"\[\[(.+?)]] ([.s,])?".r
     bracketRemovalPattern.replaceAllIn(str, m =>
       formatScaladocLinkTag(m.group(1), m.group(2))
     )
@@ -139,7 +141,7 @@ private[smartdatalake] object ScaladocUtil {
     val rawScalaDoc = annotation.flatMap(_.tree.children.last.children.collectFirst{case Literal(Constant(name: String)) => name}) // In scala 2.12 this is an AssignOrNamedArg, in Scala 2.13 a NamedArg... we need to be dynamic...
     rawScalaDoc.map { d =>
       val s = scaladoc.Scaladoc.fromString(d)
-      s.right.getOrElse(throw new IllegalStateException(s"Could not extract Scaladoc from '$d': ${s.left.e}"))
+      s.toOption.getOrElse(throw new IllegalStateException(s"Could not extract Scaladoc from '$d': ${s.left.e}"))
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkRepartitionDef.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/SparkRepartitionDef.scala
@@ -114,12 +114,12 @@ object SparkRepartitionDef extends SmartDataLakeLogger {
     if (numberOfTasksPerPartition > 1 && keyCols.isEmpty) logger.info(s"($configObjectId) SparkRepartitionDef: distribution of records over Spark tasks within Hadoop partitions not defined, using random value now. Define keyCols to have better control over the distribution.")
     // to distribute records across tasks within partitions, we need calculate a task number from keyCols
     val repartitionCols = if (numberOfTasksPerPartition == 1) partitions.map(col)
-    else if (keyCols.nonEmpty) partitions.map(col) :+ pmod(hash(keyCols.map(col): _*), lit(numberOfTasksPerPartition))
+    else if (keyCols.nonEmpty) partitions.map(col) :+ pmod(hash(keyCols.map(col).toIndexedSeq: _*), lit(numberOfTasksPerPartition))
     else partitions.map(col) :+ floor(rand() * numberOfTasksPerPartition).cast(IntegerType)
     if (nbOfPartitionValues.isDefined) {
-      df.repartition(numberOfTasksPerPartition * nbOfPartitionValues.get, repartitionCols: _*)
+      df.repartition(numberOfTasksPerPartition * nbOfPartitionValues.get, repartitionCols.toIndexedSeq: _*)
     } else {
-      df.repartition(repartitionCols: _*)
+      df.repartition(repartitionCols.toIndexedSeq: _*)
     }
   }
 
@@ -135,7 +135,7 @@ object SparkRepartitionDef extends SmartDataLakeLogger {
         case sortColRegex(colName) => col(colName).asc
         case entry => throw new ConfigurationException(s"""($configObjectId) Too many arguments provided in [sparkRepartition.sortCols] entry "$entry". Just provide colName or colName and sortDir separated by whitespace.""")
       }
-      df.sortWithinPartitions(sortExprs: _*)
+      df.sortWithinPartitions(sortExprs.toIndexedSeq: _*)
     }
     else df
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Equality.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Equality.scala
@@ -204,10 +204,10 @@ trait Equality extends StructTypeUtil with Transform {
       LogUtils.debugLog(s"hasAlmostEqualRows: rowDiffCols = ${rowDiffCols.headOption.map(_.mkString(","))}")
 
       lazy val preciseRowDiff: List[DataFrame] = symDiffCols.map { x =>
-        thiss.select(x: _*).getSymmetricDifference(thatt.select(x: _*))
+        thiss.select(x.toIndexedSeq: _*).getSymmetricDifference(thatt.select(x.toIndexedSeq: _*))
       }
       lazy val impreciseRowDiff: List[DataFrame] = rowDiffCols.map { x =>
-        thiss.select(x: _*).getRowDifferences(thatt.select(x: _*), precisionMap)
+        thiss.select(x.toIndexedSeq: _*).getRowDifferences(thatt.select(x.toIndexedSeq: _*), precisionMap)
       }
 
       val result = equinumerous && (preciseRowDiff ++ impreciseRowDiff).forall(_.isEmpty)
@@ -246,8 +246,8 @@ trait Equality extends StructTypeUtil with Transform {
                           showDiff: Boolean,
                           pk: Iterable[String])(implicit logger: Logger): Boolean = {
       ds.schema.equal(that.schema, ignoreColumnOrder, ignoreNullability, showDiff) &&
-        ds.select(ds.columns.map(col): _*)
-          .hasAlmostEqualRows(that.select(ds.columns.map(col): _*), precisionMap, showDiff, pk)
+        ds.select(ds.columns.map(col).toIndexedSeq: _*)
+          .hasAlmostEqualRows(that.select(ds.columns.map(col).toIndexedSeq: _*), precisionMap, showDiff, pk)
     }
 
     /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
@@ -83,7 +83,7 @@ trait Quality extends Transform {
       val superfluousComments = commentMap.keys.toSeq.diff(ds.columns)
       if (superfluousComments.nonEmpty) logger.warn(s"Superfluous comment detected for columns ${superfluousComments.mkString(", ")}")
       val commentedCols = ds.schema.map(f => col(f.name).as(f.name, commentField(f).metadata))
-      ds.select(commentedCols: _*).as[T](ds.encoder)
+      ds.select(commentedCols.toIndexedSeq: _*).as[T](ds.encoder)
     }
 
     /**
@@ -162,7 +162,7 @@ trait Quality extends Transform {
       val statCols = ds.columns.flatMap { cn =>
         List(countDistinct(cn).as(s"cnt_$cn"), min(cn).as(s"min_$cn"), max(cn).as(s"max_$cn"))
       }
-      ds.agg(count("*").as("cnt_rows"), statCols: _*)
+      ds.agg(count("*").as("cnt_rows"), statCols.toIndexedSeq: _*)
     }
 
 
@@ -182,8 +182,8 @@ trait Quality extends Transform {
      */
     final def fillGaps(keyColNames: Iterable[String], dataColNames: Iterable[String],
                        orderColName: String, takeNextValueFirst: Boolean = true): DataFrame = {
-      val fenestra_next = Window.partitionBy(keyColNames.head, keyColNames.tail.toSeq: _*).orderBy(orderColName).rangeBetween(Window.currentRow, Window.unboundedFollowing)
-      val fenestra_prev = Window.partitionBy(keyColNames.head, keyColNames.tail.toSeq: _*).orderBy(orderColName).rangeBetween(Window.unboundedPreceding, Window.currentRow)
+      val fenestra_next = Window.partitionBy(keyColNames.head, keyColNames.tail.toSeq.toIndexedSeq: _*).orderBy(orderColName).rangeBetween(Window.currentRow, Window.unboundedFollowing)
+      val fenestra_prev = Window.partitionBy(keyColNames.head, keyColNames.tail.toSeq.toIndexedSeq: _*).orderBy(orderColName).rangeBetween(Window.unboundedPreceding, Window.currentRow)
 
       def newColumn(colName: String): Column = if (colName.contains(colName)) {
         if (takeNextValueFirst) coalesce(first(col(colName), ignoreNulls = true).over(fenestra_next), last(col(colName), ignoreNulls = true).over(fenestra_prev)).as(colName) else {
@@ -193,7 +193,7 @@ trait Quality extends Transform {
         col(colName)
       }
       // TODO: find a way to declare columns as not-nullable
-      ds.select(ds.columns.map(newColumn): _*)
+      ds.select(ds.columns.map(newColumn).toIndexedSeq: _*)
     }
 
     /**
@@ -220,7 +220,7 @@ trait Quality extends Transform {
                       fromColName: String, toColName: String,
                       orderColNames: Iterable[String], gapIndicatorName: String = "_is_adjacent"): DataFrame = {
       val nextFromColName = s"_next_$fromColName"
-      val fenestra = Window.partitionBy(keyColNames.map(col).toSeq: _*).orderBy(orderColNames.map(col).toSeq: _*)
+      val fenestra = Window.partitionBy(keyColNames.map(col).toSeq.toIndexedSeq: _*).orderBy(orderColNames.map(col).toSeq.toIndexedSeq: _*)
 
       ds.withColumn("_islastrow", lead(col(keyColNames.head), 1).over(fenestra).isNull)
         .withColumn(nextFromColName, lead(col(fromColName), 1).over(fenestra))
@@ -266,7 +266,7 @@ trait Quality extends Transform {
       val colsInDs: Array[String] = if (cols.isEmpty) cols else cols.intersect(cols)
       if (colsInDs.isEmpty) throw new IllegalArgumentException(s"Argument cols must contain at least 1 name" +
         s" of a column of your dataset.\n   cols = ${cols.mkString(",")}\n   cols = ${cols.mkString(",")} ")
-      val dfProjected: DataFrame = ds.select(colsInDs.map(col): _*)
+      val dfProjected: DataFrame = ds.select(colsInDs.map(col).toIndexedSeq: _*)
       val dfColumns: Array[String] = dfProjected.columns
       // If df contains forbidden column then the result contains two columns with the same name
       forbiddenColumnNames.foreach(str =>
@@ -274,7 +274,7 @@ trait Quality extends Transform {
           s"data frame df must not contain column named $str. cols = ${dfColumns.mkString(",")}")
       )
 
-      dfProjected.groupBy(dfColumns.head, dfColumns.tail: _*)
+      dfProjected.groupBy(dfColumns.head, dfColumns.tail.toIndexedSeq: _*)
         .count().withColumnRenamed("count", countColname)
         .where(col(countColname) > 1)
     }
@@ -297,7 +297,7 @@ trait Quality extends Transform {
      */
     def getNonuniqueRows(cols: Array[String] = ds.columns): Dataset[T] = {
       val dfNonUnique = getNonuniqueStats(cols, "_duplicationCount_").drop("_duplicationCount_")
-      ds.join(dfNonUnique, cols).select(ds.columns.head, ds.columns.tail: _*).as[T](ds.encoder)
+      ds.join(dfNonUnique, cols).select(ds.columns.head, ds.columns.tail.toIndexedSeq: _*).as[T](ds.encoder)
     }
 
     /**
@@ -306,7 +306,7 @@ trait Quality extends Transform {
      * @param cols : names of columns on which the data frame is to be projected
      * @return projection of data frame df
      */
-    def project(cols: Array[String] = ds.columns): DataFrame = ds.select(cols.map(col): _*)
+    def project(cols: Array[String] = ds.columns): DataFrame = ds.select(cols.map(col).toIndexedSeq: _*)
 
     /**
      * Checks whether the specified columns satisfy uniqueness within the data frame

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/ReadWrite.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/ReadWrite.scala
@@ -35,7 +35,7 @@ trait ReadWrite extends Serializable {
 
   implicit class DataFrameWriterUtils[T](writer: DataFrameWriter[T]) {
     final def optionalPartitionBy(partitions: Seq[String]): DataFrameWriter[T] = {
-      if (partitions.nonEmpty) writer.partitionBy(partitions: _*) else writer
+      if (partitions.nonEmpty) writer.partitionBy(partitions.toIndexedSeq: _*) else writer
     }
 
     final def optionalOption(key: String, value: Option[String]): DataFrameWriter[T] = {

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Transform.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Transform.scala
@@ -31,31 +31,36 @@ trait Transform extends Serializable {
 
   implicit class DsTransform[T](ds: Dataset[T]) {
 
-    val asDf: DataFrame = ds.select(ds.columns.map(col): _*)
-
+    val asDf: DataFrame = ds.select(ds.columns.map(col).toIndexedSeq: _*)
 
     /**
      * If colName is defined, creates an additional column with a given expression on a DataFrame
      */
-    def withOptionalColumn(colName: Option[String], expr: Column): DataFrame = {
+    def withOptionalColumn(colName: Option[String], expr: Column): DataFrame =
       if (colName.isDefined) ds.withColumn(colName.get, expr)
       else ds.asDf
-    }
-
-    /** * transformCols: generic workers used by many other methods ** */
 
     /**
-     * transforms columns given by the tranforming function
-     * but transforms Dataset to DataFrame
-     *
-     * @param transformRenameFun : function to transform and rename columns
-     * @param colFilter          : predicate on column names to filter
-     * @param keepOriginalCols   : whether to keep original cols (make sure that there is no ambiguity!)
-     * @return DataFrame with transformed and renamed columns
+     * * transformCols: generic workers used by many other methods **
      */
-    def transformCols(transformRenameFun: String => Iterable[(Column, String)],
-                      colFilter: String => Boolean,
-                      keepOriginalCols: Boolean): DataFrame = {
+
+    /**
+     * transforms columns given by the tranforming function but transforms Dataset to DataFrame
+     *
+     * @param transformRenameFun
+     *   : function to transform and rename columns
+     * @param colFilter
+     *   : predicate on column names to filter
+     * @param keepOriginalCols
+     *   : whether to keep original cols (make sure that there is no ambiguity!)
+     * @return
+     *   DataFrame with transformed and renamed columns
+     */
+    def transformCols(
+        transformRenameFun: String => Iterable[(Column, String)],
+        colFilter: String => Boolean,
+        keepOriginalCols: Boolean
+    ): DataFrame = {
       val resultCols = ds.columns.flatMap { cn =>
         if (colFilter(cn)) {
           val newCols = transformRenameFun(cn).map { case (c, cn) => c.as(cn) }.toList
@@ -63,42 +68,54 @@ trait Transform extends Serializable {
 
         } else List(col(cn))
       }
-      ds.select(resultCols: _*)
+      ds.select(resultCols.toIndexedSeq: _*)
     }
 
     /**
-     * transforms columns given by the tranforming function
-     * but transforms Dataset to DataFrame
+     * transforms columns given by the tranforming function but transforms Dataset to DataFrame
      *
-     * @param renameFun        : function to rename columns
-     * @param transformFun     : function to transform columns
-     * @param colFilter        : predicate on column names to filter
-     * @param keepOriginalCols : whether to keep original cols (make sure that there is no ambiguity!)
-     * @return DataFrame with renamed columns
+     * @param renameFun
+     *   : function to rename columns
+     * @param transformFun
+     *   : function to transform columns
+     * @param colFilter
+     *   : predicate on column names to filter
+     * @param keepOriginalCols
+     *   : whether to keep original cols (make sure that there is no ambiguity!)
+     * @return
+     *   DataFrame with renamed columns
      */
-    def transformCols(renameFun: String => Iterable[String] = List(_),
-                      transformFun: String => Iterable[Column] = cn => Seq(col(cn)),
-                      colFilter: String => Boolean = _ => true,
-                      keepOriginalCols: Boolean = false): DataFrame = {
+    def transformCols(
+        renameFun: String => Iterable[String] = List(_),
+        transformFun: String => Iterable[Column] = cn => Seq(col(cn)),
+        colFilter: String => Boolean = _ => true,
+        keepOriginalCols: Boolean = false
+    ): DataFrame = {
       val transformRename: String => Iterable[(Column, String)] = cn => transformFun(cn).zip(renameFun(cn))
       transformCols(transformRenameFun = transformRename,
         colFilter = colFilter, keepOriginalCols = keepOriginalCols)
     }
 
     /**
-     * transforms columns given by the tranforming function
-     * but transforms Dataset to DataFrame
+     * transforms columns given by the tranforming function but transforms Dataset to DataFrame
      *
-     * @param renameFun        : function to rename columns
-     * @param transformFun     : function to transform columns
-     * @param datType          : primitive Datatype. Does not work with parametrised DataTypes
-     * @param keepOriginalCols : whether to keep original cols (make sure that there is no ambiguity!)
-     * @return DataFrame with renamed columns
+     * @param renameFun
+     *   : function to rename columns
+     * @param transformFun
+     *   : function to transform columns
+     * @param datType
+     *   : primitive Datatype. Does not work with parametrised DataTypes
+     * @param keepOriginalCols
+     *   : whether to keep original cols (make sure that there is no ambiguity!)
+     * @return
+     *   DataFrame with renamed columns
      */
-    def transformCols(renameFun: String => Iterable[String],
-                      transformFun: String => Iterable[Column],
-                      datType: DataType,
-                      keepOriginalCols: Boolean): DataFrame = {
+    def transformCols(
+        renameFun: String => Iterable[String],
+        transformFun: String => Iterable[Column],
+        datType: DataType,
+        keepOriginalCols: Boolean
+    ): DataFrame = {
       val transformRename: String => Iterable[(Column, String)] = cn => transformFun(cn).zip(renameFun(cn))
       transformCols(transformRenameFun = transformRename,
         colFilter = ds.schema(_).dataType == datType,
@@ -108,105 +125,133 @@ trait Transform extends Serializable {
     /**
      * This method assumes that all Timestamps are given in utc
      *
-     * @param timeZone      : desired time zone
-     * @param excludedTimes : not to be converted, typically lowerHorizon and upperHorizon
-     * @return dataFrame with converted time stamps
+     * @param timeZone
+     *   : desired time zone
+     * @param excludedTimes
+     *   : not to be converted, typically lowerHorizon and upperHorizon
+     * @return
+     *   dataFrame with converted time stamps
      */
-    def fromUtc(timeZone: String = "Europe/Zurich",
-                excludedTimes: Seq[Timestamp] = List(Timestamp.valueOf("0001-01-01 0:0:0"), Timestamp.valueOf("9999-12-31 0:0:0")))
-    : DataFrame = {
-      transformCols(renameFun = List(_), transformFun = cn =>
-        List(when(col(cn).isin(excludedTimes: _*), col(cn)).otherwise(from_utc_timestamp(col(cn), timeZone))),
-        datType = TimestampType, keepOriginalCols = false)
-    }
+    def fromUtc(
+        timeZone: String = "Europe/Zurich",
+        excludedTimes: Seq[Timestamp] = List(Timestamp.valueOf("0001-01-01 0:0:0"), Timestamp.valueOf("9999-12-31 0:0:0"))
+    )
+        : DataFrame =
+      transformCols(
+        renameFun = List(_),
+        transformFun = cn =>
+          List(when(col(cn).isin(excludedTimes.toIndexedSeq: _*), col(cn)).otherwise(from_utc_timestamp(col(cn), timeZone))),
+        datType = TimestampType,
+        keepOriginalCols = false
+      )
 
     /**
-     *
-     * @param timeZone      : time zone of Timestamp columns
-     * @param excludedTimes : not to be converted, typically lowerHorizon and upperHorizon
-     * @return dataFrame with UTC time stamps
+     * @param timeZone
+     *   : time zone of Timestamp columns
+     * @param excludedTimes
+     *   : not to be converted, typically lowerHorizon and upperHorizon
+     * @return
+     *   dataFrame with UTC time stamps
      */
-    def toUtc(timeZone: String = "Europe/Zurich",
-              excludedTimes: Seq[Timestamp] = List(Timestamp.valueOf("0001-01-01 0:0:0"), Timestamp.valueOf("9999-12-31 0:0:0")))
-    : DataFrame = {
-      transformCols(renameFun = List(_), transformFun = cn =>
-        List(when(col(cn).isin(excludedTimes: _*), col(cn)).otherwise(to_utc_timestamp(col(cn), timeZone))),
-        datType = TimestampType, keepOriginalCols = false)
-    }
+    def toUtc(
+        timeZone: String = "Europe/Zurich",
+        excludedTimes: Seq[Timestamp] = List(Timestamp.valueOf("0001-01-01 0:0:0"), Timestamp.valueOf("9999-12-31 0:0:0"))
+    )
+        : DataFrame =
+      transformCols(
+        renameFun = List(_),
+        transformFun = cn =>
+          List(when(col(cn).isin(excludedTimes.toIndexedSeq: _*), col(cn)).otherwise(to_utc_timestamp(col(cn), timeZone))),
+        datType = TimestampType,
+        keepOriginalCols = false
+      )
 
     /**
      * Converts the data type of columns to a specified type.
      *
      * Notes:
-     * - This function takes a column name and a target data type and updates the column's type accordingly.
-     * - The returned data frame reflects the updated column types.
+     *   - This function takes a column name and a target data type and updates the column's type
+     *     accordingly.
+     *   - The returned data frame reflects the updated column types.
      *
-     * @param newType     : The desired data type to convert to
-     * @param currentType : columns of this type will be casted to newType
-     * @return A data frame with the column type updated
-     *
+     * @param newType
+     *   : The desired data type to convert to
+     * @param currentType
+     *   : columns of this type will be casted to newType
+     * @return
+     *   A data frame with the column type updated
      */
     def castColumnsOfTypeTo(newType: DataType)(currentType: DataType): DataFrame = transformCols(
       transformFun = cn => List(col(cn).cast(newType)),
-      colFilter = ds.schema.apply(_).dataType == currentType)
+      colFilter = ds.schema.apply(_).dataType == currentType
+    )
 
     /**
      * Converts the data type of columns to a specified type.
      *
      * Notes:
-     * - This function takes a column name and a target data type and updates the column's type accordingly.
-     * - The returned data frame reflects the updated column types.
+     *   - This function takes a column name and a target data type and updates the column's type
+     *     accordingly.
+     *   - The returned data frame reflects the updated column types.
      *
-     * @param newType  : The desired data type to convert to
-     * @param colNames : List of column names whose type is to be converted
-     * @return A data frame with the column type updated
-     *
+     * @param newType
+     *   : The desired data type to convert to
+     * @param colNames
+     *   : List of column names whose type is to be converted
+     * @return
+     *   A data frame with the column type updated
      */
-    def castColumnsTo(newType: DataType)(colNames: Seq[String]): DataFrame = {
+    def castColumnsTo(newType: DataType)(colNames: Seq[String]): DataFrame =
       transformCols(transformFun = cn => List(col(cn).cast(newType)), colFilter = colNames.contains)
-    }
 
     /**
      * Converts the data type of a column to a specified type.
      *
      * Notes:
-     * - This function takes a column name and a target data type and updates the column's type accordingly.
-     * - The returned data frame reflects the updated column types.
+     *   - This function takes a column name and a target data type and updates the column's type
+     *     accordingly.
+     *   - The returned data frame reflects the updated column types.
      *
-     * @param newType : The desired data type to convert to
-     * @param colName : The name of the column whose type is to be converted
-     * @return A data frame with the column type updated
-     *
+     * @param newType
+     *   : The desired data type to convert to
+     * @param colName
+     *   : The name of the column whose type is to be converted
+     * @return
+     *   A data frame with the column type updated
      */
     def castColumnTo(newType: DataType)(colName: String): DataFrame = castColumnsTo(newType)(List(colName))
 
     /**
      * Casts type of all columns to [[StringType]].
      *
-     * @return casted [[DataFrame]]
+     * @return
+     *   casted [[DataFrame]]
      */
     def castAll2String: DataFrame = castColumnsTo(newType = StringType)(colNames = ds.columns)
 
     /**
      * Casts type of all [[DataType]] columns to [[TimestampType]].
      *
-     * @return casted [[DataFrame]]
+     * @return
+     *   casted [[DataFrame]]
      */
     def castAllDate2Timestamp: DataFrame = castColumnsOfTypeTo(newType = TimestampType)(currentType = DateType)
 
-
     /**
-     *
-     * @param typOpt desired data type if any (should be a large enough integral type)
-     * @param strict Shall the upper bounds for precision of Decicmal be a strict bound?
-     *               If strict then there an overflow cannot occur
-     *               if not(strict) then the precision is the number of digits of the integral type
-     *               but the Decimal value may be outside of the integral range.
-     *               Set strict to false on your own risk
-     * @return data frame of which all unscaled Decimal columns are converted to Integral type
+     * @param typOpt
+     *   desired data type if any (should be a large enough integral type)
+     * @param strict
+     *   Shall the upper bounds for precision of Decicmal be a strict bound? If strict then there an
+     *   overflow cannot occur if not(strict) then the precision is the number of digits of the
+     *   integral type but the Decimal value may be outside of the integral range. Set strict to
+     *   false on your own risk
+     * @return
+     *   data frame of which all unscaled Decimal columns are converted to Integral type
      */
-    def castDecimalsToIntegralType(typOpt: Option[DataType] = None,
-                                   strict: Boolean = true): DataFrame = {
+    def castDecimalsToIntegralType(
+        typOpt: Option[DataType] = None,
+        strict: Boolean = true
+    ): DataFrame = {
       val oldType: String => DataType = cn => ds.schema(cn).dataType
       val oldTypePrecisionScale: String => Option[(Int, Int)] = cn => getDecimalPrecisionScale(oldType(cn))
       val cFilter: String => Boolean = oldTypePrecisionScale(_).map(_._2).contains(0)
@@ -214,13 +259,14 @@ trait Transform extends Serializable {
       def isPrecisionSmallerThan(upperBound: Int)(p: Int) = p < upperBound || (!strict & p == upperBound)
 
       val trfFun: String => Iterable[Column] = colName => {
-        val newType = if (typOpt.isDefined) typOpt.get else oldTypePrecisionScale(colName).map(_._1).get match {
-          case n if n <= 0 => oldType(colName)
-          case n if isPrecisionSmallerThan(3)(n) => ByteType
-          case n if isPrecisionSmallerThan(5)(n) => ShortType
+        val newType = if (typOpt.isDefined) typOpt.get
+        else oldTypePrecisionScale(colName).map(_._1).get match {
+          case n if n <= 0                        => oldType(colName)
+          case n if isPrecisionSmallerThan(3)(n)  => ByteType
+          case n if isPrecisionSmallerThan(5)(n)  => ShortType
           case n if isPrecisionSmallerThan(10)(n) => IntegerType
           case n if isPrecisionSmallerThan(19)(n) => LongType
-          case _ => oldType(colName)
+          case _                                  => oldType(colName)
         }
         Seq(col(colName).cast(newType))
       }
@@ -241,17 +287,19 @@ trait Transform extends Serializable {
     /**
      * Casts type of all columns of [[DecimalType]] to an [[IntegralType]] or [[FloatType]].
      *
-     * @return casted [[DataFrame]]
+     * @return
+     *   casted [[DataFrame]]
      */
     def castAllDecimal2IntegralFloat: DataFrame = castDecimalsToIntegralType(strict = false).castDecimalsToFloatDouble()
 
     /**
-     * @return DataFrame with columns of MapType casted to ArrayType
+     * @return
+     *   DataFrame with columns of MapType casted to ArrayType
      */
     def castMapsToArrays: DataFrame = {
       val mapCols: String => Boolean = ds.schema(_).dataType match {
         case MapType(_, _, _) => true
-        case _ => false
+        case _                => false
       }
       transformCols(transformFun = cn => List(map_entries(col(cn))), colFilter = mapCols)
     }
@@ -261,60 +309,73 @@ trait Transform extends Serializable {
 
     /**
      * Enumerates groups in a dataframe. Groups are final defined based on `keyCols` and `condition`
-     * (e.g. the previous value of an attribute) after ordering by `orderCols`.
-     * The previous attr has the postfix "_prev", e.g. condition = $"id_prev" === $"id"
+     * (e.g. the previous value of an attribute) after ordering by `orderCols`. The previous attr
+     * has the postfix "_prev", e.g. condition = $"id_prev" === $"id"
      *
      * Notes about nulls:
-     *  - nulls in attr must be handled in condition, null is not equal to null!
-     *  - nulls in keyCols final define a group, all nulls fall in this groups
-     *  - nulls in orderCols are placed first (with ascending order). This can be changed with e.g.
-     *    orderCols = Seq($"sample_nb".asc_nulls_last)
+     *   - nulls in attr must be handled in condition, null is not equal to null!
+     *   - nulls in keyCols final define a group, all nulls fall in this groups
+     *   - nulls in orderCols are placed first (with ascending order). This can be changed with e.g.
+     *     orderCols = Seq($"sample_nb".asc_nulls_last)
      *
-     * @param attr        the attribute on which the enumeration depends
-     * @param keyCols     the keys onf the dataframe
-     * @param orderCols   the column for the ordering
-     * @param condition   The condition for a group
-     * @param groupNbName The name of the number col, final defaults to "nb"
+     * @param attr
+     *   the attribute on which the enumeration depends
+     * @param keyCols
+     *   the keys onf the dataframe
+     * @param orderCols
+     *   the column for the ordering
+     * @param condition
+     *   The condition for a group
+     * @param groupNbName
+     *   The name of the number col, final defaults to "nb"
      * @return
      */
     // TODO: Move enumerateGroups to a different trait as it does not transform the dataset
-    def enumerateGroups(attr: String, keyCols: Seq[Column], orderCols: Seq[Column],
-                        condition: Column, groupNbName: String = "nb")
-                       (implicit ss: SparkSession): DataFrame = {
+    def enumerateGroups(
+        attr: String,
+        keyCols: Seq[Column],
+        orderCols: Seq[Column],
+        condition: Column,
+        groupNbName: String = "nb"
+    )(implicit ss: SparkSession): DataFrame = {
       import ss.implicits._
 
-      ds.withColumn(attr + "_prev", lag(attr, 1).over(Window.partitionBy(keyCols: _*).orderBy(orderCols: _*)))
+      ds.withColumn(attr + "_prev", lag(attr, 1).over(Window.partitionBy(keyCols.toIndexedSeq: _*).orderBy(orderCols.toIndexedSeq: _*)))
         .withColumn("consecutive", col(attr + "_prev").isNotNull and condition)
-        .withColumn(groupNbName, sum(when($"consecutive", lit(0)).otherwise(lit(1))).over(Window.partitionBy(keyCols: _*).orderBy(orderCols: _*)))
+        .withColumn(groupNbName,
+          sum(when($"consecutive", lit(0)).otherwise(lit(1))).over(Window.partitionBy(keyCols.toIndexedSeq: _*).orderBy(orderCols.toIndexedSeq: _*)))
         .drop(attr + "_prev", "consecutive")
     }
 
     /**
-     * @return DataFrame with columns of ArrayType or MapType exploded
+     * @return
+     *   DataFrame with columns of ArrayType or MapType exploded
      */
-    //noinspection NoTailRecursionAnnotation
+    // noinspection NoTailRecursionAnnotation
     def explodeArrays: DataFrame = {
       // Since one array column can be exploded at time
       // we use recursion here instead of sending all columsn to the transformer
       val firstArrayCol: Option[String] = ds.columns.find(ds.schema(_).dataType.isInstanceOf[ArrayType])
       firstArrayCol match {
-        case None => ds.asInstanceOf[DataFrame]
+        case None         => ds.asInstanceOf[DataFrame]
         case Some(arrCol) => ds
-          .transformCols(transformFun = cn => List(explode(col(cn))), colFilter = arrCol == _)
-          .explodeArrays
+            .transformCols(transformFun = cn => List(explode(col(cn))), colFilter = arrCol == _)
+            .explodeArrays
       }
     }
 
     /**
-     * @return DataFrame with columns of ArrayType or MapType exploded
+     * @return
+     *   DataFrame with columns of ArrayType or MapType exploded
      */
-    //noinspection NoTailRecursionAnnotation
+    // noinspection NoTailRecursionAnnotation
     def explodeMaps: DataFrame = {
       val firstMapCol: Option[String] = ds.columns.find(ds.schema(_).dataType.isInstanceOf[MapType])
       firstMapCol match {
-        case None => ds.asInstanceOf[DataFrame]
-        case Some(mapCol) => val i = ds.columns.indexOf(mapCol)
-          ds.select(ds.columns.take(i).map(col) ++ (explode(col(mapCol)) +: ds.columns.drop(i + 1).map(col)): _*)
+        case None         => ds.asInstanceOf[DataFrame]
+        case Some(mapCol) =>
+          val i = ds.columns.indexOf(mapCol)
+          ds.select(ds.columns.take(i).map(col) ++ (explode(col(mapCol)) +: ds.columns.drop(i + 1).map(col)).toIndexedSeq: _*)
             .withColumnRenamed("key", s"${mapCol}_key")
             .withColumnRenamed("value", s"${mapCol}_value")
             .explodeMaps
@@ -324,35 +385,41 @@ trait Transform extends Serializable {
     ///// Renaming Columns /////
 
     /**
-     * renames columns given by the renaming function
-     * but transforms Dataset to DataFrame
+     * renames columns given by the renaming function but transforms Dataset to DataFrame
      *
-     * @param renameFun        : function to rename columns
-     * @param colFilter        : predicate on column names to filter
-     * @param keepOriginalCols : whether to keep original cols (make sure that there is no ambiguity!)
-     * @return DataFrame with renamed columns
-     *
+     * @param renameFun
+     *   : function to rename columns
+     * @param colFilter
+     *   : predicate on column names to filter
+     * @param keepOriginalCols
+     *   : whether to keep original cols (make sure that there is no ambiguity!)
+     * @return
+     *   DataFrame with renamed columns
      */
-    def renameCols(renameFun: String => String,
-                   colFilter: String => Boolean = _ => true,
-                   keepOriginalCols: Boolean = false): DataFrame = {
+    def renameCols(
+        renameFun: String => String,
+        colFilter: String => Boolean = _ => true,
+        keepOriginalCols: Boolean = false
+    ): DataFrame = {
       val rename: String => Iterable[String] = cn => Seq(renameFun(cn))
       transformCols(renameFun = rename, colFilter = colFilter, keepOriginalCols = keepOriginalCols)
     }
-
 
     ///// Unfolding Structs /////
 
     /**
      * loest Struct-Column in die Elementfelder auf
      *
-     * @param scheme  : schema which the column belongs to
-     * @param nested  : bestimmt ob verschachtelte Structs rekursiv aufgeloest werden sollen
-     * @param colName : column to estruct
-     * @return Sequence of column expressions
+     * @param scheme
+     *   : schema which the column belongs to
+     * @param nested
+     *   : bestimmt ob verschachtelte Structs rekursiv aufgeloest werden sollen
+     * @param colName
+     *   : column to estruct
+     * @return
+     *   Sequence of column expressions
      */
-    private def unfoldStructCol(scheme: StructType, nested: Boolean = true)
-                               (colName: String): List[String] = {
+    private def unfoldStructCol(scheme: StructType, nested: Boolean = true)(colName: String): List[String] = {
       val fld: StructField = scheme(colName)
       fld.dataType match {
         case StructType(_) =>
@@ -370,26 +437,33 @@ trait Transform extends Serializable {
     /**
      * loest alle Struct-Spalten in die Elementspalten auf
      *
-     * @param colNameFilter     : which columns to unfoldStructs
-     * @param nested            : bestimmt ob verschachtelte Structs rekursiv aufgeloest werden sollen
-     * @param fullSubcolName    : bestimmt ob der volle Spaltenpfad als Name verwendet werden soll
-     * @param fullSubcolNameSep : seperator for column names if fullSubcolName
-     * @return df mit aufgeloester Spalte fld.name falls diese vom StructType ist, sonst df unverändert
+     * @param colNameFilter
+     *   : which columns to unfoldStructs
+     * @param nested
+     *   : bestimmt ob verschachtelte Structs rekursiv aufgeloest werden sollen
+     * @param fullSubcolName
+     *   : bestimmt ob der volle Spaltenpfad als Name verwendet werden soll
+     * @param fullSubcolNameSep
+     *   : seperator for column names if fullSubcolName
+     * @return
+     *   df mit aufgeloester Spalte fld.name falls diese vom StructType ist, sonst df unverändert
      */
-    def unfoldStructs(colNameFilter: String => Boolean = _ => true,
-                      nested: Boolean = true,
-                      fullSubcolName: Boolean = true,
-                      fullSubcolNameSep: String = "·"): DataFrame = {
+    def unfoldStructs(
+        colNameFilter: String => Boolean = _ => true,
+        nested: Boolean = true,
+        fullSubcolName: Boolean = true,
+        fullSubcolNameSep: String = "·"
+    ): DataFrame = {
       def getSubColAlias(cn: String): String = if (fullSubcolName)
-        cn.replace(".", fullSubcolNameSep) else cn.replaceAll(".*\\.", "")
+        cn.replace(".", fullSubcolNameSep)
+      else cn.replaceAll(".*\\.", "")
 
       val transformRename: String => List[(Column, String)] = str =>
         unfoldStructCol(ds.schema, nested)(str)
-          .map { x => (col(x), getSubColAlias(x)) }
+          .map(x => (col(x), getSubColAlias(x)))
       transformCols(transformRenameFun = transformRename,
         colFilter = colNameFilter, keepOriginalCols = false)
     }
-
 
     ///// unpivotCast, transpose et al /////
 
@@ -399,16 +473,20 @@ trait Transform extends Serializable {
      *
      * (Adapted from [[https://stackoverflow.com/a/37865645)]]
      *
-     * Note: This could also be implemented with the SQL-expression "stack
-     * See [[https://confluence.sbb.ch/display/STA/DataFrame+Reshaping]]
+     * Note: This could also be implemented with the SQL-expression "stack See
+     * [[https://confluence.sbb.ch/display/STA/DataFrame+Reshaping]]
      *
-     * Note that the datatype of all columns to be transposed to rows must be the same!
-     * If at least 1 column is nullable, the new column will also be nullable
+     * Note that the datatype of all columns to be transposed to rows must be the same! If at least
+     * 1 column is nullable, the new column will also be nullable
      *
-     * @param idCols    The id-columns which should remain
-     * @param keyName   The name of the new key-column
-     * @param valueName The name of the new value-column
-     * @return The transformed dataframe
+     * @param idCols
+     *   The id-columns which should remain
+     * @param keyName
+     *   The name of the new key-column
+     * @param valueName
+     *   The name of the new value-column
+     * @return
+     *   The transformed dataframe
      */
     def colsToRows(idCols: Seq[String], keyName: String = "key", valueName: String = "value"): DataFrame = {
       // cols: all columns to be transformed to rows
@@ -422,37 +500,47 @@ trait Transform extends Serializable {
 
       // make an array of the values in the columns and then explode it to generate rows
       val kvs = explode(array(
-        cols.map(c => struct(
-          lit(c).alias(keyName),
-          // the "when" makes a non-nullable column nullable
-          (if (hasNullable) when(lit(true), col(c)) else col(c)
-            ).alias(valueName))): _*
-      ))
+          cols.map(c =>
+            struct(
+              lit(c).alias(keyName),
+              // the "when" makes a non-nullable column nullable
+              (if (hasNullable) when(lit(true), col(c)) else col(c)).alias(valueName)
+            )
+          ): _*
+        ))
 
       val colsToKeep = idCols.map(col)
 
       // construct final dataframe
       ds.select(colsToKeep :+ kvs.alias("_kvs"): _*)
-        .select(colsToKeep ++ Seq(col(s"_kvs.$keyName"), col(s"_kvs.$valueName")): _*)
+        .select(colsToKeep ++ Seq(col(s"_kvs.$keyName"), col(s"_kvs.$valueName")).toIndexedSeq: _*)
     }
 
     /**
-     * Unpivotiert mehrere Spalten des Datasets
-     * Gibt es eine nicht-numerische Pivotspalte, dann werden diese alle zu StringType gecastet
-     * Spalten, die weder in keys oder colNamesToPivot vorkommen werden geloescht.
+     * Unpivotiert mehrere Spalten des Datasets Gibt es eine nicht-numerische Pivotspalte, dann
+     * werden diese alle zu StringType gecastet Spalten, die weder in keys oder colNamesToPivot
+     * vorkommen werden geloescht.
      *
-     * @param keys            : columns which are to be kept but not pivoted
-     * @param namesColName    : name of column which contains names of pivoted columns
-     * @param valuesColname   : name of column which contains values of pivoted columns
-     * @param colNamesToPivot : names of column to unpivotCast
-     * @return df mit pivotierter Spalte
+     * @param keys
+     *   : columns which are to be kept but not pivoted
+     * @param namesColName
+     *   : name of column which contains names of pivoted columns
+     * @param valuesColname
+     *   : name of column which contains values of pivoted columns
+     * @param colNamesToPivot
+     *   : names of column to unpivotCast
+     * @return
+     *   df mit pivotierter Spalte
      */
-    def unpivotCast(keys: Array[Column],
-                    namesColName: String = "x", valuesColname: String = "y",
-                    colNamesToPivot: Array[String]): DataFrame = {
-      val dfTypes: Set[DataType] = ds.select(colNamesToPivot.map(col): _*).schema.map(_.dataType).toSet
+    def unpivotCast(
+        keys: Array[Column],
+        namesColName: String = "x",
+        valuesColname: String = "y",
+        colNamesToPivot: Array[String]
+    ): DataFrame = {
+      val dfTypes: Set[DataType] = ds.select(colNamesToPivot.map(col).toIndexedSeq: _*).schema.map(_.dataType).toSet
       val dfCasted = if (dfTypes.forall(_.isInstanceOf[NumericType])) ds
-      else colNamesToPivot.foldLeft(ds.asInstanceOf[DataFrame]) { (dtf, cn) => dtf.castColumnTo(StringType)(cn) }
+      else colNamesToPivot.foldLeft(ds.asInstanceOf[DataFrame])((dtf, cn) => dtf.castColumnTo(StringType)(cn))
       dfCasted.unpivot(ids = keys, values = colNamesToPivot.map(col),
         variableColumnName = namesColName, valueColumnName = valuesColname)
     }
@@ -460,8 +548,11 @@ trait Transform extends Serializable {
     /**
      * transponiert die ersten numRows Zeilen des Dataframes
      *
-     * @param numRows : Anzahl Zeilen, die transponiert werden sollen. Datentyp Byte damit nicht zu viele angegeben werden.
-     * @return df 1+numRows Zeilen und Anzahl Zeilen, die der Spaltenanzahl entspricht
+     * @param numRows
+     *   : Anzahl Zeilen, die transponiert werden sollen. Datentyp Byte damit nicht zu viele
+     *   angegeben werden.
+     * @return
+     *   df 1+numRows Zeilen und Anzahl Zeilen, die der Spaltenanzahl entspricht
      */
     def transpose(numRows: Byte = 2)(implicit ss: SparkSession): DataFrame = if (ds.isEmpty) {
       ss.createDataFrame(ds.columns.map(Row(_)).toList.asJava, StructType(List(StructField("_column", StringType, nullable = false))))
@@ -473,17 +564,15 @@ trait Transform extends Serializable {
         .unpivotCast(Array(), "_column", f"_${rows.indexOf(r)}%03d", ds.columns)
 
       rows.map(transposeRow(rows))
-        .reduce { (df1, df2) => df1.join(df2, Seq("_column")) }
+        .reduce((df1, df2) => df1.join(df2, Seq("_column")))
     }
-
 
     /**
      * dataset to curry frame
      */
-    def curryDataFrameOneColumn(keyCols: List[String], cn: String): DataFrame = {
-      ds.groupBy(keyCols.map(col): _*)
+    def curryDataFrameOneColumn(keyCols: List[String], cn: String): DataFrame =
+      ds.groupBy(keyCols.map(col).toIndexedSeq: _*)
         .agg(collect_set(struct(col(cn), col("values"))).as("values"))
-    }
 
     private def applyFunToValues(f: Column => Column)(v: Column): Column = f(v)
 
@@ -492,12 +581,14 @@ trait Transform extends Serializable {
       // Building column expression for curry_map
       val curryMapColumn = pkCols.size match {
         case 1 => map_from_entries(col("values")).as("curry_map")
-        case _ => transform_values(map_from_entries(col("values")),
-          List.range(2, pkCols.size)
-            .foldLeft[(Column, Column) => Column]((_, c) => applyFunToValues(f = map_from_entries)(c)) {
-              (col, _) => (_, x) => applyFunToValues(f = c => transform_values(map_from_entries(c), col))(x)
-            })
-          .as("curry_map")
+        case _ => transform_values(
+            map_from_entries(col("values")),
+            List.range(2, pkCols.size)
+              .foldLeft[(Column, Column) => Column]((_, c) => applyFunToValues(f = map_from_entries)(c)) {
+                (col, _) => (_, x) => applyFunToValues(f = c => transform_values(map_from_entries(c), col))(x)
+              }
+          )
+            .as("curry_map")
       }
 
       // Building column expression for values
@@ -506,7 +597,7 @@ trait Transform extends Serializable {
         s"dataSet2curryMap: The Dataset ds mut contain at least one column not in pkCols=(${pkCols.mkString(",")})")
       val valuesColumn: Column = valueColumns.length match {
         case 1 => col(valueColumns.head).as("values")
-        case _ => struct(valueColumns.map(col): _*).as("values")
+        case _ => struct(valueColumns.map(col).toIndexedSeq: _*).as("values")
       }
       val dfDs = ds.select(pkCols.map(col) :+ valuesColumn: _*)
       val pkColsInit: List[String] = pkCols.distinct.init
@@ -518,10 +609,9 @@ trait Transform extends Serializable {
       }.select(curryMapColumn)
     }
 
-    def breakLineageIfNotExecPhase(isExec: Boolean): DataFrame = {
+    def breakLineageIfNotExecPhase(isExec: Boolean): DataFrame =
       if (!isExec) getEmptyDataFrame(ds.schema)(ds.sparkSession)
       else ds.toDF()
-    }
 
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/hive/HiveUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/hive/HiveUtil.scala
@@ -19,21 +19,16 @@
 package io.smartdatalake.util.spark.hive
 
 import io.smartdatalake.definitions._
-import io.smartdatalake.util.evolution.SchemaEvolution
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionLayout, PartitionValues}
 import io.smartdatalake.util.misc.PerformanceUtils.measureTime
-import io.smartdatalake.util.misc.{EnvironmentUtil, SchemaUtil, SmartDataLakeLogger}
-import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.sql.functions.{array, col}
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
-
-import java.net.URI
-import java.time.Instant
-import scala.sys.process.{ProcessLogger, _}
-import scala.util.{Failure, Success, Try}
-import io.smartdatalake.workflow.dataframe.GenericDataFrame
-import io.smartdatalake.workflow.dataframe.spark.SparkDataFrame
+import io.smartdatalake.util.misc.SmartDataLakeLogger
 import io.smartdatalake.workflow.dataobject.generic.Table
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.time.Instant
+import scala.util.{Failure, Success, Try}
 
 /**
  * Provides utility functions for Hive.
@@ -141,7 +136,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
         throw ex
     }
 
-    session.sql(s"show partitions ${table.fullName}").as[String].collect().map( parseHDFSPartitionString).toSeq
+    session.sql(s"show partitions ${table.fullName}").as[String].collect.map( parseHDFSPartitionString).toSeq
   }
 
   // get partition columns for specified table from DDL
@@ -152,13 +147,14 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
     val tableDDL = session.sql(s"show create table ${table.fullName}").as[String].collect().mkString(" ").replace("\n"," ")
 
     // extract partition by declaration
-    val regexPartitionBy = raw"PARTITIONED BY\s+\(([^\)]+)\)".r.unanchored
+    val regexPartitionBy = raw"PARTITIONED BY\s+\(([^)]+)\)".r.unanchored
     val partitionColsAndDatatypes = tableDDL match {
-      case regexPartitionBy( partitionByDDL ) => {
-        val columnNameAllowedChars = (('a' to 'z') ++ ('A' to 'Z') ++ ( '0' to '9' ) :+ '_' :+ ' ' :+ ',')
+      case regexPartitionBy( partitionByDDL ) =>
+        val columnNameAllowedChars = {
+          ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') :+ '_' :+ ' ' :+ ','
+        }
         // first split partition columns definition separated by comma, then split column name and type separated by whitespace
-        Some(partitionByDDL.trim.split(',').map(_.trim.filter(columnNameAllowedChars.contains(_)).split(' ').filter(!_.isEmpty)))
-      }
+        Some(partitionByDDL.trim.split(',').map(_.trim.filter(columnNameAllowedChars.contains(_)).split(' ').filter(_.nonEmpty)))
       case _ => None
     }
 
@@ -262,7 +258,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
     val partitionPath = new Path(tablePath, partition.getPartitionString(partitionLayout))
     val partitionDef = partition.elements.map{ case (k,v) => s"$k='$v'"}.mkString(", ")
     execSqlStmt(s"ALTER TABLE ${table.fullName} DROP IF EXISTS PARTITION ($partitionDef)")
-    HdfsUtil.deletePath(partitionPath, false)(filesystem)
+    HdfsUtil.deletePath(path = partitionPath, doWarn = false)(filesystem)
   }
 
   def movePartition(table: Table, tablePath: Path, existingPartition: PartitionValues, newPartition: PartitionValues, filenameWithGlobs: String, filesystem: FileSystem)(implicit session: SparkSession): Unit = {
@@ -306,7 +302,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    */
   def getCatalogColumnStats(table: Table)(implicit session: SparkSession): Map[String, Map[String, Any]] = {
     session.sessionState.catalog.getTableMetadata(table.tableIdentifier).stats.toSeq.flatMap(_.colStats).toMap
-      .mapValues (
+      .view.mapValues (
         stats => Seq(
           stats.distinctCount.map(ColumnStatsType.DistinctCount.toString -> _),
           stats.nullCount.map(ColumnStatsType.NullCount.toString -> _),
@@ -323,7 +319,7 @@ private[smartdatalake] object HiveUtil extends SmartDataLakeLogger {
    */
   def getCatalogPartitionColumnStats(table: Table, partitionValues: PartitionValues)(implicit session: SparkSession): Map[String, Map[String, Any]] = {
     session.sessionState.catalog.getPartition(table.tableIdentifier, partitionValues.getMapString).stats.toSeq.flatMap(_.colStats).toMap
-      .mapValues(
+      .view.mapValues(
         stats => Seq(
           stats.distinctCount.map(ColumnStatsType.DistinctCount.toString -> _),
           stats.nullCount.map(ColumnStatsType.NullCount.toString -> _),

--- a/sdl-core/src/main/scala/io/smartdatalake/util/webservice/SttpUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/webservice/SttpUtil.scala
@@ -56,12 +56,12 @@ object SttpUtil extends SmartDataLakeLogger {
 
   def getContent[T](response: Response[Either[String, T]], context: String): T = {
     validateResponse(response, context)
-    response.body.right.get
+    response.body.toOption.get
   }
 
   private[smartdatalake] def validateResponse[T](response: Response[Either[String, T]], context: String): Unit = {
     if (response.body.isLeft) {
-      throw HttpRequestError(context, response.code.code, response.body.left.get)
+      throw HttpRequestError(context, response.code.code, response.body.swap.toOption.get)
     }
     assert(response.isSuccess, throw HttpRequestError(context, response.code.code, "StatusCode is not successfull, but there is no error message!"))
   }
@@ -71,7 +71,7 @@ object SttpUtil extends SmartDataLakeLogger {
       .orElse {
         // manually detect type as guessContentTypeFromStream doesnt work for Json and Text...
         val str = new String(content)
-        if (str.take(100).matches("(?:\\P{Cntrl}|\\p{Space})+")) { // is text
+        if (str.take(100).matches("(?:\\P{Cntrl}|\\s)+")) { // is text
           if (str.matches("\\s*[{\\[]")) Some(MediaType.ApplicationJson.toString())
           else Some(MediaType.TextPlain.toString())
         } else None

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataFrameIncrementalMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataFrameIncrementalMode.scala
@@ -43,7 +43,7 @@ case class DataFrameIncrementalMode(compareCol: String
                                     , override val alternativeOutputId: Option[DataObjectId] = None
                                     , applyCondition: Option[Condition] = None
                                    ) extends ExecutionMode with ExecutionModeWithMainInputOutput {
-  override val applyConditionsDef = applyCondition.toSeq
+  override val applyConditionsDef: Seq[Condition] = applyCondition.toSeq
 
   override def mainInputOutputNeeded: Boolean = alternativeOutputId.isEmpty
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DataValidationTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DataValidationTransformer.scala
@@ -43,7 +43,7 @@ case class DataValidationTransformer(override val name: String = "dataValidation
   rules.foreach(_.getValidationColumn(functions))
   override def transform(actionId: ActionId, partitionValues: Seq[PartitionValues], df: GenericDataFrame, dataObjectId: DataObjectId, previousTransformerName: Option[String], executionModeResultOptions: Map[String,String])(implicit context: ActionPipelineContext): GenericDataFrame = {
     import functions._
-    df.withColumn(errorsColumn, array_construct_compact(rules.map(rule => rule.getValidationColumn): _*))
+    df.withColumn(errorsColumn, array_construct_compact(rules.map(rule => rule.getValidationColumn).toIndexedSeq: _*))
   }
   override def factory: FromConfigFactory[GenericDfTransformer] = DataValidationTransformer
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/customlogic/CustomDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/customlogic/CustomDfsTransformer.scala
@@ -189,7 +189,7 @@ class CustomTransformMethodWrapper(method: universe.MethodSymbol) {
           .getOrElse(throw NotFoundError(s"No DataFrame found with name $dsName for parameter $paramName. DataFrames available are ${dfs.keys.mkString(", ")}."))
         val dfWithSelect = {
           val columnNames = ProductUtil.classAccessorNames(dsType)
-          df.select(columnNames.map(col): _*)
+          df.select(columnNames.map(col).toIndexedSeq: _*)
         }
         val ds = SparkProductUtil.createDataset(dfWithSelect, dsType)
         (dsParam, ds)
@@ -200,7 +200,7 @@ class CustomTransformMethodWrapper(method: universe.MethodSymbol) {
         val optionVal = try {
           Some(extractOptionVal(options, optionalParam, getConverterFor(optionalParam.tpe.typeArgs.head)))
         } catch {
-          case _: NotFoundError => optionalParam.defaultValue.map(_.asInstanceOf[Option[Any]]).flatten
+          case _: NotFoundError => optionalParam.defaultValue.flatMap(_.asInstanceOf[Option[Any]])
         }
         (optionalParam, optionVal)
       case seqParam if seqParam.tpe <:< typeOf[Seq[_]] =>
@@ -235,13 +235,13 @@ class CustomTransformMethodWrapper(method: universe.MethodSymbol) {
     if (returnType =:= typeOf[Map[String, DataFrame]]) {
       transformResult.asInstanceOf[Map[String, DataFrame]]
     } else if (returnType <:< typeOf[Map[String, Dataset[_]]]) {
-      transformResult.asInstanceOf[Map[String, Dataset[_]]].mapValues(_.toDF).toMap
+      transformResult.asInstanceOf[Map[String, Dataset[_]]].mapValues(_.toDF()).toMap
     } else if (returnType =:= typeOf[DataFrame]) {
       require(options.isDefinedAt(OPTION_OUTPUT_DATAOBJECT_ID), "Custom transform function returns a single DataFrame, but outputDataObjectId is ambiguous. Modify Action to have only one outputIds entry, or return a Map[String,DataFrame] from your custom transform function." )
       Map(options(OPTION_OUTPUT_DATAOBJECT_ID) -> transformResult.asInstanceOf[DataFrame])
     } else if (returnType <:< typeOf[Dataset[_]]) {
       require(options.isDefinedAt(OPTION_OUTPUT_DATAOBJECT_ID), "Custom transform function returns a single Dataset, but outputDataObjectId is ambigous. Modify Action to have only one outputIds entry, or return a Map[String,Dataset] from your custom transform function." )
-      Map(options(OPTION_OUTPUT_DATAOBJECT_ID) -> transformResult.asInstanceOf[Dataset[_]].toDF)
+      Map(options(OPTION_OUTPUT_DATAOBJECT_ID) -> transformResult.asInstanceOf[Dataset[_]].toDF())
     } else {
       throw new IllegalStateException(s"Custom transform function has unsupported return type $returnType")
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDsNTo1Transformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDsNTo1Transformer.scala
@@ -126,7 +126,7 @@ case class ScalaClassSparkDsNTo1Transformer(override val description: Option[Str
     val columnsFromCaseClass = ProductUtil.classAccessorNames(outputClassType)
 
     val resAsDF = resDs.toDF()
-    val resWithSelect = if (outputColumnAutoSelect) resAsDF.select(columnsFromCaseClass.map(col): _*) else resAsDF
+    val resWithSelect = if (outputColumnAutoSelect) resAsDF.select(columnsFromCaseClass.map(col).toIndexedSeq: _*) else resAsDF
 
     if (addPartitionValuesToOutput) {
       assert(partitionValues.size == 1, s"When using addPartitionValuesToOutput you can only process one partition-value at a time, but ${partitionValues.size} where given: {${partitionValues.mkString(";")}}")
@@ -162,7 +162,7 @@ case class ScalaClassSparkDsNTo1Transformer(override val description: Option[Str
         val dfWithSelect =
           if (inputColumnAutoSelect) {
             val columnNames = ProductUtil.classAccessorNames(dsType)
-            df.select(columnNames.map(col): _*)
+            df.select(columnNames.map(col).toIndexedSeq: _*)
           } else {
             df
           }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ExpressionParser.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ExpressionParser.scala
@@ -292,7 +292,7 @@ object ExpressionParser {
       val resolved = candidates.view.flatMap(method => buildInvocationArguments(method, args).map(method -> _)).headOption
       resolved match {
         case Some((method, invocationArgs)) =>
-          val result = method.invoke(functions, invocationArgs: _*)
+          val result = method.invoke(functions, invocationArgs.toIndexedSeq: _*)
           result match {
             case col: GenericColumn => col
             case _ => throw ExpressionParserException(s"Function '$functionName' does not return a column", position)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaDataFrame.scala
@@ -24,7 +24,6 @@ import io.smartdatalake.util.misc.{ProductUtil, SmartDataLakeLogger}
 import io.smartdatalake.workflow.DataFrameSubFeed
 import io.smartdatalake.workflow.DataFrameSubFeed.assertCorrectSubFeedType
 import io.smartdatalake.workflow.dataframe._
-import io.smartdatalake.workflow.dataframe.plainScala.ScalaDataFrameImplicits.OrderingOps
 
 import scala.collection.immutable.Queue
 import scala.reflect.ClassTag
@@ -54,7 +53,7 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
       case Array(_, "*") => ScalaColumnReference(columnName)
       case Array("*") => throw new IllegalArgumentException(s"Star expand without alias to get Columns from DataFrame is not supported. Use select(*) instead.")
       case _ => cols.find(_.definition.name == columnName)
-        .getOrElse(throw new IllegalArgumentException(s"column name ${columnName} does not exist in the dataframe"))
+        .getOrElse(throw new IllegalArgumentException(s"column name $columnName does not exist in the dataframe"))
 
     }
   }
@@ -86,7 +85,7 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
   override def schema: ScalaSchema = ScalaSchema(cols.map(_.definition))
 
   override def join(other: GenericDataFrame, joinCols: Seq[String], joinType: String = "inner"): ScalaDataFrame = other match {
-    case otherScala: ScalaDataFrame => {
+    case otherScala: ScalaDataFrame =>
       checkColumnsExist(this, joinCols)
       checkColumnsExist(otherScala, joinCols)
 
@@ -96,6 +95,7 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
       val indicesThatJoinCol = joinColumnIndices(otherScala)
       val indicesThisNonJoinCol = (this.cols.indices.toSet -- indicesThisJoinCol.toSet).toSeq
       val indicesThatNonJoinCol = (otherScala.cols.indices.toSet -- indicesThatJoinCol.toSet).toSeq
+
       def filterRow(row: ScalaRow, indices: Iterable[Int]) = indices.map(row.values)
 
       val newSchema = ScalaSchema(indicesThisJoinCol.map(this.schema.fields) ++ indicesThisNonJoinCol.map(this.schema.fields) ++ indicesThatNonJoinCol.map(otherScala.schema.fields))
@@ -143,7 +143,6 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
         case _ => throw new IllegalArgumentException(s"Join type $joinType is not supported. Supported join types are: inner, left, right, full")
       }
       ScalaDataFrame.fromRows(rows = rows, schemaIn = Some(newSchema))
-    }
     case _ => DataFrameSubFeed.throwIllegalSubFeedTypeException(other)
   }
 
@@ -209,14 +208,13 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
   //override in order to avoid Spark col() expression
   override def symmetricDifference(other: GenericDataFrame, diffColName: String): GenericDataFrame = {
     other match {
-      case otherScala: ScalaDataFrame => {
+      case otherScala: ScalaDataFrame =>
         require(schema.columns.map(_.toLowerCase).toSet == other.schema.columns.map(_.toLowerCase).toSet, "DataFrames must have the same columns for symmetricDifference calculation")
         val otherReordered: ScalaDataFrame = otherScala.select(this.schema.columns.toList)
         val df1 = this.except(otherReordered)
         val df2 = otherReordered.except(this)
-        val newCol: Seq[Boolean] = (0 until(df1.count.toInt)).map(_ => true).toSeq ++ (0 until(df1.count.toInt)).map(_ => false).toSeq
+        val newCol: Seq[Boolean] = (0 until df1.count.toInt).map(_ => true) ++ (0 until df1.count.toInt).map(_ => false)
         df1.unionByName(df2).withColumn(diffColName, ScalaColumn(diffColName, newCol))
-      }
       case _ => DataFrameSubFeed.throwIllegalSubFeedTypeException(other)
 
     }
@@ -311,10 +309,9 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
   }
 
   override def except(other: GenericDataFrame): ScalaDataFrame = other match {
-    case otherScala: ScalaDataFrame => {
+    case otherScala: ScalaDataFrame =>
       require(schema.columns == otherScala.columns, "The except operation can only be carried out with two dataframes with the same columns")
       ScalaDataFrame.fromRows(rows = (rows.toSet -- otherScala.rows.toSet).toSeq, schemaIn = Some(schema))
-    }
     case _ => DataFrameSubFeed.throwIllegalSubFeedTypeException(other)
   }
 
@@ -375,7 +372,7 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
 
   override def drop(col: GenericColumn): ScalaDataFrame = col match {
     case sc: ScalaColumn[_] => drop(sc.definition.getFullName())
-    case sc: ScalaAbstractColumn => drop(sc.getName.getOrElse(throw new IllegalArgumentException(s"Cannot drop column ${sc}, because it does not have a name. Make sure to use a column reference with a name.")))
+    case sc: ScalaAbstractColumn => drop(sc.getName.getOrElse(throw new IllegalArgumentException(s"Cannot drop column $sc, because it does not have a name. Make sure to use a column reference with a name.")))
     case _ => DataFrameSubFeed.throwIllegalSubFeedTypeException(col)
   }
 
@@ -419,7 +416,7 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
    * @return an Observation object which can return observed metrics after execution
    */
   override def setupObservation(name: String, aggregateColumns: Seq[GenericColumn], isExecPhase: Boolean, forceGenericObservation: Boolean): (GenericDataFrame, DataFrameObservation) = {
-    val observation = GenericCalculatedObservation(this, aggregateColumns: _*)
+    val observation = GenericCalculatedObservation(this, aggregateColumns.toIndexedSeq: _*)
     // Cache the DataFrame to avoid duplicate calculation. If cache is not needed, create a GenericCalculationObservation directly.
     (this, observation)
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
@@ -60,19 +60,19 @@ case class SparkDataFrame(inner: DataFrame) extends GenericDataFrame {
 
   override def select(columns: Seq[GenericColumn]): SparkDataFrame = {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, columns)
-    SparkDataFrame(inner.select(columns.map(_.asInstanceOf[SparkColumn].inner): _*))
+    SparkDataFrame(inner.select(columns.map(_.asInstanceOf[SparkColumn].inner).toIndexedSeq: _*))
   }
 
   override def groupBy(columns: Seq[GenericColumn]): SparkGroupedDataFrame = {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, columns)
     val sparkCols = columns.map(_.asInstanceOf[SparkColumn].inner)
-    SparkGroupedDataFrame(inner.groupBy(sparkCols: _*))
+    SparkGroupedDataFrame(inner.groupBy(sparkCols.toIndexedSeq: _*))
   }
 
   override def agg(columns: Seq[GenericColumn]): SparkDataFrame = {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, columns)
     val sparkCols = columns.map(_.asInstanceOf[SparkColumn].inner)
-    SparkDataFrame(inner.agg(sparkCols.head, sparkCols.tail: _*))
+    SparkDataFrame(inner.agg(sparkCols.head, sparkCols.tail.toIndexedSeq: _*))
   }
 
   override def unionByName(other: GenericDataFrame, allowMissingColumns: Boolean = false): SparkDataFrame = {
@@ -103,10 +103,10 @@ case class SparkDataFrame(inner: DataFrame) extends GenericDataFrame {
   override def orderBy(columns: Seq[GenericColumn]): SparkDataFrame = {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, columns)
     val sparkCols = columns.map(_.asInstanceOf[SparkColumn].inner)
-    SparkDataFrame(inner.orderBy(sparkCols: _*))
+    SparkDataFrame(inner.orderBy(sparkCols.toIndexedSeq: _*))
   }
 
-  override def collect: Seq[GenericRow] = inner.collect().map(SparkRow)
+  override def collect: Seq[GenericRow] = inner.collect.map(SparkRow)
 
   override def distinct: SparkDataFrame = SparkDataFrame(inner.distinct())
 
@@ -169,13 +169,13 @@ case class SparkDataFrame(inner: DataFrame) extends GenericDataFrame {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, aggregateColumns)
     // Some Spark data sources dont execute observations, e.g. jdbc. The generic observation can be forced for these cases.
     if (forceGenericObservation) {
-      val observation = GenericCalculatedObservation(this, aggregateColumns: _*)
+      val observation = GenericCalculatedObservation(this, aggregateColumns.toIndexedSeq: _*)
       // Cache the DataFrame to avoid duplicate calculation. If cache is not needed, create a GenericCalculationObservation directly.
       (this.cache, observation)
     } else {
       val observation = new SparkObservation(name)
       val sparkAggregatedColumns = aggregateColumns.map(_.asInstanceOf[SparkColumn].inner)
-      val dfObserved = observation.on(inner, isExecPhase, sparkAggregatedColumns: _*)
+      val dfObserved = observation.on(inner, isExecPhase, sparkAggregatedColumns.toIndexedSeq: _*)
       (SparkDataFrame(dfObserved), observation)
     }
   }
@@ -183,7 +183,7 @@ case class SparkDataFrame(inner: DataFrame) extends GenericDataFrame {
   def observe(name: String, aggregateColumns: Seq[GenericColumn], isExecPhase: Boolean): GenericDataFrame = {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, aggregateColumns)
     val sparkAggregatedColumns = aggregateColumns.map(_.asInstanceOf[SparkColumn].inner)
-    val dfObserved = inner.observe(name, sparkAggregatedColumns.head, sparkAggregatedColumns.tail: _*)
+    val dfObserved = inner.observe(name, sparkAggregatedColumns.head, sparkAggregatedColumns.tail.toIndexedSeq: _*)
     SparkDataFrame(dfObserved)
   }
 
@@ -198,7 +198,7 @@ case class SparkGroupedDataFrame(inner: RelationalGroupedDataset) extends Generi
   override def agg(columns: Seq[GenericColumn]): SparkDataFrame = {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, columns)
     val sparkCols = columns.map(_.asInstanceOf[SparkColumn].inner)
-    SparkDataFrame(inner.agg(sparkCols.head, sparkCols.tail: _*))
+    SparkDataFrame(inner.agg(sparkCols.head, sparkCols.tail.toIndexedSeq: _*))
   }
 }
 
@@ -356,7 +356,7 @@ case class SparkColumn(inner: Column) extends GenericColumn {
     }
   }
 
-  override def isin(list: Any*): GenericColumn = SparkColumn(inner.isin(list: _*))
+  override def isin(list: Any*): GenericColumn = SparkColumn(inner.isin(list.toIndexedSeq: _*))
 
   override def isNull: GenericColumn = SparkColumn(inner.isNull)
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkObservation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkObservation.scala
@@ -49,7 +49,7 @@ private[smartdatalake] class SparkObservation(name: String = UUID.randomUUID().t
     if (ds.isStreaming) throw new IllegalArgumentException("SparkObservation does not yet support streaming Datasets")
     sparkSession = Some(ds.sparkSession)
     if (registerListener) ds.sparkSession.listenerManager.register(listener)
-    ds.observe(name, exprs.head, exprs.tail: _*)
+    ds.observe(name, exprs.head, exprs.tail.toIndexedSeq: _*)
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
@@ -343,7 +343,7 @@ object SparkSubFeed extends DataFrameSubFeedCompanion {
     aggFunction.apply() match {
       case sparkAggFunctionColumn: SparkColumn => SparkColumn(sparkAggFunctionColumn
         .inner.over(
-          Window.partitionBy(partitionBy.map(_.asInstanceOf[SparkColumn].inner): _*)
+          Window.partitionBy(partitionBy.map(_.asInstanceOf[SparkColumn].inner).toIndexedSeq: _*)
             .orderBy(orderBy.asInstanceOf[SparkColumn].inner))
       )
       case generic => DataFrameSubFeed.throwIllegalSubFeedTypeException(generic)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObject.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow.dataobject
 
 import com.jayway.jsonpath.PathNotFoundException
 import com.typesafe.config.Config
-import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.{ResourceUtil, SmartDataLakeLogger}
@@ -29,7 +29,6 @@ import io.smartdatalake.util.spark.json.JsonUtils
 import io.smartdatalake.util.webservice.OpenApiUtil.{defaultApiDocsPath, defaultResponseContentType}
 import io.smartdatalake.util.webservice.SttpUtil.{SttpRequestExtension, createDefaultBackend}
 import io.smartdatalake.util.webservice._
-import io.smartdatalake.workflow.connection.SparkClassicConnection
 import io.smartdatalake.workflow.connection.authMode.HttpAuthMode
 import io.smartdatalake.workflow.dataobject.spark.CanCreateSparkDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
@@ -109,7 +108,7 @@ case class OpenApiDataObject(override val id: DataObjectId,
                             )(@transient implicit override val instanceRegistry: InstanceRegistry)
   extends DataObject with CanCreateSparkDataFrame with SmartDataLakeLogger {
 
-  private val mediaType = MediaType.parse(responseContentType).right.get
+  private val mediaType = MediaType.parse(responseContentType).toOption.get
   assert(pagingLinkJsonPath.isEmpty || mediaType.equalsIgnoreParameters(MediaType.ApplicationJson), "PagingLinkRegex can only be used when responseContentType=application/json")
   private val specUrl = {
     if (apiDocsUrl.startsWith("./")) apiDocsUrl
@@ -203,11 +202,11 @@ case class OpenApiDataObject(override val id: DataObjectId,
             case StringType =>
               val data = new String(getContent(targetUrl, responseContentTypeEvaluated.get))
               if (logger.isDebugEnabled) logger.debug(s"response: $data")
-              Seq(new String(data)).toDF(schema.get.fieldNames: _*)
+              Seq(new String(data)).toDF(schema.get.fieldNames.toIndexedSeq: _*)
             case BinaryType =>
               val data = getContent(targetUrl, responseContentTypeEvaluated.get)
               if (logger.isDebugEnabled) logger.debug(s"response: binary length=${data.length}")
-              Seq(data).toDF(schema.get.fieldNames: _*)
+              Seq(data).toDF(schema.get.fieldNames.toIndexedSeq: _*)
           }
         }
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
@@ -88,13 +88,13 @@ case class PKViolatorsDataObject(id: DataObjectId,
         val dataColumns = dfPKViolators.schema.columns.diff(pkColNames)
         val colSchema = lit(dfTable.schema.sql).as("schema")
         val keyCol = optionalCastColToString(flattenOutput) {
-          array(pkColNames.map(colName2colRepresentation): _*).as("key")
+          array(pkColNames.map(colName2colRepresentation).toIndexedSeq: _*).as("key")
         }
         val dataCol = optionalCastColToString(flattenOutput) {
           if (dataColumns.isEmpty) {
             lit(null).cast(arrayType(structType(Map(columnNameName -> stringType, columnValueName -> stringType))))
           } else {
-            array(dataColumns.map(colName2colRepresentation): _*)
+            array(dataColumns.map(colName2colRepresentation).toIndexedSeq: _*)
           }
         }.as("data")
         Some( dfPKViolators.select( Seq(

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
@@ -152,7 +152,7 @@ case class RelaxedCsvFileDataObject(override val id: DataObjectId,
           parseCsvContent(content, parserOptions, filename)
             .map { parsedRow =>
               val values = parsedRow.toSeq ++ csvContentRow.toSeq.drop(1) // value column is at pos 0, partition columns (if any) and filename column are after that
-              Row(values: _*)
+              Row(values.toIndexedSeq: _*)
             }
         }
       }(ExpressionEncoder.apply(StructType(sparkParserSchema ++ df.schema.drop(1)))) // value column is at pos 0, partition columns (if any) and filename column are after that

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLQueryExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLQueryExpectation.scala
@@ -22,12 +22,12 @@ import com.typesafe.config.Config
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.util.misc.ExpressionUtil
+import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.ActionHelper
 import io.smartdatalake.workflow.action.generic.transformer.SQLDfTransformer.INPUT_VIEW_NAME
 import io.smartdatalake.workflow.dataframe.{DataFrameFunctions, GenericColumn, GenericDataFrame}
 import io.smartdatalake.workflow.dataobject.expectation.ExpectationScope.{ExpectationScope, Job}
 import io.smartdatalake.workflow.dataobject.expectation.ExpectationSeverity.ExpectationSeverity
-import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/ExpectationValidation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/ExpectationValidation.scala
@@ -91,7 +91,7 @@ private[smartdatalake] trait ExpectationValidation {
       val genericObservation = if (forceGenericAggColumns.nonEmpty) Some(setupObservation(dfConstraints, forceGenericAggColumns, context.isExecPhase, pushDownTolerant, forceGenericObservation = true)._2) else None
       // if there are now two GenericCalculatedObservations, combine them to avoid duplicate query execution
       val observations = (normalObservation, genericObservation) match {
-        case (o1: GenericCalculatedObservation, Some(o2: GenericCalculatedObservation)) => Seq(GenericCalculatedObservation(o1.df, o1.aggregateColumns ++ o2.aggregateColumns: _*))
+        case (o1: GenericCalculatedObservation, Some(o2: GenericCalculatedObservation)) => Seq(GenericCalculatedObservation(o1.df, o1.aggregateColumns ++ o2.aggregateColumns.toIndexedSeq: _*))
         case (o1, o2) => Seq(Some(o1), o2).flatten
       }
       (dfObserved, observations)
@@ -204,7 +204,7 @@ private[smartdatalake] trait ExpectationValidation {
       // add validation as additional column
       val validationErrorColumns = constraints.map(_.getValidationExceptionColumn(this.id, pkCols, dfSimpleCols))
       val dfErrors = df
-        .withColumn("_validation_errors", array_construct_compact(validationErrorColumns: _*))
+        .withColumn("_validation_errors", array_construct_compact(validationErrorColumns.toIndexedSeq: _*))
       // use column in where condition to avoid elimination by optimizer before dropping the column again.
       dfErrors
         .where(size(col("_validation_errors")) < lit(constraints.size + 1)) // this is always true - but we want to force evaluating column "_validation_errors" to throw exceptions

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/spark/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/spark/SparkFileDataObject.scala
@@ -317,7 +317,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
         .optionalSchema(schema)
         .option("basePath", hadoopPath.toString) // this is needed for partitioned tables when subdirectories are read directly; it then keeps the partition columns from the subdirectory path in the dataframe
       val pathsToRead = partitionValues.flatMap(getConcreteInitPaths).map(_.toString)
-      val df = if (pathsToRead.nonEmpty) Some(reader.load(pathsToRead: _*)) else None
+      val df = if (pathsToRead.nonEmpty) Some(reader.load(pathsToRead.toIndexedSeq: _*)) else None
       df.filter(df => schema.isDefined || partitions.diff(df.columns).isEmpty) // filter DataFrames without partition columns as they are empty (this might happen if there is no schema specified and the partition is empty)
         .getOrElse {
           // if there are no paths to read for given partition values, handle no data

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigsMacroDebug.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigsMacroDebug.scala
@@ -19,13 +19,14 @@
 package io.smartdatalake.config
 
 import com.typesafe.config.ConfigFactory
-import io.smartdatalake.workflow.dataobject.{CsvFileDataObject, CsvFileDataObjectTest}
+import io.smartdatalake.workflow.dataobject.CsvFileDataObject
 
 /**
  * Configs macro expansion can be debugged in Intellij by creating a run configuration as follows:
- * - Main class: scala.tools.nsc.Main
- * - VM options: -Dscala.usejavacp=true
- * - program arguments: -cp io.smartdatalake.config.ConfigsMacroDebug C:\Entwicklung\smart-data-lake\sdl-core\src\test\scala\io\smartdatalake\config\ConfigsMacroDebug.scala
+ *   - Main class: scala.tools.nsc.Main
+ *   - VM options: -Dscala.usejavacp=true
+ *   - program arguments: -cp io.smartdatalake.config.ConfigsMacroDebug
+ *     C:\Entwicklung\smart-data-lake\sdl-core\src\test\scala\io\smartdatalake\config\ConfigsMacroDebug.scala
  */
 object ConfigsMacroDebug extends App with ConfigImplicits {
 
@@ -35,11 +36,12 @@ object ConfigsMacroDebug extends App with ConfigImplicits {
       |   id = 123
       |   path = /tmp/test.csv
       | }
-      |""".stripMargin).resolve
+      |""".stripMargin
+  ).resolve
 
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   import configs.syntax.RichConfig
   config.extract[CsvFileDataObject].value
-  //CsvFileDataObject.fromConfig(config)(new InstanceRegistry)
+  // CsvFileDataObject.fromConfig(config)(new InstanceRegistry)
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameTestHelper.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameTestHelper.scala
@@ -46,7 +46,7 @@ object DataFrameTestHelper extends Equality {
   def emptyDf()(implicit session: SparkSession): DataFrame = createDf(Map[String, TypedValue]())
 
   def createDf(input: Map[String, TypedValue]*)(implicit session: SparkSession): DataFrame = {
-    createDfWithDefaultValues(input: _*)()
+    createDfWithDefaultValues(input.toIndexedSeq: _*)()
   }
 
   private def createDfWithDefaultValues(input: Map[String, TypedValue]*)(defaultValues: Map[String, TypedValue] = Map())(implicit session: SparkSession): DataFrame = {
@@ -113,7 +113,7 @@ object DataFrameTestHelper extends Equality {
 
     // Convert rows to spark rows
     val rowData: Seq[Row] =
-      rowValues.map(row => Row(row: _*))
+      rowValues.map(row => Row(row.toIndexedSeq: _*))
 
     // Initialize test spark session and create DataFrame with the values and schema
     val rdd: RDD[Row] = session.sparkContext.parallelize(rowData)
@@ -157,7 +157,7 @@ object DataFrameTestHelper extends Equality {
   }
 
   def createDefaultDf(defaultValues: Map[String, TypedValue] = Map())(input: Map[String, TypedValue]*)(implicit session: SparkSession): DataFrame = {
-    createDfWithDefaultValues(input: _*)(defaultValues)
+    createDfWithDefaultValues(input.toIndexedSeq: _*)(defaultValues)
   }
 
   implicit def valueToTypedValue[T](value: T): TypedValue = value match {

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/MockSparkDataObject.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/MockSparkDataObject.scala
@@ -108,7 +108,7 @@ case class MockSparkDataObject(override val id: DataObjectId,
       finalSaveMode match {
         case SDLSaveMode.Overwrite =>
           // mimick partition overwrite
-          val inferredPartitionValues = PartitionValues.fromDataFrame(SparkDataFrame(newDf.select(partitions.map(col): _*)))
+          val inferredPartitionValues = PartitionValues.fromDataFrame(SparkDataFrame(newDf.select(partitions.map(col).toIndexedSeq: _*)))
           val newDataFrames = inferredPartitionValues.map(pv => (pv, newDf.where(getPartitionValueFilter(pv)))).toMap
           if (newDataFrames.nonEmpty) {
             partitionedDataFrameMock = Some(
@@ -180,7 +180,7 @@ case class MockSparkDataObject(override val id: DataObjectId,
     val updateSelectCols = targetColumns
       .map(c => (if (updateCols.contains(c)) col(s"new.$c") else if (existingColumns.contains(c)) col(s"existing.$c") else lit(null)).as(c))
     val updateCondition = saveModeExpr.updateConditionExpr.map(_.asInstanceOf[SparkColumn].inner).getOrElse(lit(true))
-    val dfUpdated = dfMatched.where(updateCondition).select(updateSelectCols: _*)
+    val dfUpdated = dfMatched.where(updateCondition).select(updateSelectCols.toIndexedSeq: _*)
       .observe("merge3", count("*").as("rows_updated"))
     val dfNotUpdated = dfMatched.where(not(updateCondition)).select($"existing.*")
 
@@ -190,7 +190,7 @@ case class MockSparkDataObject(override val id: DataObjectId,
       val updateSelectCols = targetColumns
         .map(c => (if (updateCols.contains(c)) col(s"new.$c") else if (existingColumns.contains(c)) col(s"existing.$c") else lit(null)).as(c))
       val updateExistingCondition = saveModeExpr.updateExistingConditionExpr.get.asInstanceOf[SparkColumn].inner
-      val dfUpdatedExisting = dfMatched.where(updateExistingCondition and not(updateCondition)).select(updateSelectCols: _*)
+      val dfUpdatedExisting = dfMatched.where(updateExistingCondition and not(updateCondition)).select(updateSelectCols.toIndexedSeq: _*)
         .observe(s"merge4", count("*").as("rows_updated_existing"))
       val dfNotUpdated = dfMatched.where(not(updateExistingCondition) and not(updateCondition)).select($"existing.*")
       (dfUpdated.unionByName(dfUpdatedExisting), dfNotUpdated)
@@ -202,7 +202,7 @@ case class MockSparkDataObject(override val id: DataObjectId,
     val insertSelectCols = targetColumns
       .map(c => saveModeOptions.insertValuesOverride.get(c).map(expr).getOrElse(if (insertCols.contains(c)) col(s"new.$c").as(c) else lit(null)).as(c))
     val insertCondition = saveModeExpr.insertConditionExpr.map(_.asInstanceOf[SparkColumn].inner).getOrElse(lit(true))
-    val dfInsert = dfNewNotMatched.where(insertCondition).select(insertSelectCols: _*)
+    val dfInsert = dfNewNotMatched.where(insertCondition).select(insertSelectCols.toIndexedSeq: _*)
       .observe("merge5", count("*").as("rows_inserted"))
     dfMerged = dfMerged
       .unionByName(dfInsert)

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -141,7 +141,7 @@ object TestUtil extends SmartDataLakeLogger with Equality {
   // write DataFrame to table
   def prepareHiveTable(table: Table, path: String, df: DataFrame, partitionCols: Seq[String] = Seq()): Unit =
     if (partitionCols.isEmpty) df.write.mode(SaveMode.Overwrite).option("path", path).saveAsTable(s"${table.fullName}")
-    else df.write.mode(SaveMode.Overwrite).option("path", path).partitionBy(partitionCols: _*).saveAsTable(s"${table.fullName}")
+    else df.write.mode(SaveMode.Overwrite).option("path", path).partitionBy(partitionCols.toIndexedSeq: _*).saveAsTable(s"${table.fullName}")
 
   def copyResourceToFile(resource: String, tgtFile: File): Unit = {
     val inputStream = this.getClass.getClassLoader.getResourceAsStream(resource)

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/spark/dataset/TestToolDataset.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/spark/dataset/TestToolDataset.scala
@@ -25,13 +25,11 @@ import org.slf4j.Logger
 
 trait TestToolDataset extends io.smartdatalake.util.spark.dataset.Equality {
 
-  def printFailedTestResult[T](testName: String, arguments: Seq[Dataset[T]] = Nil)
-                              (actual: Dataset[T])(expected: Dataset[T])
-                              (implicit logger: Logger): Unit = {
+  def printFailedTestResult[T](testName: String, arguments: Seq[Dataset[T]] = Nil)(actual: Dataset[T])(expected: Dataset[T])(implicit logger: Logger): Unit = {
     def printDf(df: Dataset[T]): Unit = {
       logger.error(df.schema.simpleString)
       df.printSchema()
-      df.orderBy(df.columns.head, df.columns.tail: _*).show(false)
+      df.orderBy(df.columns.head, df.columns.tail.toIndexedSeq: _*).show(false)
     }
 
     logger.error(s"!!!! Test $testName Failed !!!")
@@ -47,14 +45,13 @@ trait TestToolDataset extends io.smartdatalake.util.spark.dataset.Equality {
     actual.getSymmetricDifference(expected).show(false)
   }
 
-  def printFailedTestResultGeneric(testName: String, arguments: Seq[GenericDataFrame] = Seq())
-                                  (actual: GenericDataFrame)(expected: GenericDataFrame)
-                                  (implicit logger: Logger): Unit = {
+  def printFailedTestResultGeneric(testName: String, arguments: Seq[GenericDataFrame] = Seq())(actual: GenericDataFrame)(expected: GenericDataFrame)(implicit
+      logger: Logger
+  ): Unit =
     (actual, expected) match {
       case (actual: SparkDataFrame, expected: SparkDataFrame) =>
         assert(arguments.forall(_.isInstanceOf[SparkDataFrame]))
         printFailedTestResult(testName, arguments.map(_.asInstanceOf[SparkDataFrame].inner))(actual.inner)(expected.inner)
     }
-  }
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/SparkExpressionUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/SparkExpressionUtilTest.scala
@@ -56,7 +56,7 @@ class SparkExpressionUtilTest extends AnyFunSuite {
     if (!result) {
       println(s"Test Failed for the following rows:")
       resultDf.where($"actual" =!= $"expected")
-        .orderBy(resultDf.columns.map(col): _*).show(false)
+        .orderBy(resultDf.columns.map(col).toIndexedSeq: _*).show(false)
     }
     assert(result)
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/EqualityTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/EqualityTest.scala
@@ -110,12 +110,12 @@ class EqualityTest extends AnyFlatSpec with Matchers with ScalaCheckPropertyChec
   }
 
   "DataFrames almost equals" should "ignore column order by default" in {
-    val dfReversed = dsSimple1.select(dsSimple1.columns.reverse.map(col): _*)
+    val dfReversed = dsSimple1.select(dsSimple1.columns.reverse.map(col).toIndexedSeq: _*)
     dfSimple1.almostEqual(dfReversed) shouldBe true
   }
 
   "DataFrames almost equals" should "consider column order when asked" in {
-    dfSimple1.almostEqual(dsSimple1.select(dsSimple1.columns.reverse.map(col): _*), ignoreColumnOrder = false) shouldBe false
+    dfSimple1.almostEqual(dsSimple1.select(dsSimple1.columns.reverse.map(col).toIndexedSeq: _*), ignoreColumnOrder = false) shouldBe false
   }
 
   "DataFrames almost equals" should "fail when some cols are compared precisely" in {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/ColumnTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/ColumnTransformerTest.scala
@@ -35,7 +35,7 @@ class ColumnTransformerTest extends AnyFunSuite with BeforeAndAfter {
   import session.implicits._
 
 
-  val sdlb = DefaultSmartDataLakeBuilder
+  val sdlb: DefaultSmartDataLakeBuilder.type = DefaultSmartDataLakeBuilder
   implicit val instanceRegistry: InstanceRegistry = sdlb.instanceRegistry
   implicit val contextExec: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/DeduplicateTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/DeduplicateTransformerTest.scala
@@ -188,7 +188,7 @@ class DeduplicateTransformerTest extends AnyFunSuite with BeforeAndAfter {
 
     val transformedDf = tgtDO.getSparkDataFrame()
 
-    assert(transformedDf.collect sameElements resultDf.inner.collect)
+    assert(transformedDf.collect() sameElements resultDf.inner.collect())
   }
 
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/generic/transformer/EncryptColumnsTransformerTest.scala
@@ -73,8 +73,8 @@ class EncryptColumnsTransformerTest extends AnyFunSuite {
         |     transformers = [{
         |       type = EncryptColumnsTransformer
         |       encryptColumns = ["c2","c3"]
-        |       key = "${test_key}"
-        |       algorithm = ${enc_type}
+        |       key = "$test_key"
+        |       algorithm = $enc_type
         |     }]
         |   }
         |   actdec = {
@@ -87,8 +87,8 @@ class EncryptColumnsTransformerTest extends AnyFunSuite {
         |     transformers = [{
         |       type = DecryptColumnsTransformer
         |       decryptColumns = ["c2","c3"]
-        |       key = "${test_key}"
-        |       algorithm = ${enc_type}
+        |       key = "$test_key"
+        |       algorithm = $enc_type
         |     }]
         |   }
         |}
@@ -133,7 +133,7 @@ class EncryptColumnsTransformerTest extends AnyFunSuite {
     assert(colName.toSeq == Seq("c1", "c2", "c3"))
     val testCol = dfEnc.select("c2").map(f => f.getString(0)).collect().toList
     dfEnc.show(false)
-    print(s"### ${enc_type} encrypted dataFrame")
+    print(s"### $enc_type encrypted dataFrame")
     assert(testCol != Seq("Foo", "Space", "Space"))
     if (enc_type === "GCM") {
       assert(testCol(1) !== testCol(2), "2 encrypted items should not result in the same ciphertext with GCM")
@@ -145,7 +145,7 @@ class EncryptColumnsTransformerTest extends AnyFunSuite {
     val dec = instanceRegistry.get[ParquetFileDataObject]("dec")
     val dfDec = dec.getSparkDataFrame()
     dfDec.show(false)
-    print(s"### ${enc_type} decrypted dataFrame")
+    print(s"### $enc_type decrypted dataFrame")
 
     val colDecName = dfDec.columns
     assert(colDecName.toSeq == Seq("c1", "c2", "c3"))
@@ -199,8 +199,8 @@ class EncryptColumnsTransformerTest extends AnyFunSuite {
     val file = "./test_enc.parquet"
 
     // write/read to CSV file -> would result in String columns, since CSV does not store Metadata
-    //df_enc.write.mode(SaveMode.Overwrite).format("csv").option("header", true).save(file)
-    //val df_enc_file = session.read.format("csv").option("header", true).load(file)
+    //df_enc.write.mode(SaveMode.Overwrite).format("csv").option(key = "header", value = true).save(file)
+    //val df_enc_file = session.read.format("csv").option(key = "header", value = true).load(file)
 
     // write/read to parquet file
     df_enc.write.mode(SaveMode.Overwrite).parquet(file)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/ScalaClassSparkDsNTo1TransformerTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/spark/ScalaClassSparkDsNTo1TransformerTest.scala
@@ -320,7 +320,7 @@ class ScalaClassSparkDsNTo1TransformerTest extends AnyFunSuite with BeforeAndAft
     val (subFeeds, _): (Seq[SubFeed], Map[RuntimeEventState, Int]) = sdlb.startSimulationWithConfigFile(sdlConfig, Seq(srcDO1, srcDO2))(session)
 
     val tgt1DO: SparkSubFeed = subFeeds.head.asInstanceOf[SparkSubFeed]
-    val actual = tgt1DO.dataFrame.get.inner.as[AnotherOutputDataSetPartitioned].collect().head
+    val actual = tgt1DO.dataFrame.get.inner.as[AnotherOutputDataSetPartitioned].collect.head
     assert(actual.added_rating == 15)
     assert(actual.concatenated_name == "johndoe")
     assert(actual.year == "1992")

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/spark/SparkClassicConnectionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/connection/spark/SparkClassicConnectionTest.scala
@@ -119,7 +119,7 @@ class SparkClassicConnectionTest extends AnyFunSuite with BeforeAndAfter {
 
     // check
     val actual = tgt1DO.getSparkDataFrame()
-      .select($"rating").as[Int].collect
+      .select($"rating").as[Int].collect()
     assert(actual.toSeq == Seq(6, 11))
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObjectTest.scala
@@ -297,10 +297,10 @@ class CsvFileDataObjectTest extends DataObjectTestSuite
     val dataObj = CsvFileDataObject(id = "test1", path = tempDir.toFile.getPath, partitions = Seq("h1"), schema = Some(SparkSchema(df1.schema)), filenameColumn = Some("_filename"))
     dataObj.writeSparkDataFrame(df1, pv1)
 
-    val dfResult = dataObj.getSparkDataFrame(pv1)(contextExec).cache
+    val dfResult = dataObj.getSparkDataFrame(pv1)(contextExec).cache()
 
     assert(dfResult.columns.toSet == Set("h2", "h3", "h1", "_filename"))
-    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == data1.toSet)
+    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect().toSet == data1.toSet)
     assert(dfResult.where($"_filename".isNull).isEmpty)
   }
 
@@ -315,10 +315,10 @@ class CsvFileDataObjectTest extends DataObjectTestSuite
       schema = Some(SparkSchema(df1.drop("h1").schema)), filenameColumn = Some("_filename"))
     dataObj.writeSparkDataFrame(df1, pv1)
 
-    val dfResult = dataObj.getSparkDataFrame(pv1)(contextExec).cache
+    val dfResult = dataObj.getSparkDataFrame(pv1)(contextExec).cache()
 
     assert(dfResult.columns.toSet == Set("h2", "h3", "h1", "_filename"))
-    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == data1.toSet)
+    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect().toSet == data1.toSet)
     assert(dfResult.where($"_filename".isNull).isEmpty)
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ODataDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ODataDataObjectTest.scala
@@ -41,7 +41,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
 
   test("getODataURL basic") {
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry)
       .copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
@@ -62,7 +62,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
 
   test("getODataURL with state") {
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val sut = ODataDataObject(
@@ -84,7 +84,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
 
   test("getODataURL with state and source filter") {
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val sut = ODataDataObject(
@@ -107,7 +107,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
 
   test("getODataURL with maxrecordcount") {
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val sut = ODataDataObject(
@@ -128,7 +128,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
 
   test("getSparkDataFrame in init phase") {
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Init, currentAction = Some(action_mock))
 
     val sut = ODataDataObject(
@@ -170,7 +170,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     sut.validateConfiguration(actionPipelineContext)
@@ -189,7 +189,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     sut.validateConfiguration(actionPipelineContext)
@@ -208,7 +208,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     sut.validateConfiguration(actionPipelineContext)
@@ -227,7 +227,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     assertThrows[ConfigurationException] {
@@ -248,7 +248,7 @@ class ODataDataObjectUnitTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     assertThrows[ConfigurationException] {
@@ -292,7 +292,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val resultDf = sut.getSparkDataFrame(Seq.empty)(actionPipelineContext)
@@ -340,7 +340,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val resultDf = sut.getSparkDataFrame(Seq.empty)(actionPipelineContext)
@@ -384,7 +384,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     sut.setState(Some("2024-06-10T08:00:00.000Z"))
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val resultDf = sut.getSparkDataFrame(Seq.empty)(actionPipelineContext)
@@ -449,7 +449,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     sut.setState(Some("2024-06-10T10:03:44.000Z"))
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val resultDf = sut.getSparkDataFrame(Seq.empty)(actionPipelineContext)
@@ -510,7 +510,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
 
     val ioc_spy = m.spy(new ODataIOC())
     val now = Instant.parse("2024-06-09T23:00:00Z")
-    m.doReturn(now, Seq.empty: _*).when(ioc_spy).getInstantNow
+    m.doReturn(now, Seq.empty.toIndexedSeq: _*).when(ioc_spy).getInstantNow
 
     val temp_dir_base = Files.createTempDirectory("odatatest_filebuffer").toFile
     val buffer_setup = ODataResponseBufferSetup(tempFileDirectoryPath = Some(temp_dir_base.getAbsolutePath), memoryToFileSwitchThresholdNumOfChars = Some(20))
@@ -529,7 +529,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     sut.setState(Some("2024-06-10T10:03:44.000Z"))
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val resultDf = sut.getSparkDataFrame(Seq.empty)(actionPipelineContext)
@@ -610,7 +610,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
 
@@ -649,7 +649,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     intercept[Exception](sut.getSparkDataFrame(Seq.empty)(actionPipelineContext))
@@ -670,7 +670,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(DataObjectStateIncrementalMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Init, currentAction = Some(action_mock))
 
     assertThrows[ConfigurationException] {
@@ -697,7 +697,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
     )
 
     val action_mock = m.mock(classOf[CopyAction])
-    m.doReturn(Some(ProcessAllMode()),Seq.empty: _*).when(action_mock).executionMode
+    m.doReturn(Some(ProcessAllMode()),Seq.empty.toIndexedSeq: _*).when(action_mock).executionMode
     val actionPipelineContext = TestUtil.getDefaultActionPipelineContext(instanceRegistry).copy(phase = ExecutionPhase.Exec, currentAction = Some(action_mock))
 
     val error = intercept[HttpRequestError](sut.getSparkDataFrame(Seq.empty)(actionPipelineContext))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ODataResponseFileBufferTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ODataResponseFileBufferTest.scala
@@ -33,7 +33,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val instant = Instant.ofEpochSecond(1726124260)
 
     val mock_ioc = org.mockito.Mockito.mock(classOf[ODataIOC])
-    m.doReturn(instant, Seq.empty: _*).when(mock_ioc).getInstantNow
+    m.doReturn(instant, Seq.empty.toIndexedSeq: _*).when(mock_ioc).getInstantNow
 
     mock_ioc
 
@@ -48,7 +48,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
 
     val filesystem_mock = fileSystem.getOrElse(m.mock(classOf[org.apache.hadoop.fs.FileSystem]))
 
-    m.doReturn(filesystem_mock, Seq.empty: _*).when(ioc).newHadoopFsWithConf(any[org.apache.hadoop.fs.Path], any[ActionPipelineContext])
+    m.doReturn(filesystem_mock, Seq.empty.toIndexedSeq: _*).when(ioc).newHadoopFsWithConf(any[org.apache.hadoop.fs.Path], any[ActionPipelineContext])
 
     val sut = new ODataResponseFileBuffer("TMPDIR", setup, context.getOrElse(init_context()), ioc)
     m.spy(sut)
@@ -74,7 +74,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val ioc = init_ioc_mock()
     val filesystem = m.mock(classOf[org.apache.hadoop.fs.FileSystem])
     val mock_path = m.mock(classOf[org.apache.hadoop.fs.Path])
-    m.doReturn(mock_path, Seq.empty: _*).when(ioc).newHadoopPath(any[String])
+    m.doReturn(mock_path, Seq.empty.toIndexedSeq: _*).when(ioc).newHadoopPath(any[String])
     val sut = init_sut_spy(ioc, fileSystem = Some(filesystem))
 
     assert(sut.getFileSystem == filesystem)
@@ -100,7 +100,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val sut = init_sut_spy(ioc)
     val filesystem = sut.getFileSystem
 
-    m.doReturn(true, Seq.empty: _*).when(filesystem).exists(any[org.apache.hadoop.fs.Path])
+    m.doReturn(true, Seq.empty.toIndexedSeq: _*).when(filesystem).exists(any[org.apache.hadoop.fs.Path])
 
     sut.clearTemporaryDirectory()
 
@@ -113,7 +113,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val sut = init_sut_spy(ioc)
     val filesystem = sut.getFileSystem
 
-    m.doReturn(false, Seq.empty: _*).when(filesystem).exists(any[org.apache.hadoop.fs.Path])
+    m.doReturn(false, Seq.empty.toIndexedSeq: _*).when(filesystem).exists(any[org.apache.hadoop.fs.Path])
 
     sut.clearTemporaryDirectory()
 
@@ -128,7 +128,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val path_mock = m.mock(classOf[org.apache.hadoop.fs.Path])
 
     m.doNothing().when(sut).initTemporaryDirectory()
-    m.doReturn(path_mock, Seq.empty: _*).when(ioc).newHadoopPath(any[org.apache.hadoop.fs.Path], eqTo("FILENAME"))
+    m.doReturn(path_mock, Seq.empty.toIndexedSeq: _*).when(ioc).newHadoopPath(any[org.apache.hadoop.fs.Path], eqTo("FILENAME"))
 
 
     sut.writeToFile("FILENAME", "CONTENT")
@@ -141,7 +141,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val ioc = init_ioc_mock()
     val sut = init_sut_spy(ioc)
 
-    m.doReturn(42, Seq.empty: _*).when(sut).getResponseCount
+    m.doReturn(42, Seq.empty.toIndexedSeq: _*).when(sut).getResponseCount
 
     val result = sut.generateFileName()
 
@@ -152,7 +152,7 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val ioc = init_ioc_mock()
     val sut = init_sut_spy(ioc)
 
-    m.doReturn("FILENAME", Seq.empty: _*).when(sut).generateFileName()
+    m.doReturn("FILENAME", Seq.empty.toIndexedSeq: _*).when(sut).generateFileName()
     m.doNothing().when(sut).writeToFile(any[String], any[String])
 
     sut.addResponse("RESPONSE")
@@ -170,14 +170,14 @@ class ODataResponseFileBufferTest extends DataObjectTestSuite {
     val path = m.mock(classOf[org.apache.hadoop.fs.Path])
 
     /*
-    m.doReturn(session, Seq.empty: _*).when(context).sparkSession
-    m.doReturn(reader, Seq.empty: _*).when(session).read
-    m.doReturn(reader, Seq.empty: _*).when(reader).option(any[String], any[Boolean])
+    m.doReturn(session, Seq.empty.toIndexedSeq: _*).when(context).sparkSession
+    m.doReturn(reader, Seq.empty.toIndexedSeq: _*).when(session).read
+    m.doReturn(reader, Seq.empty.toIndexedSeq: _*).when(reader).option(any[String], any[Boolean])
 
-    m.doReturn("PATH", Seq.empty: _*).when(path).toString
-    m.doReturn(path, Seq.empty: _*).when(ioc).newHadoopPath(any[String], any[String])
-    m.doReturn(dataframe, Seq.empty: _*).when(reader).text(any[String])
-    m.doReturn(dataframe, Seq.empty: _*).when(dataframe).withColumnRenamed("value", "responseString")
+    m.doReturn("PATH", Seq.empty.toIndexedSeq: _*).when(path).toString
+    m.doReturn(path, Seq.empty.toIndexedSeq: _*).when(ioc).newHadoopPath(any[String], any[String])
+    m.doReturn(dataframe, Seq.empty.toIndexedSeq: _*).when(reader).text(any[String])
+    m.doReturn(dataframe, Seq.empty.toIndexedSeq: _*).when(dataframe).withColumnRenamed("value", "responseString")
 
     val sut = init_sut_spy(ioc, context = Some(context))
     val result = sut.getDataFrame

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectTest.scala
@@ -69,7 +69,7 @@ class OpenApiDataObjectTest extends AnyFunSuite {
     )
     do1.prepare
     val df = do1.getSparkDataFrame()(contextExec)
-    val result = df.as[(Long, String)].collect.toSeq
+    val result = df.as[(Long, String)].collect().toSeq
     assert(result == Seq((123L, "john")))
 
     wireMockServer.stop()
@@ -97,7 +97,7 @@ class OpenApiDataObjectTest extends AnyFunSuite {
     do1.prepare
     val df = do1.getSparkDataFrame()(contextExec)
       .drop("nextLink")
-    val result = df.as[(Long, String)].collect.toSeq
+    val result = df.as[(Long, String)].collect().toSeq
     assert(result == Seq((123L, "john"), (456L, "peter")))
 
     wireMockServer.stop()

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObjectTest.scala
@@ -68,7 +68,7 @@ class PKViolatorsDataObjectTest extends AnyFunSuite with BeforeAndAfter with Sma
       TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet"))),
       TestData("source_tableDO", "mock", "source_table", "id STRING,value STRING", Seq(TestKV("id", "4let")), Seq(TestKV("value", "quatriplet")))
     )
-    val expected = SparkDataFrame(rows_expected.toDF)
+    val expected = SparkDataFrame(rows_expected.toDF())
 
     // Comparing actual with expected
     val resultat: Boolean = actual.isEqual(expected)
@@ -97,7 +97,7 @@ class PKViolatorsDataObjectTest extends AnyFunSuite with BeforeAndAfter with Sma
       TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet"))),
       TestData("hive_table_pk_id_ValueDO", "mock", "hive_table_pk_id_Value", "id STRING,value STRING", Seq(TestKV("id", "4let"), TestKV("value", "quatriplet")))
     )
-    val expected = SparkDataFrame(rows_expected.toDF)
+    val expected = SparkDataFrame(rows_expected.toDF())
 
     val resultat: Boolean = actual.isEqual(expected)
     if (!resultat) printFailedTestResult("pk violations with null values",
@@ -154,7 +154,7 @@ class PKViolatorsDataObjectTest extends AnyFunSuite with BeforeAndAfter with Sma
     )
 
     val expected = SparkDataFrame(
-      rows_expectedWithData.toDF.union(rows_expectedWithOutData.toDF)
+      rows_expectedWithData.toDF().union(rows_expectedWithOutData.toDF())
     )
 
     val resultat: Boolean = actual.isEqual(expected)

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObjectTest.scala
@@ -19,15 +19,14 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.definitions.{Environment, SDLSaveMode}
-import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.testutils.{DataObjectTestSuite, TestTool}
 import io.smartdatalake.util.hdfs.PartitionValues
-import io.smartdatalake.workflow.action.NoDataToProcessWarning
+import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import org.apache.spark.SparkException
-import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types.{StringType, StructType}
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
 
 class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
 
@@ -39,17 +38,17 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
     // exact schema
     val data1 = Seq(("A", "1", "-"), ("B", "2", null))
     val df1 = data1.toDF("h1", "h2", "h3")
-    df1.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df1.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     // schema missing column h3
     val data2 = Seq(("C", "1"), ("D", "2"))
     val df2 = data2.toDF("h1", "h2")
-    df2.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df2.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     // schema has superfluous column h4
     val data3 = Seq(("C", "1", "-", "x"), ("D", "2", "-", "x"))
     val df3= data3.toDF("h1", "h2", "h3", "h4")
-    df3.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df3.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     val dataObj = RelaxedCsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = Some(SparkSchema(df1.schema)))
 
@@ -57,7 +56,7 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
 
     assert(dfResult.columns.toSeq == Seq("h1", "h2", "h3"))
     val expectedResult = data1 ++ data2.map(x => (x._1, x._2, null)) ++ data3.map(x => (x._1, x._2, x._3))
-    assert(dfResult.as[(String,String,String)].collect.toSet == expectedResult.toSet )
+    assert(dfResult.as[(String,String,String)].collect().toSet == expectedResult.toSet )
   }
 
   test("CSV files with missing and superfluous column treated as error") {
@@ -66,23 +65,23 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
     // exact schema
     val data1 = Seq(("A", "1", "-"), ("A", "2", null))
     val df1 = data1.toDF("h1", "h2", "h3")
-    df1.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df1.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     // schema missing column h3
     val data2 = Seq(("B", "1"), ("B", "2"))
     val df2 = data2.toDF("h1", "h2")
-    df2.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df2.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     // schema has superfluous column h4
     val data3 = Seq(("C", "1", "-", "x"), ("C", "2", "-", "x"))
     val df3= data3.toDF("h1", "h2", "h3", "h4")
-    df3.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df3.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     val schema = Some(df1.schema.add("_filename", StringType).add("_corrupt_record", StringType).add("_corrupt_record_msg", StringType))
     val dataObj = RelaxedCsvFileDataObject( id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = schema.map(SparkSchema.apply), filenameColumn = Some("_filename")
                                           , treatMissingColumnsAsCorrupt = true, treatSuperfluousColumnsAsCorrupt = true)
 
-    val dfResult = dataObj.getSparkDataFrame().cache
+    val dfResult = dataObj.getSparkDataFrame().cache()
 
     assert(dfResult.columns.toSeq == Seq("h1", "h2", "h3", "_corrupt_record", "_corrupt_record_msg", "_filename"))
     assert(dfResult.where($"h1"==="A" and $"_corrupt_record".isNull and $"_corrupt_record_msg".isNull).count == 2)
@@ -96,12 +95,12 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
     // column order 1
     val data1 = Seq(("A", "1", "-"), ("B", "2", null))
     val df1 = data1.toDF("h1", "h2", "h3")
-    df1.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df1.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     // column order 2
     val data2 = Seq(("1","-","C"), ("2","-","D"))
     val df2 = data2.toDF("h2", "h3", "h1")
-    df2.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df2.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     val dataObj = RelaxedCsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = Some(SparkSchema(df1.schema)))
 
@@ -109,7 +108,7 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
 
     assert(dfResult.columns.toSeq == Seq("h1", "h2", "h3"))
     val expectedResult = data1 ++ data2.map(x => (x._3, x._1, x._2))
-    assert(dfResult.as[(String,String,String)].collect.toSet == expectedResult.toSet )
+    assert(dfResult.as[(String,String,String)].collect().toSet == expectedResult.toSet )
   }
 
   test("CSV files with filename col") {
@@ -117,20 +116,20 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
 
     val data1 = Seq(("A", "1", "-"), ("B", "2", null))
     val df1 = data1.toDF("h1", "h2", "h3")
-    df1.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df1.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     val data2 = Seq(("1","-","C"), ("2","-","D"))
     val df2 = data2.toDF("h2", "h3", "h1")
-    df2.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df2.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
 
     val schema = Some(df1.schema.add("_filename", StringType))
     val dataObj = RelaxedCsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = schema.map(SparkSchema.apply), filenameColumn = Some("_filename"))
 
-    val dfResult = dataObj.getSparkDataFrame().cache
+    val dfResult = dataObj.getSparkDataFrame().cache()
 
     assert(dfResult.columns.toSet == Set("h1", "h2", "h3", "_filename"))
     val expectedResult = data1 ++ data2.map(x => (x._3, x._1, x._2))
-    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == expectedResult.toSet )
+    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect().toSet == expectedResult.toSet )
     assert(dfResult.select($"_filename").distinct.count > 1 )
   }
 
@@ -144,10 +143,10 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
     val dataObj = RelaxedCsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), partitions = Seq("h1"), schema = Some(SparkSchema(df1.schema)), filenameColumn = Some("_filename"))
     dataObj.writeSparkDataFrame(df1, pv1)
 
-    val dfResult = dataObj.getSparkDataFrame(pv1).cache
+    val dfResult = dataObj.getSparkDataFrame(pv1).cache()
 
     assert(dfResult.columns.toSeq == Seq("h2", "h3", "h1", "_filename"))
-    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == data1.toSet)
+    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect().toSet == data1.toSet)
     assert(dfResult.where($"_filename".isNull).isEmpty)
   }
 
@@ -162,10 +161,10 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
       schema = Some(SparkSchema(df1.drop("h1").schema)), filenameColumn = Some("_filename"))
     dataObj.writeSparkDataFrame(df1, pv1)
 
-    val dfResult = dataObj.getSparkDataFrame(pv1).cache
+    val dfResult = dataObj.getSparkDataFrame(pv1).cache()
 
     assert(dfResult.columns.toSet == Set("h2", "h3", "h1", "_filename"))
-    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == data1.toSet)
+    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect().toSet == data1.toSet)
     assert(dfResult.where($"_filename".isNull).isEmpty)
   }
 
@@ -176,7 +175,7 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
     val data1 = Seq[(String,String,String)]()
     val df1 = data1.toDF("h1", "h2", "h3")
     Environment._enableSparkPlanNoDataCheck = Some(false)
-    df1.write.mode(SaveMode.Append).option("header", true).csv(tempDir.toFile.getPath)
+    df1.write.mode(SaveMode.Append).option(key = "header", value = true).csv(tempDir.toFile.getPath)
     Environment._enableSparkPlanNoDataCheck = Some(true)
 
     val dataObj = RelaxedCsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = Some(SparkSchema(df1.schema)))
@@ -194,7 +193,7 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
     val data1 = Seq[(String,String,String)]()
     val df1 = data1.toDF("h1", "h2", "h3")
     Environment._enableSparkPlanNoDataCheck = Some(false)
-    df1.write.mode(SaveMode.Append).option("header", false).csv(tempDir.toFile.getPath)
+    df1.write.mode(SaveMode.Append).option(key = "header", value = false).csv(tempDir.toFile.getPath)
     Environment._enableSparkPlanNoDataCheck = Some(true)
 
     val dataObj = RelaxedCsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = Some(SparkSchema(df1.schema)))
@@ -216,11 +215,11 @@ class RelaxedCsvFileDataObjectTest extends DataObjectTestSuite with TestTool {
     val options = Map("mode" -> "permissive")
     val schema = Some(StructType.fromDDL("h1 string, h2 string, h3 string, _corrupt_record string"))
     val dataObj = RelaxedCsvFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = schema.map(SparkSchema.apply), csvOptions = options)
-    val dfResult = dataObj.getSparkDataFrame().cache
+    val dfResult = dataObj.getSparkDataFrame().cache()
 
     assert(dfResult.columns.toSeq == Seq("h1", "h2", "h3", "_corrupt_record"))
     val expectedResult = Seq[(String,String,String)](("A","1",null))
-    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect.toSet == expectedResult.toSet )
+    assert(dfResult.select($"h1", $"h2", $"h3").as[(String,String,String)].collect().toSet == expectedResult.toSet )
     assert(dfResult.where($"_corrupt_record".isNotNull).count == 1)
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SparkFileDataObjectTest.scala
@@ -29,8 +29,8 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
+import org.scalatest.Assertion
 
-import java.nio.file
 import java.nio.file.{Files, Paths, StandardOpenOption}
 
 class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogger {
@@ -156,7 +156,7 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     // test reading data
     val result = dataObject.getSparkDataFrame()
       .select($"p",$"value".cast("int"))
-      .as[(String,Int)].collect.toSeq.sorted
+      .as[(String,Int)].collect().toSeq.sorted
     assert( result == Seq(("A",1),("A",2),("B",7),("B",8)))
     assert( dataObject.listPartitions.map(pv => pv("p").toString).sorted == Seq("A","B","C"))
 
@@ -180,7 +180,7 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     // test reading data
     val result = dataObject.getSparkDataFrame()
       .select($"p",$"value".cast("int"))
-      .as[(String,Int)].collect.toSeq.sorted
+      .as[(String,Int)].collect().toSeq.sorted
     assert( result == Seq(("B",3),("B",4)))
 
     FileUtils.deleteQuietly(tempDir.toFile)
@@ -227,7 +227,7 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     // test reading data
     val result = dataObject.getSparkDataFrame()
       .select($"p",$"value".cast("int"))
-      .as[(String,Int)].collect.toSeq.sorted
+      .as[(String,Int)].collect().toSeq.sorted
     assert( result == Seq(("B",3),("B",4)))
 
     FileUtils.deleteQuietly(tempDir.toFile)
@@ -256,7 +256,7 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     dfInit.columns.contains(sourceFileColName) //retrieved Dataframe has sourcefile column appended
     val df = dataObject.getSparkDataFrame()(contextExec)
     df.columns.contains(sourceFileColName) //retrieved Dataframe has sourcefile column appended
-    df.select(sourceFileColName).collect().head.getAs[String](0).endsWith(resourceFile) //content of sourcefile column corresponds to sourcefile
+    df.select(sourceFileColName).collect.head.getAs[String](0).endsWith(resourceFile) //content of sourcefile column corresponds to sourcefile
 
     // test if it could be written again
     dataObject.initSparkDataFrame(df.drop(sourceFileColName), Seq())
@@ -301,7 +301,7 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     assert(getFullPaths(PartitionValues(Map("c" -> 1))) == Set("a=1/b=1/c=1","a=1/b=2/c=1","a=2/b=1/c=1","a=2/b=2/c=1","a=1/b=3/c=1","a=2/b=3/c=1"))
     assert(getFullPaths(PartitionValues(Map("b" -> 1, "c" -> 1))) == Set("a=1/b=1/c=1","a=2/b=1/c=1"))
     // files
-    assert(getFullPaths(PartitionValues(Map("b" -> 1)), true) == Set("a=1/b=1/c=1/abc.test"))
+    assert(getFullPaths(pv = PartitionValues(elements = Map("b" -> 1)), returnFiles = true) == Set("a=1/b=1/c=1/abc.test"))
   }
 
   test("delete files only") {
@@ -342,7 +342,9 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     a [ProcessingLogicException] should be thrownBy dataObject.writeSparkDataFrame(df, partitionValues = Seq())
   }
 
-  private def createJsonFiles(path: java.nio.file.Path, nbOfFile: Int = 100, filenamePrefix: String = "test") = {
+  private def createJsonFiles(path: java.nio.file.Path,
+                              filenamePrefix: String = "test",
+                              nbOfFile: Int = 10): Assertion = {
     Files.createDirectory(path)
     logger.info(s"creating test files in $path")
     (1 to nbOfFile).foreach { i =>
@@ -361,8 +363,8 @@ class SparkFileDataObjectTest extends DataObjectTestSuite with SmartDataLakeLogg
     // create 100 json files for partition p=A and p=B
     val partitionPathA = Paths.get(tempDir.toString, "p=A")
     val partitionPathB = Paths.get(tempDir.toString, "p=B")
-    createJsonFiles(partitionPathA, 10, "testA")
-    createJsonFiles(partitionPathB, 10, "testB")
+    createJsonFiles(path = partitionPathA, filenamePrefix = "testA")
+    createJsonFiles(path = partitionPathB, filenamePrefix = "testB")
 
     // move partition p=A to p=B
     val pvsToMove = Seq((PartitionValues(Map("p" -> "A")), PartitionValues(Map("p" -> "B"))))

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObjectTest.scala
@@ -35,10 +35,9 @@ import org.slf4j.{Logger, LoggerFactory}
 import java.nio.file.Files
 import scala.io.Source
 
-
 class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObjectSchemaBehavior
-  with io.smartdatalake.testutils.spark.dataset.TestToolDataset
-  with io.smartdatalake.util.spark.dataset.Equality {
+    with io.smartdatalake.testutils.spark.dataset.TestToolDataset
+    with io.smartdatalake.util.spark.dataset.Equality {
 
   @transient implicit private lazy val logger: Logger = LoggerFactory.getLogger(getClass.getName)
   import session.implicits._
@@ -54,24 +53,25 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
 
     val data1 = Seq(("A", "1", "-"), ("B", "2", null))
     val df1 = data1.toDF("h1", "h2", "h3")
-    val pv1 = Seq(PartitionValues(Map("h1"->"A")), PartitionValues(Map("h1"->"B")))
+    val pv1 = Seq(PartitionValues(Map("h1" -> "A")), PartitionValues(Map("h1" -> "B")))
 
     // Partitions have to be written manually as spark-xml doesn't support writing partitions
-    val dataObj = XmlFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = Some(SparkSchema(df1.schema)), filenameColumn = Some("_filename"))
-    dataObj.writeDataFrameToPath(SparkDataFrame(df1.where($"h1"==="A")), new Path(dataObj.hadoopPath, "h1=A"), SDLSaveMode.Overwrite)
-    dataObj.writeDataFrameToPath(SparkDataFrame(df1.where($"h1"==="B")), new Path(dataObj.hadoopPath, "h1=B"), SDLSaveMode.Overwrite)
+    val dataObj = XmlFileDataObject(id = "test1", path = escapedFilePath(tempDir.toFile.getPath), schema = Some(SparkSchema(df1.schema)),
+      filenameColumn = Some("_filename"))
+    dataObj.writeDataFrameToPath(SparkDataFrame(df1.where($"h1" === "A")), new Path(dataObj.hadoopPath, "h1=A"), SDLSaveMode.Overwrite)
+    dataObj.writeDataFrameToPath(SparkDataFrame(df1.where($"h1" === "B")), new Path(dataObj.hadoopPath, "h1=B"), SDLSaveMode.Overwrite)
 
     val dataObjPartitioned = dataObj.copy(partitions = Seq("h1"))
     assert(dataObjPartitioned.getFileRefs(pv1).size == 2)
 
     // read with list of partition values
-    val dfResult1 = dataObjPartitioned.getSparkDataFrame(pv1)(contextExec).cache
+    val dfResult1 = dataObjPartitioned.getSparkDataFrame(pv1)(contextExec).cache()
     assert(dfResult1.columns.toSet == Set("h1", "h2", "h3", "_filename"))
     assert(dfResult1.drop("_filename").equal(df1))
     assert(dfResult1.where($"_filename".isNull).isEmpty)
 
     // read all
-    val dfResult2 = dataObjPartitioned.getSparkDataFrame()(contextExec).cache
+    val dfResult2 = dataObjPartitioned.getSparkDataFrame()(contextExec).cache()
     assert(dfResult2.columns.toSet == Set("h1", "h2", "h3", "_filename"))
     assert(dfResult2.drop("_filename").equal(df1))
     assert(dfResult2.where($"_filename".isNull).isEmpty)
@@ -92,7 +92,7 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
 
     val dataObj = XmlFileDataObject(id = "test1", path = tempDir.toFile.getPath,
       schema = Some(SparkSchema(schema)),
-      rowTag = Some("entry"),
+      rowTag = Some("entry")
     )
     assert(dataObj.getFileRefs(Seq()).size == 1)
 
@@ -123,22 +123,22 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     // read
     // There is a bug in Spark 3.2.1, fixed in 3.2.2 which might cause "CompileException ... A method named "numElements" is not declared in any enclosing class..." with multiple level of explodes.
     // see also https://issues.apache.org/jira/browse/SPARK-38285
-    session.conf.set("spark.sql.optimizer.expression.nestedPruning.enabled", false)
-    session.conf.set("spark.sql.optimizer.nestedSchemaPruning.enabled", false)
+    session.conf.set(key = "spark.sql.optimizer.expression.nestedPruning.enabled", value = false)
+    session.conf.set(key = "spark.sql.optimizer.nestedSchemaPruning.enabled", value = false)
     // test L0: should include 1 updated L0 and 1 deleted record
-    val dfResultL0 = dataObj.getSparkDataFrame()(contextExec).cache
+    val dfResultL0 = dataObj.getSparkDataFrame()(contextExec).cache()
       .withColumn("cntDesc", functions.size($"descriptions.description"))
       .withColumn("cntChildren", functions.size($"nodes.node"))
-    val resultL0 = dfResultL0.select($"name",$"cntDesc",$"cntChildren").as[(String,Int,Int)].collect.toSeq
-    assert(resultL0 == Seq(("Test Update L0",2,1),("Test Delete",-1,-1)))
+    val resultL0 = dfResultL0.select($"name", $"cntDesc", $"cntChildren").as[(String, Int, Int)].collect().toSeq
+    assert(resultL0 == Seq(("Test Update L0", 2, 1), ("Test Delete", -1, -1)))
     // test L1: should include 1 updated L1 record
     val dfResultL1 = dfResultL0
       .withColumn("nodes", explode($"nodes.node"))
       .select($"nodes.*")
       .withColumn("cntDesc", functions.size($"descriptions.description"))
       .withColumn("cntChildren", functions.size($"nodes.node"))
-    val resultL1 = dfResultL1.select($"name",$"cntDesc",$"cntChildren").as[(String,Int,Int)].collect.toSeq
-    assert(resultL1 == Seq(("Test Update L1",2,-1)))
+    val resultL1 = dfResultL1.select($"name", $"cntDesc", $"cntChildren").as[(String, Int, Int)].collect().toSeq
+    assert(resultL1 == Seq(("Test Update L1", 2, -1)))
   }
 
   test("XML with nested lists") {
@@ -148,9 +148,9 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     // prepare schema
     val xsdContent = Source.fromResource("xmlSchema/lists.xsd").mkString
     val rootSchema = XsdSchemaConverter.read(xsdContent, 10)
-    //rootSchema.printTreeString()
+    // rootSchema.printTreeString()
     val schema = SchemaUtil.extractRowTag(rootSchema, "tree/nodes/node")
-    //schema.printTreeString()
+    // schema.printTreeString()
 
     // prepare data and config
     val xmlResourceFile = "xmlSchema/lists.xml"
@@ -162,8 +162,8 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     )
 
     // read and check
-    val dfResult = dataObj.getSparkDataFrame()(contextExec).cache
-    val cntDescriptions = dfResult.select(functions.size($"descriptions.description")).as[Int].collect.toSeq
+    val dfResult = dataObj.getSparkDataFrame()(contextExec).cache()
+    val cntDescriptions = dfResult.select(functions.size($"descriptions.description")).as[Int].collect().toSeq
     assert(cntDescriptions == Seq(2))
   }
 
@@ -178,7 +178,8 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
          |    rowTag = TestReport
          |    filenameColumn = _filename
          | }
-         """.stripMargin)
+         """.stripMargin
+    )
 
     // parse should succeed even if schema file is missing when parseSchemaFilesLazy=true
     Environment._parseSchemaFilesLazy = Some(true)
@@ -191,7 +192,6 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
     Environment._parseSchemaFilesLazy = Some(false)
   }
 
-
   private def createDataObject(path: String, schemaOpt: Option[StructType]): XmlFileDataObject = {
     val dataObj = XmlFileDataObject(id = "schemaTestXmlDO", path = path, schema = schemaOpt.map(SparkSchema.apply))
     instanceRegistry.register(dataObj)
@@ -199,12 +199,12 @@ class XmlFileDataObjectTest extends DataObjectTestSuite with SparkFileDataObject
   }
 
   private def createDataObjectWithSchemaMin(path: String, schemaOpt: Option[StructType], schemaMinOpt: Option[StructType]): XmlFileDataObject = {
-    val dataObj = XmlFileDataObject(id = "schemaTestXmlDO", path = path, schema = schemaOpt.map(SparkSchema.apply), schemaMin = schemaMinOpt.map(SparkSchema.apply))
+    val dataObj =
+      XmlFileDataObject(id = "schemaTestXmlDO", path = path, schema = schemaOpt.map(SparkSchema.apply), schemaMin = schemaMinOpt.map(SparkSchema.apply))
     instanceRegistry.register(dataObj)
     dataObj
   }
 
-  override def createFile(path: String, data: DataFrame): Unit = {
+  override def createFile(path: String, data: DataFrame): Unit =
     data.write.format("com.databricks.spark.xml").save(path)
-  }
 }

--- a/sdl-debezium/src/main/scala/io/smartdatalake/workflow/dataobject/DebeziumCdcDataObject.scala
+++ b/sdl-debezium/src/main/scala/io/smartdatalake/workflow/dataobject/DebeziumCdcDataObject.scala
@@ -116,7 +116,7 @@ case class DebeziumCdcDataObject(override val id: DataObjectId,
     // Always overwrite table.include.list property to include only the changes of the table specified in the data object
     props = props ++ Map("table.include.list" -> table.fullName)
 
-    val propsForEngine = new Properties();
+    val propsForEngine = new Properties()
     props.foreach { case (key, value) => propsForEngine.setProperty(key, value) }
     propsForEngine
   }
@@ -319,17 +319,15 @@ private object DebeziumEventConverter {
         case Type.BOOLEAN => BooleanType
         case Type.STRING => StringType
         case Type.BYTES => BinaryType
-        case Type.MAP => {
+        case Type.MAP =>
           // Infer key and value types for MapType
           val keyType = inferSparkSchema(field.schema().keySchema())
           val valueType = inferSparkSchema(field.schema().valueSchema())
           MapType(keyType, valueType)
-        }
-        case Type.ARRAY => {
+        case Type.ARRAY =>
           // Infer the element type for ArrayType
           val elementType = inferSparkSchema(field.schema().valueSchema())
           ArrayType(elementType)
-        }
         case Type.STRUCT => inferSparkSchema(field.schema())
         case _ => StringType
       }
@@ -355,7 +353,7 @@ private object DebeziumEventConverter {
       }
     }.toSeq
 
-    Row(values: _*)
+    Row(values.toIndexedSeq: _*)
 
   }
 
@@ -387,7 +385,7 @@ private object DebeziumEventConverter {
     val newColumnOrder = remainingColumns ++ colsToMove
 
     // Reorder DataFrame by selecting columns in the new order
-    val reorderedDF = df.select(newColumnOrder.head, newColumnOrder.tail: _*)
+    val reorderedDF = df.select(newColumnOrder.head, newColumnOrder.tail.toIndexedSeq: _*)
 
     reorderedDF
   }

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -272,7 +272,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
 
       require(table.primaryKey.isDefined, s"($id) PrimaryKey for table [${table.fullName}] needs to be defined when using DataObjectStateIncrementalMode")
 
-      val windowSpec = Window.partitionBy(table.primaryKey.get.map(col): _*).orderBy(col("_commit_timestamp").desc)
+      val windowSpec = Window.partitionBy(table.primaryKey.get.map(col).toIndexedSeq: _*).orderBy(col("_commit_timestamp").desc)
 
       SparkSubFeed.getSparkSession.read.format("delta")
         .option("readChangeFeed", "true")

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/action/DeltaLakeDeduplicateWithMergeActionTest.scala
@@ -31,7 +31,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import java.nio.file.Files
 
 class DeltaLakeDeduplicateWithMergeActionTest extends AnyFunSuite
-  with SmartDataLakeLogger with DeduplicateActionBehaviour {
+    with SmartDataLakeLogger with DeduplicateActionBehaviour {
 
   protected implicit val session: SparkSession = DeltaLakeTestUtils.session
 
@@ -42,7 +42,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends AnyFunSuite
 
   test("deduplicate load mergeModeEnable") {
     testDeduplicateWithMergeMode(
-      (id, registry) => MockSparkDataObject(id),
+      (id, _) => MockSparkDataObject(id),
       (id, pks, registry) => {
         val tgtTable = Table(db = Some(deltaDb), name = id.replaceAll("-", "_"), primaryKey = pks)
         DeltaLakeTableDataObject(id, Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, allowSchemaEvolution = true)(registry)
@@ -52,7 +52,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends AnyFunSuite
 
   test("deduplicate load mergeModeEnable updateCapturedColumnOnlyWhenChanged") {
     testDeduplicateWithMergeModeUpdateCapturedColumnOnlyWhenChanged(
-      (id, registry) => MockSparkDataObject(id),
+      (id, _) => MockSparkDataObject(id),
       (id, pks, registry) => {
         val tgtTable = Table(db = Some(deltaDb), name = id.replaceAll("-", "_"), primaryKey = pks)
         DeltaLakeTableDataObject(id, Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, allowSchemaEvolution = true)(registry)
@@ -62,7 +62,7 @@ class DeltaLakeDeduplicateWithMergeActionTest extends AnyFunSuite
 
   test("deduplicate 1st 2nd load with transformer changing schema") {
     testDeduplicateWithTransformerChangingSchema(
-      (id, registry) => MockSparkDataObject(id),
+      (id, _) => MockSparkDataObject(id),
       (id, pks, registry) => {
         val tgtTable = Table(db = Some(deltaDb), name = id.replaceAll("-", "_"), primaryKey = pks)
         DeltaLakeTableDataObject(id, Some(tempPath + s"/${tgtTable.fullName}"), table = tgtTable, allowSchemaEvolution = true)(registry)

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -308,7 +308,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
           // read cdc events
           val temporaryViewName = table.name + "_changes"
 
-          val windowSpec = Window.partitionBy(table.primaryKey.get.map(col): _*).orderBy(col("_change_ordinal").desc)
+          val windowSpec = Window.partitionBy(table.primaryKey.get.map(col).toIndexedSeq: _*).orderBy(col("_change_ordinal").desc)
           SparkSubFeed.getSparkSession.read
             .table(temporaryViewName)
             .where(expr("_change_type IN ('INSERT','UPDATE_AFTER')"))

--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
@@ -232,7 +232,7 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
     dfRaw
       .withOptionalColumn(datePartitionCol.map(_.colName), udfFormatPartition(col("timestamp")))
       .as("kafka")
-      .select(colsToSelect: _*)
+      .select(colsToSelect.toIndexedSeq: _*)
   }
 
   private def decodeKeyValue(dfRaw: DataFrame): DataFrame = {
@@ -487,7 +487,7 @@ case class KafkaTopicDataObject(override val id: DataObjectId,
     // search how many partitions / chrono units back of data we have
     var cntEmptyConsecutive = 0
     // TODO: once Scala 2.12 has been reomved replace Stream by LazyList
-    val detectedPartitions = Stream.from(0).map {
+    val detectedPartitions = LazyList.from(0).map {
       unitsBack =>
         val startTimeIncl = datePartitionCol.get.previous(lastCompletedPartitionStartTime, unitsBack)
         val endTimeExcl = datePartitionCol.get.next(startTimeIncl)

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/SmartDataLakeBuilderLab.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/SmartDataLakeBuilderLab.scala
@@ -120,7 +120,7 @@ case class SmartDataLakeBuilderLab[D,A](
     }
 
     // transform
-    val optionsPrep = mutable.Map(options.toSeq: _*)
+    val optionsPrep = mutable.Map(options.toSeq.toIndexedSeq: _*)
     if (transformer.isSingleOutput) optionsPrep += (OPTION_OUTPUT_DATAOBJECT_ID -> DEFAULT_DATAOBJECT_ID)
     transformer.transform(session, optionsPrep.toMap, dfs)
   }

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
@@ -190,7 +190,7 @@ object ConfigJsonExporter extends SmartDataLakeLogger {
           logger.info(s"Target ${writer.getClass.getSimpleName} does not support listing existing files.")
           Map[String, FileDescriptor]()
       }
-      val filesToDelete = mutable.Set(existingFiles.keySet.toSeq: _*)
+      val filesToDelete = mutable.Set(existingFiles.keySet.toSeq.toIndexedSeq: _*)
       logger.info(s"Searching description files in $path")
       RemoteIteratorWrapper(filesystem.listFiles(path, true))
         .filterNot(_.isDirectory)

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
@@ -98,7 +98,7 @@ case class SnowparkDataFrame(inner: DataFrame) extends GenericDataFrame with Sma
     SnowparkDataFrame(inner.sort(snowparkCols))
   }
 
-  override def collect: Seq[GenericRow] = inner.collect().map(SnowparkRow)
+  override def collect: Seq[GenericRow] = inner.collect.map(SnowparkRow)
   override def distinct: SnowparkDataFrame = SnowparkDataFrame(inner.distinct())
   override def getDataFrameSubFeed(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): DataFrameSubFeed = {
     SnowparkSubFeed(Some(this), dataObjectId, partitionValues, filter = filter)
@@ -126,7 +126,7 @@ case class SnowparkDataFrame(inner: DataFrame) extends GenericDataFrame with Sma
   }
 
   override def dropDuplicates(cols: Seq[String]): SnowparkDataFrame = {
-    SnowparkDataFrame(inner.dropDuplicates(cols: _*))
+    SnowparkDataFrame(inner.dropDuplicates(cols.toIndexedSeq: _*))
   }
   override def isEmpty: Boolean = inner.count() == 0
   override def count: Long = inner.count()

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
@@ -304,7 +304,7 @@ object SnowparkSubFeed extends DataFrameSubFeedCompanion with SmartDataLakeLogge
     aggFunction.apply() match {
       case snowparkAggFunctionColumn: SnowparkColumn => SnowparkColumn(snowparkAggFunctionColumn
         .inner.over(
-          Window.partitionBy(partitionBy.map(_.asInstanceOf[SnowparkColumn].inner): _*)
+          Window.partitionBy(partitionBy.map(_.asInstanceOf[SnowparkColumn].inner).toIndexedSeq: _*)
             .orderBy(orderBy.asInstanceOf[SnowparkColumn].inner))
       )
       case generic => DataFrameSubFeed.throwIllegalSubFeedTypeException(generic)
@@ -326,7 +326,7 @@ object SnowparkSubFeed extends DataFrameSubFeedCompanion with SmartDataLakeLogge
   }
 
   override def rowFromSeq(values: Seq[Any]): GenericRow = {
-    SnowparkRow(Row(values: _*))
+    SnowparkRow(Row(values.toIndexedSeq: _*))
   }
 
   override def schemaEvolutionUdf(srcType: GenericDataType, tgtType: GenericDataType): GenericUnaryUdf = {

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -416,7 +416,7 @@ object SnowflakeUtils {
       if (f.dataType != targetType) spark.functions.col(f.name).cast(targetType)
       else spark.functions.col(f.name)
     }
-    df.select(targetCols: _*)
+    df.select(targetCols.toIndexedSeq: _*)
   }
 }
 


### PR DESCRIPTION
- Passing an explicit array value to a Scala varargs method is deprecated (since 2.13.0) and will result in a defensive copy; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
- Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method cache, or remove the empty argument list from its definition (Java-defined methods are exempt).
### Build Status
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for sdl-core 3.0.0-SNAPSHOT:
[INFO] 
[INFO] sdl-core ........................................... SUCCESS [01:31 min]
[INFO] sdl-deltalake ...................................... SUCCESS [  7.568 s]
[INFO] sdl-iceberg ........................................ SUCCESS [  6.519 s]
[INFO] sdl-snowflake ...................................... FAILURE [  6.323 s]
[INFO] sdl-azure .......................................... SKIPPED
[INFO] sdl-gcp ............................................ SKIPPED
[INFO] sdl-debezium ....................................... SKIPPED
[INFO] sdl-lang ........................................... SKIPPED
[INFO] ------------------------------------------------------------------------
```