### PR TITLE
Transform.transposeCustom deleted

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Transform.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Transform.scala
@@ -24,8 +24,6 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
 import java.sql.Timestamp
-import scala.collection.mutable.ArrayBuffer
-import scala.jdk.CollectionConverters._
 
 trait Transform extends Serializable {
 
@@ -306,7 +304,7 @@ trait Transform extends Serializable {
     }
 
     def decomposeArrayColumn[S](arrayCol: Column, indexMap: Map[S, String]): DataFrame = ds
-      .withColumns(indexMap.map { case (i, s) => (s, get(arrayCol,lit(i))) })
+      .withColumns(indexMap.map { case (i, s) => (s, get(arrayCol, lit(i))) })
 
     /**
      * Enumerates groups in a dataframe. Groups are final defined based on `keyCols` and `condition`
@@ -344,7 +342,9 @@ trait Transform extends Serializable {
       ds.withColumn(attr + "_prev", lag(attr, 1).over(Window.partitionBy(keyCols.toIndexedSeq: _*).orderBy(orderCols.toIndexedSeq: _*)))
         .withColumn("consecutive", col(attr + "_prev").isNotNull and condition)
         .withColumn(groupNbName,
-          sum(when($"consecutive", lit(0)).otherwise(lit(1))).over(Window.partitionBy(keyCols.toIndexedSeq: _*).orderBy(orderCols.toIndexedSeq: _*)))
+          sum(when($"consecutive", lit(0)).otherwise(lit(1))).over(
+            Window.partitionBy(keyCols.toIndexedSeq: _*).orderBy(orderCols.toIndexedSeq: _*)
+          ))
         .drop(attr + "_prev", "consecutive")
     }
 
@@ -544,28 +544,6 @@ trait Transform extends Serializable {
       else colNamesToPivot.foldLeft(ds.asInstanceOf[DataFrame])((dtf, cn) => dtf.castColumnTo(StringType)(cn))
       dfCasted.unpivot(ids = keys, values = colNamesToPivot.map(col),
         variableColumnName = namesColName, valueColumnName = valuesColname)
-    }
-
-    /**
-     * transponiert die ersten numRows Zeilen des Dataframes
-     *
-     * @param numRows
-     *   : Anzahl Zeilen, die transponiert werden sollen. Datentyp Byte damit nicht zu viele
-     *   angegeben werden.
-     * @return
-     *   df 1+numRows Zeilen und Anzahl Zeilen, die der Spaltenanzahl entspricht
-     */
-    def transposeCustom(numRows: Byte = 2)(implicit ss: SparkSession): DataFrame = if (ds.isEmpty) {
-      ss.createDataFrame(ds.columns.map(Row(_)).toList.asJava, StructType(List(StructField("_column", StringType, nullable = false))))
-    } else {
-      val rows: Array[Row] = ds.asInstanceOf[DataFrame].take(numRows)
-
-      def transposeRow(rows: Array[Row])(r: Row): DataFrame = ss
-        .createDataFrame(ArrayBuffer(r).asJava, ds.schema)
-        .unpivotCast(Array(), "_column", f"_${rows.indexOf(r)}%03d", ds.columns)
-
-      rows.map(transposeRow(rows))
-        .reduce((df1, df2) => df1.join(df2, Seq("_column")))
     }
 
     /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/ActionHelper.scala
@@ -18,21 +18,15 @@
  */
 package io.smartdatalake.workflow.action
 
-import io.smartdatalake.config.SdlConfigObject.ConnectionId
-import io.smartdatalake.config.{ConfigurationException, InstanceRegistry, TypeMismatchException}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.misc.SmartDataLakeLogger
-import io.smartdatalake.workflow.connection.Connection
 import io.smartdatalake.workflow.dataframe.{DataFrameFunctions, GenericDataFrame}
 import io.smartdatalake.workflow.dataobject.DataObject
 import io.smartdatalake.workflow.dataobject.generic.CanCreateDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, InitSubFeed, SubFeed}
-import org.apache.spark.sql.AnalysisException
 
 import java.sql.Timestamp
-import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.Type
-import scala.reflect.runtime.universe.TypeTag
 
 /**
  * Collection of helper functions for Actions
@@ -95,7 +89,7 @@ object ActionHelper extends SmartDataLakeLogger {
     case e: IllegalArgumentException if e.getMessage.contains("DataObject schema is undefined") => None
     case e
         if e.getClass.getSimpleName == "AnalysisException" && e.getMessage.contains("[TABLE_OR_VIEW_NOT_FOUND]") ||
-          e.getMessage().contains("[UNABLE_TO_INFER_SCHEMA]") || e.getMessage().contains("[DELTA_MISSING_DELTA_TABLE]") => None
+          e.getMessage.contains("[UNABLE_TO_INFER_SCHEMA]") || e.getMessage.contains("[DELTA_MISSING_DELTA_TABLE]") => None
     case _: NoDataToProcessWarning => None
   }
 

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/custom/TestCustomDfsTransformer.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/custom/TestCustomDfsTransformer.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 
 class TestCustomDfsTransformer extends CustomDfsTransformer {
 
-  def transform(session: SparkSession, srcData: DataFrame): DataFrame = {
+  def transform(session: SparkSession, srcData: DataFrame): DataFrame =
     srcData.withColumn("_rnk", row_number().over(Window.partitionBy(col("text")).orderBy(col("id"))))
-  }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/spark/dataset/Collection.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/spark/dataset/Collection.scala
@@ -94,7 +94,7 @@ object Collection extends StructTypeUtil {
     (1, Some(3.0), Some(4.0), -2.72, Timestamp.valueOf("2020-01-01 00:00:00"), doomsTime),
     (1, None,      Some(5.0), 100.1, Timestamp.valueOf("2020-01-01 00:00:00"), Timestamp.valueOf("2020-03-31 23:59:59.999")),
     (1, Some(4.0), Some(5.0), 9.87,  Timestamp.valueOf("2020-04-01 00:00:00"), doomsTime)
-  ).toDF("id", "x", "y", "wert", "valid_from", "valid_to")
+  ).toDF("id", "x", "y", "val", "valid_from", "valid_to")
   val dfSnapshotsWithGaps: DataFrame = List(
     (0, 20190101, Some(3.14),  None),
     (0, 20190102, Some(3.14),  Some(-2.37)),
@@ -210,7 +210,7 @@ object Collection extends StructTypeUtil {
     (1, -2.0,  "2019-03-03 01:00:0",            "2021-12-01 02:34:56.1")
   )
   val dfTimeRanges: DataFrame = rowsTimeRanges.map(makeRowsWithTimeRanges[Int, Double])
-    .toDF("id", "Wert", "valid_from", "valid_to")
+    .toDF("id", "val", "valid_from", "valid_to")
 
   /**
    * * DataFrames with Map **

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsQualityTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsQualityTest.scala
@@ -68,7 +68,7 @@ class DsQualityTest extends AnyFlatSpec with Matchers
   ///// tests treating gaps in axis (time or space) /////
 
   "fillGaps_next" should "fill the gaps taking value from next row" in {
-    val actual = dfSnapshotsWithGaps.fillGaps(Seq("id"), Seq("Wert"), "dt")
+    val actual = dfSnapshotsWithGaps.fillGaps(Seq("id"), Seq("val"), "dt")
     val expected = Seq(
       (Some(0), Some(20190101), Some(3.14),  Some(-2.37)),
       (Some(0), Some(20190102), Some(3.14),  Some(-2.37)),
@@ -86,7 +86,7 @@ class DsQualityTest extends AnyFlatSpec with Matchers
   }
 
   "fillGaps_next" should "fill the gaps taking value from previous row" in {
-    val actual = dfSnapshotsWithGaps.fillGaps(Seq("id"), Seq("Wert"), "dt", takeNextValueFirst = false)
+    val actual = dfSnapshotsWithGaps.fillGaps(Seq("id"), Seq("val"), "dt", takeNextValueFirst = false)
     val expected = Seq(
       (Some(0), Some(20190101), Some(3.14),  Some(-2.37)),
       (Some(0), Some(20190102), Some(3.14),  Some(-2.37)),

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/TransformTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/TransformTest.scala
@@ -22,7 +22,7 @@ import io.smartdatalake.testutils.spark.dataset.Collection._
 import io.smartdatalake.testutils.spark.dataset.TestToolDataset
 import io.smartdatalake.testutils.{TestTool, TestUtil}
 import io.smartdatalake.util.spark.GetSession.loggEnv
-import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -35,7 +35,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
 class TransformTest extends AnyFlatSpec with Matchers
-  with TestTool with TestToolDataset with Equality with StructTypeUtil {
+    with TestTool with TestToolDataset with Equality with StructTypeUtil {
   private implicit val logger: Logger = LoggerFactory.getLogger(getClass.getName)
   private implicit val spark: SparkSession = TestUtil.session
 
@@ -66,23 +66,24 @@ class TransformTest extends AnyFlatSpec with Matchers
   "castColumnTo" should "cast the type of the column" in {
     val actual = dfTimeRanges.castColumnTo(ByteType)("id")
     val rowsExpected: List[(Byte, Double, String, String)] = List(
-      (0, 3.14, "2019-01-01 00:00:00.123456789", "2019-01-05 12:34:56.123456789"),
-      (0, 2.72, "2019-01-05 12:34:56.123456789", "2019-02-01 02:34:56.1235"),
-      (0, 42.0, "2019-02-01 02:34:56.1235", "2019-02-01 02:34:56.1245"),
-      (0, 13.0, "2019-02-01 02:34:56.1245", "2019-03-03 00:00:0"),
-      (0, 12.0, "2019-03-03 00:00:0", "2019-04-04 00:00:0"),
-      (0, 42.0, "2019-09-05 02:34:56.1231", "2019-09-05 02:34:56.1239"),
-      (0, 18.17, "2020-01-01 01:00:0", "9999-12-31 23:59:59.999999999"),
-      (1, -1.0, "2019-01-01 00:00:0.123456789", "2019-02-02 00:00:00"),
-      (1, -2.0, "2019-03-03 01:00:0", "2021-12-01 02:34:56.1"))
+      (0, 3.14,  "2019-01-01 00:00:00.123456789", "2019-01-05 12:34:56.123456789"),
+      (0, 2.72,  "2019-01-05 12:34:56.123456789", "2019-02-01 02:34:56.1235"),
+      (0, 42.0,  "2019-02-01 02:34:56.1235",      "2019-02-01 02:34:56.1245"),
+      (0, 13.0,  "2019-02-01 02:34:56.1245",      "2019-03-03 00:00:0"),
+      (0, 12.0,  "2019-03-03 00:00:0",            "2019-04-04 00:00:0"),
+      (0, 42.0,  "2019-09-05 02:34:56.1231",      "2019-09-05 02:34:56.1239"),
+      (0, 18.17, "2020-01-01 01:00:0",            "9999-12-31 23:59:59.999999999"),
+      (1, -1.0,  "2019-01-01 00:00:0.123456789",  "2019-02-02 00:00:00"),
+      (1, -2.0,  "2019-03-03 01:00:0",            "2021-12-01 02:34:56.1")
+    )
     val expected = rowsExpected.map(makeRowsWithTimeRanges[Byte, Double])
-      .toDF("id", "Wert", "valid_from", "valid_to")
+      .toDF("id", "val", "valid_from", "valid_to")
     actual.equal(expected) should be(true)
   }
 
   "castAll2String" should "cast all columns to StringType" in {
     val actual = dfManyTypes.castAll2String
-    val expected = actual.columns.foldLeft(actual)({ (df, s) => df.withColumn(s, col(s).cast(StringType)) })
+    val expected = actual.columns.foldLeft(actual)((df, s) => df.withColumn(s, col(s).cast(StringType)))
     actual.equal(expected) should be(true)
   }
 
@@ -95,10 +96,11 @@ class TransformTest extends AnyFlatSpec with Matchers
   "castColumnsOfTypeTo" should "cast the type of double columns to float" in {
     val actual = dsSimple1.castColumnsOfTypeTo(FloatType)(DoubleType)
     val schemaExpected: StructType = StructType(Array(
-      StructField(name = "id", dataType = StringType, nullable = false),
-      StructField(name = "n", dataType = IntegerType, nullable = false),
-      StructField(name = "x", dataType = FloatType, nullable = false),
-      StructField(name = "y", dataType = FloatType, nullable = false)))
+        StructField(name = "id", dataType = StringType, nullable = false),
+        StructField(name = "n", dataType = IntegerType, nullable = false),
+        StructField(name = "x", dataType = FloatType, nullable = false),
+        StructField(name = "y", dataType = FloatType, nullable = false)
+      ))
     val expected = spark.createDataFrame(ArrayBuffer(Row("A", 1, 0f, 10f)).asJava, schemaExpected)
     actual.equal(expected) should be(true)
   }
@@ -107,12 +109,19 @@ class TransformTest extends AnyFlatSpec with Matchers
     val actual = dfIntDecimal.castDecimalsToIntegralType()
     val rowsExpected = ArrayBuffer(
       Row(-1, -99.toByte, -9999.toShort, -999999999, -999999999999999999L, BigDecimal(Long.MinValue), BigDecimal(-1.1)),
-      Row(0, 12.toByte, 1234.toShort, 123456789, 123456789012345678L, BigDecimal(Long.MaxValue) + java.math.BigDecimal.ONE, BigDecimal(0.123)),
+      Row(0, 12.toByte, 1234.toShort, 123456789, 123456789012345678L, BigDecimal(Long.MaxValue) + java.math.BigDecimal.ONE,
+        BigDecimal(0.123)),
       Row(1, 99.toByte, 9999.toShort, 999999999, 999999999999999999L, BigDecimal(Long.MaxValue), BigDecimal(1.2345))
     ).asJava
-    val schema_expected = createStruct(Array[(String, DataType)](("id", IntegerType),
-      ("deci_byte", ByteType), ("deci_short", ShortType), ("deci_int", IntegerType),
-      ("deci_long", LongType), ("deci_tolong", DecimalType(19, 0)), ("deci", DecimalType(8, 4)))
+    val schema_expected = createStruct(Array[(String, DataType)](
+        ("id",          IntegerType),
+        ("deci_byte",   ByteType),
+        ("deci_short",  ShortType),
+        ("deci_int",    IntegerType),
+        ("deci_long",   LongType),
+        ("deci_tolong", DecimalType(19, 0)),
+        ("deci",        DecimalType(8, 4))
+      )
     )
     val expected = spark.createDataFrame(rowsExpected, schema_expected)
     actual.equal(expected) should be(true)
@@ -137,9 +146,15 @@ class TransformTest extends AnyFlatSpec with Matchers
       Row(0, 12.toByte, 1234.toShort, 123456789, 123456789012345678L, None, BigDecimal(0.123)),
       Row(1, 99.toByte, 9999.toShort, 999999999, 999999999999999999L, Long.MaxValue, BigDecimal(1.2345))
     ).asJava
-    val schema_expected = createStruct(Array[(String, DataType)](("id", IntegerType),
-      ("deci_byte", ByteType), ("deci_short", ShortType), ("deci_int", IntegerType),
-      ("deci_long", LongType), ("deci_tolong", LongType), ("deci", DecimalType(8, 4)))
+    val schema_expected = createStruct(Array[(String, DataType)](
+        ("id",          IntegerType),
+        ("deci_byte",   ByteType),
+        ("deci_short",  ShortType),
+        ("deci_int",    IntegerType),
+        ("deci_long",   LongType),
+        ("deci_tolong", LongType),
+        ("deci",        DecimalType(8, 4))
+      )
     )
     val expected = spark.createDataFrame(rowsExpected, schema_expected)
     actual.equal(expected) should be(true)
@@ -147,9 +162,15 @@ class TransformTest extends AnyFlatSpec with Matchers
 
   "castDecimalsToIntegralType" should "cast unscaled decimals to DecimalType(38, 0)" in {
     val actual = dfIntDecimal.castDecimalsToIntegralType(typOpt = Some(DecimalType(38, 0)))
-    val schema_expected = createStruct(Array[(String, DataType)](("id", IntegerType),
-      ("deci_byte", DecimalType(38, 0)), ("deci_short", DecimalType(38, 0)), ("deci_int", DecimalType(38, 0)),
-      ("deci_long", DecimalType(38, 0)), ("deci_tolong", DecimalType(38, 0)), ("deci", DecimalType(8, 4)))
+    val schema_expected = createStruct(Array[(String, DataType)](
+        ("id",          IntegerType),
+        ("deci_byte",   DecimalType(38, 0)),
+        ("deci_short",  DecimalType(38, 0)),
+        ("deci_int",    DecimalType(38, 0)),
+        ("deci_long",   DecimalType(38, 0)),
+        ("deci_tolong", DecimalType(38, 0)),
+        ("deci",        DecimalType(8, 4))
+      )
     )
     val expected = spark.createDataFrame(rowsIntDecimal, schema_expected)
     actual.equal(expected) should be(true)
@@ -164,9 +185,13 @@ class TransformTest extends AnyFlatSpec with Matchers
     val indexMap = SortedMap(0 -> "element_0", 1 -> "element_1", 2 -> "element_2", 3 -> "element_3")
     val actual = dfArray2.decomposeArrayColumn(arrayCol = $"arr", indexMap = indexMap)
     val expectedSchema = createStruct(Array[(String, DataType)](
-      ("id", IntegerType), ("arr", ArrayType(IntegerType, containsNull = true)),
-      ("element_0", IntegerType), ("element_1", IntegerType),
-      ("element_2", IntegerType), ("element_3", IntegerType)))
+        ("id",        IntegerType),
+        ("arr",       ArrayType(IntegerType, containsNull = true)),
+        ("element_0", IntegerType),
+        ("element_1", IntegerType),
+        ("element_2", IntegerType),
+        ("element_3", IntegerType)
+      ))
     val rowsExpected: java.util.List[Row] = ArrayBuffer(
       Row(-2, None, None, None, None, None),
       Row(-1, Some(List(None)), None, None, None, None),
@@ -182,42 +207,45 @@ class TransformTest extends AnyFlatSpec with Matchers
   "explodeArrays" should "explode its columns of ArrayType" in {
     val actual = dfArray.select($"exponent", $"powerfun", $"powerfun".as("array_2")).explodeArrays
     val expectedSchema = StructType(Array(
-      StructField("exponent", IntegerType, nullable = false),
-      StructField("powerfun",
-        StructType(List(
-          StructField("key", IntegerType, nullable = false),
-          StructField("value", IntegerType, nullable = false))),
-        nullable = false),
-      StructField("array_2",
-        StructType(List(
-          StructField("key", IntegerType, nullable = false),
-          StructField("value", IntegerType, nullable = false))),
-        nullable = false)))
+        StructField("exponent", IntegerType, nullable = false),
+        StructField("powerfun",
+          StructType(List(
+              StructField("key", IntegerType, nullable = false),
+              StructField("value", IntegerType, nullable = false)
+            )),
+          nullable = false),
+        StructField("array_2",
+          StructType(List(
+              StructField("key", IntegerType, nullable = false),
+              StructField("value", IntegerType, nullable = false)
+            )),
+          nullable = false)
+      ))
     val expectedRows: java.util.List[Row] = ArrayBuffer(
-      Row(1, (1, 1), (1, 1)),
-      Row(1, (1, 1), (2, 2)),
-      Row(1, (1, 1), (3, 3)),
-      Row(1, (2, 2), (1, 1)),
-      Row(1, (2, 2), (2, 2)),
-      Row(1, (2, 2), (3, 3)),
-      Row(1, (3, 3), (1, 1)),
-      Row(1, (3, 3), (2, 2)),
-      Row(1, (3, 3), (3, 3)),
-      Row(2, (1, 1), (1, 1)),
-      Row(2, (1, 1), (2, 4)),
-      Row(2, (1, 1), (3, 9)),
-      Row(2, (2, 4), (1, 1)),
-      Row(2, (2, 4), (2, 4)),
-      Row(2, (2, 4), (3, 9)),
-      Row(2, (3, 9), (1, 1)),
-      Row(2, (3, 9), (2, 4)),
-      Row(2, (3, 9), (3, 9)),
-      Row(3, (1, 1), (1, 1)),
-      Row(3, (1, 1), (2, 8)),
-      Row(3, (1, 1), (3, 27)),
-      Row(3, (2, 8), (1, 1)),
-      Row(3, (2, 8), (2, 8)),
-      Row(3, (2, 8), (3, 27)),
+      Row(1, (1, 1), (1,  1)),
+      Row(1, (1, 1), (2,  2)),
+      Row(1, (1, 1), (3,  3)),
+      Row(1, (2, 2), (1,  1)),
+      Row(1, (2, 2), (2,  2)),
+      Row(1, (2, 2), (3,  3)),
+      Row(1, (3, 3), (1,  1)),
+      Row(1, (3, 3), (2,  2)),
+      Row(1, (3, 3), (3,  3)),
+      Row(2, (1, 1), (1,  1)),
+      Row(2, (1, 1), (2,  4)),
+      Row(2, (1, 1), (3,  9)),
+      Row(2, (2, 4), (1,  1)),
+      Row(2, (2, 4), (2,  4)),
+      Row(2, (2, 4), (3,  9)),
+      Row(2, (3, 9), (1,  1)),
+      Row(2, (3, 9), (2,  4)),
+      Row(2, (3, 9), (3,  9)),
+      Row(3, (1, 1), (1,  1)),
+      Row(3, (1, 1), (2,  8)),
+      Row(3, (1, 1), (3,  27)),
+      Row(3, (2, 8), (1,  1)),
+      Row(3, (2, 8), (2,  8)),
+      Row(3, (2, 8), (3,  27)),
       Row(3, (3, 27), (1, 1)),
       Row(3, (3, 27), (2, 8)),
       Row(3, (3, 27), (3, 27))
@@ -229,12 +257,14 @@ class TransformTest extends AnyFlatSpec with Matchers
   "explodeMaps" should "explode its columns of MapType" in {
     val actual = dfMap.explodeMaps
     val expectedSchema = StructType(Array(
-      StructField("id", StringType, nullable = false),
-      StructField("xMap_key", IntegerType, nullable = false),
-      StructField("xMap_value", DoubleType, nullable = true)))
+        StructField("id", StringType, nullable = false),
+        StructField("xMap_key", IntegerType, nullable = false),
+        StructField("xMap_value", DoubleType, nullable = true)
+      ))
     val expectedRows: java.util.List[Row] = ArrayBuffer(
       Row("A", 0, Some(0d)),
-      Row("A", 1, Some(1d))).asJava
+      Row("A", 1, Some(1d))
+    ).asJava
     val expected = spark.createDataFrame(expectedRows, expectedSchema)
 
     actual.equal(expected) shouldBe true
@@ -244,12 +274,14 @@ class TransformTest extends AnyFlatSpec with Matchers
     val actual = dfMapIntInt.castMapsToArrays.explodeArrays
 
     val expectedSchema = StructType(List(
-      StructField("exponent", IntegerType, nullable = false),
-      StructField("powerfun",
-        StructType(List(
-          StructField("key", IntegerType, nullable = false),
-          StructField("value", IntegerType, nullable = false))),
-        nullable = false)))
+        StructField("exponent", IntegerType, nullable = false),
+        StructField("powerfun",
+          StructType(List(
+              StructField("key", IntegerType, nullable = false),
+              StructField("value", IntegerType, nullable = false)
+            )),
+          nullable = false)
+      ))
     val expectedRows: java.util.List[Row] = ArrayBuffer(
       Row(1, (1, 1)),
       Row(1, (2, 2)),
@@ -288,28 +320,29 @@ class TransformTest extends AnyFlatSpec with Matchers
     longDF.equal(expectedDF) shouldBe true
   }
 
-  "given a wide dataFrame which has nullable and non-nullable columns, colsToRows" should "transform it to a long dataframe with a nullable columns and keep nulls" in {
+  "given a wide dataFrame which has nullable and non-nullable columns, colsToRows" should
+    "transform it to a long dataframe with a nullable columns and keep nulls" in {
 
-    val wideDF = List(
-      (1, 1, Option(10)),
-      (2, 2, None),
-      (3, 3, Option(30))
-    ).toDF("id", "a", "b")
+      val wideDF = List(
+        (1, 1, Option(10)),
+        (2, 2, None),
+        (3, 3, Option(30))
+      ).toDF("id", "a", "b")
 
-    val expectedDF = List(
-      (1, "a", Option(1)),
-      (2, "a", Option(2)),
-      (3, "a", Option(3)),
-      (1, "b", Option(10)),
-      (2, "b", None),
-      (3, "b", Option(30))
-    ).toDF("id", "feature", "value")
+      val expectedDF = List(
+        (1, "a", Option(1)),
+        (2, "a", Option(2)),
+        (3, "a", Option(3)),
+        (1, "b", Option(10)),
+        (2, "b", None),
+        (3, "b", Option(30))
+      ).toDF("id", "feature", "value")
 
-    val longDF = wideDF.colsToRows(keyName = "feature", idCols = List("id"))
+      val longDF = wideDF.colsToRows(keyName = "feature", idCols = List("id"))
 
-    longDF.equal(expectedDF) shouldBe true
-    // note : this implies that the feature column is nullable
-  }
+      longDF.equal(expectedDF) shouldBe true
+      // note : this implies that the feature column is nullable
+    }
 
   "given a wide dataFrame with various data-types, colsToRows" should "fail because data-types have been mixed in the wide dataFrame" in {
     val wideDF = List(
@@ -381,9 +414,9 @@ class TransformTest extends AnyFlatSpec with Matchers
       ("S0_A", 2L, "GTGA", 1L),
       ("S0_A", 3L, "GTGB", 2L),
       ("S0_A", 4L, "GTGB", 2L),
-      ("S0_A", 5L, null, 3L),
-      ("S0_A", 6L, null, 4L),
-      ("S0_A", 7L, null, 5L)
+      ("S0_A", 5L, null,   3L),
+      ("S0_A", 6L, null,   4L),
+      ("S0_A", 7L, null,   5L)
     ).toDF("id_section", "sample_nb", "id_gtg_strang", "nb")
 
     enumeratedDf.equal(expectedDF) should be
@@ -394,9 +427,9 @@ class TransformTest extends AnyFlatSpec with Matchers
     val inputDF = List(
       ("S0_A", 1L, "GTGA"),
       ("S0_A", 2L, "GTGA"),
-      (null, 3L, "GTGB"),
-      (null, 4L, "GTGB"),
-      (null, 5L, "GTGE"),
+      (null,   3L, "GTGB"),
+      (null,   4L, "GTGB"),
+      (null,   5L, "GTGE"),
       ("S0_A", 6L, "GTGC"),
       ("S0_A", 7L, "GTGC")
     ).toDF("id_section", "sample_nb", "id_gtg_strang")
@@ -413,9 +446,9 @@ class TransformTest extends AnyFlatSpec with Matchers
     val expectedDF = List(
       ("S0_A", 1L, "GTGA", 1L),
       ("S0_A", 2L, "GTGA", 1L),
-      (null, 3L, "GTGB", 1L),
-      (null, 4L, "GTGB", 1L),
-      (null, 5L, "GTGE", 2L),
+      (null,   3L, "GTGB", 1L),
+      (null,   4L, "GTGB", 1L),
+      (null,   5L, "GTGE", 2L),
       ("S0_A", 6L, "GTGC", 2L),
       ("S0_A", 7L, "GTGC", 2L)
     ).toDF("id_section", "sample_nb", "id_gtg_strang", "nb")
@@ -451,12 +484,13 @@ class TransformTest extends AnyFlatSpec with Matchers
   "data frame structs" should "be unfolded" in {
     val actual = df_struct.unfoldStructs(fullSubcolName = false)
     val expectedSchema: StructType = createStruct(Array[(String, DataType)](
-      ("n", IntegerType),
-      ("is_prime", BooleanType),
-      ("is_square", BooleanType),
-      ("is_even", BooleanType),
-      ("divided_by", ArrayType(numberTyp, containsNull = false)),
-      ("smaller_coprime", ArrayType(numberTyp, containsNull = false))))
+        ("n",               IntegerType),
+        ("is_prime",        BooleanType),
+        ("is_square",       BooleanType),
+        ("is_even",         BooleanType),
+        ("divided_by",      ArrayType(numberTyp, containsNull = false)),
+        ("smaller_coprime", ArrayType(numberTyp, containsNull = false))
+      ))
     val rowsExpected: java.util.List[Row] = ArrayBuffer(
       Row(1, false, true, false, List(oneRow), List(oneRow)),
       Row(2, true, false, true, List(oneRow, twoRow), List(oneRow)),
@@ -472,10 +506,11 @@ class TransformTest extends AnyFlatSpec with Matchers
   "data frame structs" should "be unfolded but not nested structs" in {
     val actual = df_struct.unfoldStructs(nested = false)
     val expectedSchema: StructType = createStruct(Array[(String, DataType)](
-      ("number·n", IntegerType),
-      ("number·property", propertyTyp),
-      ("relation·divided_by", ArrayType(numberTyp, containsNull = false)),
-      ("relation·smaller_coprime", ArrayType(numberTyp, containsNull = false))))
+        ("number·n",                 IntegerType),
+        ("number·property",          propertyTyp),
+        ("relation·divided_by",      ArrayType(numberTyp, containsNull = false)),
+        ("relation·smaller_coprime", ArrayType(numberTyp, containsNull = false))
+      ))
     val rowsExpected: java.util.List[Row] = ArrayBuffer(
       Row(1, Row(false, true, false), List(oneRow), List(oneRow)),
       Row(2, Row(true, false, true), List(oneRow, twoRow), List(oneRow)),
@@ -491,35 +526,36 @@ class TransformTest extends AnyFlatSpec with Matchers
   "fromUtc" should "convert all timestamps from UTC to Zurich" in {
     val actual = dfTemporalPeriods.fromUtc()
     val expected = List(
-      (1, Some(0.0), Some(1.2), 3.14, Timestamp.valueOf("2020-01-01 01:00:00"), doomsTime),
+      (1, Some(0.0), Some(1.2), 3.14,  Timestamp.valueOf("2020-01-01 01:00:00"), doomsTime),
       (1, Some(0.7), Some(1.4), -0.17, Timestamp.valueOf("2020-01-01 01:00:00"), Timestamp.valueOf("2020-07-01 01:59:59.999")),
-      (1, Some(1.2), Some(1.4), 42.0, Timestamp.valueOf("2020-07-01 02:00:00"), doomsTime),
-      (1, Some(1.4), Some(2.0), 0.0, Timestamp.valueOf("2020-01-01 01:00:00"), Timestamp.valueOf("2020-10-01 01:59:59.999")),
+      (1, Some(1.2), Some(1.4), 42.0,  Timestamp.valueOf("2020-07-01 02:00:00"), doomsTime),
+      (1, Some(1.4), Some(2.0), 0.0,   Timestamp.valueOf("2020-01-01 01:00:00"), Timestamp.valueOf("2020-10-01 01:59:59.999")),
       (1, Some(1.4), Some(3.0), 13.17, Timestamp.valueOf("2020-10-01 02:00:00"), doomsTime),
       (1, Some(3.0), Some(4.0), -2.72, Timestamp.valueOf("2020-01-01 01:00:00"), doomsTime),
-      (1, None, Some(5.0), 100.1, Timestamp.valueOf("2020-01-01 01:00:00"), Timestamp.valueOf("2020-04-01 01:59:59.999")),
-      (1, Some(4.0), Some(5.0), 9.87, Timestamp.valueOf("2020-04-01 02:00:00"), doomsTime)
-    ).toDF("id", "x", "y", "wert", "valid_from", "valid_to")
+      (1, None,      Some(5.0), 100.1, Timestamp.valueOf("2020-01-01 01:00:00"), Timestamp.valueOf("2020-04-01 01:59:59.999")),
+      (1, Some(4.0), Some(5.0), 9.87,  Timestamp.valueOf("2020-04-01 02:00:00"), doomsTime)
+    ).toDF("id", "x", "y", "val", "valid_from", "valid_to")
     actual.equal(expected) should be(true)
   }
 
   "toUtc" should "convert all timestamps from Zurich to UTC" in {
     val actual = dfTemporalPeriods.toUtc()
     val expected = List(
-      (1, Some(0.0), Some(1.2), 3.14, Timestamp.valueOf("2019-12-31 23:0:0"), doomsTime),
-      (1, Some(0.7), Some(1.4), -0.17, Timestamp.valueOf("2019-12-31 23:0:0"), Timestamp.valueOf("2020-06-30 21:59:59.999")),
-      (1, Some(1.2), Some(1.4), 42.0, Timestamp.valueOf("2020-06-30 22:00:00"), doomsTime),
-      (1, Some(1.4), Some(2.0), 0.0, Timestamp.valueOf("2019-12-31 23:0:0"), Timestamp.valueOf("2020-09-30 21:59:59.999")),
+      (1, Some(0.0), Some(1.2), 3.14,  Timestamp.valueOf("2019-12-31 23:0:0"),   doomsTime),
+      (1, Some(0.7), Some(1.4), -0.17, Timestamp.valueOf("2019-12-31 23:0:0"),   Timestamp.valueOf("2020-06-30 21:59:59.999")),
+      (1, Some(1.2), Some(1.4), 42.0,  Timestamp.valueOf("2020-06-30 22:00:00"), doomsTime),
+      (1, Some(1.4), Some(2.0), 0.0,   Timestamp.valueOf("2019-12-31 23:0:0"),   Timestamp.valueOf("2020-09-30 21:59:59.999")),
       (1, Some(1.4), Some(3.0), 13.17, Timestamp.valueOf("2020-09-30 22:00:00"), doomsTime),
-      (1, Some(3.0), Some(4.0), -2.72, Timestamp.valueOf("2019-12-31 23:0:0"), doomsTime),
-      (1, None, Some(5.0), 100.1, Timestamp.valueOf("2019-12-31 23:0:0"), Timestamp.valueOf("2020-03-31 21:59:59.999")),
-      (1, Some(4.0), Some(5.0), 9.87, Timestamp.valueOf("2020-03-31 22:00:00"), doomsTime)
-    ).toDF("id", "x", "y", "wert", "valid_from", "valid_to")
+      (1, Some(3.0), Some(4.0), -2.72, Timestamp.valueOf("2019-12-31 23:0:0"),   doomsTime),
+      (1, None,      Some(5.0), 100.1, Timestamp.valueOf("2019-12-31 23:0:0"),   Timestamp.valueOf("2020-03-31 21:59:59.999")),
+      (1, Some(4.0), Some(5.0), 9.87,  Timestamp.valueOf("2020-03-31 22:00:00"), doomsTime)
+    ).toDF("id", "x", "y", "val", "valid_from", "valid_to")
     actual.equal(expected) should be(true)
   }
 
-
-  /** * tests for unpivotCast, transpose et al ** */
+  /**
+   * * tests for unpivotCast, transpose et al **
+   */
 
   "colsToRows" should "transform it to a long dataframe" in {
 
@@ -547,9 +583,9 @@ class TransformTest extends AnyFlatSpec with Matchers
   "unpivotCast" should "unpivotCast df_SnapshotsWithGaps" in {
     val actual = dfSnapshotsWithGaps.unpivotCast(keys = Array($"id", $"dt"), colNamesToPivot = Array("x", "y"))
     val expectedSchema: StructType = createStruct(Array[(String, DataType, Boolean)](("id", IntegerType, false),
-      ("dt", IntegerType, false),
-      ("x", StringType, false),
-      ("y", DoubleType, true)))
+      ("dt",                                                                                IntegerType, false),
+      ("x",                                                                                 StringType,  false),
+      ("y",                                                                                 DoubleType,  true)))
     val rowsExpected: java.util.List[Row] = ArrayBuffer(
       Row(0, 20190101, "x", Some(3.14)),
       Row(0, 20190102, "x", Some(3.14)),
@@ -572,7 +608,8 @@ class TransformTest extends AnyFlatSpec with Matchers
       Row(1, 20190101, "y", None),
       Row(1, 20190102, "y", None),
       Row(1, 20190103, "y", None),
-      Row(1, 20190104, "y", None))
+      Row(1, 20190104, "y", None)
+    )
       .asJava
     val expected = spark.createDataFrame(rowsExpected, expectedSchema)
     actual.equal(expected) shouldBe true
@@ -582,9 +619,9 @@ class TransformTest extends AnyFlatSpec with Matchers
     val argument = dfSnapshotsWithGaps.select($"id", $"dt", $"x", $"y".cast(IntegerType))
     val actual = argument.unpivotCast(keys = Array($"id", $"dt"), colNamesToPivot = Array("x", "y"))
     val expectedSchema: StructType = createStruct(Array[(String, DataType, Boolean)](("id", IntegerType, false),
-      ("dt", IntegerType, false),
-      ("x", StringType, false),
-      ("y", DoubleType, true)))
+      ("dt",                                                                                IntegerType, false),
+      ("x",                                                                                 StringType,  false),
+      ("y",                                                                                 DoubleType,  true)))
     val rowsExpected: java.util.List[Row] = ArrayBuffer(
       Row(0, 20190101, "x", Some(3.14)),
       Row(0, 20190102, "x", Some(3.14)),
@@ -607,7 +644,8 @@ class TransformTest extends AnyFlatSpec with Matchers
       Row(1, 20190101, "y", None),
       Row(1, 20190102, "y", None),
       Row(1, 20190103, "y", None),
-      Row(1, 20190104, "y", None))
+      Row(1, 20190104, "y", None)
+    )
       .asJava
     val expected = spark.createDataFrame(rowsExpected, expectedSchema)
     actual.equal(expected) shouldBe true
@@ -617,8 +655,8 @@ class TransformTest extends AnyFlatSpec with Matchers
     val argument = dfSnapshotsWithGaps.castColumnTo(StringType)("dt")
     val actual = argument.unpivotCast(keys = Array($"id"), colNamesToPivot = Array("dt", "x"))
     val expectedSchema: StructType = createStruct(Array[(String, DataType, Boolean)](("id", IntegerType, false),
-      ("x", StringType, false),
-      ("y", StringType, true)))
+      ("x",                                                                                 StringType,  false),
+      ("y",                                                                                 StringType,  true)))
     val rowsExpected: java.util.List[Row] = ArrayBuffer(
       Row(0, "dt", Some("20190101")),
       Row(0, "dt", Some("20190102")),
@@ -647,57 +685,26 @@ class TransformTest extends AnyFlatSpec with Matchers
     actual.equal(expected) shouldBe true
   }
 
-  "transpose" should "transpose empty DataFrame" in {
-    val actual = dfSnapshotsWithGaps.where(lit(false)).transposeCustom(11)
-    val expectedSchema: StructType = createStruct(Array[(String, DataType, Boolean)](("_column", StringType, false)))
-    val rowsExpected: java.util.List[Row] = ArrayBuffer(
-      Row("id"), Row("dt"), Row("x"), Row("y")).asJava
-    val expected = spark.createDataFrame(rowsExpected, expectedSchema)
-    actual.equal(expected) shouldBe true
-  }
-
-  "transpose" should "transpose the first 11 rows of a DataFrame" in {
-    val actual = dfSnapshotsWithGaps.transposeCustom(11)
-    val expectedSchema: StructType = createStruct(Array[(String, DataType, Boolean)](
-      ("_column", StringType, false),
-      ("_000", DoubleType, true),
-      ("_001", DoubleType, true),
-      ("_002", DoubleType, true),
-      ("_003", DoubleType, true),
-      ("_004", DoubleType, true),
-      ("_005", DoubleType, true),
-      ("_006", DoubleType, true),
-      ("_007", DoubleType, true),
-      ("_008", DoubleType, true),
-      ("_009", DoubleType, true),
-      ("_010", DoubleType, true)))
-    val rowsExpected: java.util.List[Row] = ArrayBuffer(
-      Row("id", Some(0.0), Some(0.0), Some(0.0), Some(0.0), Some(0.0), Some(0.0), Some(0.0), Some(1.0), Some(1.0), Some(1.0), Some(1.0)),
-      Row("dt", Some(20190101.0), Some(20190102.0), Some(20190103.0), Some(20190104.0), Some(20190106.0), Some(20190201.0), Some(20190207.0), Some(20190101.0), Some(20190102.0), Some(20190103.0), Some(20190104.0)),
-      Row("x", Some(3.14), Some(3.14), Some(2.72), None, Some(1.0), Some(3.14), Some(1.0), Some(42.0), None, Some(-21.3), None),
-      Row("y", None, Some(-2.37), Some(4.57), None, Some(3.0), None, Some(2.5), None, None, None, None)
-    ).asJava
-    val expected = spark.createDataFrame(rowsExpected, expectedSchema)
-    actual.equal(expected) shouldBe true
-  }
-
-
-  /** * tests for dataset to curry frame ** */
+  /**
+   * * tests for dataset to curry frame **
+   */
 
   "dataSet2curryFrame" should "return curried dataFrame" in {
     val argument = List((-2, 7, 9, 8, -2798f),
-      (0, 0, 0, 0, 0f), (0, 0, 1, 2, 12f), (0, 0, 4, 2, 42f), (0, 1, 0, 0, 100f),
-      (1, 2, 3, 4, 1234f), (1, 7, 0, 0, 1700f)
+      (0,                    0, 0, 0, 0f), (0,    0, 1, 2, 12f), (0, 0, 4, 2, 42f), (0, 1, 0, 0, 100f),
+      (1,                    2, 3, 4, 1234f), (1, 7, 0, 0, 1700f)
     ).toDF("x", "y", "z", "t", "val")
     val actual = SortedMap[Int, Map[Int, Map[Int, Map[Int, Float]]]]() ++
       argument.dataSet2curryFrame(pkCols = List("x", "y", "z", "t"))
         .as[Map[Int, Map[Int, Map[Int, Map[Int, Float]]]]].head
     val expected = SortedMap[Int, Map[Int, Map[Int, Map[Int, Float]]]]() ++ Map(
       -2 -> Map(7 -> Map(9 -> Map(8 -> -2798f))),
-      0 -> Map(
+      0  -> Map(
         0 -> Map(0 -> Map(0 -> 0f), 1 -> Map(2 -> 12f), 4 -> Map(2 -> 42f)),
-        1 -> Map(0 -> Map(0 -> 100f))),
-      1 -> Map(2 -> Map(3 -> Map(4 -> 1234f)), 7 -> Map(0 -> Map(0 -> 1700f))))
+        1 -> Map(0 -> Map(0 -> 100f))
+      ),
+      1 -> Map(2 -> Map(3 -> Map(4 -> 1234f)), 7 -> Map(0 -> Map(0 -> 1700f)))
+    )
     actual should be(expected)
   }
 
@@ -713,15 +720,15 @@ class TransformTest extends AnyFlatSpec with Matchers
 
   "dataSet2curryFrame" should "work on Dataset with 2 PK cols" in {
     val argument = List((-2, 7, -27f),
-      (0, 0, 0f), (0, 1, 1f), (1, 2, 12f), (1, 7, 17f)
+      (0,                    0, 0f), (0, 1, 1f), (1, 2, 12f), (1, 7, 17f)
     ).toDF("x", "y", "val")
     val actual = SortedMap[Int, Map[Int, Float]]() ++
       argument.dataSet2curryFrame(pkCols = List("x", "y"))
         .as[Map[Int, Map[Int, Float]]].head
     val expected = SortedMap[Int, Map[Int, Float]]() ++ Map(
       -2 -> Map(7 -> -27f),
-      0 -> Map(0 -> 0f, 1 -> 1f),
-      1 -> Map(2 -> 12f, 7 -> 17f)
+      0  -> Map(0 -> 0f, 1 -> 1f),
+      1  -> Map(2 -> 12f, 7 -> 17f)
     )
     actual should be(expected)
   }


### PR DESCRIPTION
as Dataset.transform provided by Sp…ark does the same, except naming result columns

and coilumn "wert" renamed to "val"