### PR TITLE
SparkFileDataObject: ExecutionPlanSparkFilenameObservation replaced by ObserverSparkFilenameObservation

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/webservice/SttpUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/webservice/SttpUtil.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration.FiniteDuration
 object SttpUtil extends SmartDataLakeLogger {
 
   /**
-   * Validates if the a provided uri has the scheme/protocol 'http' or 'https'
+   * Validates if the provided uri has the scheme/protocol 'http' or 'https'
    */
   def canHandleScheme(uri: String): Boolean = uri.matches("https?:.*")
 
@@ -63,13 +63,14 @@ object SttpUtil extends SmartDataLakeLogger {
     if (response.body.isLeft) {
       throw HttpRequestError(context, response.code.code, response.body.swap.toOption.get)
     }
-    assert(response.isSuccess, throw HttpRequestError(context, response.code.code, "StatusCode is not successfull, but there is no error message!"))
+    assert(response.isSuccess,
+      throw HttpRequestError(context, response.code.code, "StatusCode is not successful, but there is no error message!"))
   }
 
   def guessMimeType(content: Array[Byte]): Option[String] = {
     Option(URLConnection.guessContentTypeFromStream(new ByteArrayInputStream(content)))
       .orElse {
-        // manually detect type as guessContentTypeFromStream doesnt work for Json and Text...
+        // manually detect type as guessContentTypeFromStream does not work for Json and Text...
         val str = new String(content)
         if (str.take(100).matches("(?:\\P{Cntrl}|\\s)+")) { // is text
           if (str.matches("\\s*[{\\[]")) Some(MediaType.ApplicationJson.toString())
@@ -131,7 +132,7 @@ object SttpUtil extends SmartDataLakeLogger {
   type SttpRequest[R] = RequestT[Empty, Either[String, R], Any]
 
   /**
-   * Extend functionality of the the RequestT class
+   * Extend functionality of the RequestT class
    */
   implicit class SttpRequestExtension[R](request: SttpRequest[R]) {
     def optionally[A](config: Option[A], func: (A, SttpRequest[R]) => SttpRequest[R]): SttpRequest[R] = {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/spark/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/spark/SparkFileDataObject.scala
@@ -285,6 +285,9 @@ trait SparkFileDataObject extends HadoopFileDataObject
     df
   }
 
+  private def filterWithoutPartitions(schemaOpt: Option[StructType])(df: DataFrame): Boolean = schemaOpt.isDefined ||
+    partitions.diff(df.columns).isEmpty
+
   /**
    * Update incremental output state and prepare options for filtering DataSource.
    */
@@ -312,23 +315,27 @@ trait SparkFileDataObject extends HadoopFileDataObject
    * Prepares the DataFrame with the content when reading.
    * Uses Spark DataSource V2 interface.
    */
-  protected def getContentV2(partitionValues: Seq[PartitionValues], schema: Option[StructType], incrementalOutputOptions: Map[String,String])(implicit context: ActionPipelineContext): DataFrame = {
+  protected def getContentV2(partitionValues: Seq[PartitionValues], schemaOpt: Option[StructType],
+                             incrementalOutputOptions: Map[String,String])
+                            (implicit context: ActionPipelineContext): DataFrame = {
     implicit val session: SparkSession = getSparkSession
     if (partitions.isEmpty || partitionValues.isEmpty) {
       session.read
         .format(readFormat)
         .options(readOptions ++ incrementalOutputOptions)
-        .optionalSchema(schema)
+        .optionalSchema(schemaOpt)
         .load(hadoopPath.toString)
     } else {
       val reader = session.read
         .format(readFormat)
         .options(readOptions ++ incrementalOutputOptions)
-        .optionalSchema(schema)
+        .optionalSchema(schemaOpt)
         .option("basePath", hadoopPath.toString) // this is needed for partitioned tables when subdirectories are read directly; it then keeps the partition columns from the subdirectory path in the dataframe
       val pathsToRead = partitionValues.flatMap(getConcreteInitPaths).map(_.toString)
-      val df = if (pathsToRead.nonEmpty) Some(reader.load(pathsToRead.toIndexedSeq: _*)) else None
-      df.filter(df => schema.isDefined || partitions.diff(df.columns).isEmpty) // filter DataFrames without partition columns as they are empty (this might happen if there is no schema specified and the partition is empty)
+      val dfOpt: Option[DataFrame] = if (pathsToRead.nonEmpty) Some(reader.load(pathsToRead.toIndexedSeq: _*)) else None
+      // filter DataFrames without partition columns as they are empty
+      // this might happen if there is no schema specified and the partition is empty
+      dfOpt.filter(filterWithoutPartitions(schemaOpt))
         .getOrElse {
           // if there are no paths to read for given partition values, handle no data
           if (context.isExecPhase) {
@@ -337,7 +344,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
           } else {
             // create empty data frame in init phase
             require(schema.isDefined, s"($id) DataObject schema is undefined. A schema must be defined as there are no existing files for partition values ${partitionValues.mkString(", ")}.")
-            getEmptyDataFrame(schema.get)
+            getEmptyDataFrame(schemaOpt.get)
           }
         }
     }
@@ -359,7 +366,8 @@ trait SparkFileDataObject extends HadoopFileDataObject
           .format(readFormat)
           .options(readOptions ++ incrementalOutputOptions)
           .optionalSchema(schemaOpt)
-          .option("path", hadoopPath.toString) // spark-xml is a V1 source and only supports one path, which must be given as option...
+          // spark-xml is a V1 source and only supports one path, which must be given as option...
+          .option("path", hadoopPath.toString)
           .load()
       } else {
         val schemaWithoutPartitions = schemaOpt
@@ -373,14 +381,16 @@ trait SparkFileDataObject extends HadoopFileDataObject
             getConcreteFullPaths(pv).map(p =>
               (extractPartitionValuesFromDirPath(p.toString), p)))
           .filter{case (_,path) => filesystem.globStatus(new Path(path,fileName)).nonEmpty} // filter empty path to avoid NullPointerException in DataFrame
-        val df = if (pathsToRead.nonEmpty) Some(
+        val dfOpt: Option[DataFrame] = if (pathsToRead.nonEmpty) Some(
           pathsToRead.map { case (pv, path) =>
             partitions.foldLeft(reader.option("path", path.toString).load()) { // spark-xml is a V1 source and only supports one path, which must be given as option...
               case (df, partition) => df.withColumn(partition, lit(pv(partition).toString))
             }
           }.reduce(_ unionByName _)
         ) else None
-        df.filter(df => schemaOpt.isDefined || partitions.diff(df.columns).isEmpty) // filter DataFrames without partition columns as they are empty (this might happen if there is no schema specified and the partition is empty)
+        // filter DataFrames without partition columns as they are empty.
+        // This might happen if there is no schema specified and the partition is empty.
+        dfOpt.filter(filterWithoutPartitions(schemaOpt))
           .getOrElse {
             // if there are no paths to read for given partition values, handle no data
             if (context.isExecPhase) {
@@ -453,10 +463,12 @@ trait SparkFileDataObject extends HadoopFileDataObject
       // if there are no paths to read for given partition values, handle no data
       if (context.isExecPhase) {
         // skip action in exec phase
-        throw NoDataToProcessWarning(id.id, s"($id) No existing files found for partition values ${partitionValues.mkString(", ")}.")
+        throw NoDataToProcessWarning(id.id, s"getContentFilesOneByOne: ($id) No existing files found for partition values ${partitionValues.mkString(", ")}.")
       } else {
         // create empty data frame in init phase
-        require(schema.isDefined, s"($id) DataObject schema is undefined. A schema must be defined as there are no existing files for partition values ${partitionValues.mkString(", ")}.")
+        require(schema.isDefined,
+          s"getContentFilesOneByOne: ($id) DataObject schema is undefined." +
+            s" A schema must be defined as there are no existing files for partition values ${partitionValues.mkString(", ")}.")
         getEmptyDataFrame(schema.get)
       }
     }
@@ -732,24 +744,26 @@ private[smartdatalake] abstract class SparkFilenameObservation[T](name: String) 
   def getFilesProcessed: Seq[String]
 }
 
-
 /**
- * TODO: Where is ObserverSparkFilenameObservation used?
- *
  * Get files processed by using Spark observer on filename column
- * Note: There is a Spark problem - NullPointerException/*private[smartdatalake] class ObserverSparkFilenameObservation[T](name: String) extends SparkFilenameObservation[T](name) {
- * def on(ds: Dataset[T], filenameColumnName: String): Dataset[T] = {
- * logger.debug(s"($name) add files observation to Dataset")
- * on(ds, true, DatasetHelper.toCol(collect_set_deterministic(col(filenameColumnName).expr)).as("filesProcessed"))
- * }
- *
- * def getFilesProcessed: Seq[String] = {
- * waitFor().getOrElse("filesProcessed", throw new IllegalStateException(s"($name) Did not receive filesProcessed observation!"))
- * .asInstanceOf[Seq[String]]
- * }
- * }*/n with TypedImperativeAggregate (like CollectSetDeterministic) in observe if there is no data, but sometimes also occurs otherwise on prod...
+ * Note: There is a Spark problem - NullPointerException with TypedImperativeAggregate
+ * (like CollectSetDeterministic) in observe if there is no data, but sometimes also occurs otherwise on prod...
  * see also https://issues.apache.org/jira/browse/SPARK-39044
  */
+
+/*
+TODO: Replace ExecutionPlanSparkFilenameObservation by ExecutionPlanSparkFilenameObservation
+private[smartdatalake] class ObserverSparkFilenameObservation[T](name: String) extends SparkFilenameObservation[T](name) {
+  def on(ds: Dataset[T], filenameColumnName: String): Dataset[T] = {
+    logger.debug(s"($name) add files observation to Dataset")
+    on(ds, true, DatasetHelper.toCol(collect_set_deterministic(col(filenameColumnName).expr)).as("filesProcessed"))
+  }
+
+  def getFilesProcessed: Seq[String] = {
+    waitFor().getOrElse("filesProcessed", throw new IllegalStateException(s"($name) Did not receive filesProcessed observation!"))
+      .asInstanceOf[Seq[String]]
+  }
+}*/
 
 
 /**

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/spark/SparkFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/spark/SparkFileDataObject.scala
@@ -24,6 +24,7 @@ import io.smartdatalake.definitions.{Environment, SDLSaveMode, SaveModeOptions}
 import io.smartdatalake.util.LogUtils.debugLog
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.misc.{EnvironmentUtil, SmartDataLakeLogger}
+import io.smartdatalake.util.spark.CollectSetDeterministic.collect_set_deterministic
 import io.smartdatalake.util.spark.dataset.{Quality, ReadWrite, Transform, getEmptyDataFrame}
 import io.smartdatalake.util.spark.{SparkRepartitionDef, SparkStageMetricsListener}
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
@@ -39,7 +40,7 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.{DataSource, FileScanRDD}
-import org.apache.spark.sql.functions.{input_file_name, lit}
+import org.apache.spark.sql.functions.{col, input_file_name, lit}
 import org.apache.spark.sql.types.{DataType, StringType, StructType}
 import org.slf4j.Logger
 
@@ -526,7 +527,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
   }
 
   // Store files observation object between call to setupFilesObserver until it is used in getSparkDataFrame.
-  @transient private val filesObservers: mutable.Map[ActionId, ExecutionPlanSparkFilenameObservation[Row]] = mutable.Map()
+  @transient private val filesObservers: mutable.Map[ActionId, ObserverSparkFilenameObservation[Row]] = mutable.Map()
 
   /**
    * Set up an observation of files processed through custom metrics.
@@ -536,7 +537,7 @@ trait SparkFileDataObject extends HadoopFileDataObject
   def setupFilesObserver(actionId: ActionId): SparkFilenameObservation[Row] = {
     logger.debug(s"($id) setting up files observer for $actionId")
     // return existing observation for this action if existing, otherwise create a new one.
-    filesObservers.getOrElseUpdate(actionId, new ExecutionPlanSparkFilenameObservation(actionId.id + "/" + id.id))
+    filesObservers.getOrElseUpdate(actionId, new ObserverSparkFilenameObservation(actionId.id + "/" + id.id))
   }
 
   override def getStreamingDataFrame(options: Map[String, String], pipelineSchema: Option[StructType])(implicit context: ActionPipelineContext): DataFrame = {
@@ -750,39 +751,19 @@ private[smartdatalake] abstract class SparkFilenameObservation[T](name: String) 
  * (like CollectSetDeterministic) in observe if there is no data, but sometimes also occurs otherwise on prod...
  * see also https://issues.apache.org/jira/browse/SPARK-39044
  */
-
-/*
-TODO: Replace ExecutionPlanSparkFilenameObservation by ExecutionPlanSparkFilenameObservation
 private[smartdatalake] class ObserverSparkFilenameObservation[T](name: String) extends SparkFilenameObservation[T](name) {
+
+  import org.apache.spark.sql.classic.ColumnConversions._
+
   def on(ds: Dataset[T], filenameColumnName: String): Dataset[T] = {
-    logger.debug(s"($name) add files observation to Dataset")
+    logger.debug(s"on(name=$name,filenameColumnName=$filenameColumnName) add files observation to Dataset")
     on(ds, true, DatasetHelper.toCol(collect_set_deterministic(col(filenameColumnName).expr)).as("filesProcessed"))
   }
 
   def getFilesProcessed: Seq[String] = {
-    waitFor().getOrElse("filesProcessed", throw new IllegalStateException(s"($name) Did not receive filesProcessed observation!"))
+    logger.debug(s"getFilesProcessed(name=$name): START")
+    waitFor().getOrElse("filesProcessed",
+        throw new IllegalStateException(s"($name) Did not receive filesProcessed observation!"))
       .asInstanceOf[Seq[String]]
-  }
-}*/
-
-
-/**
- * Workaround for bug in ObserverSparkFilenameObservation - get files processed from DataFrames execution plan.
- * Note that this might be incorrect if there are additional filters applied.
- */
-private[smartdatalake] class ExecutionPlanSparkFilenameObservation[T](name: String) extends SparkFilenameObservation[T](name) {
-
-  private var filesInExecutionPlan: Option[Seq[String]] = None
-
-  def on(ds: Dataset[T], filenameColumnName: String): Dataset[T] = {
-    logger.debug(s"($name) add files observation to Dataset")
-    filesInExecutionPlan = Some(SparkFileDataObject.getFilesProcessedFromSparkPlan(name, ds))
-    ds
-  }
-
-  override def getFilesProcessed: Seq[String] = {
-    val files = filesInExecutionPlan.getOrElse(throw new IllegalStateException(s"($name) filesInExecutionPlan is empty!"))
-    if (logger.isDebugEnabled()) logger.debug(s"($name) files processed: ${files.mkString(", ")}")
-    files
   }
 }

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStatusInfoTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStatusInfoTest.scala
@@ -44,7 +44,10 @@ class SmartDataLakeBuilderStatusInfoTest extends AnyFunSuite with Quality with B
   @transient implicit private lazy val logger: Logger = LoggerFactory.getLogger(getClass.getName)
   private implicit val session: SparkSession = TestUtil.session
   private val sdlb = DefaultSmartDataLakeBuilder
+  private val javaVersion: String = System.getProperty("java.version")
+
   import session.implicits._
+  logger.info(s"Java Version : $javaVersion")
 
   before {
     sdlb.instanceRegistry.clear()
@@ -85,14 +88,18 @@ class SmartDataLakeBuilderStatusInfoTest extends AnyFunSuite with Quality with B
     val client = new WebSocketClient
     client.start()
     val session = client.connect(new UnitTestSocket, URI.create("ws://localhost:4440/ws/")).get
+    logger.debug(s"session = $session")
 
     logger.debug("Verify Rest API context endpoint is reachable and returns correct results")
-    val webserviceDOContext = WebserviceFileDataObject("dummy",
+    val webserviceDOContext: WebserviceFileDataObject = WebserviceFileDataObject("dummy",
       url = s"http://localhost:4440/api/v1/context/")(sdlb.instanceRegistry)
-    val webserviceClientContext = SttpWebserviceClient(webserviceDOContext)
+    val webserviceClientContext: SttpWebserviceClient = SttpWebserviceClient(webserviceDOContext)
     webserviceClientContext.get() match {
-      case Failure(exception) =>
-        throw exception
+      case Failure(e) =>
+        logger.error("webserviceClientContext.get() FAILED!")
+        logger.error(s"webserviceDOContext     = $webserviceDOContext")
+        logger.error(s"webserviceClientContext = $webserviceClientContext")
+        throw e
       case Success(value) =>
         val str = new String(value, StandardCharsets.UTF_8)
         assert(str.contains("\"feedSel\":\"test\""))

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStatusInfoTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderStatusInfoTest.scala
@@ -20,6 +20,7 @@ package io.smartdatalake.app
 
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.util.spark.GetSession.loggEnv
 import io.smartdatalake.util.spark.dataset.Quality
 import io.smartdatalake.util.webservice.SttpWebserviceClient
 import io.smartdatalake.workflow.ActionPipelineContext
@@ -44,10 +45,9 @@ class SmartDataLakeBuilderStatusInfoTest extends AnyFunSuite with Quality with B
   @transient implicit private lazy val logger: Logger = LoggerFactory.getLogger(getClass.getName)
   private implicit val session: SparkSession = TestUtil.session
   private val sdlb = DefaultSmartDataLakeBuilder
-  private val javaVersion: String = System.getProperty("java.version")
 
   import session.implicits._
-  logger.info(s"Java Version : $javaVersion")
+  loggEnv
 
   before {
     sdlb.instanceRegistry.clear()


### PR DESCRIPTION
* `ParquetFileDataObjectTest` and many others suceed, but I cannot run all tests locally.
* `SmartDataLakeBuilderStatusInfoTest`: logging improved but test still fails :(