### PR TITLE
config parser replacer for correct table names

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
@@ -271,8 +271,10 @@ private[smartdatalake] object ConfigParser extends SmartDataLakeLogger {
   }
 
   /**
-   * Substitutes parts inside values by other paths of the configuration
-   * Token for substitution is "~{replacementPath}"
+   * Substitutes parts inside values by other paths of the configuration.
+   * Token for substitution is "~{replacementPath}".
+   * An optional modifier can be appended with a pipe, e.g. "~{replacementPath|snake}", to transform the resolved value:
+   *  - "snake": replaces dashes ('-') with underscores ('_'), e.g. to use an element id like 'int-airports' as table name 'int_airports'.
    *
    * @param config configuration object for local substitution
    * @param path   path to search for local substitution tokens and execute substitution
@@ -282,16 +284,23 @@ private[smartdatalake] object ConfigParser extends SmartDataLakeLogger {
 
     val localSubstituter = (regMatch: Regex.Match) => {
       val replacementPath = regMatch.group(1)
-      if (config.hasPath(replacementPath)) {
-        if (config.getValue(replacementPath).valueType() == ConfigValueType.STRING
-          || config.getValue(replacementPath).valueType() == ConfigValueType.NUMBER) config.getString(replacementPath)
-        else throw ConfigurationException(s"local substitution path '$replacementPath' in path '$path' is not a string")
-      } else throw ConfigurationException(s"local substitution path '$replacementPath' in path '$path' does not exist")
+      val modifier = Option(regMatch.group(2))
+      val value =
+        if (config.hasPath(replacementPath)) {
+          if (config.getValue(replacementPath).valueType() == ConfigValueType.STRING
+            || config.getValue(replacementPath).valueType() == ConfigValueType.NUMBER) config.getString(replacementPath)
+          else throw ConfigurationException(s"local substitution path '$replacementPath' in path '$path' is not a string")
+        } else throw ConfigurationException(s"local substitution path '$replacementPath' in path '$path' does not exist")
+      modifier match {
+        case None => value
+        case Some("snake") => value.replace('-', '_')
+        case Some(m) => throw ConfigurationException(s"unknown local substitution modifier '$m' for path '$replacementPath' in path '$path'. Supported modifiers: snake")
+      }
     }
 
     if (config.hasPath(path) && config.getValue(path).valueType() == ConfigValueType.STRING) {
       val value = config.getString(path)
-      val valueSubstituted = """~\{(.*?)\}""".r.replaceAllIn(value, localSubstituter)
+      val valueSubstituted = """~\{(.*?)(?:\|(\w+))?\}""".r.replaceAllIn(value, localSubstituter)
       config.withValue(path, ConfigValueFactory.fromAnyRef(valueSubstituted))
     } else config
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
@@ -271,10 +271,25 @@ private[smartdatalake] object ConfigParser extends SmartDataLakeLogger {
   }
 
   /**
+   * Converts a value to snake_case: inserts an underscore at camelCase boundaries (including acronyms),
+   * replaces dashes with underscores and lowercases the result.
+   * Examples: "camelCase" -> "camel_case", "int-airports" -> "int_airports", "myHTTPServer" -> "my_http_server".
+   */
+  private[config] def toSnakeCase(value: String): String = {
+    value
+      .replaceAll("([a-z0-9])([A-Z])", "$1_$2") // camelCase boundary, e.g. camelCase -> camel_Case
+      .replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2") // acronym boundary, e.g. HTTPServer -> HTTP_Server
+      .replace('-', '_')
+      .toLowerCase
+  }
+
+  /**
    * Substitutes parts inside values by other paths of the configuration.
    * Token for substitution is "~{replacementPath}".
    * An optional modifier can be appended with a pipe, e.g. "~{replacementPath|snake}", to transform the resolved value:
-   *  - "snake": replaces dashes ('-') with underscores ('_'), e.g. to use an element id like 'int-airports' as table name 'int_airports'.
+   *  - "snake": converts the resolved value to snake_case, i.e. inserts underscores at camelCase boundaries, replaces
+   *    dashes ('-') with underscores ('_') and lowercases, e.g. to use an element id like 'int-airports' or 'intAirports'
+   *    as table name 'int_airports'.
    *
    * @param config configuration object for local substitution
    * @param path   path to search for local substitution tokens and execute substitution
@@ -293,7 +308,7 @@ private[smartdatalake] object ConfigParser extends SmartDataLakeLogger {
         } else throw ConfigurationException(s"local substitution path '$replacementPath' in path '$path' does not exist")
       modifier match {
         case None => value
-        case Some("snake") => value.replace('-', '_')
+        case Some("snake") => toSnakeCase(value)
         case Some(m) => throw ConfigurationException(s"unknown local substitution modifier '$m' for path '$replacementPath' in path '$path'. Supported modifiers: snake")
       }
     }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
@@ -33,10 +33,10 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param camelCaseToLower If selected, converts Camel case names to lower case  with underscores, i.e. TestString -> test_string, testABCtest -> test_ABCtest
- *                         Otherwise converts just to lower case.
- * @param normalizeToAscii If selected, converts UTF-8 special characters (e.g. diacritics, umlauts) to ASCII chars (best effort), i.e. Öffi_émily -> Oeffi_emily
- * @param removeNonStandardSQLNameChars Remove all chars from a string which don't belong to lowercase SQL standard naming characters, i.e abc$!-& -> abc
- * @param replaceNonStandardSQLNameCharsWithUnderscores If selected, replaces all chars from a string which don't belong to lowercase SQL standard naming characters with underscores (_), i.e. "value of property!in$$" -> "value_of_property_in_". Note: removeNonStandardSQLNameChars needs to be disabled
+ *                         Otherwise converts just to lower case. Default=true
+ * @param normalizeToAscii If selected, converts UTF-8 special characters (e.g. diacritics, umlauts) to ASCII chars (best effort), i.e. Öffi_émily -> Oeffi_emily. Default: true
+ * @param removeNonStandardSQLNameChars Remove all chars from a string which don't belong to lowercase SQL standard naming characters, i.e abc$!-& -> abc. Default=true
+ * @param replaceNonStandardSQLNameCharsWithUnderscores If selected, replaces all chars from a string which don't belong to lowercase SQL standard naming characters with underscores (_), i.e. "value of property!in$$" -> "value_of_property_in_". Note: removeNonStandardSQLNameChars needs to be disabled. Default=false
  */
 case class StandardizeColNamesTransformer(override val name: String = "colNamesLowercase",
                                           override val description: Option[String] = None,

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
@@ -683,6 +683,30 @@ class ConfigParsingTest extends AnyFlatSpec with Matchers {
     configSubstituted.getString("table.name") shouldEqual "int_airports"
   }
 
+  it should "convert camelCase to snake_case" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "intAirports"
+        | name = "~{id|snake}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "int_airports"
+  }
+
+  it should "handle acronyms and mixed camelCase with dashes" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "my-HTTPServerData"
+        | name = "~{id|snake}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "my_http_server_data"
+  }
+
   it should "leave a value without dashes unchanged" in {
     val config = ConfigFactory.parseString(
       """{

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
@@ -668,6 +668,55 @@ class ConfigParsingTest extends AnyFlatSpec with Matchers {
     refinedConfig.getString("postWriteSql") shouldEqual "test10/abc"
     refinedConfig.getString("table.name") shouldEqual "test10/abc"
   }
+
+  "local substitution with snake modifier" should "replace dashes with underscores" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "int-airports"
+        | table {
+        |  name = "~{id|snake}"
+        | }
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "table.name")
+    configSubstituted.getString("table.name") shouldEqual "int_airports"
+  }
+
+  it should "leave a value without dashes unchanged" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = abc
+        | name = "~{id|snake}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "abc"
+  }
+
+  it should "support mixing modified and plain tokens in the same value" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "int-airports"
+        | name = "schema.~{id|snake}_~{id}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "schema.int_airports_int-airports"
+  }
+
+  "local substitution with an unknown modifier" should "throw a ConfigurationException" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "int-airports"
+        | name = "~{id|kebab}"
+        |}""".stripMargin
+    )
+
+    intercept[ConfigurationException](ConfigParser.localSubstitution(config, "name"))
+  }
 }
 
 

--- a/sdl-jms/src/main/scala/io/smartdatalake/workflow/dataobject/JmsDataObject.scala
+++ b/sdl-jms/src/main/scala/io/smartdatalake/workflow/dataobject/JmsDataObject.scala
@@ -44,7 +44,7 @@ import scala.concurrent.duration.Duration
  * @param connectionFactory JMS Connection Factory
  * @param queue Name of MQ Queue
  */
-@deprecated(since = "2.9.0")
+@deprecated("deprecated", "2.9.0")
 @Deprecated
 case class JmsDataObject(override val id: DataObjectId,
                          jndiContextFactory: String,

--- a/sdl-splunk/src/main/scala/io/smartdatalake/workflow/dataobject/SplunkDataObject.scala
+++ b/sdl-splunk/src/main/scala/io/smartdatalake/workflow/dataobject/SplunkDataObject.scala
@@ -44,7 +44,7 @@ import scala.jdk.CollectionConverters._
  * [[DataObject]] of type Splunk.
  * Provides details to an action to access Splunk logs.
  */
-@deprecated(since = "2.9.0")
+@deprecated("deprecated", "2.9.0")
 @Deprecated
 case class SplunkDataObject(override val id: DataObjectId,
                              params: SplunkParams,


### PR DESCRIPTION
Allow transforming a resolved ~{path} value with an optional pipe modifier, e.g. ~{id|snake}. The snake modifier replaces dashes with underscores, so an element id like 'int-airports' can be reused as a table name 'int_airports' where dashes are not permitted.

Unknown modifiers fail with a ConfigurationException; the plain ~{path} form is unchanged.

What changes are included in the pull request?
Solves https://github.com/smart-data-lake/smart-data-lake/issues/1086
For the path replacer a substitution can be specified. So far only snake, but more can be added. Any further ideas?