### PR TITLE
cofigParser: replacer now with chained modifier, and noPrefix operator

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/config/ConfigParser.scala
@@ -284,12 +284,36 @@ private[smartdatalake] object ConfigParser extends SmartDataLakeLogger {
   }
 
   /**
+   * Removes the first part of a value, where parts are separated by a dash ('-'), an underscore ('_')
+   * or a camelCase boundary (a lowercase letter or digit followed by an uppercase letter).
+   * The earliest separator in the value determines the prefix to remove; for dash/underscore the separator
+   * itself is dropped, for a camelCase boundary the leading uppercase letter of the remainder is kept.
+   * Examples: "int-airports" -> "airports", "int_airports" -> "airports", "intAirports" -> "Airports",
+   * "abc" -> "abc" (no separator, unchanged).
+   */
+  private[config] def removePrefix(value: String): String = {
+    val idx = value.indices.find { i =>
+      val c = value(i)
+      c == '-' || c == '_' ||
+        (i > 0 && c.isUpper && (value(i - 1).isLower || value(i - 1).isDigit))
+    }
+    idx match {
+      case Some(i) if value(i) == '-' || value(i) == '_' => value.substring(i + 1) // drop separator
+      case Some(i) => value.substring(i) // keep the uppercase letter that starts the remainder
+      case None => value
+    }
+  }
+
+  /**
    * Substitutes parts inside values by other paths of the configuration.
    * Token for substitution is "~{replacementPath}".
-   * An optional modifier can be appended with a pipe, e.g. "~{replacementPath|snake}", to transform the resolved value:
+   * One or more modifiers can be appended with a pipe and are applied left-to-right, e.g. "~{replacementPath|snake}"
+   * or chained "~{replacementPath|noPrefix|snake}", to transform the resolved value:
    *  - "snake": converts the resolved value to snake_case, i.e. inserts underscores at camelCase boundaries, replaces
    *    dashes ('-') with underscores ('_') and lowercases, e.g. to use an element id like 'int-airports' or 'intAirports'
    *    as table name 'int_airports'.
+   *  - "noPrefix": removes the first part of the value, separated by a dash ('-'), underscore ('_') or camelCase
+   *    boundary, e.g. an element id like 'int-airports' or 'intAirports' as table name 'airports' resp. 'Airports'.
    *
    * @param config configuration object for local substitution
    * @param path   path to search for local substitution tokens and execute substitution
@@ -299,23 +323,25 @@ private[smartdatalake] object ConfigParser extends SmartDataLakeLogger {
 
     val localSubstituter = (regMatch: Regex.Match) => {
       val replacementPath = regMatch.group(1)
-      val modifier = Option(regMatch.group(2))
+      val modifiers = Option(regMatch.group(2)).map(_.split('|').filter(_.nonEmpty).toSeq).getOrElse(Seq.empty)
       val value =
         if (config.hasPath(replacementPath)) {
           if (config.getValue(replacementPath).valueType() == ConfigValueType.STRING
             || config.getValue(replacementPath).valueType() == ConfigValueType.NUMBER) config.getString(replacementPath)
           else throw ConfigurationException(s"local substitution path '$replacementPath' in path '$path' is not a string")
         } else throw ConfigurationException(s"local substitution path '$replacementPath' in path '$path' does not exist")
-      modifier match {
-        case None => value
-        case Some("snake") => toSnakeCase(value)
-        case Some(m) => throw ConfigurationException(s"unknown local substitution modifier '$m' for path '$replacementPath' in path '$path'. Supported modifiers: snake")
+      modifiers.foldLeft(value) { (v, m) =>
+        m match {
+          case "snake" => toSnakeCase(v)
+          case "noPrefix" => removePrefix(v)
+          case other => throw ConfigurationException(s"unknown local substitution modifier '$other' for path '$replacementPath' in path '$path'. Supported modifiers: snake, noPrefix")
+        }
       }
     }
 
     if (config.hasPath(path) && config.getValue(path).valueType() == ConfigValueType.STRING) {
       val value = config.getString(path)
-      val valueSubstituted = """~\{(.*?)(?:\|(\w+))?\}""".r.replaceAllIn(value, localSubstituter)
+      val valueSubstituted = """~\{([^|}]*)((?:\|\w+)*)\}""".r.replaceAllIn(value, localSubstituter)
       config.withValue(path, ConfigValueFactory.fromAnyRef(valueSubstituted))
     } else config
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/config/ConfigParsingTest.scala
@@ -731,11 +731,107 @@ class ConfigParsingTest extends AnyFlatSpec with Matchers {
     configSubstituted.getString("name") shouldEqual "schema.int_airports_int-airports"
   }
 
+  "local substitution with noPrefix modifier" should "remove a dash separated prefix" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "int-airports"
+        | name = "~{id|noPrefix}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "airports"
+  }
+
+  it should "remove an underscore separated prefix" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "int_airports"
+        | name = "~{id|noPrefix}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "airports"
+  }
+
+  it should "remove a camelCase prefix and keep the remainder" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "intAirports"
+        | name = "~{id|noPrefix}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "Airports"
+  }
+
+  it should "remove only the first part at the earliest separator" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "int-airPorts"
+        | name = "~{id|noPrefix}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "airPorts"
+  }
+
+  it should "leave a value without a separator unchanged" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = airports
+        | name = "~{id|noPrefix}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "airports"
+  }
+
+  "local substitution with chained modifiers" should "apply modifiers left-to-right" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "intAirports"
+        | name = "~{id|noPrefix|snake}"
+        |}""".stripMargin
+    )
+
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "airports"
+  }
+
+  it should "apply chained modifiers in the given order" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "stage-intAirports"
+        | name = "~{id|snake|noPrefix}"
+        |}""".stripMargin
+    )
+
+    // snake first: "stage_int_airports", then noPrefix removes the first underscore separated part
+    val configSubstituted = ConfigParser.localSubstitution(config, "name")
+    configSubstituted.getString("name") shouldEqual "int_airports"
+  }
+
   "local substitution with an unknown modifier" should "throw a ConfigurationException" in {
     val config = ConfigFactory.parseString(
       """{
         | id = "int-airports"
         | name = "~{id|kebab}"
+        |}""".stripMargin
+    )
+
+    intercept[ConfigurationException](ConfigParser.localSubstitution(config, "name"))
+  }
+
+  it should "throw a ConfigurationException for an unknown modifier in a chain" in {
+    val config = ConfigFactory.parseString(
+      """{
+        | id = "int-airports"
+        | name = "~{id|snake|kebab}"
         |}""".stripMargin
     )
 


### PR DESCRIPTION
Generalize the local config substitution (~{path}) to support chaining multiple modifiers applied left-to-right, e.g. ~{id|noPrefix|snake}. Previously only a single modifier (snake) was supported.

Adds a new noPrefix modifier that removes the first part of a value, separated by a dash (-), underscore (_) or camelCase boundary:
  - int-airports → airports
  - int_airports → airports
  - intAirports → Airports
  
Includes tests for noPrefix (each separator type, earliest-separator selection, no-separator passthrough), for both chaining orders, and for unknown modifiers in a chain. Scaladoc and the "unknown modifier" error message updated accordingly.

Why are the changes needed?

The snake modifier (#1086) only handled one transform per token. Reusing an element id as a downstream name often needs more than one step — e.g. stripping a stage/layer prefix and converting to snake_case. noPrefix covers the common case of dropping a
  prefix (like int-/stage-) from an id, and chaining lets these be combined in a single substitution.
