### PR TITLE
use table.fullName in SQL statements.

### DIFF
--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -733,13 +733,13 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   }
 
   def addTableComment(comment: String)(implicit context: ActionPipelineContext): Unit = {
-    val query = f"ALTER TABLE ${table.name} SET TBLPROPERTIES ('comment' = '$comment');"
+    val query = f"ALTER TABLE ${table.fullName} SET TBLPROPERTIES ('comment' = '$comment');"
     SparkQueryUtil.executeSqlStatementBasedOnTable(context.sparkSession, query, table)
   }
 
   def updateExistingColumnComments(comments: Map[String, String])(implicit context: ActionPipelineContext): Unit = {
     comments.foreach( comment => {
-      val query = f"ALTER TABLE ${table.name} ALTER COLUMN ${comment._1} COMMENT '${comment._2}';"
+      val query = f"ALTER TABLE ${table.fullName} ALTER COLUMN ${comment._1} COMMENT '${comment._2}';"
       SparkQueryUtil.executeSqlStatementBasedOnTable(context.sparkSession, query, table)
     }
     )


### PR DESCRIPTION
### What changes are included in the pull request?

Use `table.fullName` instead of `table.name` in the SQL statements built by
`addTableComment` and `updateExistingColumnComments` in `DeltaLakeTableDataObject`.

### Why are the changes needed?

Both methods passed an unqualified table name to `executeSqlStatementBasedOnTable`,
which prepends `USE CATALOG` / `USE SCHEMA` to the statement before executing it on
the shared `SparkSession`. Under parallel execution (`--parallelism > 1`) a concurrent
action can flip the session's current schema between the `USE` and the `ALTER TABLE`,
causing Spark to look up the table in the wrong schema and fail with
`TABLE_OR_VIEW_NOT_FOUND` — even though the table exists.

Switching to `table.fullName` makes the `ALTER TABLE` statements self-contained
(`catalog.schema.table`), so they resolve correctly regardless of whatever
`USE SCHEMA` a concurrent thread last executed on the shared session.

fixes #1092