### PR TITLE
quality: Add fluent Column extensions for comments and non-nullability

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
@@ -22,6 +22,7 @@ package io.smartdatalake.util.spark.dataset
 import io.smartdatalake.util.LogUtils.{debLogFun, debugLog}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
@@ -47,6 +48,26 @@ trait Quality extends Transform {
         s" use withComment(colName: String, column: Column, commentText: String) instead.")
     }
     withComment(colName, commentText)
+  }
+
+  implicit class DsColComment(column: Column) {
+
+    /**
+     * Fluent alternative to withComment(column, commentText): col("abc").withComment("my description")
+     */
+    def withComment(commentText: String): Column = Quality.this.withComment(column, commentText)
+
+    /**
+     * Marks this column as not-nullable.
+     * The check is enforced at runtime: an actual null value in the underlying data throws a NullPointerException.
+     */
+    def makeNotNullable: Column = {
+      val asserted = new Column(AssertNotNull(column.expr))
+      column.expr match {
+        case named: NamedExpression => asserted.as(named.name)
+        case _ => asserted
+      }
+    }
   }
 
   /**

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
@@ -21,6 +21,7 @@ package io.smartdatalake.util.spark.dataset
 
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.spark.GetSession.loggEnv
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -62,6 +63,24 @@ class DsCommentTest extends AnyFlatSpec with Matchers
     val expected = Set("desc_id", "desc_x", "desc_y")
     actual shouldBe expected
     dfCommented.columns shouldBe df.columns
+  }
+
+  "DsColComment.withComment" should "add a comment fluently on a Column" in {
+    val df = List(TestCaseClass(1, 1f, TestInnerClass(1, 1))).toDF()
+    val dfCommented = df.select(col("id").withComment("desc_id"))
+    dfCommented.getColumnComments.select("comment").as[String].collect().toSet shouldBe Set("desc_id")
+  }
+
+  "DsColComment.makeNotNullable" should "mark the column as not-nullable in the schema" in {
+    val df = List(TestCaseClass(1, 1f, TestInnerClass(1, 1))).toDF()
+    val dfNotNullable = df.select(col("id").makeNotNullable)
+    dfNotNullable.schema("id").nullable shouldBe false
+  }
+
+  it should "throw at runtime if the column actually contains a null value" in {
+    val df = List(Some(1), None).toDF("id")
+    val dfNotNullable = df.select(col("id").makeNotNullable)
+    a[Exception] should be thrownBy dfNotNullable.collect()
   }
 
 }


### PR DESCRIPTION
### What changes are included in the pull request?                                                                                                                                                                                                                
  Adds a new `DsColComment` implicit class to `Quality` (`sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala`) that extends `Column` with two fluent methods:                                                                                
  - `col("abc").withComment("my description")` — shorthand for the existing `Quality.withComment(column, commentText)`.                                                                                                                                             
  - `col("abc").makeNotNullable` — marks a column as not-nullable. Implemented via Spark's `AssertNotNull` expression so that the schema's `nullable` flag is actually set to `false` and a runtime exception is thrown if a null value is encountered.             
                                                                                                                                                                                                                                                                    
  Added tests in `DsCommentTest.scala` covering the fluent `withComment` call, the schema nullability change, and the runtime null-check.                                                                                                                           
                                                                                                                                                                                                                                                                    
### Why are the changes needed?                                                                                                                                                                                                                                   
  `Quality` already supports setting column comments, but only via standalone functions (e.g. `withComment("abc", "desc")`) or dataset-level helpers. This adds a more ergonomic, chainable API directly on `Column`, and extends it to also cover changing column  
  nullability — which wasn't previously supported at all.                       