### PR TITLE
cleanup unneeded test libraries 

### DIFF
--- a/sdl-azure/pom.xml
+++ b/sdl-azure/pom.xml
@@ -164,6 +164,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.5.15</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/sdl-azure/pom.xml
+++ b/sdl-azure/pom.xml
@@ -138,24 +138,9 @@
         </dependency>
 
         <!-- test dependencies -->
-        <!--		 sdl-core test utils-->
-        <dependency>
-            <groupId>io.smartdatalake</groupId>
-            <artifactId>sdl-core_${scala.minor.version}</artifactId>
-            <version>${project.parent.version}</version>
-            <classifier>test-jar</classifier>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.minor.version}</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.5.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -165,22 +150,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-core</artifactId>
-            <version>${sshd.test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-standalone</artifactId>
-            <version>2.25.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!--		 sdl-core test utils-->
+        <dependency>
+            <groupId>io.smartdatalake</groupId>
+            <artifactId>sdl-core_${scala.minor.version}</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>test-jar</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/app/SmartDataLakeBuilderTest.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ActionId, DataObjectId, stringTo
 import io.smartdatalake.config.{ConfigParser, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions._
 import io.smartdatalake.testutils.custom.TestCustomDfsTransformer
-import io.smartdatalake.testutils.{MockSparkDataObject, TestUtil}
+import io.smartdatalake.testutils.{MockSparkDataObject, TestUtil, WebserviceTestUtil}
 import io.smartdatalake.util.dag.TaskFailedException
 import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.misc.StateUploader
@@ -859,8 +859,8 @@ class SmartDataLakeBuilderTest extends AnyFunSuite with BeforeAndAfter
     val port = 8888
     val httpsPort = 8889
     val host = "127.0.0.1"
-    val wireMockServer = TestUtil.startWebservice(host, port, httpsPort)
-    TestUtil.setupWebserviceStubs()
+    val wireMockServer = WebserviceTestUtil.startWebservice(host, port, httpsPort)
+    WebserviceTestUtil.setupWebserviceStubs()
 
     val feedName = "test"
     implicit val actionPipelineContext: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext(sdlb.instanceRegistry)

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/SshTestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/SshTestUtil.scala
@@ -1,0 +1,57 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.testutils
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.util.spark.dataset.Equality
+import org.apache.sshd.common.file.nativefs.NativeFileSystemFactory
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.auth.password.PasswordAuthenticator
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
+import org.apache.sshd.server.session.ServerSession
+import org.apache.sshd.server.subsystem.SubsystemFactory
+import org.apache.sshd.sftp.server.SftpSubsystemFactory
+
+import java.nio.file.Files
+import scala.jdk.CollectionConverters._
+
+/**
+ * Utility methods for testing.
+ */
+object SshTestUtil extends SmartDataLakeLogger with Equality {
+
+  def setupSSHServer(port: Int, usr: String, pwd: String): SshServer = {
+    val sshd = SshServer.setUpDefaultServer()
+    sshd.setFileSystemFactory(new NativeFileSystemFactory())
+    sshd.setPort(port)
+    sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(Files.createTempDirectory("sshd").resolve("hostkey.ser")))
+    sshd.setSubsystemFactories(List(new SftpSubsystemFactory().asInstanceOf[SubsystemFactory]).asJava)
+    sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
+      override def authenticate(user: String, password: String, session: ServerSession): Boolean = user == usr && password == pwd
+    })
+    sshd.start()
+    // Thread.sleep(1000000)
+    // return
+    sshd
+  }
+
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TestUtil.scala
@@ -62,20 +62,9 @@ import scala.jdk.CollectionConverters._
  */
 object TestUtil extends SmartDataLakeLogger with Equality {
 
-  // extract keystore file from resource jar for wiremock server
-  private lazy val wiremockKeyStoreFile = {
-    val resource = "test_keystore.pkcs12"
-    val keyStorePath = Files.createTempDirectory("test").resolve(resource)
-    val inputStream = Option(getClass.getResourceAsStream("/" + resource))
-      .getOrElse(throw new RuntimeException(s"Could not find resource $resource in classpath"))
-    Files.copy(inputStream, keyStorePath)
-    inputStream.close()
-    keyStorePath.toString
-  }
-
-// TODO: merge with io.smartdatalake.util.spark.GetSession, to avoid code duplication.
-//  Note that GetSession is in main sources, so it cannot depend on test sources,
-//  but maybe we can move the common code to a separate object in main sources.
+  // TODO: merge with io.smartdatalake.util.spark.GetSession, to avoid code duplication.
+  //  Note that GetSession is in main sources, so it cannot depend on test sources,
+  //  but maybe we can move the common code to a separate object in main sources.
   def sparkSessionBuilder(additionalSparkProperties: Map[String, StringOrSecret] = Map()): SparkSession.Builder = {
     // create builder
     val builder = additionalSparkProperties.foldLeft(SparkSession.builder()) {
@@ -146,80 +135,6 @@ object TestUtil extends SmartDataLakeLogger with Equality {
     val inputStream = this.getClass.getClassLoader.getResourceAsStream(resource)
     assert(inputStream != null, s"resource file $resource not found")
     FileUtils.copyInputStreamToFile(inputStream, tgtFile)
-  }
-
-  def setupSSHServer(port: Int, usr: String, pwd: String): SshServer = {
-    val sshd = SshServer.setUpDefaultServer()
-    sshd.setFileSystemFactory(new NativeFileSystemFactory())
-    sshd.setPort(port)
-    sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider(Files.createTempDirectory("sshd").resolve("hostkey.ser")))
-    sshd.setSubsystemFactories(List(new SftpSubsystemFactory().asInstanceOf[SubsystemFactory]).asJava)
-    sshd.setPasswordAuthenticator(new PasswordAuthenticator() {
-      override def authenticate(user: String, password: String, session: ServerSession): Boolean = user == usr && password == pwd
-    })
-    sshd.start()
-    // Thread.sleep(1000000)
-    // return
-    sshd
-  }
-
-  /**
-   * Setup simple webserver with given ports Different stubs are generated automatically to answer
-   * different URLs with predefined return codes
-   *
-   * @param host
-   *   bind address, usually localhost / 127.0.0.1
-   * @param port
-   *   port for http calls
-   * @param httpsPort
-   *   port for https calls
-   * @return
-   *   instance of [[WireMockServer]]
-   */
-  def startWebservice(host: String, port: Int, httpsPort: Int): WireMockServer = {
-    configureFor(host, port)
-    val wireMockServer =
-      new WireMockServer(
-        wireMockConfig()
-          .port(port)
-          .httpsPort(httpsPort)
-          .bindAddress(host)
-          .keystorePath(wiremockKeyStoreFile)
-          .keystorePassword("mytruststorepassword")
-          .asynchronousResponseEnabled(false)
-      )
-    wireMockServer
-      .start()
-    wireMockServer
-  }
-
-  def setupWebserviceStubs(): Unit = {
-    stubFor(post(urlEqualTo("/good/post/no_auth"))
-        .willReturn(aResponse().withBody("{{request.path.[0]}}"))
-    )
-
-    stubFor(get(urlEqualTo("/good/no_auth/"))
-        .willReturn(aResponse().withStatus(200))
-    )
-
-    stubFor(get(urlMatching("/good/basic_auth/"))
-        .withHeader("Authorization", equalTo("Basic ZnMxOmZyZWl0YWcyMDE3x"))
-        .willReturn(ok("request looks good"))
-    )
-
-    stubFor(get(urlMatching("/good/client_id/"))
-        .withHeader("Authorization", equalTo("Basic ZnMxOmZyZWl0YWcyMDE3x"))
-        .willReturn(ok("request looks good"))
-    )
-
-    stubFor(get(urlMatching("/good/token/"))
-        .withHeader("Authorization", equalTo("Bearer ZnMxOmZyZWl0YWcyMDE3x"))
-        .willReturn(ok("request looks good"))
-    )
-
-    stubFor(get(urlMatching("/bad/*/"))
-        .willReturn(aResponse.withStatus(404))
-    )
   }
 
   // a few data frames

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/WebserviceTestUtil.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/WebserviceTestUtil.scala
@@ -1,0 +1,104 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.testutils
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.util.spark.dataset.Equality
+
+import java.nio.file.Files
+
+/**
+ * Utility methods for testing.
+ */
+object WebserviceTestUtil extends SmartDataLakeLogger with Equality {
+
+  // extract keystore file from resource jar for wiremock server
+  private lazy val wiremockKeyStoreFile = {
+    val resource = "test_keystore.pkcs12"
+    val keyStorePath = Files.createTempDirectory("test").resolve(resource)
+    val inputStream = Option(getClass.getResourceAsStream("/" + resource))
+      .getOrElse(throw new RuntimeException(s"Could not find resource $resource in classpath"))
+    Files.copy(inputStream, keyStorePath)
+    inputStream.close()
+    keyStorePath.toString
+  }
+
+  /**
+   * Setup simple webserver with given ports Different stubs are generated automatically to answer
+   * different URLs with predefined return codes
+   *
+   * @param host
+   * bind address, usually localhost / 127.0.0.1
+   * @param port
+   * port for http calls
+   * @param httpsPort
+   * port for https calls
+   * @return
+   * instance of [[WireMockServer]]
+   */
+  def startWebservice(host: String, port: Int, httpsPort: Int): WireMockServer = {
+    configureFor(host, port)
+    val wireMockServer =
+      new WireMockServer(
+        wireMockConfig()
+          .port(port)
+          .httpsPort(httpsPort)
+          .bindAddress(host)
+          .keystorePath(wiremockKeyStoreFile)
+          .keystorePassword("mytruststorepassword")
+          .asynchronousResponseEnabled(false)
+      )
+    wireMockServer
+      .start()
+    wireMockServer
+  }
+
+  def setupWebserviceStubs(): Unit = {
+    stubFor(post(urlEqualTo("/good/post/no_auth"))
+      .willReturn(aResponse().withBody("{{request.path.[0]}}"))
+    )
+
+    stubFor(get(urlEqualTo("/good/no_auth/"))
+      .willReturn(aResponse().withStatus(200))
+    )
+
+    stubFor(get(urlMatching("/good/basic_auth/"))
+      .withHeader("Authorization", equalTo("Basic ZnMxOmZyZWl0YWcyMDE3x"))
+      .willReturn(ok("request looks good"))
+    )
+
+    stubFor(get(urlMatching("/good/client_id/"))
+      .withHeader("Authorization", equalTo("Basic ZnMxOmZyZWl0YWcyMDE3x"))
+      .willReturn(ok("request looks good"))
+    )
+
+    stubFor(get(urlMatching("/good/token/"))
+      .withHeader("Authorization", equalTo("Bearer ZnMxOmZyZWl0YWcyMDE3x"))
+      .willReturn(ok("request looks good"))
+    )
+
+    stubFor(get(urlMatching("/bad/*/"))
+      .willReturn(aResponse.withStatus(404))
+    )
+  }
+
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/util/webservice/OpenApiUtilTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/webservice/OpenApiUtilTest.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.util.webservice
 
 import com.github.tomakehurst.wiremock.client.{WireMock => w}
-import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.testutils.WebserviceTestUtil
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.json4s.jackson.JsonMethods.parse
@@ -213,7 +213,7 @@ class OpenApiUtilTest extends AnyFunSuite {
     val port = 8080
     val httpsPort = 8443
     val host = "127.0.0.1"
-    val server = TestUtil.startWebservice(host, port, httpsPort)
+    val server = WebserviceTestUtil.startWebservice(host, port, httpsPort)
 
     val specJson =
       """

--- a/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/webservice/WebserviceClientTest.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.util.webservice
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.testutils.{TestUtil, WebserviceTestUtil}
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.connection.authMode.{AuthHeaderMode, BasicAuthMode, CustomHttpAuthModeLogic}
@@ -44,14 +44,14 @@ class WebserviceClientTest extends AnyFunSuite with BeforeAndAfter with BeforeAn
   implicit val context: ActionPipelineContext = TestUtil.getDefaultActionPipelineContext
 
   override protected def beforeAll(): Unit =
-    wireMockServer = TestUtil.startWebservice(host, port, httpsPort)
+    wireMockServer = WebserviceTestUtil.startWebservice(host, port, httpsPort)
 
   override protected def afterAll(): Unit =
     wireMockServer.stop()
 
   before {
     wireMockServer.resetAll()
-    TestUtil.setupWebserviceStubs()
+    WebserviceTestUtil.setupWebserviceStubs()
   }
 
   test("Call webservice with wrong Url") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/action/file/FileTransferActionTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/action/file/FileTransferActionTest.scala
@@ -22,7 +22,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, stubFor, urlEqualTo}
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.definitions.SDLSaveMode
-import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.testutils.{SshTestUtil, TestUtil, WebserviceTestUtil}
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.workflow.action.FileTransferAction
@@ -56,8 +56,8 @@ class FileTransferActionTest extends AnyFunSuite with BeforeAndAfter with Before
   val host = "127.0.0.1"
 
   override protected def beforeAll(): Unit = {
-    sshd = TestUtil.setupSSHServer(sshPort, sshUser, sshPwd)
-    wireMockServer = TestUtil.startWebservice(host, port, httpsPort)
+    sshd = SshTestUtil.setupSSHServer(sshPort, sshUser, sshPwd)
+    wireMockServer = WebserviceTestUtil.startWebservice(host, port, httpsPort)
   }
 
   override protected def afterAll(): Unit = {
@@ -75,7 +75,7 @@ class FileTransferActionTest extends AnyFunSuite with BeforeAndAfter with Before
         ignoreHostKeyVerification = true
       ))
     wireMockServer.resetAll()
-    TestUtil.setupWebserviceStubs()
+    WebserviceTestUtil.setupWebserviceStubs()
   }
 
   test("copy file from sftp to hadoop without partitions") {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ODataDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/ODataDataObjectTest.scala
@@ -22,7 +22,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.{WireMock => w}
 import io.smartdatalake.config.ConfigurationException
 import io.smartdatalake.config.SdlConfigObject.DataObjectId
-import io.smartdatalake.testutils.{DataObjectTestSuite, TestUtil}
+import io.smartdatalake.testutils.{DataObjectTestSuite, TestUtil, WebserviceTestUtil}
 import io.smartdatalake.util.secrets.StringOrSecret
 import io.smartdatalake.util.webservice.{HttpRequestError, HttpTimeoutConfig}
 import io.smartdatalake.workflow.ExecutionPhase
@@ -267,7 +267,7 @@ class ODataDataObjectComponentTest extends DataObjectTestSuite {
   var server: WireMockServer = _
 
   override def additionalBefore(): Unit = {
-    server = TestUtil.startWebservice(host, port, httpsPort)
+    server = WebserviceTestUtil.startWebservice(host, port, httpsPort)
   }
 
   after {

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObjectTest.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow.dataobject
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.testutils.{TestUtil, WebserviceTestUtil}
 import io.smartdatalake.util.misc.ResourceUtil
 import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase}
 import org.apache.hadoop.fs.Path
@@ -54,7 +54,7 @@ class OpenApiDataObjectTest extends AnyFunSuite {
 
   test("read openapi webservice") {
     import session.implicits._
-    val wireMockServer = TestUtil.startWebservice(host, port, httpsPort)
+    val wireMockServer = WebserviceTestUtil.startWebservice(host, port, httpsPort)
     stubFor(get(urlEqualTo("/sampleApiDoc.json"))
       .willReturn(aResponse().withBody(ResourceUtil.readResourceAsString(new Path("cp:/openApiSpec/sampleApiDoc.json"))))
     )
@@ -77,7 +77,7 @@ class OpenApiDataObjectTest extends AnyFunSuite {
 
   test("read openapi webservice with paging") {
     import session.implicits._
-    val wireMockServer = TestUtil.startWebservice(host, port, httpsPort)
+    val wireMockServer = WebserviceTestUtil.startWebservice(host, port, httpsPort)
     stubFor(get(urlEqualTo("/sampleApiDocPaging.json"))
       .willReturn(aResponse().withBody(ResourceUtil.readResourceAsString(new Path("cp:/openApiSpec/sampleApiDocPaging.json"))))
     )

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObjectTest.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.workflow.dataobject
 
 import io.smartdatalake.config.InstanceRegistry
-import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.testutils.{SshTestUtil, TestUtil, WebserviceTestUtil}
 import io.smartdatalake.util.filetransfer.StreamFileTransfer
 import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.util.secrets.StringOrSecret
@@ -50,7 +50,7 @@ class SFtpFileRefDataObjectTest extends AnyFunSuite with Matchers with BeforeAnd
   var tempDir: Path = _
 
   override protected def beforeAll(): Unit = {
-    sshd = TestUtil.setupSSHServer(sshPort, sshUser, sshPwd)
+    sshd = SshTestUtil.setupSSHServer(sshPort, sshUser, sshPwd)
     con = SFtpFileRefConnection("con1", "localhost", sshPort,
       BasicAuthMode(user = StringOrSecret(sshUser), password = StringOrSecret(sshPwd)),
       ignoreHostKeyVerification = true, maxParallelConnections = 10)

--- a/sdl-debezium/pom.xml
+++ b/sdl-debezium/pom.xml
@@ -177,30 +177,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-sftp</artifactId>
-      <version>${sshd.test.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-common</artifactId>
-      <version>${sshd.test.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.sshd</groupId>
-      <artifactId>sshd-core</artifactId>
-      <version>${sshd.test.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <version>2.25.1</version>
-      <scope>test</scope>
-    </dependency>
 
   </dependencies>
 

--- a/sdl-deltalake/pom.xml
+++ b/sdl-deltalake/pom.xml
@@ -112,12 +112,6 @@
 			<artifactId>config</artifactId>
 			<scope>${sdl-core.scope}</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.github.kxbmap</groupId>
-			<artifactId>configs_${scala.minor.version}</artifactId>
-			<scope>${sdl-core.scope}</scope>
-		</dependency>
-
 
 		<!-- TEST dependencies -->
 		<dependency>
@@ -135,6 +129,7 @@
 			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<!-- sdl-core test utils -->
 		<dependency>
 			<groupId>io.smartdatalake</groupId>
@@ -142,30 +137,6 @@
 			<version>${project.parent.version}</version>
 			<classifier>test-jar</classifier>
 			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-sftp</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-common</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-core</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-standalone</artifactId>
-			<version>2.25.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/sdl-gcp/pom.xml
+++ b/sdl-gcp/pom.xml
@@ -80,11 +80,6 @@
             <artifactId>config</artifactId>
             <scope>${sdl-core.scope}</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.kxbmap</groupId>
-            <artifactId>configs_${scala.minor.version}</artifactId>
-            <scope>${sdl-core.scope}</scope>
-        </dependency>
 
 
         <!-- TEST dependencies -->
@@ -110,30 +105,6 @@
             <version>${project.parent.version}</version>
             <classifier>test-jar</classifier>
             <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-sftp</artifactId>
-            <version>${sshd.test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-common</artifactId>
-            <version>${sshd.test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-core</artifactId>
-            <version>${sshd.test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-standalone</artifactId>
-            <version>2.25.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/sdl-iceberg/pom.xml
+++ b/sdl-iceberg/pom.xml
@@ -123,11 +123,6 @@
 			<artifactId>config</artifactId>
 			<scope>${sdl-core.scope}</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.github.kxbmap</groupId>
-			<artifactId>configs_${scala.minor.version}</artifactId>
-			<scope>${sdl-core.scope}</scope>
-		</dependency>
 
 
 		<!-- TEST dependencies -->
@@ -146,6 +141,13 @@
 			<artifactId>scalacheck-1-18_${scala.minor.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<version>${hsqldb.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- sdl-core test utils -->
 		<dependency>
 			<groupId>io.smartdatalake</groupId>
@@ -153,37 +155,6 @@
 			<version>${project.parent.version}</version>
 			<classifier>test-jar</classifier>
 			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-sftp</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-common</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-core</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-standalone</artifactId>
-			<version>2.25.1</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<version>${hsqldb.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/sdl-kafka/pom.xml
+++ b/sdl-kafka/pom.xml
@@ -127,11 +127,6 @@
 			<artifactId>config</artifactId>
 			<scope>${sdl-core.scope}</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.github.kxbmap</groupId>
-			<artifactId>configs_${scala.minor.version}</artifactId>
-			<scope>${sdl-core.scope}</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.scala-lang</groupId>
@@ -168,24 +163,6 @@
 			<version>${project.parent.version}</version>
 			<classifier>test-jar</classifier>
 			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-sftp</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-common</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-core</artifactId>
-			<version>${sshd.test.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/sdl-lang/pom.xml
+++ b/sdl-lang/pom.xml
@@ -142,12 +142,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sshd</groupId>
-            <artifactId>sshd-core</artifactId>
-            <version>${sshd.test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
             <version>2.25.1</version>

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -19,7 +19,7 @@
 package io.smartdatalake.meta.configexporter
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import io.smartdatalake.testutils.TestUtil
+import io.smartdatalake.testutils.WebserviceTestUtil
 import org.apache.hadoop.conf.Configuration
 import org.json4s._
 import org.json4s.jackson.JsonMethods
@@ -65,7 +65,7 @@ class ConfigJsonExporterTest extends AnyFunSuite {
     val port = 8080 // for some reason, only the default port seems to work
     val httpsPort = 8443
     val host = "127.0.0.1"
-    val wireMockServer = TestUtil.startWebservice(host, port, httpsPort)
+    val wireMockServer = WebserviceTestUtil.startWebservice(host, port, httpsPort)
     stubFor(put(urlPathMatching("/api/v1/.*"))
         .willReturn(aResponse().withStatus(200))
     )

--- a/sdl-snowflake/pom.xml
+++ b/sdl-snowflake/pom.xml
@@ -64,11 +64,6 @@
 			<artifactId>config</artifactId>
 			<scope>${sdl-core.scope}</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.github.kxbmap</groupId>
-			<artifactId>configs_${scala.minor.version}</artifactId>
-			<scope>${sdl-core.scope}</scope>
-		</dependency>
 
 		<!-- Snowflake dependencies -->
 		<!-- Note that there might be a version conflict in the transitive dependency snowflake-jdbc between snowpark and spark-snowflake -->
@@ -127,18 +122,6 @@
 			<version>${project.parent.version}</version>
 			<classifier>test-jar</classifier>
 			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.sshd</groupId>
-			<artifactId>sshd-core</artifactId>
-			<version>${sshd.test.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-standalone</artifactId>
-			<version>2.25.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
### What changes are included in the pull request?

Separating SshTestUtil and WebserviceTestUtil from TestUtil

### Why are the changes needed?

As soon as TestUtil was used in a module like sdl-deltalake, the module needed also sshd and mockito dependencies, because TestUtil imported corresponding classes. The library where needed, but most modules didnt really use the functionality.

By separating SshTestUtil and WebserviceTestUtil from TestUtil, only modules using SshTestUtil need a dependency to sshd library.
