### PR TITLE
Fix Quality.withComment discarding column expression for renamed/computed columns

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
@@ -22,6 +22,7 @@ package io.smartdatalake.util.spark.dataset
 import io.smartdatalake.util.LogUtils.{debLogFun, debugLog}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
@@ -47,6 +48,26 @@ trait Quality extends Transform {
         s" use withComment(colName: String, column: Column, commentText: String) instead.")
     }
     withComment(colName, commentText)
+  }
+
+  implicit class DsColComment(column: Column) {
+
+    /**
+     * Fluent alternative to withComment(column, commentText): col("abc").withComment("my description")
+     */
+    def withComment(commentText: String): Column = Quality.this.withComment(column, commentText)
+
+    /**
+     * Marks this column as not-nullable.
+     * The check is enforced at runtime: an actual null value in the underlying data throws a NullPointerException.
+     */
+    def makeNotNullable: Column = {
+      val asserted = new Column(AssertNotNull(column.expr))
+      column.expr match {
+        case named: NamedExpression => asserted.as(named.name)
+        case _ => asserted
+      }
+    }
   }
 
   /**

--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
@@ -47,7 +47,7 @@ trait Quality extends Transform {
         s" as it is not a NamedExpression." +
         s" use withComment(colName: String, column: Column, commentText: String) instead.")
     }
-    withComment(colName, commentText)
+    withComment(colName, column, commentText)
   }
 
   implicit class DsColComment(column: Column) {

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
@@ -21,6 +21,7 @@ package io.smartdatalake.util.spark.dataset
 
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.spark.GetSession.loggEnv
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -62,6 +63,24 @@ class DsCommentTest extends AnyFlatSpec with Matchers
     val expected = Set("desc_id", "desc_x", "desc_y")
     actual shouldBe expected
     dfCommented.columns shouldBe df.columns
+  }
+
+  "DsColComment.withComment" should "add a comment fluently on a Column" in {
+    val df = List(TestCaseClass(1, 1f, TestInnerClass(1, 1))).toDF()
+    val dfCommented = df.select(col("id").withComment("desc_id"))
+    dfCommented.getColumnComments.select("comment").as[String].collect().toSet shouldBe Set("desc_id")
+  }
+
+  "DsColComment.makeNotNullable" should "mark the column as not-nullable in the schema" in {
+    val df = List(TestCaseClass(1, 1f, TestInnerClass(1, 1))).toDF()
+    val dfNotNullable = df.select(col("id").makeNotNullable)
+    dfNotNullable.schema("id").nullable shouldBe false
+  }
+
+  it should "throw at runtime if the column actually contains a null value" in {
+    val df = List(Some(1), None).toDF("id")
+    val dfNotNullable = df.select(col("id").makeNotNullable)
+    a[Exception] should be thrownBy dfNotNullable.collect()
   }
 
 }


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                    
`Quality.withComment(column, commentText)` — the overload reachable via the fluent `col(...).withComment(...)` syntax from `DsColComment` — throws away the `Column` it was given and re-resolves a plain `col(colName)`  against whatever DataFrame the surrounding `.select(...)` compiles against. This happens because it delegates to the two-string overload  instead of the three-argument overload that actually aliases the passed column.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                    
Effect on any column built from a new expression (window aggregate, coalesce, alias not already present upstream):                                                                                                                                                                                                                    
  - if the alias name doesn't exist in the source DataFrame, Spark analysis throws `UNRESOLVED_COLUMN.WITH_SUGGESTION`                                                                                                                                                                                                                      
  - if the alias name collides with a different pre-existing column, the computed value is silently discarded and the wrong column is written instead — no error, no warning                                                                                                                                                                                                                                  

Plain passthrough columns (same name before and after) happened to work by coincidence.                                                                                                                                                                                                                                                   

## Fix                                                                                                                                                                                                                                                            

One-line change: the single-Column overload now calls `withComment(colName, column, commentText)` (three-arg overload) instead of `withComment(colName, commentText)` (two-string overload), so the original column expression is preserved through `.as(colName, metadata)`.         