### PR TITLE
Add HOCON examples and @param coverage to config type scaladoc (part A of #1106)

### DIFF
--- a/sdl-azure/src/main/scala/io/smartdatalake/util/azure/AzureADClientGrantAuthMode.scala
+++ b/sdl-azure/src/main/scala/io/smartdatalake/util/azure/AzureADClientGrantAuthMode.scala
@@ -27,6 +27,41 @@ import io.smartdatalake.workflow.connection.authMode.HttpAuthMode
 
 import java.util.Collections
 
+/**
+ * Authenticate against an HTTP service with an Azure AD (Microsoft Entra ID) access token, using the
+ * OAuth2 client credentials grant.
+ *
+ * A token is requested from the given Azure AD `authority` for the registered application (service principal)
+ * and passed on as `Authorization: Bearer <token>` header. Use this instead of the generic
+ * [[io.smartdatalake.workflow.connection.authMode.OAuthMode]] if the token should be acquired through the
+ * Microsoft MSAL library, e.g. because the authority handles tenant discovery and token caching.
+ * All parameters support secret providers, so no credential has to be stored in clear text.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-airports {
+ *     type = WebserviceFileDataObject
+ *     url = "https://my-api.azurewebsites.net/airports"
+ *     authMode = {
+ *       type = AzureADClientGrantAuthMode
+ *       authority = "https://login.microsoftonline.com/{tenant-guid}/"
+ *       applicationId = "###ENV#AZURE_CLIENT_ID###"
+ *       clientSecret = "###ENV#AZURE_CLIENT_SECRET###"
+ *       scope = "api://my-api/.default"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note This authentication mode lives in the sdl-azure module, so that module has to be on the classpath.
+ * @param authority     URL of the Azure AD authority to request the token from, including the tenant,
+ *                      e.g. "https://login.microsoftonline.com/{tenant-guid}/" (supports secret providers)
+ * @param applicationId application (client) id of the registered Azure AD application (supports secret providers)
+ * @param clientSecret  client secret of the registered Azure AD application (supports secret providers)
+ * @param scope         OAuth2 scope to request the token for, normally "<resource>/.default" for the client
+ *                      credentials grant (supports secret providers)
+ */
 case class AzureADClientGrantAuthMode(authority: StringOrSecret, applicationId: StringOrSecret, clientSecret: StringOrSecret, scope: StringOrSecret) extends HttpAuthMode with SmartDataLakeLogger {
 
   override def getHeaders: Map[String,String] = {

--- a/sdl-azure/src/main/scala/io/smartdatalake/workflow/agent/AzureRelayAgent.scala
+++ b/sdl-azure/src/main/scala/io/smartdatalake/workflow/agent/AzureRelayAgent.scala
@@ -34,6 +34,34 @@ import java.nio.ByteBuffer
  *  [[Agent]] that communicates via a Azure Relay Service.
  * See the class SmartDataLakeBuilderAzureRelayAgentIT for an example.
  *
+ * An Agent lets a "main" SDLB instance delegate the execution of an Action to a remote SDLB instance, e.g. to read
+ * data from an on-premise source that the main instance cannot reach. AzureRelayAgent uses an Azure Relay Hybrid
+ * Connection, so the remote instance does not need an inbound port open: both sides connect outbound to the relay.
+ * Prefer this over [[JettyAgent]] (development only) and [[StorageAgent]] (file based) when the remote instance
+ * sits behind a firewall.
+ *
+ * Actions are delegated to the agent by setting `agentId` on the Action. The `connections` defined on the agent
+ * override the connections with the same id on the remote instance, but only if the agent server is started with
+ * `useOnlyLocalConnectionConfig=false`. With the default `true` the agent server uses its own local connection
+ * configuration only and the connections defined here are ignored.
+ *
+ * Example:
+ * {{{
+ * agents = {
+ *   agent-onprem {
+ *     type = AzureRelayAgent
+ *     url = "Endpoint=sb://my-relay.servicebus.windows.net/;SharedAccessKeyName=my-policy;EntityPath=my-connection;SharedAccessKey="${SharedAccessKey}
+ *     connections {
+ *       remoteFile { id = remoteFile, type = HadoopFileConnection, pathPrefix = "/data/remote" }
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note Requires the sdl-azure module on the classpath and a running SDLB agent server listening on the same
+ *       Azure Relay hybrid connection.
+ * @note The `connections` block of the example is only taken into account if the agent server is started with
+ *       `useOnlyLocalConnectionConfig=false`, which is not the default for security reasons.
  * @param url         Connection URL on how the agent can be reached. See io.smartdatalake.app.SmartDataLakeBuilderAzureRelayAgentIT#azureRelayUrl for an example.
  */
 case class AzureRelayAgent(override val id: AgentId, url: String, override val connections: Map[String, Connection] = Map())

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CopyAction.scala
@@ -40,6 +40,26 @@ import scala.reflect.runtime.universe.Type
  * DataFrame might be transformed using SQL or DataFrame transformations. Then the output
  * DataObjects writes the DataFrame to the output according to its definition.
  *
+ * CopyAction is the standard 1:1 Action. Use it whenever exactly one input should be written to
+ * exactly one output. Choose [[CustomDataFrameAction]] instead if you need multiple inputs or
+ * outputs, and [[FileTransferAction]] if the data should be moved byte-by-byte without being read
+ * into a DataFrame.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformers = [{
+ *       type = SQLDfTransformer
+ *       code = "select ident, name, latitude_deg, longitude_deg from %{inputViewName}"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param inputId
  *   inputs DataObject
  * @param outputId

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
@@ -39,6 +39,29 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * The input DataFrames might be transformed using SQL or DataFrame transformations.
  * When chaining multiple transformers, output DataFrames of previous transformers are available as input DataFrames for later transformers by their corresponding name.
  *
+ * Use CustomDataFrameAction for joins, unions and fan-outs. For simple 1:1 copies prefer [[CopyAction]],
+ * which derives more accurate lineage. Note that a transformer must return a result for every outputId,
+ * keyed by the output DataObject id, otherwise the Action fails with a configuration error.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-departures-airports {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-departures, int-airports]
+ *     outputIds = [btl-departures-arrivals-airports]
+ *     mainInputId = stg-departures
+ *     transformers = [{
+ *       type = SQLDfsTransformer
+ *       code = {
+ *         btl-departures-arrivals-airports = """select d.*, a.name from %{inputViewName_stg-departures} d
+ *           join %{inputViewName_int-airports} a on d.estdepartureairport = a.ident"""
+ *       }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param inputIds               input DataObject's
  * @param outputIds              output DataObject's
  * @param transformers list of transformations to apply. See [[spark.transformer]] for a list of included Transformers.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomScriptAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomScriptAction.scala
@@ -32,6 +32,30 @@ import io.smartdatalake.workflow.{ActionPipelineContext, ScriptSubFeed}
  *
  * Note that this action can also be used to give your data pipeline additional structure, e.g. adding a decision point after several actions have been executed.
  *
+ * No data is read or written by this Action: the input DataObjects are only used as dependencies to order the DAG,
+ * and the output DataObjects just receive a notification once all scripts succeeded. The last line of a script's
+ * standard output is parsed as `key=value` pairs and passed on as parameters to the next script and output SubFeeds.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   refresh-dashboard {
+ *     type = CustomScriptAction
+ *     inputIds = [int-airports]
+ *     outputIds = [ext-dashboard]
+ *     scripts = [{
+ *       type = CmdScript
+ *       linuxCmd = "./scripts/refresh-dashboard.sh"
+ *       winCmd = "scripts\\refresh-dashboard.cmd"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note Output DataObjects must implement [[io.smartdatalake.workflow.dataobject.script.CanReceiveScriptNotification]]
+ *       to be able to receive the notification. No DataObject shipped with SDLB implements it yet, so `outputIds`
+ *       normally references a custom DataObject implementation. Otherwise the Action fails with a
+ *       ConfigurationException when the configuration is parsed.
  * @param inputIds               input DataObject's
  * @param outputIds              output DataObject's
  * @param scripts                definition of scripts to execute

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DeduplicateAction.scala
@@ -56,6 +56,19 @@ import scala.reflect.runtime.universe.Type
  * This can be achieved through adding a DeduplicateTransformer to transformers. Note that this is
  * not included by default in DeduplicateAction, as it is a performance intensive operation.
  *
+ * Example:
+ * {{{
+ * actions = {
+ *   dedup-airports {
+ *     type = DeduplicateAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     updateCapturedColumnOnlyWhenChanged = true
+ *     mergeModeAdditionalJoinPredicate = "existing.dl_ts_captured > current_date - interval 7 days"
+ *   }
+ * }
+ * }}}
+ *
  * @param inputId
  *   inputs DataObject
  * @param outputId

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/FileTransferAction.scala
@@ -33,6 +33,19 @@ import io.smartdatalake.workflow.{ActionPipelineContext, ExecutionPhase, FileSub
  * As data is transferred as is, matching the data format between the Input DataObject (e.g. CSV from WebserviceFileDataObject) and Output DataObject (e.g. CsvFileDataObject) is in the responsibility of the developer/user.
  * If you want to convert or transform data formats between input and output, use the CopyAction instead. CopyAction will read the data from the Input DataObject into a DataFrame, and write that DataFrame to the Output DataObject. In this case the DataObjects are responsible to convert the data into a DataFrame and back.
  *
+ * Example:
+ * {{{
+ * actions = {
+ *   download-airports {
+ *     type = FileTransferAction
+ *     inputId = ext-airports
+ *     outputId = stg-airports
+ *     overwrite = false
+ *     maxParallelism = 4
+ *   }
+ * }
+ * }}}
+ *
  * @param inputId inputs DataObject
  * @param outputId output DataObject
  * @param overwrite Allow existing output file to be overwritten. If false the action will fail if a file to be created already exists. Default is true.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/HistorizeAction.scala
@@ -62,6 +62,19 @@ import scala.reflect.runtime.universe.Type
  * If you still have a legacy full historization table, migration to incremental historization should happen
  * automatically. The missing hash column is detected and added to existing data.
  *
+ * Example:
+ * {{{
+ * actions = {
+ *   historize-airports {
+ *     type = HistorizeAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     timeAxisUnit = 1d
+ *     historizeBlacklist = [last_updated]
+ *   }
+ * }
+ * }}}
+ *
  * @param inputId
  *   inputs DataObject
  * @param outputId

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/CustomMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/CustomMode.scala
@@ -27,9 +27,32 @@ import io.smartdatalake.workflow.dataobject.DataObject
 import io.smartdatalake.workflow.{ActionPipelineContext, SubFeed}
 
 /**
- * Execution mode to create custom execution mode logic.
- * Define a function which receives main input&output DataObject and returns execution mode result
+ * Execution mode to create custom execution mode logic in Scala/Java code.
+ * Implement trait [[CustomModeLogic]] in a class on the classpath and reference it by `className`.
+ * The implementation receives the main input & output DataObject together with the given partition values and
+ * returns an [[ExecutionModeResult]], so it can freely select partition values, a data filter or file references.
+ * Use this only if none of the built-in modes ([[PartitionDiffMode]], [[DataFrameIncrementalMode]],
+ * [[CustomPartitionMode]], ...) fits your selection logic.
  *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     executionMode = {
+ *       type = CustomMode
+ *       className = "com.company.dataPipeline.SelectLatestPartitionMode"
+ *       options = { lookbackDays = "7" }
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note Deprecated since 2.8.2. Implement [[ExecutionMode]] directly and use your class name as `type` in the
+ *       configuration instead.
+ * @see [[CustomPartitionMode]] for the variant which only selects partition values.
  * @param className           class name implementing trait [[CustomModeLogic]]
  * @param alternativeOutputId optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
  *                            It can be used to ensure processing over multiple actions in case of errors.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/CustomPartitionMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/CustomPartitionMode.scala
@@ -29,9 +29,31 @@ import io.smartdatalake.workflow.{ActionPipelineContext, SubFeed}
 
 /**
  * Execution mode to create custom partition execution mode logic.
+ * Implement trait [[CustomPartitionModeLogic]] in a class on the classpath and reference it by `className`.
+ * The implementation receives the main input & output DataObject together with the given partition values and
+ * returns the partition values to process as `Seq[Map[String,String]]`.
+ * Use this if the partition selection of [[PartitionDiffMode]] is not sufficient, e.g. if you need to reprocess
+ * the last n partitions or select partitions by an external trigger table.
+ * Both main input and main output DataObject must support partitions (CanHandlePartitions), otherwise the action fails.
  *
- * Define a function which receives main input&output DataObject and returns partition values to process as `Seq[Map[String,String]]`
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     executionMode = {
+ *       type = CustomPartitionMode
+ *       className = "com.company.dataPipeline.SelectLastDaysPartitionMode"
+ *       options = { nbOfDays = "3" }
+ *     }
+ *   }
+ * }
+ * }}}
  *
+ * @see [[PartitionDiffMode]] for the built-in partition comparison, [[CustomMode]] for full control over the
+ *      [[ExecutionModeResult]].
  * @param className           class name implementing trait [[CustomPartitionModeLogic]]
  * @param alternativeOutputId optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
  *                            It can be used to ensure processing all partitions over multiple actions in case of errors.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataFrameIncrementalMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataFrameIncrementalMode.scala
@@ -33,6 +33,30 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, SubFe
  * Compares max entry in "compare column" between mainOutput and mainInput and incrementally loads the delta.
  * This mode works only with SparkSubFeeds. The filter is not propagated to following actions.
  *
+ * Pick this mode for non-partitioned sources which have a monotonically increasing column, e.g. a technical
+ * timestamp or a sequence-based id: the mode reads `max(compareCol)` from the output and adds a filter
+ * `compareCol > <lastValue>` on the input. If the output is still empty all records are selected.
+ * If input and output are on the same value, a NoDataToProcessWarning is thrown and following actions are skipped.
+ * `compareCol` must exist in both main input and main output and be of a sortable type.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     executionMode = {
+ *       type = DataFrameIncrementalMode
+ *       compareCol = "dl_ts_captured"
+ *       applyCondition = { expression = "isStartNode" }
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @see [[PartitionDiffMode]] if the input DataObject is partitioned, [[DataObjectStateIncrementalMode]] if the
+ *      input DataObject can remember its own state.
  * @param compareCol          a comparable column name existing in mainInput and mainOutput used to identify the delta. Column content should be bigger for newer records.
  * @param alternativeOutputId optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
  *                            It can be used to ensure processing all partitions over multiple actions in case of errors.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataObjectStateIncrementalMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataObjectStateIncrementalMode.scala
@@ -27,6 +27,27 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataObjectState, SubFee
 
 /**
  * An execution mode for incremental processing by remembering DataObjects state from last increment.
+ *
+ * In contrast to [[DataFrameIncrementalMode]] the state is not derived by comparing input and output, but kept by the
+ * input DataObject itself and persisted in the SDLB run state. Choose this mode for sources which can create an
+ * increment on their own, e.g. Airbyte, OData, Debezium CDC or JDBC sources with an incremental cursor.
+ * It has no configuration attributes.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = ext-airports
+ *     outputId = stg-airports
+ *     executionMode = { type = DataObjectStateIncrementalMode }
+ *   }
+ * }
+ * }}}
+ *
+ * @note SmartDataLakeBuilder must be started with a state path (command line option `--state-path`), otherwise the
+ *       mode fails in the init phase. At least one input DataObject must implement `CanCreateIncrementalOutput`.
+ * @see [[DataFrameIncrementalMode]], [[PartitionDiffMode]]
  */
 case class DataObjectStateIncrementalMode() extends ExecutionMode {
   private var inputsWithIncrementalOutput: Seq[DataObject with CanCreateIncrementalOutput] = Seq()

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/ExecutionMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/ExecutionMode.scala
@@ -133,6 +133,31 @@ trait ExecutionModeWithMainInputOutput {
 /**
  * An execution mode which just validates that partition values are given.
  * Note: For start nodes of the DAG partition values can be defined by command line, for subsequent nodes partition values are passed on from previous nodes.
+ *
+ * Use it as a guard on actions which must never process a full load by accident: if the main input SubFeed has no
+ * partition values, the action fails with an IllegalStateException instead of reading everything.
+ * It selects no data itself and has no configuration attributes. In dry-run mode the check is skipped.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     partitions = [dt]
+ *   }
+ * }
+ * actions = {
+ *   copy-departures {
+ *     type = CopyAction
+ *     inputId = int-departures
+ *     outputId = btl-departures
+ *     executionMode = { type = FailIfNoPartitionValuesMode }
+ *   }
+ * }
+ * }}}
+ *
+ * @see [[PartitionDiffMode]] to select the missing partitions automatically instead of failing.
  */
 case class FailIfNoPartitionValuesMode() extends ExecutionMode {
   override def apply(actionId: ActionId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
@@ -155,6 +180,30 @@ object FailIfNoPartitionValuesMode extends FromConfigFactory[ExecutionMode] {
 
 /**
  * An execution mode which forces processing all data from its inputs.
+ *
+ * It resets the partition values and data filter received from the preceding action, so the action always reads the
+ * full content of its inputs. Typical use case is an action which needs the complete history of a predecessor's output
+ * (e.g. a full aggregation or a deduplication), combined with an `executionCondition` of "true" to also run it when
+ * the predecessor was skipped because it had no new data. It has no configuration attributes.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   agg-departures {
+ *     type = CustomDataFrameAction
+ *     inputIds = [int-departures]
+ *     outputIds = [btl-departures-agg]
+ *     transformers = [{
+ *       type = SQLDfsTransformer
+ *       code = {
+ *         btl-departures-agg = "select estdepartureairport, count(*) as cnt from %{inputViewName_int-departures} group by estdepartureairport"
+ *       }
+ *     }]
+ *     executionMode = { type = ProcessAllMode }
+ *     executionCondition = { expression = "true" }
+ *   }
+ * }
+ * }}}
  */
 case class ProcessAllMode() extends ExecutionMode {
   override def apply(actionId: ActionId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/PartitionDiffMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/PartitionDiffMode.scala
@@ -38,12 +38,37 @@ import java.sql.Timestamp
  * This mode needs mainInput/Output DataObjects which CanHandlePartitions to list partitions.
  * Partition values are passed to following actions for partition columns which they have in common.
  *
+ * This is the standard mode for incremental loading of partitioned DataObjects: it needs no state to be persisted,
+ * as the partitions still missing in the output define the increment. By default it is only applied if no partition
+ * values are given on the command line or by the preceding action. If no partition is missing, a
+ * NoDataToProcessWarning is raised and the following actions are skipped.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-departures {
+ *     type = CopyAction
+ *     inputId = stg-departures
+ *     outputId = int-departures
+ *     executionMode = {
+ *       type = PartitionDiffMode
+ *       partitionColNb = 1
+ *       nbOfPartitionValuesPerRun = 10
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @see [[DataFrameIncrementalMode]] for non-partitioned DataObjects, [[CustomPartitionMode]] for custom partition
+ *      selection logic.
  * @param partitionColNb                  optional number of partition columns to use as a common 'init'.
  * @param alternativeOutputId             optional alternative outputId of DataObject later in the DAG. This replaces the mainOutputId.
  *                                        It can be used to ensure processing all partitions over multiple actions in case of errors.
  * @param nbOfPartitionValuesPerRun       optional restriction of the number of partition values per run.
  * @param applyCondition                  Condition to decide if execution mode should be applied or not. Define a spark sql expression working with attributes of [[DefaultExecutionModeExpressionData]] returning a boolean.
  *                                        Default is to apply the execution mode if given partition values (partition values from command line or passed from previous action) are empty.
+ * @param failCondition                   optional single condition to fail application of execution mode if true. Define as spark sql expression working with attributes of [[PartitionDiffModeExpressionData]] returning a boolean.
+ *                                        This is a shortcut for `failConditions` with one entry and without description. It is evaluated in addition to `failConditions`.
  * @param failConditions                  List of conditions to fail application of execution mode if true. Define as spark sql expressions working with attributes of [[PartitionDiffModeExpressionData]] returning a boolean.
  *                                        Default is that the application of the PartitionDiffMode does not fail the action. If there is no data to process, the following actions are skipped.
  *                                        Multiple conditions are evaluated individually and every condition may fail the execution mode (or-logic)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/expectation/CompletenessExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/expectation/CompletenessExpectation.scala
@@ -31,7 +31,28 @@ import io.smartdatalake.workflow.dataobject.expectation.{ActionExpectation, Expe
 
 /**
  * Definition of expectation on comparing count all records of input and output table.
- * Completness is calculated as the fraction of main output count-all over main input count-all.
+ * Completeness is calculated as the fraction of main output count-all over main input count-all.
+ *
+ * Use it to detect unintended record loss in an Action, e.g. rows dropped by a join or a filter.
+ * As it needs a main input and a main output to compare, it can only be configured as `expectations`
+ * of an Action (see [[ActionExpectation]]), not on a DataObject. The scope is fixed to the whole
+ * table, and the fraction is rounded down, so an incomplete result is detected aggressively.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-departures-airports {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-departures, int-airports]
+ *     outputIds = [btl-departures-arrivals-airports]
+ *     mainInputId = stg-departures
+ *     expectations = [{
+ *       type = CompletenessExpectation
+ *       expectation = "> 0.95"
+ *     }]
+ *   }
+ * }
+ * }}}
  *
  * @param expectation Optional SQL comparison operator and literal to define expected value for validation. Default is '= 1".
  *                    Together with the result of the aggExpression evaluation on the left side, it forms the condition to validate the expectation.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/expectation/TransferRateExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/expectation/TransferRateExpectation.scala
@@ -32,6 +32,28 @@ import io.smartdatalake.workflow.dataobject.expectation.{ActionExpectation, Expe
  * Definition of expectation on transfer rate.
  * Transfer rate is calculated as the fraction of main output count over main input count.
  *
+ * Use this Action level expectation to detect records unintentionally lost (or multiplied) by the transformation of an Action,
+ * e.g. by a join that does not match, or a filter that is too restrictive. In contrast to [[CompletenessExpectation]],
+ * which always compares the count of the whole table (scope `All`), the transfer rate compares the number of records
+ * processed by the current job, e.g. only the incrementally loaded records.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     expectations = [
+ *       { type = TransferRateExpectation, expectation = "> 0.95", failedSeverity = Warn }
+ *     ]
+ *   }
+ * }
+ * }}}
+ *
+ * @note The metric is only available for Actions with a main input and a main output, e.g. [[io.smartdatalake.workflow.action.CopyAction]]
+ *       or [[io.smartdatalake.workflow.action.CustomDataFrameAction]].
+ * @see [[CompletenessExpectation]]
  * @param expectation Optional SQL comparison operator and literal to define expected value for validation. Default is '= 1".
  *                    Together with the result of the aggExpression evaluation on the left side, it forms the condition to validate the expectation.
  *                    If no expectation is defined, the aggExpression evaluation result is just recorded in metrics.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/BlacklistTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/BlacklistTransformer.scala
@@ -27,7 +27,33 @@ import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
 /**
- * Apply a column blacklist to a DataFrame.
+ * Apply a column blacklist to a DataFrame: every column listed in `columnBlacklist` is dropped, all
+ * remaining columns are passed through unchanged.
+ * Use this if a source delivers many columns and only a few need to be removed, e.g. to strip technical
+ * or sensitive attributes before writing them to the target DataObject.
+ * Use [[WhitelistTransformer]] instead if it is easier to enumerate the columns to keep.
+ *
+ * Column names are matched case-insensitively, unless case sensitivity is enabled globally by setting
+ * `global.environment.caseSensitive = true`. Blacklisted columns that do not exist in the DataFrame do not
+ * fail the Action, they are logged as a warning and ignored.
+ * Note that the original column order is only preserved in the default case-insensitive mode; with case
+ * sensitivity enabled the order of the remaining columns is undefined.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   load-orders {
+ *     type = CopyAction
+ *     inputId = stg-orders
+ *     outputId = int-orders
+ *     transformers = [{
+ *       type = BlacklistTransformer
+ *       columnBlacklist = [dl_load_ts, source_system, customer_email]
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param columnBlacklist List of columns to exclude from DataFrame

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ColumnsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ColumnsTransformer.scala
@@ -30,16 +30,21 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Add, Rename or Drop columns from the Input DataFrame. The order of execution of the operations is the same as the parameters of the transformer: (1. add context info, 2. add custom sql, 3. rename, 4. drop).
  * Note that you can mix and match these operations to your liking and reference the same column from a previous operation if needed.
  *
- * Example Config:
+ * Example:
  * {{{
- * multiply {
- *   type = CopyAction
- *   inputId = src1DO
- *   outputId = tgt1DO
- *   metadata.feed = test_feed_name
- *   transformers = [
- *     {type = ColumnsTransformer, additionalDerivedColumns = {rating_doubled = "rating * 2"}, renamedColumns = {rating_doubled = rating_doubled_renamed}, droppedColumns = [name]}
- *   ]
+ * actions = {
+ *   multiply {
+ *     type = CopyAction
+ *     inputId = stg-ratings
+ *     outputId = int-ratings
+ *     transformers = [{
+ *       type = ColumnsTransformer
+ *       additionalColumns = {dl_run_id = "runId"}
+ *       additionalDerivedColumns = {rating_doubled = "rating * 2"}
+ *       renamedColumns = {rating_doubled = rating_doubled_renamed}
+ *       droppedColumns = [name]
+ *     }]
+ *   }
  * }
  * }}}
  *

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ConvertNullValuesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ConvertNullValuesTransformer.scala
@@ -26,7 +26,35 @@ import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSimpleDataT
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
 /**
- * Convert null values in a dataframe
+ * Replace null values in a DataFrame by a configurable placeholder value, so that downstream joins,
+ * comparisons and primary keys do not have to deal with nulls.
+ * String columns are filled with `valueForString` and numeric columns with `valueForNumber`; in both cases
+ * the placeholder is cast to the data type of the column. Columns of any other data type (date, timestamp,
+ * boolean, struct, array, ...) are left untouched.
+ *
+ * By default all columns of the DataFrame are converted. Limit the scope with either `includeColumns` or
+ * `excludeColumns` - the two are mutually exclusive and configuring both fails the transformation.
+ * All column names listed must exist in the DataFrame, otherwise the transformation fails.
+ * Column names are matched case-insensitively, unless case sensitivity is enabled globally by setting
+ * `global.environment.caseSensitive = true`.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   load-ratings {
+ *     type = CopyAction
+ *     inputId = stg-ratings
+ *     outputId = int-ratings
+ *     transformers = [{
+ *       type = ConvertNullValuesTransformer
+ *       excludeColumns = [comment]
+ *       valueForString = "n/a"
+ *       valueForNumber = 0
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name              Name of the transformer
  * @param description       Optional description of the transformer
  * @param includeColumns   Optional list of columns to include into the transformation

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DataValidationTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DataValidationTransformer.scala
@@ -26,7 +26,35 @@ import io.smartdatalake.workflow.dataframe.{DataFrameFunctions, GenericColumn, G
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
 /**
- * Apply validation rules to a DataFrame and collect potential violation error messages in a new column.
+ * Apply a list of validation rules to a DataFrame and collect the error messages of all violated rules in
+ * a new array column, instead of failing the Action.
+ * No rows are removed: the errors column stays empty for records that satisfy all rules. This allows to
+ * keep bad records for reporting, or to split them off with a subsequent [[FilterTransformer]] on the
+ * errors column. If the job should rather fail on bad data, use [[io.smartdatalake.workflow.dataobject.generic.Constraint]]
+ * or an Expectation like [[io.smartdatalake.workflow.dataobject.expectation.SQLExpectation]] on the output DataObject.
+ *
+ * The rule expressions are already parsed when the configuration is read, so syntax errors are detected
+ * before the pipeline is started.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   validate-ratings {
+ *     type = CopyAction
+ *     inputId = stg-ratings
+ *     outputId = int-ratings
+ *     transformers = [{
+ *       type = DataValidationTransformer
+ *       errorsColumn = validation_errors
+ *       rules = [
+ *         { type = RowLevelValidationRule, condition = "rating is not null", errorMsg = "rating should not be empty" }
+ *         { type = RowLevelValidationRule, condition = "rating between 1 and 5" }
+ *       ]
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param rules        list of validation rules to apply to the DataFrame
@@ -58,6 +86,26 @@ sealed trait ValidationRule {
 
 /**
  * Definition for a row level data validation rule.
+ * The condition is evaluated for every row on its own, so it can only reference columns of the current
+ * record. Aggregations over the whole DataFrame are not possible, use an Expectation on the output
+ * DataObject for that.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   validate-ratings {
+ *     type = CopyAction
+ *     inputId = stg-ratings
+ *     outputId = int-ratings
+ *     transformers = [{
+ *       type = DataValidationTransformer
+ *       rules = [
+ *         { type = RowLevelValidationRule, condition = "rating between 1 and 5", errorMsg = "rating must be between 1 and 5" }
+ *       ]
+ *     }]
+ *   }
+ * }
+ * }}}
  *
  * @param condition an SQL expression defining the condition to be tested. The condition should return true if the condition is satisfied.
  * @param errorMsg  Optional error msg to be create if the condition fails. Default is to use a text representation of the condition.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DebugTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DebugTransformer.scala
@@ -32,6 +32,27 @@ import org.slf4j.event.Level
  * Log schema, sample data and plan of DataFrame to transform.
  * This transformer can be used to log debug output between different transformers.
  * It's not intended for production use.
+ * The DataFrame is returned unchanged, so the transformer can be inserted at any position in the
+ * `transformers` list of an Action without influencing its result.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   load-ratings {
+ *     type = CopyAction
+ *     inputId = stg-ratings
+ *     outputId = int-ratings
+ *     transformers = [{
+ *       type = DebugTransformer
+ *       show = true
+ *       showOptions = { numRows = "20", vertical = "true" }
+ *       explain = true
+ *       explainOptions = { mode = "extended" }
+ *       logLevel = debug
+ *     }]
+ *   }
+ * }
+ * }}}
  *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DeduplicateTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DeduplicateTransformer.scala
@@ -33,6 +33,26 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  *
  * If primaryKeyColumns is left empty, the primaryKey of the Actions output DataObject must be defined.
  *
+ * With a rankingExpression the record with the largest value of that expression is kept per primary key
+ * (the ranking is applied in descending order), which is the usual way to keep the most recent version of
+ * a record. Without it an arbitrary record per primary key is kept.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   dedup-ratings {
+ *     type = CopyAction
+ *     inputId = stg-ratings
+ *     outputId = int-ratings
+ *     transformers = [{
+ *       type = DeduplicateTransformer
+ *       primaryKeyColumns = [id]
+ *       rankingExpression = "coalesce(updated_at, created_at)"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name              Name of the transformer
  * @param description       Optional description of the transformer
  * @param rankingExpression Optional ranking expression to choose the record to keep if there are duplicates.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DfTransformerWrapperDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/DfTransformerWrapperDfsTransformer.scala
@@ -29,6 +29,33 @@ import io.smartdatalake.workflow.dataframe.GenericDataFrame
  * A Transformer to use single DataFrame Transformers as multiple DataFrame Transformers.
  * This works by selecting the SubFeeds (DataFrames) the single DataFrame Transformer should be applied to.
  * All other SubFeeds will be passed through without transformation.
+ * Use it in Actions working on many DataFrames at once, like CustomDataFrameAction, to reuse a
+ * one-DataFrame transformer such as [[FilterTransformer]], [[BlacklistTransformer]] or
+ * [[DebugTransformer]] there. The transformation is applied to each selected SubFeed separately.
+ * The name and description of this transformer are taken over from the wrapped transformer.
+ * The Action fails if a name in `subFeedsToApply` does not match one of the SubFeeds handed to this transformer.
+ * These are the input DataObject ids if this is the first transformer of the chain, otherwise the output names
+ * of the preceding transformer.
+ *
+ * Example: filter one of the input SubFeeds before joining them with a SQL transformation.
+ * {{{
+ * actions = {
+ *   join-ratings {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-ratings, stg-airports]
+ *     outputIds = [int-ratings]
+ *     transformers = [{
+ *       type = DfTransformerWrapperDfsTransformer
+ *       subFeedsToApply = [stg-ratings]
+ *       transformer = { type = FilterTransformer, filterClause = "rating is not null" }
+ *     },{
+ *       type = SQLDfsTransformer
+ *       code = { int-ratings = "select * from %{inputViewName_stg-ratings} join %{inputViewName_stg-airports} using (airport_id)" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param transformer Configuration for a GenericDfTransformerDef to be applied
  * @param subFeedsToApply Names of SubFeeds the transformation should be applied to. Default is an empty list,
  *                        which will apply the transformation to all subfeeds.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/FilterTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/FilterTransformer.scala
@@ -28,7 +28,30 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, DataF
 import scala.util.{Failure, Success, Try}
 
 /**
- * Apply a filter condition to a DataFrame.
+ * Apply a filter condition to a DataFrame, keeping only the rows for which `filterClause` evaluates to true.
+ * This is the simplest way to reduce data inside an Action, e.g. to drop technically invalid or irrelevant records
+ * before writing them to the output DataObject.
+ *
+ * The filter expression is parsed already when the configuration is read, so a syntax error is reported as
+ * ConfigurationException at startup and not only when the Action is executed.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformers = [{
+ *       type = FilterTransformer
+ *       filterClause = "type in ('large_airport','medium_airport') and ident is not null"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note Filtering rows does not remove columns. Use [[WhitelistTransformer]] or [[BlacklistTransformer]] to
+ *       select columns, and [[ColumnsTransformer]] to add or rename them.
  *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfTransformer.scala
@@ -40,6 +40,26 @@ import org.apache.hadoop.fs.Path
  * It is therefore recommended to use special token `%{inputViewName}` or `%{inputViewName_<input name>}` that will be
  * replaced with the name of the temporary view at runtime.
  *
+ * Use SQLDfTransformer for 1:1 transformations that are easiest expressed in SQL. Exactly one of `code` or `file`
+ * must be defined. For transformations with multiple inputs or outputs use [[SQLDfsTransformer]] in a
+ * [[io.smartdatalake.workflow.action.CustomDataFrameAction]] instead.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   select-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformers = [{
+ *       type = SQLDfTransformer
+ *       code = "select ident, name, latitude_deg, longitude_deg from %{inputViewName} where type = '%{airportType}'"
+ *       options = { airportType = "large_airport" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param file           File where SQL code for transformation is loaded from.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/SQLDfsTransformer.scala
@@ -44,6 +44,27 @@ import org.apache.hadoop.fs.Path
  * Note that you can access arbitrary tables from the metastore in the SQL code, but this is against the principle of SDLB
  * to access data through DataObjects. Accessing tables directly in SQL code has a negative impact on the maintainability of the project.
  *
+ * Use SQLDfsTransformer inside a [[io.smartdatalake.workflow.action.CustomDataFrameAction]] for joins, unions and
+ * fan-outs expressed in SQL. Either `code` or `files` must be non empty, and per output name only one of them may
+ * be defined. If this is the last transformer of the chain, its output names must match the Action's outputIds.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-departures-airports {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-departures, int-airports]
+ *     outputIds = [btl-departures-airports]
+ *     transformers = [{
+ *       type = SQLDfsTransformer
+ *       code = {
+ *         btl-departures-airports = "select d.*, a.name from %{inputViewName_stg-departures} d join %{inputViewName_int-airports} a on d.estdepartureairport = a.ident"
+ *       }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param files          Map of output names to corresponding Files where SQL code for transformation is loaded from for transformation.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfTransformer.scala
@@ -32,6 +32,31 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Define a transform function which receives a DataObjectId, a DataFrame and a map of options and has to return a
  * DataFrame. The Java/Scala class has to implement interface [[CustomGenericDfTransformer]].
  *
+ * The class is instantiated by reflection through its no-argument constructor, so it must be on the classpath of the
+ * SDLB job. Because it works on [[GenericDataFrame]] and receives the matching
+ * [[io.smartdatalake.workflow.dataframe.DataFrameFunctions]], the transformation stays engine independent.
+ * Use `options`/`runtimeOptions` to parameterize the code instead of hard-coding values.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformers = [{
+ *       type = ScalaClassGenericDfTransformer
+ *       className = com.sample.MyAirportsTransformer
+ *       options = { maxLatitude = "60" }
+ *       runtimeOptions = { runId = "runId" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @see [[ScalaClassGenericDfsTransformer]] for the n:m variant, and [[SQLDfTransformer]] if the transformation can
+ *      be expressed in SQL.
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param className      class name implementing trait [[CustomGenericDfTransformer]]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfsTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/ScalaClassGenericDfsTransformer.scala
@@ -32,6 +32,27 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
  * Define a transform function which receives a map of input DataObjectIds with DataFrames and a map of options and as
  * to return a map of output DataObjectIds with DataFrames, see also trait [[CustomGenericDfsTransformer]].
  *
+ * Use this transformer inside a [[io.smartdatalake.workflow.action.CustomDataFrameAction]] whenever a join, union or
+ * fan-out is easier to implement in Scala/Java than in SQL. The class is instantiated by reflection through its
+ * no-argument constructor and must be on the classpath of the SDLB job. If this is the last transformer of the chain,
+ * the returned map must contain an entry for every outputId of the Action.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-departures-airports {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-departures, int-airports]
+ *     outputIds = [btl-departures-airports]
+ *     transformers = [{
+ *       type = ScalaClassGenericDfsTransformer
+ *       className = com.sample.MyJoinTransformer
+ *       options = { joinType = "left" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param className      class name implementing trait [[CustomGenericDfsTransformer]]

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/StandardizeColNamesTransformer.scala
@@ -29,6 +29,31 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 /**
  * Standardizes column names to be used without quoting by using camelCase to lower_case_with_underscore rule (default), and further cleanup rules for special characters (default).
  * Parameters below can be used to disable specific rules if needed.
+ *
+ * Add it as first transformer when reading from sources with inconsistent or unsafe column names (Excel sheets, CSV
+ * exports, JSON APIs), so that all downstream SQL can reference columns without quoting.
+ * With the default settings `testColumn` becomes `test_column` and `c?olumnN[ä]me` becomes `column_naeme`.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformers = [{
+ *       type = StandardizeColNamesTransformer
+ *       camelCaseToLower = true
+ *       normalizeToAscii = true
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note `removeNonStandardSQLNameChars` and `replaceNonStandardSQLNameCharsWithUnderscores` are mutually exclusive;
+ *       enabling both fails at runtime. To get underscores instead of removed characters, disable the former and
+ *       enable the latter.
+ *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param camelCaseToLower If selected, converts Camel case names to lower case  with underscores, i.e. TestString -> test_string, testABCtest -> test_ABCtest

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/WhitelistTransformer.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/generic/transformer/WhitelistTransformer.scala
@@ -27,7 +27,33 @@ import io.smartdatalake.workflow.dataframe.GenericDataFrame
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 
 /**
- * Apply a column whitelist to a DataFrame.
+ * Apply a column whitelist to a DataFrame: only the columns listed in `columnWhitelist` are kept, all others are
+ * dropped. Use it to project a wide source down to the attributes a pipeline really needs, e.g. to exclude
+ * confidential columns, without writing a SQL select statement.
+ *
+ * Column names are matched case-insensitively unless case sensitivity is enabled globally
+ * (`global.environment.caseSensitive`). In the default case-insensitive mode the output keeps the column order
+ * of the input DataFrame; with case sensitivity enabled the order of the selected columns is undefined.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformers = [{
+ *       type = WhitelistTransformer
+ *       columnWhitelist = [ident, name, latitude_deg, longitude_deg]
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note Names in `columnWhitelist` which do not exist in the input DataFrame are logged as warning and ignored,
+ *       they do not fail the Action.
+ * @see [[BlacklistTransformer]] to instead drop a list of columns and keep the rest.
+ *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param columnWhitelist List of columns to keep from DataFrame

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/CmdScript.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/CmdScript.scala
@@ -34,13 +34,33 @@ import scala.collection.mutable
  * If return value is not zero an exception is thrown.
  *
  * Note about internal implementation: on execution value of parameter map entries where key starts with
- * - 'param' will be added as parameter after the docker run command, sorted by key.
+ * - 'param' will be added as parameter after the command, sorted by key.
  * This allows to customize execution behaviour through Actions or DataObjects using CmdScript.
  *
+ * Example:
+ * {{{
+ * actions = {
+ *   export-airports {
+ *     type = CustomScriptAction
+ *     inputIds = [int-airports]
+ *     outputIds = [ext-airports]
+ *     scripts = [{
+ *       type = CmdScript
+ *       linuxCmd = "sh ./scripts/export_airports.sh"
+ *       winCmd = "wsl sh ./scripts/export_airports.sh"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note Only the command for the current operating system needs to be defined, but the job will fail on startup
+ *       if the command for the operating system it is running on is missing.
+ * @see [[DockerRunScript]] to run the command inside a docker container instead.
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param winCmd       Cmd to execute on Windows operating systems - note that it is executed with "cmd /C" prefixed
- * @param linuxCmd     Cmd to execute on Linux operating systems - note that it is executed with "sh -c" prefixed.
+ * @param linuxCmd     Cmd to execute on Linux operating systems - note that it is executed directly and not through a
+ *                     shell, so an interpreter must be part of the command if needed, e.g. "sh ./scripts/export.sh".
  */
 case class CmdScript(override val name: String = "cmd", override val description: Option[String] = None, winCmd: Option[String] = None, linuxCmd: Option[String] = None) extends CmdScriptBase {
   if (EnvironmentUtil.isWindowsOS) assert(winCmd.isDefined, s"($name) winCmd must be defined when running on Windows")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/DockerRunScript.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/script/DockerRunScript.scala
@@ -34,6 +34,29 @@ import java.nio.file.{FileSystems, Paths}
  * - 'dockerParam' will be added as parameter for the docker command, e.g. before the image name in the docker run command, sorted by their key.
  * This allows to customize execution behaviour through Actions or DataObjects using CmdScript.
  *
+ * A typical use case is launching an Airbyte connector image with AirbyteDataObject, but it can be used wherever a
+ * script definition is expected, e.g. in the `scripts` attribute of a CustomScriptAction.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-postgres {
+ *     type = AirbyteDataObject
+ *     streamName = "airports"
+ *     cmd = {
+ *       type = DockerRunScript
+ *       image = "airbyte/source-postgres:1.0.17"
+ *       localDataDirToMount = "data"
+ *     }
+ *     # the entries of config are connector specific, see the documentation of the connector used
+ *     config = { host = "localhost", port = 5432, database = "airports", username = "sdlb", password = "###" }
+ *   }
+ * }
+ * }}}
+ *
+ * @note Docker must be installed and callable on the machine running the SDLB job (the driver). The container runs
+ *       locally, it is not distributed to Spark executors.
+ * @see [[CmdScript]] to execute a plain command line instead.
  * @param name                name of the transformer
  * @param description         Optional description of the transformer
  * @param image               Docker image to run

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/agent/JettyAgent.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/agent/JettyAgent.scala
@@ -34,6 +34,29 @@ import java.net.URI
  * Simple, unsecured SDLB Remote [[Agent]] for development use that communicates via a plain Jetty Websocket.
  * See the class SmartDataLakeBuilderAgentTest for an example.
  *
+ * An Agent lets a "main" SDLB instance delegate the execution of an Action to a remote SDLB instance, e.g. to read
+ * data from a source only the remote instance can reach. Actions are delegated by setting `agentId` on the Action.
+ * The `connections` defined on the agent override the connections with the same id on the remote instance, but only
+ * if the agent server is started with `useOnlyLocalConnectionConfig=false`. With the default `true` the agent server
+ * uses its own local connection configuration only and the connections defined here are ignored.
+ *
+ * Example:
+ * {{{
+ * agents = {
+ *   jetty-agent1 {
+ *     type = JettyAgent
+ *     url = "ws://localhost:4441/ws/"
+ *     connections {
+ *       remoteFile { id = remoteFile, type = HadoopFileConnection, pathPrefix = "target/remote" }
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note The websocket connection is neither encrypted nor authenticated, so use this only for local development
+ *       and tests. For productive setups use [[StorageAgent]] or the AzureRelayAgent of the sdl-azure module.
+ * @note The `connections` block of the example is only taken into account if the agent server is started with
+ *       `useOnlyLocalConnectionConfig=false`, which is not the default for security reasons.
  * @param url Connection URL on how the agent can be reached, example: "ws://localhost:4441/ws/"
  */
 case class JettyAgent(override val id: AgentId, url: String, override val connections: Map[String, Connection] = Map())

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/agent/StorageAgent.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/agent/StorageAgent.scala
@@ -33,6 +33,33 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 /**
  * An SDLB Remote Agent that communicates through Hadoop storage (e.g. HDFS, S3, Azure Blob Storage, ...)
  *
+ * An Agent lets a "main" SDLB instance delegate the execution of an Action to a remote SDLB instance, e.g. to read
+ * data from a source only the remote instance can reach. Actions are delegated by setting `agentId` on the Action.
+ * Instead of a network connection, instruction and result are exchanged as files under `path`, so this is the right
+ * choice if the two instances share a storage location but cannot open a socket between them. The `connections`
+ * defined on the agent override the connections with the same id on the remote instance, but only if the agent
+ * server is started with `useOnlyLocalConnectionConfig=false`. With the default `true` the agent server uses its
+ * own local connection configuration only and the connections defined here are ignored.
+ *
+ * Example:
+ * {{{
+ * agents = {
+ *   storage-agent1 {
+ *     type = StorageAgent
+ *     path = "~{env.basedir}/storage-agent1"
+ *     execTimeoutSec = 900
+ *     connections {
+ *       remoteFile { id = remoteFile, type = HadoopFileConnection, pathPrefix = "/data/remote" }
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note Only one instruction is sent at a time per agent instance. If no agent picks up the instruction within
+ *       `startTimeoutSec`, or does not finish within `execTimeoutSec`, the Action fails with a timeout.
+ * @note The `connections` block of the example is only taken into account if the agent server is started with
+ *       `useOnlyLocalConnectionConfig=false`, which is not the default for security reasons.
+ * @see [[JettyAgent]]
  * @param path            Hadoop path where the agent reads instructions from and writes result information to
  * @param startTimeoutSec maximum time to wait for the start of the processing by the agent in seconds (default: 300s)
  * @param execTimeoutSec  maximum time to wait for the execution result in seconds (default: 300s)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/HadoopFileConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/HadoopFileConnection.scala
@@ -23,11 +23,30 @@ import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 
 /**
- * Connection information for files on hadoop
+ * Connection information for files on hadoop.
+ *
+ * It centralizes the schema, authority and base directory (`pathPrefix`) of a hadoop compatible filesystem
+ * (local filesystem, HDFS, ADLS, S3, ...). File based DataObjects referencing this connection through
+ * `connectionId` only configure a relative `path`, which is resolved against `pathPrefix`. Use it to keep
+ * environment specific storage locations out of the DataObject definitions, so the same DataObjects can be
+ * deployed to different environments by exchanging the connection only.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   cloud-staging {
+ *     type = HadoopFileConnection
+ *     pathPrefix = "abfs://staging@mystorage.dfs.core.windows.net/data"
+ *   }
+ * }
+ * }}}
  *
  * @param id unique id of this connection
  * @param pathPrefix schema, authority and base path for accessing files on hadoop
- * @param metadata
+ * @param sparkConnectionId optional id of a Spark engine connection (e.g. `SparkClassicConnection`).
+ *                          Note that this attribute is currently not evaluated by SDLB. The engine connection
+ *                          used is selected per Action through its `engineConnectionId`, which falls back to
+ *                          `Environment.defaultEngineConnectionId`.
  */
 case class HadoopFileConnection(override val id: ConnectionId,
                                 pathPrefix: String,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/SFtpFileRefConnection.scala
@@ -34,7 +34,32 @@ import java.time.Duration
 import scala.util.{Try, Using}
 
 /**
- * SFTP Connection information
+ * SFTP Connection information.
+ *
+ * It holds host, port and credentials of an SFTP server and manages a pool of SSH connections which is shared
+ * by all DataObjects referencing this connection. Use it together with `SFtpFileRefDataObject` to list and
+ * transfer remote files, e.g. with a FileTransferAction. Only [[BasicAuthMode]] (user/password) and
+ * [[PublicKeyAuthMode]] (user, key taken from the local ssh agent/key store) are supported.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   sftp-partner {
+ *     type = SFtpFileRefConnection
+ *     host = "sftp.partner.example.com"
+ *     port = 22
+ *     authMode = {
+ *       type = BasicAuthMode
+ *       user = "###ENV#SFTP_USER###"
+ *       password = "###ENV#SFTP_PASSWORD###"
+ *     }
+ *     maxParallelConnections = 4
+ *   }
+ * }
+ * }}}
+ *
+ * @note the host key of the server must be known (e.g. present in `~/.ssh/known_hosts`), otherwise the connection
+ *       fails unless `ignoreHostKeyVerification` is enabled.
  *
  * @param id unique id of this connection
  * @param host sftp host
@@ -118,6 +143,24 @@ object SFtpFileRefConnection extends FromConfigFactory[Connection] {
 
 /**
  * Proxy configuration to create java.net.Proxy instance.
+ * Use it if the SFTP server can only be reached through a forward proxy.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   sftp-partner {
+ *     type = SFtpFileRefConnection
+ *     host = "sftp.partner.example.com"
+ *     authMode = { type = PublicKeyAuthMode, user = "sdlb" }
+ *     proxy = {
+ *       host = "proxy.company.example.com"
+ *       port = 8080
+ *       proxyType = HTTP
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param host proxy host
  * @param port proxy port
  * @param proxyType Type of proxy: HTTP or SOCKS. Default is HTTP.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/ScalaConnection.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/ScalaConnection.scala
@@ -25,6 +25,27 @@ import io.smartdatalake.workflow.dataframe.plainScala.ScalaSubFeed
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe.typeOf
 
+/**
+ * Engine connection for the plain Scala execution engine.
+ *
+ * An [[EngineConnection]] declares which DataFrame engine an Action uses; this one selects the lightweight,
+ * Spark-free engine working on `ScalaSubFeed`. Pick it over `SparkClassicConnection` for small pipelines and
+ * unit tests where starting a Spark session is unnecessary overhead. Actions select an engine connection with
+ * their `engineConnectionId` attribute; if none is given the connection with id `default-engine` is used
+ * (configurable through the SDLB parameter `defaultEngineConnectionId`).
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   default-engine {
+ *     type = ScalaConnection
+ *   }
+ * }
+ * }}}
+ *
+ * @param id unique id of this connection, e.g. `default-engine`
+ * @param metadata additional metadata for this connection (name, description, layer, ...)
+ */
 case class ScalaConnection (
                              id: SdlConfigObject.ConnectionId,
                              metadata: Option[ConnectionMetadata] = None

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/AWSUserPwdAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/AWSUserPwdAuthMode.scala
@@ -36,12 +36,38 @@ import sttp.model.{Header, MediaType, Uri}
  * This first calls AWS Cognito InitiateAuth endpoint from the selected region to authenticate the user.
  * The tokens returned can then be refreshed with the corresponding token endpoint of the user pool.
  *
+ * Use this for HTTP endpoints protected by an AWS Cognito user pool, e.g. the SDLB UI backend.
+ * The authentication flow used is USER_PASSWORD_AUTH, so the app client of the user pool must have it enabled.
+ *
+ * Example:
+ * {{{
+ * global {
+ *   uiBackend {
+ *     baseUrl = "https://xxxxxxxxxx.execute-api.eu-central-1.amazonaws.com/DEV/api/v1"
+ *     repo = my-project
+ *     authMode = {
+ *       type = AWSUserPwdAuthMode
+ *       region = eu-central-1
+ *       userPool = sdlb-ui
+ *       clientId = "###FILE#ui-auth;clientId###"
+ *       user = "###FILE#ui-auth;user###"
+ *       password = "###FILE#ui-auth;pwd###"
+ *       useIdToken = true
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param region     AWS region
+ * @param userPool   Cognito domain prefix of the AWS Cognito user pool, e.g. "sdlb-ui" (not the user pool name and
+ *                   not the user pool id). It is used to build the token endpoint
+ *                   https://{userPool}.auth.{region}.amazoncognito.com/oauth2/token used to refresh tokens.
  * @param clientId   client id of the AWS application
  * @param user       user to login
  * @param password   password to use for login.
  * @param useIdToken If true, id_token is used for Http Authorization header, otherwise access_token. Default is false.
  * @param timeouts   configuration of HTTP timeouts. Default is connectionTimeout=500ms, readTimeout=1s.
+ * @param proxy      optional configuration of an HTTP proxy used for the Cognito and token requests.
  */
 case class AWSUserPwdAuthMode(region: String, userPool: String, clientId: StringOrSecret, user: StringOrSecret, password: StringOrSecret, useIdToken: Boolean = false,
                               timeouts: HttpTimeoutConfig = HttpTimeoutConfig(500, 1000),

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/AuthHeaderMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/AuthHeaderMode.scala
@@ -24,6 +24,30 @@ import io.smartdatalake.util.secrets.StringOrSecret
 
 /**
  * Authenticate using a custom HTTP header.
+ *
+ * Use this when the webservice expects its credential in a proprietary header like `X-API-KEY` instead of
+ * the standard `Authorization` header. The secret is sent verbatim as header value, so a scheme prefix such
+ * as "Basic " or "Bearer " must be part of the secret itself. Only usable for HTTP based connections and
+ * DataObjects.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-departures {
+ *     type = WebserviceFileDataObject
+ *     url = "https://opensky-network.org/api/flights/departure"
+ *     authMode = {
+ *       type = AuthHeaderMode
+ *       headerName = "X-API-KEY"
+ *       secret = "###ENV#API_KEY###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @param headerName name of the HTTP header to set, e.g. "X-API-KEY"
+ * @param secret     value to set as header content (supports secret providers)
+ * @see [[BasicAuthMode]] and [[TokenAuthMode]] for the standard `Authorization` header variants.
  */
 case class AuthHeaderMode(
     headerName: String,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/BasicAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/BasicAuthMode.scala
@@ -28,6 +28,30 @@ import java.util.Base64
  * Authenticate using basic user/pwd authentication.
  *
  * For http connection this will create a basic authentication header.
+ *
+ * This is the most commonly used authentication mode. It is the only AuthMode supported by JdbcTableConnection and
+ * DebeziumConnection, and one of the supported modes of SFtpFileRefConnection, SnowflakeConnection and HTTP based
+ * DataObjects. Note that no connection falls back to it implicitly - authMode has to be configured explicitly.
+ * Both user and password support secret providers, so credentials do not have to be stored in clear text in the
+ * configuration.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   sftp-src {
+ *     type = SFtpFileRefConnection
+ *     host = "sftp.example.com"
+ *     authMode = {
+ *       type = BasicAuthMode
+ *       user = "###ENV#SFTP_USER###"
+ *       password = "###ENV#SFTP_PWD###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @param user     user to login with (supports secret providers, e.g. "###ENV#SFTP_USER###")
+ * @param password password to login with (supports secret providers)
  */
 case class BasicAuthMode(
     private val user: StringOrSecret,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/CustomHttpAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/CustomHttpAuthMode.scala
@@ -27,6 +27,27 @@ import io.smartdatalake.util.secrets.StringOrSecret
 /**
  * Connect with custom HTTP-header based authentication
  *
+ * The configured class implements [[CustomHttpAuthModeLogic]] and returns the HTTP headers to add to every
+ * request; `options` are handed over once in the prepare phase, e.g. to acquire a token.
+ *
+ * Deprecated since 2.7.1: implement [[HttpAuthMode]] (or [[AuthMode]]) directly instead, which gives access
+ * to typed configuration attributes rather than an untyped option map.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-departures {
+ *     type = WebserviceFileDataObject
+ *     url = "https://opensky-network.org/api/flights/departure"
+ *     authMode = {
+ *       type = CustomHttpAuthMode
+ *       className = "com.example.auth.MyCustomHttpAuthMode"
+ *       options = { apiKey = "###ENV#API_KEY###" }
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param className class name implementing trait [[CustomHttpAuthModeLogic]]
  * @param options   Options to pass to the custom auth mode logic in prepare function.
  */

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/OAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/OAuthMode.scala
@@ -33,6 +33,30 @@ import sttp.model.{Header, MediaType}
 /**
  * [[OAuthMode]] contains the coordinates and credentials to gain access to the OData DataSource
  *
+ * Authenticates with the OAuth2 client_credentials flow: an access token is fetched from `oauthUrl` for the
+ * given `oauthScope` and cached until it expires, then refreshed automatically. Pick this over
+ * [[TokenAuthMode]] whenever tokens are short-lived and must be renewed during a run, e.g. for Microsoft
+ * Dynamics 365 / Dataverse, other OData or REST services, and SnowflakeConnection.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-tasks {
+ *     type = ODataDataObject
+ *     baseUrl = "https://myorg.crm4.dynamics.com/api/data/v9.2/"
+ *     tableName = "tasks"
+ *     schema = "activityid string, subject string, modifiedon string"
+ *     authMode = {
+ *       type = OAuthMode
+ *       oauthUrl = "https://login.microsoftonline.com/{tenant-guid}/oauth2/v2.0/token"
+ *       clientId = "###ENV#CRM_CLIENT_ID###"
+ *       clientSecret = "###ENV#CRM_CLIENT_SECRET###"
+ *       oauthScope = "https://myorg.crm4.dynamics.com/.default"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param oauthUrl URL to the OAuth2 authorization instance like "https://login.microsoftonline.com/{tenant-guid}/oauth2/v2.0/token" (supports secret providers)
  * @param clientId Name of the user (supports secrets providers)
  * @param clientSecret Password of the user (supports secret providers)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/PublicKeyAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/PublicKeyAuthMode.scala
@@ -24,6 +24,28 @@ import io.smartdatalake.util.secrets.StringOrSecret
 
 /**
  * Validate by user and private/public key Private key is read from .ssh
+ *
+ * Only the user name is configured; the private key is taken from the default ssh location (~/.ssh) of the
+ * process running SDLB, and the corresponding public key must be registered on the server. Choose this over
+ * [[BasicAuthMode]] to avoid storing a password in the configuration. Currently supported by
+ * SFtpFileRefConnection only.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   sftp-src {
+ *     type = SFtpFileRefConnection
+ *     host = "sftp.example.com"
+ *     authMode = {
+ *       type = PublicKeyAuthMode
+ *       user = "###ENV#SFTP_USER###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @param user user to login with (supports secret providers). Although declared optional for configuration
+ *             parsing, it must be defined, otherwise a ConfigurationException is thrown.
  */
 case class PublicKeyAuthMode(private val user: Option[StringOrSecret]) extends AuthMode {
   private[smartdatalake] val userSecret: StringOrSecret = user

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/SASLSCRAMAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/SASLSCRAMAuthMode.scala
@@ -25,7 +25,43 @@ import io.smartdatalake.util.secrets.StringOrSecret
 /**
  * Authenticate using SASL_SSL Authentication.
  *
- * Configuration needed are user, password and a Java truststore.
+ * Configuration needed are username and password, plus a Java truststore if the brokers certificate is not trusted
+ * by the default JVM truststore.
+ *
+ * Sets Kafka `security.protocol=SASL_SSL` and builds the corresponding `sasl.jaas.config`. Pick this over
+ * [[SSLCertsAuthMode]] if the broker authenticates users by name/password (SCRAM or PLAIN) rather than by
+ * client certificate. Currently supported by KafkaConnection only.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   kafka-con {
+ *     type = KafkaConnection
+ *     brokers = "kafka-broker-1:9093,kafka-broker-2:9093"
+ *     authMode = {
+ *       type = SASLSCRAMAuthMode
+ *       username = "###ENV#KAFKA_USER###"
+ *       password = "###ENV#KAFKA_PWD###"
+ *       sslMechanism = "SCRAM-SHA-512"
+ *       truststorePath = "/etc/kafka/secrets/kafka.truststore.jks"
+ *       truststorePassSecret = "###ENV#KAFKA_TRUSTSTORE_PWD###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @param username             user name to authenticate with (supports secret providers)
+ * @param password             password to authenticate with (supports secret providers). Although declared
+ *                             optional for configuration parsing, it must be defined, otherwise a
+ *                             ConfigurationException is thrown.
+ * @param sslMechanism         SASL mechanism to use, e.g. "SCRAM-SHA-512", "SCRAM-SHA-256" or "PLAIN". It is
+ *                             passed as Kafka `sasl.mechanism` and selects the JAAS login module
+ *                             (PlainLoginModule for "plain", ScramLoginModule otherwise).
+ * @param truststorePath       optional path to the Java truststore holding the brokers CA certificate. Only
+ *                             needed if the broker certificate is not trusted by the default JVM truststore.
+ * @param truststoreType       type of the truststore, e.g. "JKS" or "PKCS12" (default: "JKS")
+ * @param truststorePassSecret password of the truststore (supports secret providers). Mandatory if
+ *                             `truststorePath` is set.
  */
 case class SASLSCRAMAuthMode(
     username: StringOrSecret,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/SSLCertsAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/SSLCertsAuthMode.scala
@@ -26,6 +26,37 @@ import io.smartdatalake.util.secrets.StringOrSecret
  * Authenticate using SSL Certificates.
  *
  * Configuration needed are a Java keystore and truststore.
+ *
+ * Sets Kafka `security.protocol=SSL` and configures mutual TLS: the keystore holds the client certificate and
+ * private key presented to the broker, the truststore holds the CA certificate used to verify the broker.
+ * Pick this over [[SASLSCRAMAuthMode]] if the broker authenticates clients by certificate instead of
+ * user/password. Currently supported by KafkaConnection only.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   kafka-con {
+ *     type = KafkaConnection
+ *     brokers = "kafka-broker-1:9093,kafka-broker-2:9093"
+ *     authMode = {
+ *       type = SSLCertsAuthMode
+ *       keystorePath = "/etc/kafka/secrets/kafka.keystore.jks"
+ *       keystorePass = "###ENV#KAFKA_KEYSTORE_PWD###"
+ *       truststorePath = "/etc/kafka/secrets/kafka.truststore.jks"
+ *       truststorePass = "###ENV#KAFKA_TRUSTSTORE_PWD###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @param keystorePath   path to the Java keystore containing the client certificate and private key
+ * @param keystoreType   type of the keystore, e.g. "JKS" or "PKCS12" (default: "JKS")
+ * @param keystorePass   password of the keystore (supports secret providers). Although declared optional for
+ *                       configuration parsing, it must be defined, otherwise a ConfigurationException is thrown.
+ * @param truststorePath path to the Java truststore containing the CA certificate of the server
+ * @param truststoreType type of the truststore, e.g. "JKS" or "PKCS12" (default: "JKS")
+ * @param truststorePass password of the truststore (supports secret providers). Although declared optional for
+ *                       configuration parsing, it must be defined, otherwise a ConfigurationException is thrown.
  */
 case class SSLCertsAuthMode(
     keystorePath: String,

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/TokenAuthMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/connection/authMode/TokenAuthMode.scala
@@ -38,8 +38,30 @@ trait TokenAuth {
  *
  * For HTTP Connections the token is used as Authorization header.
  *
+ * The header is built as "tokenType token", e.g. "Authorization: Bearer eyJ...". Use this for services
+ * accessed with a long-living personal access token or API key. If the token has to be requested and
+ * refreshed during the run, use [[OAuthMode]] instead; if the credential goes into a non-standard header,
+ * use [[AuthHeaderMode]].
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-departures {
+ *     type = WebserviceFileDataObject
+ *     url = "https://opensky-network.org/api/flights/departure"
+ *     authMode = {
+ *       type = TokenAuthMode
+ *       token = "###ENV#API_TOKEN###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param tokenType
  *   token type to use in HTTP Authorization header. Default is "Bearer".
+ * @param token
+ *   token to authenticate with (supports secret providers). Although declared optional for configuration
+ *   parsing, it must be defined, otherwise a ConfigurationException is thrown.
  */
 case class TokenAuthMode(
     tokenType: String = "Bearer",

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/PKViolatorsDataObject.scala
@@ -40,17 +40,20 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * Example:
  * {{{
  * dataObjects = {
- *  ...
- *  primarykey-violations {
- *    type = PKViolatorsDataObject
- *    config = path/to/myconfiguration.conf
- *  }
- *  ...
+ *   primarykey-violations {
+ *     type = PKViolatorsDataObject
+ *     config = "path/to/myconfiguration.conf"
+ *     flattenOutput = true
+ *   }
  * }
  * }}}
  *
+ * @param id: unique name of this data object
  * @param config: The config value can point to a configuration file or a directory containing configuration files.
- * @param flattenOutput: if true, key and data column are converted from type map<k,v> to string (default).
+ *                Multiple locations can be given as comma separated list. If not defined, the DataObjects of the
+ *                current run's [[InstanceRegistry]] are checked.
+ * @param flattenOutput: if true, the key and data column are cast from their default type
+ *                       `array<struct<name,value>>` to string (default: false).
  *
  * @see Refer to [[ConfigLoader.loadConfigFromFilesystem()]] for details about the configuration loading.
  */

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/SFtpFileRefDataObject.scala
@@ -46,6 +46,31 @@ import scala.util.{Failure, Success, Try}
  * -> user/pwd authentication: user and password is taken from two variables set as parameters.
  *                             These variables could come from clear text (CLEAR), a file (FILE) or an environment variable (ENV)
  *
+ * Host, port and credentials are not configured here but in the referenced [[SFtpFileRefConnection]], so that they can
+ * be shared between multiple DataObjects. Files are only referenced, not parsed - use a FileTransferAction to copy
+ * them to/from another FileRefDataObject.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   sftp-src {
+ *     type = SFtpFileRefConnection
+ *     host = "sftp.example.com"
+ *     authMode = { type = BasicAuthMode, user = "###ENV#SFTP_USER###", password = "###ENV#SFTP_PWD###" }
+ *   }
+ * }
+ * dataObjects = {
+ *   ext-airports {
+ *     type = SFtpFileRefDataObject
+ *     path = "/data/airports"
+ *     connectionId = sftp-src
+ *     partitions = [year]
+ *     partitionLayout = "%year%/"
+ *   }
+ * }
+ * }}}
+ *
+ * @param connectionId id of the [[SFtpFileRefConnection]] defining host, port and authentication mode
  * @param partitionLayout partition layout defines how partition values can be extracted from the path.
  *                        Use "%<colname>%" as token to extract the value for a partition column.
  *                        As partition layout extracts partition from the path of individual files, it can also be used to extract partitions from the file name.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/WebserviceFileDataObject.scala
@@ -54,6 +54,23 @@ case class WebservicePartitionDefinition(name: String, values: Seq[String])
  * Query parameter (partitions) and possible values can be configured through `partitionDefs` attribute.
  * If no values are given for a query parameter, the values are taken from the partition values of the input SubFeed, e.g. the command line if it is the first Action in the DAG.
  *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-departures {
+ *     type = WebserviceFileDataObject
+ *     url = "https://opensky-network.org/api/flights/departure"
+ *     authMode = { type = BasicAuthMode, user = "###ENV#API_USER###", password = "###ENV#API_PWD###" }
+ *     followRedirects = true
+ *     retries = 3
+ *     partitionDefs = [
+ *       { name = airport, values = [LSZB, EDDF] }
+ *     ]
+ *     partitionLayout = "?airport=%airport%"
+ *   }
+ * }
+ * }}}
+ *
  * @param url URL of the webservice
  * @param additionalHeaders Additional headers to pass with the http request
  * @param timeouts optional configuration of HTTP timeouts

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLExpectation.scala
@@ -30,6 +30,32 @@ import io.smartdatalake.workflow.dataobject.expectation.ExpectationSeverity.Expe
 /**
  * Definition of expectation based on a SQL aggregate expression to evaluate on dataset-level.
  *
+ * This is the most generic [[Expectation]]: any SQL aggregate function supported by the calculation engine can be used.
+ * Its result is recorded as a metric named after the expectation, and validated against `expectation` if that is defined.
+ * Use it when none of the specialized expectations like [[SQLFractionExpectation]] or [[UniqueKeyExpectation]] fits.
+ * If the aggregate cannot be expressed as a single expression, use [[SQLQueryExpectation]] instead.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     expectations = [{
+ *       type = SQLExpectation
+ *       name = "avgRatingGt1"
+ *       description = "avg rating should be bigger than 1"
+ *       aggExpression = "avg(rating)"
+ *       expectation = "> 1"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note The expression is evaluated as a DataFrame observation for the default `scope = Job`, so it must be a valid
+ *       aggregate expression over the columns of the DataObject.
+ * @see [[SQLFractionExpectation]]
+ * @see [[SQLQueryExpectation]]
  * @param aggExpression SQL aggregate expression to evaluate on dataset, e.g. count(*).
  * @param expectation Optional SQL comparison operator and literal to define expected value for validation, e.g. '= 0".
  *                    Together with the result of the aggExpression evaluation on the left side, it forms the condition to validate the expectation.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLFractionExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLFractionExpectation.scala
@@ -33,6 +33,27 @@ import io.smartdatalake.workflow.dataobject.generic.ExpectationValidation
  * Definition of an expectation based on counting how many rows match an expression vs the number of all rows.
  * The fraction of these two counts is compared against a given expectation.
  *
+ * Use it for share-based data quality rules, e.g. "at most 1% of the records may have an unknown status", where an
+ * absolute count would depend on the size of the increment. Optionally restrict both counts to a subset of the data
+ * with `globalConditionExpression`, e.g. to ignore records that are known to be incomplete.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     expectations = [{
+ *       type = SQLFractionExpectation
+ *       name = "pctBob"
+ *       countConditionExpression = "firstname = 'bob'"
+ *       expectation = "= 0"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @see [[SQLExpectation]] for an expectation on an arbitrary aggregate expression.
  * @param countConditionExpression SQL expression returning a boolean to match the rows to count for the fraction.
  * @param globalConditionExpression SQL expression returning a boolean used as global filter, e.g. fraction row count and total row count are filtered with global filter before counting.
  * @param expectation Optional SQL comparison operator and literal to define expected percentage for validation, e.g. '= 0.9".

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLQueryExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/SQLQueryExpectation.scala
@@ -35,6 +35,29 @@ import io.smartdatalake.workflow.dataobject.expectation.ExpectationSeverity.Expe
  * The SQL query will be evaluated in a separate Spark job against the DataFrame.
  * It supports scope Job and All, but not JobPartition.
  *
+ * Use it when the check cannot be written as a single aggregate expression, e.g. because it needs a subquery,
+ * a `group by ... having`, or a join. Note that this costs an additional Spark job over the data, so prefer
+ * [[SQLExpectation]] whenever a plain aggregate expression is sufficient.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     expectations = [{
+ *       type = SQLQueryExpectation
+ *       name = "countOfPartitionsWith1Record"
+ *       code = "select count(*) from (select lastname from %{inputViewName} group by lastname having count(*) = 1)"
+ *       scope = All
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note `scope = JobPartition` is not supported and fails on initialization.
+ * @see [[SQLExpectation]]
+ * @see [[SQLFractionExpectation]]
  * @param code a SQL query returning a single row. All column will be added as metrics.
  *             If there are more than one column, there has to be one column with the same name as this expectation. This column will be used to compare against a potential condition of the expectation.
  *             The special token %{inputViewName} must be used to insert the temporary view name used to provide the DataFrame to the query.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/UniqueKeyExpectation.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/UniqueKeyExpectation.scala
@@ -35,6 +35,29 @@ import io.smartdatalake.workflow.dataobject.generic.TableDataObject
  * Uniqueness is calculated as the fraction of output count distinct on key columns over output count.
  * It supports scope Job and All, but not JobPartition.
  *
+ * Use it to assert that a primary key or business key has no duplicates. If `key` is left empty, the
+ * `table.primaryKey` of the DataObject is used, which requires the DataObject to be a `TableDataObject`
+ * with a primary key defined. Set `scope = All` to check uniqueness over the whole table instead of only
+ * the records written by the current job.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-airports {
+ *     type = DeltaLakeTableDataObject
+ *     path = "~{env.basedir}/int_airports"
+ *     table = { db = "default", name = "int_airports", primaryKey = [ident] }
+ *     expectations = [{
+ *       type = UniqueKeyExpectation
+ *       name = "primaryKeyTest"
+ *       scope = All
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note `scope = JobPartition` is not supported and fails on initialization.
+ *       The fraction is rounded down (floor), so any duplicate is detected aggressively.
  * @param key Optional list of key columns to evaluate uniqueness. If empty primary key definition of DataObject is used if present.
  * @param expectation Optional SQL comparison operator and literal to define expected value for validation. Default is '= 1'.
  *                    Together with the result of the aggExpression evaluation on the left side, it forms the condition to validate the expectation.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/HousekeepingMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/HousekeepingMode.scala
@@ -34,18 +34,39 @@ trait HousekeepingMode extends ParsableFromConfig[HousekeepingMode] with ConfigH
 }
 
 /**
- * Keep partitions while retention condition is fulfilled, delete other partitions. Example: cleanup
- * partitions with partition layout dt=<yyyymmdd> after 90 days:
+ * Keep partitions while retention condition is fulfilled, delete other partitions.
+ *
+ * The condition is evaluated after every write against all existing partitions of the DataObject, and every
+ * partition for which it returns false is deleted. Use it to implement a rolling time window on a partitioned
+ * DataObject. Use [[PartitionArchiveMode]] instead if old data should be kept but consolidated into fewer
+ * partitions.
+ *
+ * Example: cleanup partitions with partition layout dt=<yyyymmdd> after 90 days:
  * {{{
- * housekeepingMode = {
- *   type = PartitionRetentionMode
- *   retentionCondition = "datediff(now(), to_date(elements['dt'], 'yyyyMMdd')) <= 90"
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     partitions = [dt]
+ *     housekeepingMode = {
+ *       type = PartitionRetentionMode
+ *       retentionCondition = "datediff(now(), to_date(elements['dt'], 'yyyyMMdd')) <= 90"
+ *     }
+ *   }
  * }
  * }}}
+ *
+ * @note Only supported for DataObjects implementing `CanHandlePartitions`; this is asserted in the prepare phase.
+ *       If such a DataObject has no partition column defined, a ConfigurationException is thrown when housekeeping
+ *       runs after the write.
+ * @see [[PartitionArchiveMode]]
  * @param retentionCondition
  *   Condition to decide if a partition should be kept. Define a spark sql expression working with
  *   the attributes of [[PartitionExpressionData]] returning a boolean with value true if the
  *   partition should be kept.
+ * @param description
+ *   Optional description of this housekeeping mode, e.g. to document the business rule behind the
+ *   retention condition. It is not interpreted by SDLB.
  */
 case class PartitionRetentionMode(retentionCondition: String, description: Option[String] = None) extends HousekeepingMode
     with SmartDataLakeLogger {
@@ -86,21 +107,43 @@ object PartitionRetentionMode extends FromConfigFactory[HousekeepingMode] {
 
 /**
  * Archive old partitions: Archive partition reduces the number of partitions in the past by moving
- * older partitions into special "archive partitions". Example: archive a table with partition
- * layout run_id=<integer>
- *   - archive partitions after 1000 partitions into "archive partition" equal to floor(run_id/1000)
- *     {{{
- * housekeepingMode = {
- *   type = PartitionArchiveCompactionMode
- *   archivePartitionExpression = "if( elements['run_id'] < runId - 1000, map('run_id', elements['run_id'] div 1000), elements)"
+ * older partitions into special "archive partitions".
+ *
+ * Use it to avoid an ever growing number of small partitions for a DataObject that is loaded frequently, while still
+ * keeping the historical data. In contrast to [[PartitionRetentionMode]] no data is deleted, but the partition column
+ * values of the archived records change to the archive partition value. Note that files are relocated as they are and
+ * not merged, so the number of files stays the same.
+ *
+ * Example: archive a table with partition layout run_id=<integer>, moving partitions older than 1000 runs into an
+ * "archive partition" equal to floor(run_id/1000):
+ * {{{
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     partitions = [run_id]
+ *     housekeepingMode = {
+ *       type = PartitionArchiveMode
+ *       archivePartitionExpression = "if( elements['run_id'] < runId - 1000, map('run_id', elements['run_id'] div 1000), elements)"
+ *     }
+ *   }
  * }
- *     }}}
+ * }}}
+ *
+ * @note Only supported for DataObjects implementing `CanHandlePartitions`; this is asserted in the prepare phase.
+ *       If such a DataObject has no partition column defined, a ConfigurationException is thrown when housekeeping
+ *       runs after the write.
+ * @see [[PartitionRetentionMode]]
  * @param archivePartitionExpression
  *   Expression to define the archive partition for a given partition. Define a spark sql expression
  *   working with the attributes of [[PartitionExpressionData]] returning archive partition values
  *   as Map[String,String]. If return value is the same as input elements, partition is not touched,
  *   otherwise all files of the partition are moved to the returned partition definition. Be aware
  *   that the value of the partition columns changes for these files/records.
+ *   If not defined, no partition is archived.
+ * @param description
+ *   Optional description of this housekeeping mode, e.g. to document the archiving strategy.
+ *   It is not interpreted by SDLB.
  */
 case class PartitionArchiveMode(
     archivePartitionExpression: Option[String] = None,

--- a/sdl-debezium/src/main/scala/io/smartdatalake/workflow/connection/DebeziumConnection.scala
+++ b/sdl-debezium/src/main/scala/io/smartdatalake/workflow/connection/DebeziumConnection.scala
@@ -24,30 +24,41 @@ import io.smartdatalake.definitions.Environment
 import io.smartdatalake.workflow.connection.authMode.{AuthMode, BasicAuthMode}
 
 /**
- * Connection information for debezium connection
+ * Connection information for a Debezium change-data-capture (CDC) source database.
+ *
+ * It describes the source database server which the embedded Debezium engine connects to in order to read its
+ * transaction log. Use it together with `DebeziumCdcDataObject` to stream inserts/updates/deletes out of an
+ * operational database instead of repeatedly reading full tables over JDBC. The Debezium connector class is
+ * derived from `dbEngine` when the connector properties are assembled, e.g. when a `DebeziumCdcDataObject`
+ * starts reading. The connector must then be on the classpath, otherwise a `ClassNotFoundException` is thrown -
+ * add the corresponding optional maven dependency of the sdl-debezium module (e.g.
+ * `io.debezium:debezium-connector-postgres` for postgresql, `io.smartdatalake:debezium-connector-mysql-shaded`
+ * for mysql).
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   dbzCon {
+ *     type = DebeziumConnection
+ *     dbEngine = "postgresql"
+ *     hostname = "localhost"
+ *     port = 5432
+ *     db = "test"
+ *     authMode = {
+ *       type = BasicAuthMode
+ *       user = "###ENV#POSTGRES_USER###"
+ *       password = "###ENV#POSTGRES_PW###"
+ *     }
+ *   }
+ * }
+ * }}}
  *
  * @param id unique id of this connection
- * @param dbEngine what database engine to use, currently supported engines: mysql, postgresql, oracle, mariadb, mongodb, sqlserver, db2, vitess, spanner
+ * @param dbEngine what database engine to use, currently supported engines: mysql, postgresql, oracle, mariadb, sqlserver, db2.
  * @param hostname database server
- * @param db database to read data from
- * @param port
+ * @param db database to read data from. Optional, as some engines (e.g. mysql) do not need it.
+ * @param port port the database server listens on, e.g. 5432 for postgresql
  * @param authMode authentication information: for now BasicAuthMode is supported.
- * @param metadata optional connection metadata
- *
- *  Example config:
- *
- *  dbzCon {
- *  type = DebeziumConnection
- *  dbEngine = "postgresql"
- *  hostname = "localhost"
- *  db = "test"
- *  port = 5432
- *  authMode {
- *    type = BasicAuthMode
- *    userVariable = "ENV#POSTGRES_USER"
- *    passwordVariable  = "ENV#POSTGRES_PW"
- *   }
- *  }
  */
 case class DebeziumConnection(override val id: ConnectionId,
                               dbEngine: String,

--- a/sdl-debezium/src/main/scala/io/smartdatalake/workflow/dataobject/DebeziumCdcDataObject.scala
+++ b/sdl-debezium/src/main/scala/io/smartdatalake/workflow/dataobject/DebeziumCdcDataObject.scala
@@ -50,26 +50,46 @@ import scala.jdk.CollectionConverters._
  * Provides details to access Change data over Debezium Engine.
  * Note that this implementation is not yet tested on production, and must therefore be seen as experimental.
  *
+ * The DataObject runs an embedded Debezium engine to read the change events of one database table. The returned
+ * DataFrame contains the columns of the changed row, followed by two SDLB metadata columns: `__commit_event`
+ * (create, update_preimage, update_postimage, delete or read) and `__event_timestamp`. Debezium's own envelope
+ * fields (before, after, source, op, ...) are not part of the result. Read offsets are stored in SDLBs state, so it
+ * supports incremental output and should be used together with DataObjectStateIncrementalMode. Reading stops once no
+ * more events arrive within `maxWaitTimeAfterLastBatchMilliSeconds`. If no event arrives at all, `schemaMin` is used
+ * as fallback schema for the empty DataFrame.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   dbz-postgres {
+ *     type = DebeziumConnection
+ *     dbEngine = "postgresql"
+ *     hostname = "localhost"
+ *     port = 5432
+ *     db = "demo"
+ *     authMode = { type = BasicAuthMode, user = "###ENV#PG_USER###", password = "###ENV#PG_PWD###" }
+ *   }
+ * }
+ * dataObjects = {
+ *   src-test {
+ *     type = DebeziumCdcDataObject
+ *     connectionId = dbz-postgres
+ *     table = { db = "demo", name = "test" }
+ *     debeziumProperties = {
+ *       "plugin.name" = "pgoutput"
+ *       "schema.history.internal" = "io.debezium.storage.file.history.FileSchemaHistory"
+ *       "schema.history.internal.file.filename" = "/tmp/schemahistory.dat"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param id unique name of this data object
  * @param connectionId optional id of [[io.smartdatalake.workflow.connection.DebeziumConnection]]
  * @param table Source table to get change data from
  * @param debeziumProperties Properties for the specific Debezium connector
  * @param metadata (optional) data object metadata
  * @param maxWaitTimeAfterLastBatchMilliSeconds (optional) Waiting time interval for debezium to finish (when a batch arrived, the engine waits the defined interval for completion), default = 10 seconds
- *
- * Example config:
- *
- * Source {
- *	type = DebeziumCdcDataObject
- *	connectionId = "connection1"
- *	table = "Test"
- *	debeziumProperties = {
- *		"database.server.id" = "1234345345"
- *		"plugin.name" = "pgoutput"
- *		"schema.history.internal" = "io.debezium.storage.file.history.FileSchemaHistory"
- *		"schema.history.internal.file.filename" = "C://TEMP/schemahistory.dat"
- *	}
- * }
  */
 case class DebeziumCdcDataObject(override val id: DataObjectId,
                                  connectionId: ConnectionId,

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/connection/DeltaLakeTableConnection.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/connection/DeltaLakeTableConnection.scala
@@ -23,13 +23,33 @@ import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 
 /**
- * Connection information for DeltaLake tables
+ * Connection information for DeltaLake tables.
+ *
+ * It centralizes catalog, database and the base directory of the table files, so that DeltaLakeTableDataObjects
+ * referencing it through `connectionId` do not need to repeat them. Catalog and db of the DataObjects `table` are
+ * taken from this connection, and the DataObjects `path` is resolved relative to `pathPrefix`. This keeps
+ * environment specific storage locations out of the DataObject definitions.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   deltalake-int {
+ *     type = DeltaLakeTableConnection
+ *     db = "integration"
+ *     pathPrefix = "~{env.basedir}/deltalake"
+ *   }
+ * }
+ * }}}
+ *
+ * @note the database given in `db` must already exist; SDLB does not create it.
  *
  * @param id unique id of this connection
  * @param catalog optional catalog to be used for this connection
  * @param db hive db
  * @param pathPrefix schema, authority and base path for tables directory on hadoop
- * @param metadata
+ * @param checkDeltaLakeSparkOptions if true (default) it is verified on prepare that the Spark session registers
+ *                                   `io.delta.sql.DeltaSparkSessionExtension` in `spark.sql.extensions`.
+ *                                   Set to false to skip this check. The check is skipped automatically on Databricks.
  */
 case class DeltaLakeTableConnection(override val id: ConnectionId,
                                     catalog: Option[String] = None,

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -71,6 +71,23 @@ import scala.util.Try
  * - [[CanEvolveSchema]] by using mergeSchema option.
  * - Overwriting partitions is implemented by replaceWhere option in one transaction.
  *
+ * Use this DataObject instead of a plain file DataObject if you need ACID transactions, merge (upsert) or schema
+ * evolution on a table.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-airports {
+ *     type = DeltaLakeTableDataObject
+ *     path = "~{env.basedir}/int_airports"
+ *     table = { db = "default", name = "int_airports", primaryKey = [ident] }
+ *     saveMode = Merge
+ *     allowSchemaEvolution = true
+ *     retentionPeriod = 168
+ *   }
+ * }
+ * }}}
+ *
  * @param id unique name of this data object
  * @param path Optional hadoop directory for this table. If path is not defined, table is handled as a managed table.
  *             If it doesn't contain scheme and authority, the connections pathPrefix is applied.
@@ -108,6 +125,13 @@ import scala.util.Try
  * @param connectionId optional id of [[io.smartdatalake.workflow.connection.HiveTableConnection]]
  * @param metadata metadata of the table. NOTE: if the value metadata.description is set, the table.db and the table.catalog
  *                  attributes are required as the pipeline will try to add the description to the catalog.
+ *
+ * @note DeltaLake needs the spark properties spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension and
+ *       spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog. They are added automatically
+ *       by DeltaLakeModulePlugin when SDLB creates the SparkSession (except on Databricks, where they are preset),
+ *       so normally no manual configuration is needed.
+ * @see [[io.smartdatalake.workflow.connection.DeltaLakeTableConnection]] to share catalog, db and path prefix between
+ *      multiple DeltaLake DataObjects.
  */
 case class DeltaLakeTableDataObject(override val id: DataObjectId,
                                     path: Option[String] = None,

--- a/sdl-gcp/src/main/scala/io/smartdatalake/workflow/connection/BigQueryTableConnection.scala
+++ b/sdl-gcp/src/main/scala/io/smartdatalake/workflow/connection/BigQueryTableConnection.scala
@@ -32,16 +32,37 @@ import java.util.Base64
 import scala.io.Source
 
 /**
- * Connection information for GCP BigQuery Tables
+ * Connection information for GCP BigQuery Tables.
+ *
+ * It holds the GCP project used for billing/API access and the service account credentials shared by all
+ * BigQueryTableDataObjects referencing it through `connectionId`. The credentials are also used to build a
+ * BigQuery client for metadata operations (e.g. checking table existence), so a connection is required to read
+ * or write BigQuery tables.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   google-playground {
+ *     type = BigQueryTableConnection
+ *     parentProject = "playground-223717"
+ *     authMode = {
+ *       type = GCPCredentialsKeyAuth
+ *       serviceAccountKeyFile = "~{env.basedir}/playground-223717-key.json"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note authentication is only supported with [[GCPCredentialsKeyAuth]]; any other AuthMode is rejected on
+ *       instantiation.
  *
  * @param id unique id of this connection
- * @param parentProject project used for this connection. It is defined as the GCP Project ID of the table
- *                      to bull for the export. It defaults to the project of the Service Account being used
- *                      in the credentials.
+ * @param parentProject GCP Project ID to be billed for the BigQuery jobs of this connection. It is passed to the
+ *                      BigQuery Spark connector as `parentProject` option and is mandatory, e.g. it is not
+ *                      derived from the Service Account of the credentials.
  * @param authMode Credentials to be used for this connection using [[GCPCredentialsKeyAuth]]
  *                 As of now, only Service Account keys (either as encoded Strings or as json-files)
  *                 are supported as an authentication method.
- * @param metadata
  */
 case class BigQueryTableConnection(override val id: ConnectionId,
                                    val authMode: AuthMode,

--- a/sdl-gcp/src/main/scala/io/smartdatalake/workflow/connection/authMode/GCPCredentialsKeyAuth.scala
+++ b/sdl-gcp/src/main/scala/io/smartdatalake/workflow/connection/authMode/GCPCredentialsKeyAuth.scala
@@ -26,6 +26,25 @@ import io.smartdatalake.util.secrets.StringOrSecret
  * Authorization parameters to access a GCP-ressource using Service Account Keys.
  * A Service Account Key can be either read as Base64-encoded JSON file (String),
  * or as a path containing the JSON-File with the key, as described by Google. Only one of the options should be provided.
+ *
+ * Exactly one of `serviceAccountKey` and `serviceAccountKeyFile` must be set. Configuring both is rejected with a
+ * ConfigurationException in the prepare phase, configuring none already fails while BigQueryTableConnection is
+ * instantiated during config parsing. Currently supported by BigQueryTableConnection only.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   google-playground {
+ *     type = BigQueryTableConnection
+ *     parentProject = "playground-223717"
+ *     authMode = {
+ *       type = GCPCredentialsKeyAuth
+ *       serviceAccountKeyFile = "/etc/secrets/playground-223717-7baadcb4cfef.json"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param serviceAccountKey A String that represents the Service Account Key encoded in Base64.
  * @param serviceAccountKeyFile A path that represents the location of the JSON-file with the service account key.
  */

--- a/sdl-gcp/src/main/scala/io/smartdatalake/workflow/dataobject/BigQueryTableDataObject.scala
+++ b/sdl-gcp/src/main/scala/io/smartdatalake/workflow/dataobject/BigQueryTableDataObject.scala
@@ -41,6 +41,32 @@ import org.apache.spark.sql.DataFrame
  * Provides details to access BigQuery Tables to an Action.
  * The object uses the official Spark-connector by Google see: [[https://github.com/GoogleCloudDataproc/spark-bigquery-connector]].
  * As of now, the only authentication mode supported is a Service Account Key.
+ *
+ * A [[io.smartdatalake.workflow.connection.BigQueryTableConnection]] is required, as it holds the service account key
+ * used to authenticate. The table can either be read directly (table.name/table.db) or through a SQL query
+ * (table.query), in which case viewsEnabled must be true and BigQuery materializes a temporary table.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   google-playground {
+ *     type = BigQueryTableConnection
+ *     parentProject = "playground-223717"
+ *     authMode = { type = GCPCredentialsKeyAuth, serviceAccountKeyFile = "/secrets/playground-sa-key.json" }
+ *   }
+ * }
+ * dataObjects = {
+ *   int-test-table {
+ *     type = BigQueryTableDataObject
+ *     connectionId = google-playground
+ *     project = "playground-223717"
+ *     table = { db = "sdl_playground", name = "test_table" }
+ *     writeMethod = "indirect"
+ *     temporaryGcsBucket = "sdl-playground-tmp"
+ *   }
+ * }
+ * }}}
+ *
  * @param id unique name of this data object
  * @param table BigQuery table to by written by this output. BigQuery requires a table name and a dataset.
  * @param viewsEnabled Required if the table is being read with a query, as BigQuery will create a temporary table in the background.

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/connection/IcebergTableConnection.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/connection/IcebergTableConnection.scala
@@ -23,7 +23,26 @@ import io.smartdatalake.config.SdlConfigObject.ConnectionId
 import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 
 /**
- * Connection information for DeltaLake tables
+ * Connection information for Iceberg tables.
+ *
+ * It centralizes catalog, database and the base directory of the table files, so that IcebergTableDataObjects
+ * referencing it through `connectionId` do not need to repeat them. Catalog and db of the DataObjects `table` are
+ * taken from this connection, and the DataObjects `path` is resolved relative to `pathPrefix`. This keeps
+ * environment specific storage locations out of the DataObject definitions.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   iceberg-int {
+ *     type = IcebergTableConnection
+ *     db = "integration"
+ *     pathPrefix = "~{env.basedir}/iceberg"
+ *     addFilesParallelism = 8
+ *   }
+ * }
+ * }}}
+ *
+ * @note the database given in `db` must already exist; SDLB does not create it.
  *
  * @param id unique id of this connection
  * @param catalog optional catalog to be used for this connection

--- a/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-iceberg/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -80,6 +80,25 @@ import scala.util.{Failure, Success, Try}
  * - [[CanEvolveSchema]] by using internal Iceberg API.
  * - Overwriting partitions is implemented by using DataFrameWriterV2.overwrite(condition) API in one transaction.
  *
+ * Pick this DataObject over a plain file DataObject if you need ACID transactions, merge (upsert), schema evolution
+ * or snapshot expiration on a table, and over DeltaLakeTableDataObject if your platform standardizes on Iceberg.
+ * Note that `partitions` are always mapped to Iceberg identity transforms; other Iceberg partition transforms
+ * (bucket, truncate, days, ...) cannot be configured from SDLB.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-airports {
+ *     type = IcebergTableDataObject
+ *     path = "~{env.basedir}/int_airports"
+ *     table = { db = "default", name = "int_airports", primaryKey = [ident] }
+ *     partitions = [country]
+ *     saveMode = Merge
+ *     allowSchemaEvolution = true
+ *   }
+ * }
+ * }}}
+ *
  * @param path                   hadoop directory for this table. If it doesn't contain scheme and authority, the connections pathPrefix is applied.
  *                               If pathPrefix is not defined or doesn't define scheme and authority, default schema and authority is applied.
  *                               If Iceberg table is defined on a hadoop catalog, path must be None as it is defined through the catalog directory structure.
@@ -98,6 +117,10 @@ import scala.util.{Failure, Success, Try}
  *                               explicitly defined, the ones present in the configured "table" object are used.
  * @param postWriteSql           SQL-statement to be executed in exec phase after writing output table. If the catalog and/or schema are not
  *                               explicitly defined, the ones present in the configured "table" object are used.
+ *
+ * @note If the Iceberg table is defined on a hadoop catalog, `path` must not be set as it is derived from the catalog
+ *       directory structure.
+ * @see [[IcebergTableConnection]] to share catalog, db and path prefix between multiple Iceberg DataObjects.
  */
 case class IcebergTableDataObject(override val id: DataObjectId,
                                   path: Option[String] = None,

--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/connection/KafkaConnection.scala
@@ -31,7 +31,30 @@ import java.util.Properties
 import scala.jdk.CollectionConverters._
 
 /**
- * Connection information for kafka
+ * Connection information for kafka.
+ *
+ * It holds the bootstrap servers, the optional Confluent schema registry url and the authentication settings
+ * shared by all KafkaTopicDataObjects referencing it through `connectionId`. The authentication settings are used
+ * both for the Spark Kafka data source (options prefixed with `kafka.`) and for the Kafka AdminClient which SDLB
+ * uses to validate that a topic exists. Configure `schemaRegistry` if topics use Confluent Avro/Json
+ * schema-registry serialization.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   kafka-int {
+ *     type = KafkaConnection
+ *     brokers = "broker1.example.com:9092,broker2.example.com:9092"
+ *     schemaRegistry = "https://schemaregistry.example.com"
+ *     authMode = {
+ *       type = SASLSCRAMAuthMode
+ *       username = "###ENV#KAFKA_USER###"
+ *       password = "###ENV#KAFKA_PASSWORD###"
+ *       sslMechanism = "SCRAM-SHA-512"
+ *     }
+ *   }
+ * }
+ * }}}
  *
  * @param id
  *   unique id of this connection
@@ -42,7 +65,9 @@ import scala.jdk.CollectionConverters._
  * @param options
  *   Options for the Kafka stream reader (see
  *   https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html)
- * @param metadata
+ * @param authMode
+ *   optional authentication information. Only SASLSCRAMAuthMode and SSLCertsAuthMode are supported; if not set,
+ *   an unauthenticated PLAINTEXT connection is used.
  */
 case class KafkaConnection(
     override val id: ConnectionId,

--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/dataobject/KafkaTopicDataObject.scala
@@ -104,7 +104,29 @@ private object TemporalQueries {
  *
  * Support incremental output and use with DataObjectStateIncrementalMode.
  *
+ * Example:
+ * {{{
+ * connections = {
+ *   kafka-con {
+ *     type = KafkaConnection
+ *     brokers = "localhost:9092"
+ *     schemaRegistry = "http://localhost:8081"
+ *   }
+ * }
+ * dataObjects = {
+ *   stg-departures {
+ *     type = KafkaTopicDataObject
+ *     topicName = "departures"
+ *     connectionId = kafka-con
+ *     valueType = AvroSchemaRegistry
+ *     selectCols = ["value.*", "timestamp"]
+ *   }
+ * }
+ * }}}
+ *
  * @param topicName The name of the topic to read
+ * @param connectionId id of the [[io.smartdatalake.workflow.connection.KafkaConnection]] defining brokers, schema registry and authentication.
+ *                     A schemaRegistry must be configured in the connection if keyType or valueType is set to Json/AvroSchemaRegistry.
  * @param keyType    Optional type the key column should be converted to. If none is given it will be interpreted as string.
  * @param keySchema  An optional schema for parsing the key column. This can be used if keyType = JSON or Avro to parse the corresponding content.
  *                   Define the schema by using one of the schema providers DDL, jsonSchemaFile, avroSchemaFile, xsdFile or caseClassName.

--- a/sdl-kafka/src/main/scala/io/smartdatalake/workflow/executionMode/KafkaStateIncrementalMode.scala
+++ b/sdl-kafka/src/main/scala/io/smartdatalake/workflow/executionMode/KafkaStateIncrementalMode.scala
@@ -31,6 +31,32 @@ import java.sql.Timestamp
 
 /**
  * A special incremental execution mode for Kafka Inputs, remembering the state from the last increment through the Kafka Consumer, e.g. committed offsets.
+ *
+ * The state is not kept in the SDLB run state but as committed consumer group offsets in Kafka itself, so no state
+ * store is needed and the Action can be run without `--state-path`. Offsets are only committed after the Action
+ * succeeded, so a failed run is re-read on the next attempt. Pick this over
+ * [[io.smartdatalake.workflow.action.executionMode.DataFrameIncrementalMode]] whenever the input is a
+ * [[io.smartdatalake.workflow.dataobject.KafkaTopicDataObject]], as it avoids reading a comparison value from the output.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-departures {
+ *     type = CopyAction
+ *     inputId = ext-departures-kafka
+ *     outputId = stg-departures
+ *     executionMode = {
+ *       type = KafkaStateIncrementalMode
+ *       delayedMaxTimestampExpr = "timestamp_seconds(unix_seconds(now()) - 10)"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note At least one input DataObject of the Action must be a
+ *       [[io.smartdatalake.workflow.dataobject.KafkaTopicDataObject]], otherwise initialization fails.
+ *       The input KafkaTopicDataObject must set the `groupIdPrefix` option, as it is used as prefix for the Kafka
+ *       consumer group id in which the offsets are committed.
  * @param delayedMaxTimestampExpr Optional expression to define a delay to read latest offsets from Kafka. The expression has to return a timestamp which is used to select ending offsets to read from Kafka.
  *                                Define a spark sql expression working with the attributes of [[DefaultExpressionData]] returning a timestamp.
  *                                Default is to read latest offsets existing in Kafka.

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/action/snowflake/transformer/ScalaClassSnowparkDfTransformer.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/action/snowflake/transformer/ScalaClassSnowparkDfTransformer.scala
@@ -38,6 +38,29 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * Define a transform function which receives a DataObjectId, a DataFrame and a map of options and has to return a
  * DataFrame. The Java/Scala class has to implement interface [[CustomSnowparkDfTransformer]].
  *
+ * The transformation is pushed down to Snowflake and executed by Snowpark, so no data is transferred to the Spark
+ * driver or executors. It can be combined in the same `transformers` list with generic transformers like
+ * SQLDfTransformer or ColumnsTransformer, as long as input and output DataObjects are Snowflake tables.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-snowpark {
+ *     type = CopyAction
+ *     inputId = sf-airports-stg
+ *     outputId = sf-airports
+ *     transformers = [{
+ *       type = ScalaClassSnowparkDfTransformer
+ *       className = com.company.transformer.CleanAirportsSnowparkTransformer
+ *       options = { minRating = "3" }
+ *       runtimeOptions = { appName = "application" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note Input and output DataObject must be of type SnowflakeTableDataObject, as the Snowpark session is taken from
+ *       the Action's first input. The class given in `className` must be on the classpath of the SDLB job.
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param className      class name implementing trait [[CustomSnowparkDfTransformer]]

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/action/snowflake/transformer/ScalaClassSnowparkDfsTransformer.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/action/snowflake/transformer/ScalaClassSnowparkDfsTransformer.scala
@@ -35,10 +35,32 @@ import io.smartdatalake.workflow.dataobject.SnowflakeTableDataObject
 import scala.reflect.runtime.universe.{Type, typeOf}
 
 /**
- * Configuration of a custom Spark-DataFrame transformation between many inputs and many outputs (n:m)
+ * Configuration of a custom Snowpark-DataFrame transformation between many inputs and many outputs (n:m) as Java/Scala Class.
  * Define a transform function which receives a map of input DataObjectIds with DataFrames and a map of options and as
  * to return a map of output DataObjectIds with DataFrames, see also trait [[CustomSnowparkDfsTransformer]].
  *
+ * Use this transformer to implement joins or splits between several Snowflake tables in Scala/Java code, which is
+ * pushed down to Snowflake and executed by Snowpark. If a single input and output is sufficient, prefer the simpler
+ * [[ScalaClassSnowparkDfTransformer]].
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-snowpark {
+ *     type = CustomDataFrameAction
+ *     inputIds = [sf-airports, sf-departures]
+ *     outputIds = [sf-departures-enriched]
+ *     transformers = [{
+ *       type = ScalaClassSnowparkDfsTransformer
+ *       className = com.company.transformer.JoinDeparturesSnowparkTransformer
+ *       options = { joinType = "left" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note All input and output DataObjects must be of type SnowflakeTableDataObject, as the Snowpark session is taken
+ *       from the Action's first input. The returned map must be keyed by the output DataObject ids.
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param className      class name implementing trait [[CustomSnowparkDfsTransformer]]

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/connection/SnowflakeConnection.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/connection/SnowflakeConnection.scala
@@ -37,6 +37,30 @@ import java.sql.{Connection => SqlConnection}
  * The connection can be used for SnowflakeTableDataObjects
  * If multiple SnowflakeTableDataObjects share a connection, they share the same Snowpark session
  *
+ * Beside the Snowpark session it also maintains a JDBC connection pool used for metadata and DDL queries
+ * (e.g. checking table existence, pre/postSQL). The schema is not part of the connection - it is taken from
+ * `table.db` of the referencing SnowflakeTableDataObject, so one connection can serve multiple schemas.
+ * Authentication is supported with BasicAuthMode (user/password) or OAuthMode; any other AuthMode is rejected
+ * on instantiation.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   sfCon {
+ *     type = SnowflakeConnection
+ *     url = "https://myaccount.snowflakecomputing.com"
+ *     warehouse = "COMPUTE_WH"
+ *     database = "TEST_DB"
+ *     role = "SDLB_ROLE"
+ *     authMode = {
+ *       type = BasicAuthMode
+ *       user = "###ENV#SNOWFLAKE_USER###"
+ *       password = "###ENV#SNOWFLAKE_PASSWORD###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param id        unique id of this connection
  * @param url       Snowflake connection url
  * @param warehouse Snowflake namespace
@@ -45,7 +69,6 @@ import java.sql.{Connection => SqlConnection}
  * @param authMode  optional authentication information: for now BasicAuthMode is supported.
  * @param proxy     optional HTTP Proxy for Snowflake connection (Jdbc & Snowpark)
  * @param sparkOptions Options for the Snowflake Spark Connector, see https://docs.snowflake.com/en/user-guide/spark-connector-use#additional-options.
- * @param metadata  Connection metadata
  */
 case class SnowflakeConnection(override val id: ConnectionId,
                                url: String,

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -62,6 +62,22 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * Note 3: case-insensitive column names are all uppercase in Snowflake tables. This is opposite from Spark when Spark is in case-insensitive mode (see also `Environment.caseSensitive`)
  * If `Environment.caseSensitive=false` then SDLB converts all case-insensitive column names to lowercase when reading from Snowflake with Spark Connector.
  *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   tgt-airports {
+ *     type = SnowflakeTableDataObject
+ *     connectionId = sf-con
+ *     table {
+ *       db = "test_schema"
+ *       name = "airports"
+ *     }
+ *     virtualPartitions = [dt]
+ *     saveMode = Append
+ *   }
+ * }
+ * }}}
+ *
  * @param id           unique name of this data object
  * @param table        Snowflake table to be written by this output
  * @param constraints  List of row-level [[Constraint]]s to enforce when writing to this data object.

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/CustomFileAction.scala
@@ -39,6 +39,30 @@ import scala.util.Using
  * The transformation is executed in distributed mode on Spark executors.
  * A custom file transformer must be given, which reads a file from Hadoop and writes it back to Hadoop.
  *
+ * Use this Action if files must be processed as files (byte or line streams), e.g. to unzip, decrypt or repair a file
+ * format Spark can not read. The list of files to transfer is created on the driver and then distributed to the
+ * executors, where the transformer gets the input stream and the output stream of one file at a time. If the content
+ * can be read as a DataFrame, prefer [[CopyAction]], if the files only need to be moved unchanged prefer
+ * [[FileTransferAction]].
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   transform-airports {
+ *     type = CustomFileAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformer = {
+ *       className = com.company.transformer.CutColumnsFileTransformer
+ *       options = { delimiter = "," }
+ *     }
+ *     filesPerPartition = 5
+ *   }
+ * }
+ * }}}
+ *
+ * @note inputId must be a HadoopFileDataObject and outputId a SparkFileDataObject, and the transformer code must be
+ *       serializable as it is shipped to the Spark executors.
  * @param inputId inputs DataObject
  * @param outputId output DataObject
  * @param transformer a custom file transformer, which reads a file from HadoopFileDataObject and writes it back to another HadoopFileDataObject

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/executionMode/FileIncrementalMoveMode.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/executionMode/FileIncrementalMoveMode.scala
@@ -42,6 +42,27 @@ import org.apache.spark.sql.Row
  * A better implementation would be to observe files by a custom metric. Unfortunately there is a problem in Spark with that, see also [[CollectSetDeterministic]]
  * - Partition values preserved.
  *
+ * Use this mode for "process once and clean up" file pipelines, e.g. an inbound directory which is emptied by every
+ * run. No state needs to be persisted, because the presence of a file is the state. If there is no file to process,
+ * a NoDataToProcessWarning is raised and the following actions are skipped.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   transfer-airports {
+ *     type = FileTransferAction
+ *     inputId = ext-airports
+ *     outputId = stg-airports
+ *     executionMode = {
+ *       type = FileIncrementalMoveMode
+ *       archivePath = "_archive"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note Files are deleted after processing unless `archivePath` is set. Make sure the action really succeeded before
+ *       relying on this mode, as the source files are gone afterwards.
  * @param archivePath if an archive directory is configured, files are moved into that directory instead of deleted, preserving partition layout. See also `archiveInsidePartition` option.
  *                    If this is a relative path, e.g. "_archive", it is appended after the path of the DataObject.
  *                    If this is an absolute path it replaces the path of the DataObject.

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/executionMode/SparkStreamingMode.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/executionMode/SparkStreamingMode.scala
@@ -38,6 +38,26 @@ import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
  * synchronously in the DAG by using triggerType=Once, or asynchronously as Streaming Query with
  * triggerType = ProcessingTime or Continuous.
  *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-departures {
+ *     type = CopyAction
+ *     inputId = stg-departures
+ *     outputId = int-departures
+ *     executionMode = {
+ *       type = SparkStreamingMode
+ *       checkpointLocation = "~{env.basedir}/checkpoints/copy-departures"
+ *       triggerType = ProcessingTime
+ *       triggerTime = "10 seconds"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note The checkpoint location holds the streaming state. Deleting it makes the query restart from the source's
+ *       configured starting position (which for some sources, e.g. Kafka with startingOffsets=latest, skips data
+ *       instead of reprocessing it); two actions must never share the same location.
  * @param checkpointLocation
  *   location for checkpoints of streaming query to keep state
  * @param triggerType
@@ -53,6 +73,10 @@ import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, Trigger}
  * @param outputOptions
  *   additional option to apply when writing to streaming sink. This overwrites options set by the
  *   DataObjects.
+ * @param outputMode
+ *   output mode of the streaming query. Possible values are append (default), complete and update.
+ *   See [[OutputMode]] for details. Note that complete and update are only supported by sinks and
+ *   queries which can handle them, e.g. an aggregation query writing to a Delta Lake table.
  */
 case class SparkStreamingMode(
     checkpointLocation: String,

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/DecryptColumnsTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/DecryptColumnsTransformer.scala
@@ -31,11 +31,36 @@ import org.apache.spark.sql.DataFrame
 /**
  * Decryption of specified columns using AES/GCM algorithm.
  *
+ * Use this transformer to read back data that was written with [[EncryptColumnsTransformer]]. The listed columns are
+ * decrypted in place, keeping name and position; all other columns are passed through unchanged. The columns must be of
+ * type string and contain the cipher text produced by the same algorithm and the same key, otherwise decryption fails
+ * or returns garbage.
+ *
+ * Note that the key should not be written into the configuration in clear text, but referenced as a secret, e.g.
+ * `###ENV#CRYPT_KEY###`. See [[EncryptColumnsTransformer]] for the write side.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   dec-customers {
+ *     type = CopyAction
+ *     inputId = enc-customers
+ *     outputId = int-customers
+ *     transformers = [{
+ *       type = DecryptColumnsTransformer
+ *       decryptColumns = ["email", "phone"]
+ *       key = "###ENV#CRYPT_KEY###"
+ *       algorithm = "GCM"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param decryptColumns List of columns [columnA, columnB] to be encrypted
- * @param key            contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
- *                       e.g. ENV#<ENV_VARIABLE_NAME> to get a secret from an environment variable OR CLEAR#mYsEcReTkeY
+ * @param key            contains the id of the provider and the name of the secret with format ###<PROVIDERID>#<SECRETNAME>###,
+ *                       e.g. ###ENV#<ENV_VARIABLE_NAME>### to get a secret from an environment variable OR ###CLEAR#mYsEcReTkeY###
  * @param algorithm      Specify: "GCM" (AES/GCM/NoPadding), "ECB" (AES/ECB/PKCS5Padding),
  *                       alternatively a class name extending trait EncryptDecrypt can be provided. DEFAULT: GCM
  */

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/EncryptColumnsTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/EncryptColumnsTransformer.scala
@@ -31,11 +31,40 @@ import org.apache.spark.sql.DataFrame
 /**
  * Encryption of specified columns using AES/GCM algorithm.
  *
+ * Use this transformer to pseudonymize sensitive attributes before they are persisted. The listed columns are replaced
+ * by their cipher text at the same position and get data type String, all other columns are passed through unchanged.
+ * The original data type is remembered in the column metadata, so that [[DecryptColumnsTransformer]] can restore it on
+ * read. Note that this only works if the output format preserves column metadata (Parquet, Hive, Delta, Iceberg); with
+ * formats like CSV the original data type is lost and the decrypted columns stay String.
+ * Choose "GCM" (randomized, recommended) unless you need deterministic cipher text for joins or deduplication, in which
+ * case use "ECB".
+ *
+ * Note that the key should not be written into the configuration in clear text, but referenced as a secret, e.g.
+ * `###ENV#CRYPT_KEY###`. The same key and algorithm are needed to read the data back, see
+ * [[DecryptColumnsTransformer]].
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   enc-customers {
+ *     type = CopyAction
+ *     inputId = stg-customers
+ *     outputId = enc-customers
+ *     transformers = [{
+ *       type = EncryptColumnsTransformer
+ *       encryptColumns = ["email", "phone"]
+ *       key = "###ENV#CRYPT_KEY###"
+ *       algorithm = "GCM"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param encryptColumns List of columns [columnA, columnB] to be encrypted
- * @param key            contains the id of the provider and the name of the secret with format <PROVIDERID>#<SECRETNAME>,
- *                       e.g. ENV#<ENV_VARIABLE_NAME> to get a secret from an environment variable OR CLEAR#mYsEcReTkeY
+ * @param key            contains the id of the provider and the name of the secret with format ###<PROVIDERID>#<SECRETNAME>###,
+ *                       e.g. ###ENV#<ENV_VARIABLE_NAME>### to get a secret from an environment variable OR ###CLEAR#mYsEcReTkeY###
  * @param algorithm      Specify: "GCM" (AES/GCM/NoPadding), "ECB" (AES/ECB/PKCS5Padding),
  *                       alternatively a class name extending trait EncryptDecrypt can be provided. DEFAULT: GCM
  */

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfTransformer.scala
@@ -41,6 +41,29 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * - `dataObjectId`: Id of input dataObject as String
  * Output DataFrame must be set with `setOutputDf(df)`.
  *
+ * Either `code` (inline PySpark code, best for a few lines) or `file` (a path to a `.py` file, best for longer logic
+ * and unit-testable code) must be defined. Prefer [[ScalaClassSparkDfTransformer]] or an SQL transformer if you do not
+ * specifically need Python libraries, as starting the Python gateway adds overhead per Action.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   select-airports {
+ *     type = CopyAction
+ *     inputId = stg-airports
+ *     outputId = int-airports
+ *     transformers = [{
+ *       type = PythonCodeDfTransformer
+ *       code = """
+ *         from pyspark.sql.functions import col
+ *         setOutputDf(inputDf.where(col('country') == options['country']))
+ *       """
+ *       options = { country = "CH" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param file           Optional file with python code to use for python transformation. The python code can use variables inputDf, dataObjectId and options. The transformed DataFrame has to be set with setOutputDf.

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfsTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/PythonCodeSparkDfsTransformer.scala
@@ -42,6 +42,29 @@ import scala.jdk.CollectionConverters._
  * - `options`: Transformation options as Map[String,String]
  * Output DataFrames must be set with `setOutputDfs(dict)`.
  *
+ * `inputDfs` is a dict keyed by input DataObjectId, and the dict passed to `setOutputDfs` must be keyed by output
+ * DataObjectId. Either `code` (inline PySpark code) or `file` (a path to a `.py` file) must be defined. Use this
+ * transformer with [[io.smartdatalake.workflow.action.CustomDataFrameAction]]; for a single input and output prefer
+ * [[PythonCodeDfTransformer]].
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-flights {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-airports, stg-departures]
+ *     outputIds = [int-departures]
+ *     transformers = [{
+ *       type = PythonCodeDfsTransformer
+ *       code = """
+ *         df = inputDfs['stg-departures'].join(inputDfs['stg-airports'], 'ident')
+ *         setOutputDfs({'int-departures': df})
+ *       """
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name           name of the transformer
  * @param description    Optional description of the transformer
  * @param file           Optional file with python code to use for python transformation. The python code can use variables inputDfs and options. The transformed DataFrames has to be set with setOutputDfs.

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDfTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDfTransformer.scala
@@ -41,6 +41,27 @@ import org.slf4j.Logger
  * Note that the following options are passed by default to the transformation:
  *   - isExec: defined as `context.isExecPhase`
  *
+ * Pick this transformer when the transformation logic is too complex for SQL and should live in compiled, unit-testable
+ * code. The class named by `className` must be on the classpath of the SDLB job and needs a constructor without
+ * arguments. For transformations with multiple inputs or outputs use [[ScalaClassSparkDfsTransformer]] instead.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   compute-departures {
+ *     type = CopyAction
+ *     inputId = stg-departures
+ *     outputId = int-departures
+ *     transformers = [{
+ *       type = ScalaClassSparkDfTransformer
+ *       className = com.sample.transformer.ComputeDistanceTransformer
+ *       options = { unit = "km" }
+ *       runtimeOptions = { runId = "runId" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name
  *   name of the transformer
  * @param description

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDfsTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDfsTransformer.scala
@@ -57,6 +57,28 @@ import org.slf4j.Logger
  *   - outputDataObjectId: defined as outputDataObject.id if transformation has only one output
  *     DataObject configured.
  *
+ * The class named by `className` must be on the classpath of the SDLB job and needs a constructor without arguments.
+ * Input and output DataFrames are matched by DataObjectId; use `renamedInputIds`/`renamedOutputIds` to write generic
+ * transformers whose names are independent of the configured DataObjectIds. For a single input and output,
+ * [[ScalaClassSparkDfTransformer]] is simpler.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-departures {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-airports, stg-departures]
+ *     outputIds = [int-departures]
+ *     transformers = [{
+ *       type = ScalaClassSparkDfsTransformer
+ *       className = com.sample.transformer.JoinDeparturesTransformer
+ *       options = { country = "CH" }
+ *       renamedInputIds = { stg-airports = airports }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param name
  *   name of the transformer
  * @param description

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDsNTo1Transformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDsNTo1Transformer.scala
@@ -44,8 +44,31 @@ import scala.reflect.runtime.universe.typeOf
  * Define a transform function that receives a SparkSession, a map of options and as many DataSets as you want, and that has to return one Dataset.
  * The Java/Scala class has to implement interface [[CustomDsNto1Transformer]].
  *
+ * Compared to [[ScalaClassSparkDfsTransformer]] the input DataFrames are converted to typed Datasets of your case
+ * classes, so the transform method is checked against the input schemas and reads like normal Scala code. Each Dataset
+ * parameter is matched to an input by parameter name, or by the order of the Actions `inputIds` when
+ * `parameterResolution = DataObjectOrdering`. Matching by name compares case-insensitive and without `-` and `_`, and a
+ * leading lowercase `ds` is stripped from the parameter name beforehand (so `dsAirports` matches input `airports`, but
+ * `DsAirports` does not). Note that the transformer name is fixed to `className` and cannot be configured.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   double_rating {
+ *     type = CustomDataFrameAction
+ *     inputIds = [src1Ds, src2Ds]
+ *     outputIds = [tgt1Ds]
+ *     transformers = [{
+ *       type = ScalaClassSparkDsNTo1Transformer
+ *       className = com.sample.transformer.DoubleRatingDs2To1Transformer
+ *       parameterResolution = DataObjectOrdering
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
  * @param description                Optional description of the transformer
- * @param className                  Class name implementing trait [[CustomDfsTransformer]]
+ * @param className                  Class name implementing trait [[CustomDsNto1Transformer]]
  * @param options                    Options to pass to the transformation
  * @param runtimeOptions             Optional tuples of [key, spark SQL expression] to be added as additional options when executing transformation.
  *                                   The spark SQL expressions are evaluated against an instance of [[DefaultExpressionData]].

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDsTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaClassSparkDsTransformer.scala
@@ -39,6 +39,31 @@ private[smartdatalake] abstract class FakeProduct extends Product
  * Define a transform function which receives a SparkSession, a Dataset and a map of options and has to return a Dataset.
  * The Java/Scala class has to implement interface [[CustomDsTransformer]].
  *
+ * Pick this transformer when the transformation logic should live in your own jar as strongly typed
+ * code: input and output are converted to/from case classes, so the compiler checks the schema for you.
+ * Use [[ScalaCodeSparkDfTransformer]] instead if you prefer to inline untyped DataFrame code directly
+ * in the configuration file.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   double-rating {
+ *     type = CopyAction
+ *     inputId = src1DS
+ *     outputId = tgt1DS
+ *     transformers = [{
+ *       type = ScalaClassSparkDsTransformer
+ *       transformerClassName = com.sample.DoubleRatingDsTransformer
+ *       options = { factor = "2" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note The class named by `transformerClassName` must be on the classpath of the SDLB job and needs a
+ *       no-argument constructor.
+ * @see [[CustomDsTransformer]]
+ *
  * @param name                 name of the transformer
  * @param description          Optional description of the transformer
  * @param transformerClassName class name implementing trait [[CustomDsTransformer]]

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaCodeSparkDfTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaCodeSparkDfTransformer.scala
@@ -39,6 +39,34 @@ import org.slf4j.Logger
  * DataObjectId, a DataFrame and a map of options and has to return a DataFrame. The Scala code has
  * to implement a function of type [[fnTransformType]].
  *
+ * Use this transformer for ad-hoc DataFrame logic that should be kept next to the pipeline definition
+ * instead of in a separate jar. Exactly one of `code` or `file` must be defined. The code is compiled
+ * with the Scala compiler on job startup (or lazily, see `Environment.compileScalaCodeLazy`), so syntax
+ * errors surface in the prepare phase and not only when data is processed.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   increment-rating {
+ *     type = CopyAction
+ *     inputId = src1DO
+ *     outputId = tgt1DO
+ *     transformers = [{
+ *       type = ScalaCodeSparkDfTransformer
+ *       code = """
+ *         import org.apache.spark.sql.{DataFrame, SparkSession}
+ *         (session: SparkSession, options: Map[String,String], df: DataFrame, dataObjectId: String) => {
+ *           df.withColumn("rating", df("rating") + 1)
+ *         }
+ *       """
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note Runtime compilation needs the Scala compiler on the classpath; for production pipelines a
+ *       compiled transformer ([[ScalaClassSparkDsTransformer]]) is usually preferable.
+ *
  * @param name
  *   name of the transformer
  * @param description

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaCodeSparkDfsTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaCodeSparkDfsTransformer.scala
@@ -40,6 +40,34 @@ import org.slf4j.Logger
  * DataObjectIds with DataFrames. The Scala code has to implement a function of type
  * [[fnTransformType]].
  *
+ * Use this transformer inside a `CustomDataFrameAction` whenever a transformation needs more than one
+ * input DataFrame (joins, unions) or produces more than one output DataFrame. The returned map must
+ * contain an entry for every output DataObject id of the action. Exactly one of `code` or `file` must
+ * be defined; the code is compiled at job startup so errors surface in the prepare phase.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   join-departures-airports {
+ *     type = CustomDataFrameAction
+ *     inputIds = [stg-departures, int-airports]
+ *     outputIds = [btl-departures-arrivals-airports]
+ *     transformers = [{
+ *       type = ScalaCodeSparkDfsTransformer
+ *       code = """
+ *         import org.apache.spark.sql.{DataFrame, SparkSession}
+ *         (session: SparkSession, options: Map[String,String], dfs: Map[String,DataFrame]) => {
+ *           val df = dfs("stg-departures").join(dfs("int-airports"), Seq("ident"))
+ *           Map("btl-departures-arrivals-airports" -> df)
+ *         }
+ *       """
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @see [[ScalaCodeSparkDfTransformer]] for the 1:1 case
+ *
  * @param name
  *   name of the transformer
  * @param description

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaNotebookSparkDfTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/ScalaNotebookSparkDfTransformer.scala
@@ -43,6 +43,32 @@ import scala.util.{Failure, Success}
  * map of options and has to return a DataFrame, see also ([[fnTransformType]]). Notebook-cells
  * starting with "//!IGNORE" will be ignored.
  *
+ * Use this transformer to move a transformation prototyped interactively in a notebook into a pipeline
+ * without copying the code: SDLB downloads the notebook from `url`, concatenates all Scala code cells
+ * and compiles the function named `functionName`. Cells containing only exploratory code (test data,
+ * `show()` calls) should be marked with a leading "//!IGNORE" comment so they are skipped.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   increment-rating {
+ *     type = CopyAction
+ *     inputId = src1DO
+ *     outputId = tgt1DO
+ *     transformers = [{
+ *       type = ScalaNotebookSparkDfTransformer
+ *       url = "http://my-notebook-server:8192/notebook/Test.ipynb?download=true"
+ *       functionName = testTransform
+ *       authMode = { type = BasicAuthMode, user = "notebook-user", password = "###ENV#NOTEBOOK_PWD###" }
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note The notebook is downloaded on every job start, so the pipeline result depends on the current
+ *       notebook content. Prefer [[ScalaCodeSparkDfTransformer]] or [[ScalaClassSparkDsTransformer]]
+ *       for reproducible production pipelines.
+ *
  * @param name
  *   name of the transformer
  * @param description

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDfTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkFlattenDfTransformer.scala
@@ -45,6 +45,31 @@ import scala.annotation.tailrec
  * |---parent_child1
  *
  * |---parent_child2
+ *
+ * Nesting is resolved recursively, so deeply nested structs end up as a single flat level of columns
+ * named by their full path joined with "_". This is typically used right after reading semi-structured
+ * sources (JSON, XML, webservice payloads) to obtain a table-like schema that can be written to a
+ * relational or file DataObject. With `enableExplode = true` array columns are exploded as well, which
+ * multiplies rows instead of columns; the transformer needs no column list and adapts to schema changes.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   flatten-departures {
+ *     type = CopyAction
+ *     inputId = stg-departures
+ *     outputId = int-departures
+ *     transformers = [{
+ *       type = SparkFlattenDfTransformer
+ *       enableExplode = true
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note Exploding arrays changes the cardinality of the DataFrame - primary keys of the input are no
+ *       longer unique in the output.
+ *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param enableExplode Enables exploding Arrays in the Dataframe, therefore potentially increasing the number of rows. Default is set to "false"

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkRepartitionTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/SparkRepartitionTransformer.scala
@@ -28,8 +28,33 @@ import io.smartdatalake.workflow.action.generic.transformer.GenericDfTransformer
 import org.apache.spark.sql.DataFrame
 
 /**
- * Repartition DataFrame
- * For detailled description about repartitioning DataFrames see also [[SparkRepartitionDef]]
+ * Repartition a Spark DataFrame in the middle of a transformation chain, controlling how many Spark
+ * tasks - and therefore how many output files per partition value - the following steps work with.
+ * Use it to avoid the small-files problem when writing many small partitions, or to increase
+ * parallelism before an expensive transformation. Repartitioning triggers a shuffle, so apply it
+ * deliberately.
+ *
+ * For a detailled description about repartitioning DataFrames see also [[SparkRepartitionDef]].
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-departures {
+ *     type = CopyAction
+ *     inputId = stg-departures
+ *     outputId = int-departures
+ *     transformers = [{
+ *       type = SparkRepartitionTransformer
+ *       numberOfTasksPerPartition = 10
+ *       keyCols = [icao24]
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note If the output DataObject already defines `sparkRepartition`, prefer configuring it there;
+ *       this transformer is for repartitioning between transformation steps.
+ *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer
  * @param numberOfTasksPerPartition Number of Spark tasks to create per partition value by repartitioning the DataFrame.

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/StandardizeSparkDatatypesTransformer.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/action/spark/transformer/StandardizeSparkDatatypesTransformer.scala
@@ -28,7 +28,28 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
  * Standardize datatypes of a Spark-DataFrame.
- * Current implementation converts all decimal datatypes to a corresponding integral or float datatype
+ * Current implementation converts all decimal datatypes to a corresponding integral or float datatype.
+ *
+ * Decimal columns are common when reading from JDBC sources or Parquet files written by other tools, but
+ * they are inconvenient downstream: they compare and serialize differently and often carry an unnecessarily
+ * wide precision. Adding this transformer as the first entry of a transformation chain gives all Actions a
+ * uniform, narrow numeric type per column without listing columns explicitly. The transformer takes no
+ * configuration attributes beyond the common `name`/`description`.
+ *
+ * Example:
+ * {{{
+ * actions = {
+ *   copy-departures {
+ *     type = CopyAction
+ *     inputId = stg-departures
+ *     outputId = int-departures
+ *     transformers = [{ type = StandardizeSparkDatatypesTransformer }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note The conversion is lossy if a decimal column holds values that do not fit the derived integral or
+ *       float type; check precision and scale of the source schema before enabling it.
  *
  * @param name         name of the transformer
  * @param description  Optional description of the transformer

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/connection/SparkClassicConnection.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/connection/SparkClassicConnection.scala
@@ -41,8 +41,33 @@ import scala.util.Try
 /**
  * Connection information for a classic Spark session.
  *
+ * This is the [[EngineConnection]] for the Spark DataFrame engine: it creates and configures the SparkSession
+ * shared by all Actions using it, including spark options, Kryo classes, Hive support and user defined functions.
+ * Actions select an engine connection with their `engineConnectionId` attribute; if none is given the connection
+ * with id `default-engine` is used (configurable through the SDLB parameter `defaultEngineConnectionId`).
+ * Leave `master` unset to attach to an existing Spark session provided by the environment (e.g. Databricks,
+ * EMR, spark-submit); set it (e.g. `local`, `yarn`) to let SDLB create the session itself.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   default-engine {
+ *     type = SparkClassicConnection
+ *     master = "local[*]"
+ *     enableHive = false
+ *     sparkOptions {
+ *       "spark.sql.shuffle.partitions" = "8"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note with `master = "yarn"` the environment variable SPARK_HOME must be set.
+ *
  * @param master
  *  master URL for the Spark session. If not set, it will try to get an existing Spark session from the environment.
+ * @param deployMode
+ *   Spark deploy mode ("client" or "cluster"), passed on to the Spark session builder as "deploy-mode" configuration.
  * @param enableHive
  *   enable hive for spark session
  * @param sparkOptions

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/connection/jdbc/JdbcTableConnection.scala
@@ -40,6 +40,31 @@ import java.sql.{Connection => SqlConnection, DatabaseMetaData, DriverManager, R
  * Connection information for JDBC tables. If authentication is needed, user and password must be
  * provided.
  *
+ * It holds url, driver and credentials shared by all JdbcTableDataObjects referencing it through `connectionId`,
+ * and maintains a small JDBC connection pool which SDLB uses for metadata and DDL statements (checking table
+ * existence, creating tables, pre/postSQL, constraints). Note that Spark opens its own connections for reading
+ * and writing data, so `maxParallelConnections` limits SDLB's own connections only. A database specific
+ * [[JdbcCatalog]] is derived from `driver` to run catalog queries in the correct dialect.
+ *
+ * Example:
+ * {{{
+ * connections {
+ *   jdbc-dwh {
+ *     type = JdbcTableConnection
+ *     url = "jdbc:postgresql://dwh.example.com:5432/dwh"
+ *     driver = "org.postgresql.Driver"
+ *     db = "public"
+ *     authMode = {
+ *       type = BasicAuthMode
+ *       user = "###ENV#JDBC_USER###"
+ *       password = "###ENV#JDBC_PASSWORD###"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note the JDBC driver named in `driver` must be on the classpath; only BasicAuthMode is supported as authMode.
+ *
  * @param id
  *   unique id of this connection
  * @param url
@@ -65,6 +90,9 @@ import java.sql.{Connection => SqlConnection, DatabaseMetaData, DriverManager, R
  *   will write data first into a temporary table, and then use a "DELETE" + "INSERT INTO SELECT"
  *   statement to overwrite data in the target table within one transaction. Also note that
  *   SDLSaveMode.Merge always creates a temporary table.
+ * @param connectionPool
+ *   fine tuning of the JDBC connection pool used by SDLB, see [[ConnectionPoolConfig]], e.g. idle timeout and
+ *   connection validation. Default is [[ConnectionPoolConfig]] with its default values.
  */
 case class JdbcTableConnection(
     override val id: ConnectionId,

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/AccessTableDataObject.scala
@@ -41,7 +41,29 @@ import scala.jdk.CollectionConverters._
 
 /**
  * [[DataObject]] of type Microsoft Access.
- * Can read a table from a Microsoft Access DB.
+ * Can read a single table from a Microsoft Access database file (.mdb/.accdb) and expose it as a Spark DataFrame.
+ * The database file is read through the Hadoop filesystem layer, copied to a local temporary file and opened with
+ * the Jackcess library. Column types are mapped from JDBC types to Spark types, dates/times become Timestamps.
+ * Use this to ingest legacy Access files into the data lake; for a real database prefer [[JdbcTableDataObject]].
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-orders {
+ *     type = AccessTableDataObject
+ *     path = "~{env.basedir}/ext_orders/northwind.accdb"
+ *     table {
+ *       db = "northwind"
+ *       name = "Orders"
+ *       primaryKey = [OrderID]
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note read-only: writing and `dropTable` are not implemented. The whole table is materialized on the driver,
+ *       so this is not suited for very large Access tables.
+ * @see [[JdbcTableDataObject]]
  * @param path: the path to the access database file
  * @param table: the Access table to be read
  */

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ActionsExporterDataObject.scala
@@ -52,6 +52,10 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
  * The config value can point to a configuration file or a directory containing configuration files.
  *
  * @see Refer to [[ConfigLoader.loadConfigFromFilesystem()]] for details about the configuration loading.
+ * @param id unique name of this data object
+ * @param config optional location of the config to export, either a configuration file or a directory containing
+ *               configuration files. Multiple locations can be given as a comma-separated list.
+ *               If not defined, the Actions registered in the current [[InstanceRegistry]] are exported.
  */
 case class ActionsExporterDataObject(id: DataObjectId,
                                      config: Option[String] = None,

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/AirbyteDataObject.scala
@@ -58,8 +58,32 @@ import scala.reflect.{ClassTag, classTag}
  *
  * Also note that the getDataFrame method is not lazy in Exec-Phase. It will query the Airbyte Connector before creating the DataFrame.
  *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-users {
+ *     type = AirbyteDataObject
+ *     streamName = "users"
+ *     # the entries of config are connector specific, see the documentation of the connector used
+ *     config {
+ *       host = "db.example.com"
+ *       port = 5432
+ *       database = "postgres"
+ *       username = "sdlb"
+ *       password = "###"
+ *     }
+ *     cmd {
+ *       type = DockerRunScript
+ *       image = "airbyte/source-postgres:latest"
+ *     }
+ *     incrementalCursorFields = ["updated_at"]
+ *   }
+ * }
+ * }}}
+ *
  * @param id DataObject identifier
- * @param config Configuration for the source
+ * @param config Configuration for the source. Its entries are connector specific and are validated against the
+ *               specification reported by the connector itself in prepare phase.
  * @param streamName The stream name to read. Must match an entry of the catalog of the source.
  * @param incrementalCursorFields Some sources need a specification of the cursor field for incremental mode
  * @param maxRecordsPerPartition Maximum number of records to put into one Spark partition.

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/AvroFileDataObject.scala
@@ -43,6 +43,24 @@ import org.apache.spark.sql.DataFrame
  * and [[org.apache.spark.sql.DataFrameWriter]] respectively. The reader and writer implementations are provided by
  * the [[https://github.com/databricks/spark-avro databricks spark-avro]] project.
  *
+ * Avro files carry their own schema. If the `schema` attribute is defined, it is not pushed to the reader but applied
+ * afterwards to select and cast the content to the target schema.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   stg-airports {
+ *     type = AvroFileDataObject
+ *     path = "~{env.basedir}/stg_airports"
+ *     partitions = [dt]
+ *     saveMode = Append
+ *     avroOptions {
+ *       compression = "snappy"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param avroOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *                    [[org.apache.spark.sql.DataFrameWriter]].
  *

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/CsvFileDataObject.scala
@@ -50,18 +50,36 @@ import org.apache.spark.sql.types.{DateType, StringType}
  * option is disabled (default) in `csvOptions`, then all column types are set to String and the
  * first row of the CSV file is read to determine the column names and the number of fields.
  *
- * If the `header` option is disabled (default) in `csvOptions`, then the header is defined as "_c#"
- * for each column where "#" is the column index. Otherwise the first row of the CSV file is not
- * included in the DataFrame content and its entries are used as the column names for the schema.
+ * If the `header` option is disabled in `csvOptions` (it is enabled by default, see note below),
+ * then the header is defined as "_c#" for each column where "#" is the column index. Otherwise the
+ * first row of the CSV file is not included in the DataFrame content and its entries are used as
+ * the column names for the schema.
  *
  * If a data object schema is not defined via the `schema` attribute and `inferSchema` is enabled in
  * `csvOptions`, then the `samplingRatio` (default: 1.0) option in `csvOptions` is used to extract a
  * sample from the CSV file in order to determine the input schema automatically.
  *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   stg-airports {
+ *     type = CsvFileDataObject
+ *     path = "~{env.basedir}/stg_airports"
+ *     csvOptions {
+ *       delimiter = ";"
+ *       inferSchema = true
+ *     }
+ *     partitions = [dt]
+ *     saveMode = Append
+ *   }
+ * }
+ * }}}
+ *
  * @note
- *   This data object sets the following default values for `csvOptions`: delimiter = "|", quote =
- *   null, header = false, and inferSchema = false. All other `csvOption` default to the values
- *   defined by Apache Spark.
+ *   This data object sets the following default values for `csvOptions`: header = true,
+ *   inferSchema = false, delimiter = ",", and quote = null. All other `csvOption` default to the
+ *   values defined by Apache Spark. Note that either `header` or `inferSchema` must be enabled in
+ *   `csvOptions`, or an explicit `schema` must be defined.
  *
  * @see
  *   [[org.apache.spark.sql.DataFrameReader]]
@@ -72,7 +90,9 @@ import org.apache.spark.sql.types.{DateType, StringType}
  *   Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *   [[org.apache.spark.sql.DataFrameWriter]].
  * @param dateColumnType
- *   Specifies the string format used for writing date typed data.
+ *   how to convert columns of Spark type date before writing (default: date). With `date` they are
+ *   cast to timestamp, with `string` they are cast to string. See
+ *   [[io.smartdatalake.definitions.DateColumnType]].
  */
 case class CsvFileDataObject(
     override val id: DataObjectId,

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/DataObjectsExporterDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/DataObjectsExporterDataObject.scala
@@ -52,6 +52,13 @@ import org.apache.spark.sql.DataFrame
  * @see
  *   Refer to [[ConfigLoader.loadConfigFromFilesystem()]] for details about the configuration
  *   loading.
+ *
+ * @param id
+ *   unique name of this data object
+ * @param config
+ *   optional location of the config to export, either a configuration file or a directory containing
+ *   configuration files. Multiple locations can be given as a comma-separated list. If not defined,
+ *   the DataObjects registered in the current [[InstanceRegistry]] are exported.
  */
 case class DataObjectsExporterDataObject(
     id: DataObjectId,

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ExcelFileDataObject.scala
@@ -53,6 +53,25 @@ import org.apache.spark.sql.DataFrame
  * (excluding the first).
  * When no schema is provided and `inferSchema` is disabled, all columns are assumed to be of string type.
  *
+ * Column names read from the header are cleaned up on read: blanks, dashes and dots become underscores, all other
+ * non-alphanumeric characters are dropped and camel case is converted to lower case with underscores.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-airports {
+ *     type = ExcelFileDataObject
+ *     path = "~{env.basedir}/ext_airports"
+ *     excelOptions {
+ *       sheetName = "airports"
+ *       maxRowsInMemory = 20000
+ *     }
+ *   }
+ * }
+ * }}}
+ *
+ * @note The Excel data source cannot read a whole directory at once, so files are read one by one.
+ *       `numLinesToSkip` and `startColumn` are read-only options and must not be set when writing.
  * @param excelOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
  */
 case class ExcelFileDataObject(override val id: DataObjectId,

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -58,6 +58,27 @@ import scala.util.{Failure, Success, Try}
  * - [[CanEvolveSchema]] by generating corresponding alter table DDL statements.
  * - Overwriting partitions is implemented by using SQL delete and insert statement embedded in one transaction.
  *
+ * Requires a [[JdbcTableConnection]] referenced by `connectionId`, which holds url, driver and credentials.
+ *
+ * Example:
+ * {{{
+ * connections = {
+ *   jdbc-dwh {
+ *     type = JdbcTableConnection
+ *     url = "jdbc:postgresql://dwh:5432/mydb"
+ *     driver = org.postgresql.Driver
+ *   }
+ * }
+ * dataObjects = {
+ *   int-airports {
+ *     type = JdbcTableDataObject
+ *     connectionId = jdbc-dwh
+ *     table = { db = public, name = airports, primaryKey = [ident] }
+ *     saveMode = Merge
+ *   }
+ * }
+ * }}}
+ *
  * @param id unique name of this data object
  * @param createSql DDL-statement to be executed in prepare phase, using output jdbc connection.
  *                  Note that it is also possible to let Spark create the table in Init-phase. See jdbcOptions to customize column data types for auto-created DDL-statement.
@@ -71,7 +92,8 @@ import scala.util.{Failure, Success, Try}
  *                   Use tokens with syntax %{<spark sql expression>} to substitute with values from [[DefaultExpressionData]].
  * @param schemaMin An optional, minimal schema that this DataObject must have to pass schema validation on reading and writing.
  *                  Define schema by using a DDL-formatted string, which is a comma separated list of field definitions, e.g., a INT, b STRING.
- * @param saveMode [[SDLSaveMode]] to use when writing table, default is "Overwrite". Only "Append" and "Overwrite" supported.
+ * @param saveMode [[SDLSaveMode]] to use when writing table, default is "Overwrite". Only "Append", "Overwrite" and "Merge" are supported.
+ *                 "Merge" requires a primary key to be defined on `table`.
  * @param allowSchemaEvolution If set to true schema evolution will automatically occur when writing to this DataObject with different schema, otherwise SDL will stop with error.
  * @param table The jdbc table to be read
  * @param jdbcFetchSize Number of rows to be fetched together by the Jdbc driver

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/JsonFileDataObject.scala
@@ -40,6 +40,21 @@ import org.apache.spark.sql.DataFrame
  * Reading and writing details are delegated to Apache Spark [[org.apache.spark.sql.DataFrameReader]]
  * and [[org.apache.spark.sql.DataFrameWriter]] respectively.
  *
+ * Use this DataObject for semi-structured, nested data. As JSON carries no fixed schema, Spark infers it from the data
+ * unless an explicit `schema` is configured - configuring a schema is recommended for stable pipelines.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   stg-airports {
+ *     type = JsonFileDataObject
+ *     path = "~{env.basedir}/stg_airports"
+ *     jsonOptions { multiLine = false }
+ *     saveMode = Overwrite
+ *   }
+ * }
+ * }}}
+ *
  * @param stringify Set the data type for all values to string. Use action/transformers instead.
  * @param jsonOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and
  *                    [[org.apache.spark.sql.DataFrameWriter]].

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ODataDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ODataDataObject.scala
@@ -199,6 +199,34 @@ class ODataIOC {
 /**
  * [[DataObject]] of type OData.
  *
+ * Reads one entity set (table) of an OData v4 REST service, e.g. Microsoft Dynamics 365 / Dataverse, into a Spark
+ * DataFrame. The requested columns are derived from the configured `schema`, which is mandatory - the service is
+ * queried with a corresponding OData `select` system query option, optionally narrowed by `sourceFilters`. This
+ * DataObject is read-only (there is no write support) and requests are executed on the driver, not distributed to
+ * executors. Responses are collected in a memory buffer that spills to temporary files once it grows too large, see
+ * `responseBufferSetup`.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-tasks {
+ *     type = ODataDataObject
+ *     baseUrl = "https://myorg.crm4.dynamics.com/api/data/v9.2/"
+ *     tableName = "tasks"
+ *     schema = "activityid string, subject string, modifiedon string"
+ *     sourceFilters = "statecode eq 0"
+ *     incrementalOutputExpr = "modifiedon"
+ *     authMode = {
+ *       type = AzureADClientGrantAuthMode
+ *       authority = "https://login.microsoftonline.com/{tenant-guid}/"
+ *       applicationId = "###ENV#AZURE_CLIENT_ID###"
+ *       clientSecret = "###ENV#AZURE_CLIENT_SECRET###"
+ *       scope = "https://myorg.crm4.dynamics.com/.default"
+ *     }
+ *   }
+ * }
+ * }}}
+ *
  * @param schema
  *   Schema of the expected output. It can be provided as a string in the form of <<array< struct<
  *   columnA:string, columnB: integer ... >>, as ddl-File, caseClass, java Bean, XSD-File,
@@ -213,11 +241,16 @@ class ODataIOC {
  *   "objecttypecode eq 'task' and createdon ge 2024-01-01T00:00:00.000Z"
  * @param timeouts
  *   Optional. Timeout settings of type [[HttpTimeoutConfig]]
+ * @param proxy
+ *   Optional. HTTP proxy configuration of type [[HttpProxyConfig]] used to make the HTTP-connection.
  * @param authMode
  *   Optional configuration of webservice authentication. Supported `AuthMode`s are all
  *   HttpAuthModes, e.g. BasicAuthMode, OAuthMode, CustomHttpAuthMode. CustomHttpAuthMode can be
  *   used to implement a custom authentication protocol, e.g. AzureADClientGrantAuthMode in
  *   sdl-azure module.
+ * @param followRedirects
+ *   Optional. If HTTP redirects should be followed when creating the HTTP-connection, default = false because of
+ *   security concerns.
  * @param incrementalOutputExpr:
  *   Optional. Name of the column which will be used to read incrementally (like "modifiedon"). The
  *   column must be part of the schema. If this column is originally of datatype Timestamp in the

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/OpenApiDataObject.scala
@@ -58,6 +58,20 @@ import sttp.model.{MediaType, Uri}
  * Also note that the getDataFrame method is not lazy in Exec-Phase.
  * It will query the WebService before creating the DataFrame.
  *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   ext-datasets {
+ *     type = OpenApiDataObject
+ *     baseUrl = "https://data.sbb.ch/api/explore/v2.1"
+ *     apiDocsUrl = "swagger.json"
+ *     operationId = getDatasets
+ *     urlParameters = { include_links = "true" }
+ *     pagingLinkJsonPath = "$._links[?(@.rel == 'next')].href"
+ *   }
+ * }
+ * }}}
+ *
  * @param id                        DataObject identifier
  * @param baseUrl                   the server url to use for querying the OpenApi specification and content
  * @param operationId               the operationId from the OpenApi specification to use to get data for this DataObject

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/ParquetFileDataObject.scala
@@ -35,13 +35,29 @@ import org.apache.spark.sql.DataFrame
 
 /**
  *
- * A [[io.smartdatalake.workflow.dataobject.DataObject]] backed by an Apache Hive data source.
+ * A [[io.smartdatalake.workflow.dataobject.DataObject]] backed by an Apache Parquet data source.
  *
  * It manages read and write access and configurations required for [[io.smartdatalake.workflow.action.Action]]s to
  * work on Parquet formatted files.
  *
  * Reading and writing details are delegated to Apache Spark [[org.apache.spark.sql.DataFrameReader]]
  * and [[org.apache.spark.sql.DataFrameWriter]] respectively.
+ *
+ * This is the default choice for storing intermediate and integration layer data in a data lake: it is columnar,
+ * compressed and carries its schema, so no `schema` needs to be configured for reading. If a `schema` is configured
+ * it is applied after reading to select and cast the given columns, see also [[NestedColumnUtil]].
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-airports {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_airports"
+ *     partitions = [year, month]
+ *     saveMode = Overwrite
+ *   }
+ * }
+ * }}}
  *
  * @see [[org.apache.spark.sql.DataFrameReader]]
  * @see [[org.apache.spark.sql.DataFrameWriter]]

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/RawFileDataObject.scala
@@ -37,6 +37,35 @@ import io.smartdatalake.workflow.dataobject.spark.SparkFileDataObject
  *
  * By specifying customFormat, binary or text files can read with Spark.
  *
+ * Use this DataObject to move files around without interpreting their content, e.g. with a FileTransferAction, or to
+ * ingest formats SDLB has no dedicated DataObject for. Without customFormat this DataObject can only be used by
+ * file based Actions; reading or writing it with Spark then fails with a configuration exception.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   stg-documents {
+ *     type = RawFileDataObject
+ *     path = "~{env.basedir}/stg_documents"
+ *     customFormat = binaryFile
+ *     partitions = [year]
+ *   }
+ * }
+ * }}}
+ *
+ * Note that customPartitionLayout is only supported by file based Actions, not by Spark:
+ * {{{
+ * dataObjects = {
+ *   stg-documents-files {
+ *     type = RawFileDataObject
+ *     path = "~{env.basedir}/stg_documents"
+ *     fileName = "*.pdf"
+ *     partitions = [year]
+ *     customPartitionLayout = "%year%/"
+ *   }
+ * }
+ * }}}
+ *
  * @param customFormat Custom Spark data source format, e.g. binaryFile or text.
  *                     Only needed if you want to read/write this DataObject with Spark.
  * @param customPartitionLayout Define a different partition layout than the default Hadoop directory partitioning.

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/RelaxedCsvFileDataObject.scala
@@ -58,6 +58,20 @@ import scala.reflect.runtime.universe.typeOf
  * CSV files are read by Spark as whole text files and then parsed manually with Sparks CSV parser class. You can therefore use the
  * normal CSV options of spark, but some properties are fixed, e.g. header=true, inferSchema=false, enforceSchema (ignored).
  *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   stg-airports {
+ *     type = RelaxedCsvFileDataObject
+ *     path = "~{env.basedir}/stg_airports"
+ *     schema = "ident string, name string, elevation_ft integer, _corrupt_record string, _corrupt_record_msg string"
+ *     csvOptions { delimiter = ";" }
+ *     treatMissingColumnsAsCorrupt = true
+ *     treatSuperfluousColumnsAsCorrupt = true
+ *   }
+ * }
+ * }}}
+ *
  * @note This data object sets the following default values for `csvOptions`: delimiter = ",", quote = null
  *       All other `csvOption` default to the values defined by Apache Spark.
  * @see [[org.apache.spark.sql.DataFrameReader]]
@@ -67,7 +81,9 @@ import scala.reflect.runtime.universe.typeOf
  * RelaxCsvFileDataObject also supports getting an error msg by adding "<options.columnNameOfCorruptRecord>_msg" as field to the schema.
  *
  * @param csvOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
- * @param dateColumnType Specifies the string format used for writing date typed data.
+ * @param dateColumnType how to convert columns of Spark type date before writing (default: date). With `date` they are
+ *                       cast to timestamp, with `string` they are cast to string.
+ *                       See [[io.smartdatalake.definitions.DateColumnType]].
  * @param treatMissingColumnsAsCorrupt If set to true records from files with missing columns in its header are treated as corrupt (default=false).
  *                                   Corrupt records are handled according to options.mode (default=permissive).
  * @param treatSuperfluousColumnsAsCorrupt If set to true records from files with superfluous columns in its header are treated as corrupt (default=false).

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/XmlFileDataObject.scala
@@ -45,6 +45,21 @@ import org.apache.spark.sql.DataFrame
  * the [[https://github.com/databricks/spark-xml databricks spark-xml]] project.
  * Note that writing XML-file partitioned is not supported by spark-xml.
  *
+ * The most important entry in `xmlOptions` is `rowTag`, which selects the XML element that is mapped to one row of the
+ * resulting DataFrame. Nested elements become structs and arrays, so a transformer is normally needed to flatten them.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   stg-airports {
+ *     type = XmlFileDataObject
+ *     path = "~{env.basedir}/stg_airports"
+ *     xmlOptions { rowTag = "entry", dateFormat = "yyyy-MM-dd" }
+ *     schema = "ident string, name string, elevation_ft integer"
+ *   }
+ * }
+ * }}}
+ *
  * @param xmlOptions Settings for the underlying [[org.apache.spark.sql.DataFrameReader]] and [[org.apache.spark.sql.DataFrameWriter]].
  */
 case class XmlFileDataObject(override val id: DataObjectId,

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/AvgCountPerPartitionExpectation.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/AvgCountPerPartitionExpectation.scala
@@ -34,6 +34,30 @@ import io.smartdatalake.workflow.dataobject.expectation.ExpectationSeverity.Expe
  *
  * Note that the scope for evaluating this expectation is fixed to Job.
  *
+ * The result is the `count` of the current job divided by the number of partition values processed. Note that it is
+ * reported as metric `countAvgPerPartition` and not under the name of the expectation. Use it instead of
+ * [[CountExpectation]] when a job may process a varying number of partitions, so that a fixed total count would
+ * produce false alarms.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     partitions = [dt]
+ *     expectations = [{
+ *       type = AvgCountPerPartitionExpectation
+ *       name = "avgCountPerDay"
+ *       expectation = "> 100000"
+ *     }]
+ *   }
+ * }
+ * }}}
+ *
+ * @note The expectation can only be evaluated if the job processes partition values. If there are none, a warning
+ *       is logged and the expectation is skipped.
+ * @see [[CountExpectation]]
  * @param expectation Optional SQL comparison operator and literal to define expected value for validation, e.g. '> 100000".
  *                    If no expectation is defined, the result value is just recorded in metrics.
  */

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/CountExpectation.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/expectation/CountExpectation.scala
@@ -34,6 +34,28 @@ import org.apache.spark.sql.Column
 /**
  * Definition of an expectation based on the number of records.
  *
+ * This is the cheapest expectation: for the default `name = "count"` and `scope = Job` the record count is measured
+ * anyway, so no additional aggregation is added. Use it as a basic sanity check that an Action did not produce an empty
+ * or unexpectedly small result. Define multiple CountExpectations with different names to check several scopes at once,
+ * e.g. the records of the current job and the total number of records in the table.
+ *
+ * Example:
+ * {{{
+ * dataObjects = {
+ *   int-departures {
+ *     type = ParquetFileDataObject
+ *     path = "~{env.basedir}/int_departures"
+ *     expectations = [
+ *       { type = CountExpectation, expectation = ">= 1" },
+ *       { type = CountExpectation, name = "countAll", expectation = "> 100000", scope = All }
+ *     ]
+ *   }
+ * }
+ * }}}
+ *
+ * @note If several CountExpectations are configured on the same DataObject, all but one must be given a distinct `name`,
+ *       as the name is used as metric name.
+ * @see [[AvgCountPerPartitionExpectation]] if the number of partitions processed varies between runs.
  * @param expectation Optional SQL comparison operator and literal to define expected value for validation, e.g. '> 100000".
  *                    If no expectation is defined, the result value is is just recorded in metrics.
  * @param scope The aggregation scope used to evaluate the aggregate expression.


### PR DESCRIPTION
 ### What changes are included in the pull request?                                                                                        
                                                                                                                                            
  Part A of #1106 — scaladoc/HOCON example coverage for all config-instantiable                                                             
  types (`case class X` with a companion `object X extends FromConfigFactory[_]`).                                                          
  Part B (moving the Docusaurus site off the `documentation` branch) is not in                                                              
  this PR.                                                                                                                                  
                                                                                                                                            
  | | before | after |                                                                                                                      
  |---|---|---|                                                                                                                             
  | types with a HOCON example | 7 / 108 | **108 / 108** |                                                                                  
  | own constructor params without `@param` | 45 | **0** |                                                                                  
  | class descriptions under 25 words | 41 | **0** |                                                                                        
                                                                                                                                            
  106 files, +2535 / −110. `sdl-core` 52, `sdl-spark` 36, plus `sdl-azure`,                                                                 
  `sdl-debezium`, `sdl-deltalake`, `sdl-gcp`, `sdl-iceberg`, `sdl-kafka`,                                                                   
  `sdl-snowflake`.                                                                                                                          
                                                                                                                                            
  Per type: an `Example:` `{{{ }}}` HOCON block at the correct nesting level, an                                                            
  `@param` for every non-`override` constructor parameter, and a class                                                                      
  description covering purpose, when to pick it over the alternatives, and                                                                  
  caveats.                                                                                                                                  
                                                                                                                                            
  `override` parameters are deliberately left undocumented here —                                                                           
  `GenericTypeUtil.attributesForCaseClass` resolves their description from the                                                              
  first overridden base trait member, so a local `@param` would shadow the trait                                                            
  doc and drift from it.                                                                                                                    
                                                                                                                                            
  Incidental fixes to existing documentation:                                                                                               
                                                                                                                                            
  - `PartitionArchiveMode`: example declared `type = PartitionArchiveCompactionMode`                                                        
  - `PartitionArchiveMode`: `{{{` opened under a list item at deeper indent than                                                            
    its content, which makes `ScaladocUtil.dedentCodeBlock` throw at runtime                                                                
  - `CsvFileDataObject`: `@note` listed `delimiter = "|"`, `header = false`; the                                                            
    code defaults to `","` and `true`                                                                                                       
  - `IcebergTableDataObject`: claimed hidden partitioning, but                                                                              
    `createIcebergTable` only builds identity transforms                                                                                    
                                                                                                                                            
  ### Why are the changes needed?                                                                                                           
                                                                                                                                            
  Scaladoc on these types is not only API documentation. The                                                                                
  `runtime-scaladoc-reader` compiler plugin attaches it as a runtime annotation,                                                            
  and `GenericTypeUtil` exports it into the SDLB configuration JSON schema that                                                             
  powers the online Schema Viewer and IDE autocompletion for `application.conf`.                                                            
  An undocumented parameter is an undocumented config attribute, so users had to                                                            
  read the source or guess HOCON syntax for anything outside the Getting Started                                                            
  guide.                                                                                                                                    
                                                                                                                                            
  ### Verification                                                                                                                          
                                                                                                                                            
  - `mvn clean compile` — BUILD SUCCESS, 14 modules                                                                                         
  - `JsonSchemaExporter` runs clean, and all 108 types appear in the generated                                                              
    schema with their example rendered as a fenced code block, confirming the                                                               
    scaladoc parses at runtime and reaches the Schema Viewer                                                                                
  - comment-only: 0 non-comment lines changed across all 106 files                                                                          
  - every attribute used in an example (305 keys) checked against the real                                                                  
    constructor parameters; GPLv3 headers unchanged in all 106 files                                                                        
                                                                                                                                            
  No tests added: this is a comment-only change with no behaviour to test. #1106                                                            
  also proposes a report-only coverage check to keep new types from regressing —                                                            
  that is not included here and is better as its own PR.                                                               