### PR TITLE
spark-connect: use Spark instead of generic observations (#953)

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataObjectStateIncrementalMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataObjectStateIncrementalMode.scala
@@ -74,7 +74,7 @@ case class DataObjectStateIncrementalMode() extends ExecutionMode {
       inputsWithIncrementalOutput.foreach(i => i.setState(i.getState))
     }
   }
-  override def factory: FromConfigFactory[ExecutionMode] = ProcessAllMode
+  override def factory: FromConfigFactory[ExecutionMode] = DataObjectStateIncrementalMode
 }
 
 object DataObjectStateIncrementalMode extends FromConfigFactory[ExecutionMode] {

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/TableDataObjectBehaviour.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/TableDataObjectBehaviour.scala
@@ -69,6 +69,10 @@ trait TableDataObjectBehaviour extends GenericTestTool {
 
   /** factory for the table DataObject under test */
   type TableDataObjectFactory = (String, TableDataObjectTestParams, InstanceRegistry) =>
+    TransactionalTableDataObject with CanMergeDataFrame with CanHandlePartitions
+
+  /** factory for the table DataObject under test, for behaviours needing incremental output */
+  type IncrementalTableDataObjectFactory = (String, TableDataObjectTestParams, InstanceRegistry) =>
     TransactionalTableDataObject with CanMergeDataFrame with CanHandlePartitions with CanCreateIncrementalOutput
 
   private def setupRegistryAndContext(): (InstanceRegistry, ActionPipelineContext, ActionPipelineContext) = {
@@ -558,7 +562,7 @@ trait TableDataObjectBehaviour extends GenericTestTool {
   /**
    * Normal output mode: reading after setting the state returns the full data.
    */
-  def testNormalOutputModeWithoutCdc(createTgtDataObject: TableDataObjectFactory): Unit = {
+  def testNormalOutputModeWithoutCdc(createTgtDataObject: IncrementalTableDataObjectFactory): Unit = {
     val (instanceRegistry, contextInit, contextExec) = setupRegistryAndContext()
     implicit val registry: InstanceRegistry = instanceRegistry
     implicit val context: ActionPipelineContext = contextInit
@@ -586,7 +590,7 @@ trait TableDataObjectBehaviour extends GenericTestTool {
    * Incremental output mode: only data written since the last state is returned.
    * @param stateIsOrdered set to false for DataObjects whose state is not monotonically increasing (e.g. Iceberg snapshot ids)
    */
-  def testIncrementalOutputModeWithInserts(createTgtDataObject: TableDataObjectFactory, stateIsOrdered: Boolean = true): Unit = {
+  def testIncrementalOutputModeWithInserts(createTgtDataObject: IncrementalTableDataObjectFactory, stateIsOrdered: Boolean = true): Unit = {
     val (instanceRegistry, contextInit, contextExec) = setupRegistryAndContext()
     implicit val registry: InstanceRegistry = instanceRegistry
     implicit val context: ActionPipelineContext = contextInit
@@ -638,7 +642,7 @@ trait TableDataObjectBehaviour extends GenericTestTool {
   /**
    * Incremental output mode needs a primary key defined on the table.
    */
-  def testIncrementalOutputModeWithoutPrimaryKey(createTgtDataObject: TableDataObjectFactory): Unit = {
+  def testIncrementalOutputModeWithoutPrimaryKey(createTgtDataObject: IncrementalTableDataObjectFactory): Unit = {
     val (instanceRegistry, contextInit, contextExec) = setupRegistryAndContext()
     implicit val registry: InstanceRegistry = instanceRegistry
     implicit val context: ActionPipelineContext = contextInit
@@ -667,7 +671,7 @@ trait TableDataObjectBehaviour extends GenericTestTool {
    * Incremental output mode with updates and inserts: only new records and the latest version of updated records are returned.
    * Updates and inserts are done with merge writes, as an engine-agnostic replacement for SQL INSERT/UPDATE statements.
    */
-  def testIncrementalOutputModeWithUpdatesAndInserts(createTgtDataObject: TableDataObjectFactory): Unit = {
+  def testIncrementalOutputModeWithUpdatesAndInserts(createTgtDataObject: IncrementalTableDataObjectFactory): Unit = {
     val (instanceRegistry, contextInit, contextExec) = setupRegistryAndContext()
     implicit val registry: InstanceRegistry = instanceRegistry
     implicit val context: ActionPipelineContext = contextInit

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkObservation.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkObservation.scala
@@ -33,6 +33,15 @@ import java.util.UUID
  *
  * Note 1: Observations are not supported for streaming Datasets
  * Note 2: the name is used to make metrics unique across parallel queries in the same Spark session
+ *
+ * Note 3: Why not use org.apache.spark.sql.Observation directly, like SparkConnectObservation of sdl-sparkconnect?
+ *   The standard Observation gets the metrics of its own CollectMetrics node only, while this implementation uses the
+ *   QueryExecutionListener to read *all* observed metrics of the QueryExecution. That is what setOtherObservationNames
+ *   and setOtherObservationsPrefix need, in order to also pick up Spark observations which are set up independently of
+ *   GenericDataFrame.setupObservation - notably the file name observers of SparkFileDataObject (see FileIncrementalMoveMode),
+ *   and custom observations of the user. Switching to the standard Observation would lose this, so it is kept as is.
+ *   Note that metrics of sibling input observations do not need the listener: they are combined by DataFrameActionImpl
+ *   with SuffixedObservation, see DataFrameObservation.includeInInputObservationCombine.
  */
 private[smartdatalake] class SparkObservation(name: String = UUID.randomUUID().toString) extends DataFrameObservation with SmartDataLakeLogger {
 

--- a/sdl-sparkconnect/README.md
+++ b/sdl-sparkconnect/README.md
@@ -33,6 +33,9 @@ This module contributes:
 | `SparkConnectConnection` | `workflow/connection/SparkConnectConnection.scala` | Owns the Spark Connect session (`SparkSession.builder().remote(url)`). Implements `EngineConnection` with `subFeedType = SparkConnectSubFeed`, which drives engine selection in `DataFrameActionImpl`. `activate` tags remote operations with the current action id for traceability on the server. |
 | `SparkConnectSubFeed` | `workflow/dataframe/sparkconnect/SparkConnectSubFeed.scala` | The SubFeed transporting DataFrames between Actions, plus its companion implementing `DataFrameSubFeedCompanion`/`DataFrameFunctions` by delegating to the shared `org.apache.spark.sql.functions`. `getSparkSession` resolves the session from the `SparkConnectConnection` in the context (parallel to `SparkSubFeed.getSparkSession`, which stays hard-wired to `SparkClassicConnection`). |
 | Wrapper classes | `workflow/dataframe/sparkconnect/SparkConnectDataFrame.scala` | `SparkConnectDataFrame`, `SparkConnectColumn`, `SparkConnectSchema`, `SparkConnectField`, `SparkConnectDataType` (+ Simple/Struct/Array/Map), `SparkConnectRow`, `SparkConnectGroupedDataFrame`, `SparkConnectUnaryUdf` - each wrapping the corresponding shared Spark SQL API type. |
+| `DeltaLakeTableSparkConnectEngine` | `workflow/dataobject/DeltaLakeTableSparkConnectEngine.scala` | Spark Connect implementation of the `DeltaLakeTableEngine` SPI of `sdl-core`, so that the engine-agnostic `DeltaLakeTableDataObject` can be used over Spark Connect. Read/write/merge, schema evolution, partition handling, delta operation metrics from `DESCRIBE HISTORY`, and incremental output (`CanCreateIncrementalOutput`) with the delta change data feed (`readChangeFeed`/`startingVersion`). Everything through SQL and the Spark API, without the DeltaTable Java API and without filesystem access. |
+| `IcebergTableSparkConnectEngine` | `workflow/dataobject/IcebergTableSparkConnectEngine.scala` | Spark Connect implementation of the `IcebergTableEngine` SPI of `sdl-core`, analogous to the delta engine. Incremental output uses the Iceberg stored procedure `system.create_changelog_view`, snapshot ids are read from the `<table>.snapshots` metadata table instead of the Iceberg Java API. |
+| `SparkConnectObservation` | `workflow/dataframe/sparkconnect/SparkConnectObservation.scala` | `DataFrameObservation` based on the standard Spark API `org.apache.spark.sql.Observation` and `Dataset.observe(Observation, ...)`. Needs no `QueryExecutionListener`: the observed metrics are transported back to the client with the response of the query or command executing the plan. Falls back to calculating the metrics with a separate query if the execution reports no metrics, see "Observations and metrics" below. |
 | `SparkConnectTableDataObject` | `workflow/dataobject/SparkConnectTableDataObject.scala` | `TransactionalTableDataObject` over the normal Spark Table API: read via `session.read.table` (or `table.query` via `session.sql`), write via `saveAsTable` with SDLSaveMode mapping, existence checks via `session.catalog`, `dropTable`/pre-/post-SQL via `session.sql`. Outside the exec phase DataFrames are limited to 1 row for fast schema propagation. Implements `CanHandlePartitions` (write with `partitionBy`, overwrite given partitions by delete+append, dynamic partition overwrite via `insertInto`, list partitions by select distinct, delete/move partitions with SQL DELETE/UPDATE) and `CanMergeDataFrame` (SDLSaveMode.Merge implemented with the Spark native merge API `Dataset.mergeInto`, analogous to `DeltaLakeTableDataObject.mergeDataFrameByPrimaryKey`). Note that merge and delete/move partitions need a table format supporting row-level operations on the server side, e.g. `format = delta`. |
 
 There is no registration mechanism needed: SDLB discovers SubFeed types, connections and DataObjects by
@@ -89,25 +92,74 @@ actions {
 }
 ```
 
+## Supported DataObject features
+
+| DataObject | Features |
+|---|---|
+| `SparkConnectTableDataObject` | `CanHandlePartitions`, `CanMergeDataFrame`, `CanEvolveSchema`, `ExpectationValidation` (constraints and expectations) |
+| `DeltaLakeTableDataObject` (sdl-core) | additionally `CanCreateIncrementalOutput` (delta change data feed) and `CanHandleConstraints` (primary key constraints) |
+| `IcebergTableDataObject` (sdl-core) | additionally `CanCreateIncrementalOutput` (Iceberg changelog view) |
+
+Expectations and constraints are engine-agnostic: they are composed of `SqlExpressionColumn`s and standard
+`DataFrameFunctions`, and the metrics are observed with `SparkConnectObservation`. The validation expressions
+themselves are evaluated client-side by `ScalaExpressionEvaluatorFactory` (the fallback of
+`Environment.expressionEvaluatorFactory`), which does not need Spark at all.
+
+## Observations and metrics
+
+Expectations and the row counts of an Action are collected with `DataFrame` observations. On a Spark Connect client
+there is no `QueryExecutionListener`, but the standard `org.apache.spark.sql.Observation` API works: the client
+registers the observation, and the server returns the observed metrics with the response of the query or command
+executing the plan - for `ExecutePlan` requests as well as for commands like a write.
+
+However, not every execution reports metrics. The response then contains an *empty* metrics row, and
+`SparkConnectObservation` falls back to calculating the metrics with a separate aggregation query on the cached
+DataFrame (this is what `GenericCalculatedObservation` of sdl-core does, and what this module did before). Known cases:
+
+- **writing with a DataSource which creates its own `QueryExecution` on the server** - this includes delta lake and
+  Iceberg, i.e. `DeltaLakeTableDataObject` and `IcebergTableDataObject` always use the fallback for their output metrics.
+  A plain `saveAsTable` (e.g. `SparkConnectTableDataObject` on the servers default format) does report metrics.
+- **plans which are not sent to the server as such**, e.g. when the observed DataFrame is registered as a temporary
+  view and referenced by a SQL statement (`SQLDfTransformer`, `SQLDfsTransformer`).
+- **the observed DataFrame is not part of the executed plan at all**, e.g. an input which is not used by the
+  transformation of an Action.
+
+Because of the fallback, the DataFrame is still cached in the exec phase - `cacheInput`/`cacheOutput` remain the
+explicit materialization knobs on top of that.
+
+Metrics of the input observations are collected by the output observation (`linkWithInputObservations`) rather than
+combined with `CombinedObservation`, analogous to `SparkObservation` of sdl-spark: an `Observation` only carries the
+metrics of its own `CollectMetrics` node, and waiting for an input which is not part of the executed plan would block
+until timeout. Input metrics get the input DataObjectId as postfix, e.g. `count#src1`, same as with the classic engine.
+
 ## Current limitations
 
 The following features are stubbed with `NotImplementedError` or reduced functionality, following the Snowpark precedent:
 
 - **Streaming**: streaming DataFrames, dummy streaming DataFrames and the streaming lifecycle hooks are not supported yet.
+  Observations are not supported for streaming Datasets either.
 - **Schema evolution of struct types**: needs custom catalyst expressions which cannot be created on the client side
   (simple type casts and array/map recursion work).
-- **Write metrics**: there is no `QueryExecutionListener` on the connect client, so `writeDataFrame` returns an empty
-  MetricsMap. Observations fall back to `GenericCalculatedObservation` (metrics calculated with a separate query on the
-  cached DataFrame).
+- **Write metrics of `SparkConnectTableDataObject`**: there is no `QueryExecutionListener` on the connect client, so
+  `writeDataFrame` returns an empty MetricsMap, i.e. there is no `records_written`/`bytes_written`. The number of
+  written rows is still reported as `count` metric from the observation.
+  The delta and iceberg engines do return operation metrics (`DESCRIBE HISTORY` / snapshot summary).
+- **Observed metrics are not reported for every execution**, see "Observations and metrics" above. The metrics are
+  correct in any case, but for delta lake and Iceberg writes they need a second query on the cached DataFrame.
+- **No filter push-down for input row counts**: the `!pushDownTolerant` marker that SDLB adds to input observation names
+  is evaluated by the catalyst rule `PushPredicateThroughTolerantCollectMetricsRule`, which is injected by
+  `SDLSparkExtension` of sdl-spark. That is a *server-side* session extension and normally not installed on a Spark
+  Connect server, so input counts are taken above the filter instead of at the source.
 - **`hash` function**: implemented as `hash(to_json(struct(...), ignoreNullFields=false))` to keep null-awareness without
   the custom `NullAwareMurmur3HashExpr` catalyst expression. Hash values are therefore *not* comparable to hash values
   written by the classic Spark engine.
-- **Column introspection**: `GenericColumn.exprSql` and `getName` are not available (columns are unresolved plan
-  expressions on the client side).
+- **Column introspection**: `GenericColumn.exprSql` is not available (columns are unresolved plan expressions on the
+  client side). This also means that the expectations implemented in sdl-spark (`CountExpectation`,
+  `AvgCountPerPartitionExpectation`) cannot be used. Use the generic `SQLExpectation`, 
+  e.g. `SQLExpectation(name = "count", aggExpression = "count(*)", expectation = Some("> 0"))`.
 - **Merge and partition deletion need a v2 table format**: SDLSaveMode.Merge, `deletePartitions` and `movePartitions`
   use row-level operations (MERGE/DELETE/UPDATE) which are not supported for plain parquet tables - use e.g. `format = delta`.
   Schema evolution on merge is not supported yet.
-- `DataObject` features deferred to later phases: `CanEvolveSchema`, incremental output, expectations/constraints.
 
 ## Testing
 

--- a/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectDataFrame.scala
+++ b/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectDataFrame.scala
@@ -165,10 +165,19 @@ case class SparkConnectDataFrame(override val inner: DataFrame) extends GenericD
 
   override def setupObservation(name: String, aggregateColumns: Seq[GenericColumn], isExecPhase: Boolean, forceGenericObservation: Boolean = false): (GenericDataFrame, DataFrameObservation) = {
     DataFrameSubFeed.assertCorrectSubFeedType(subFeedType, aggregateColumns)
-    // Spark Connect has no QueryExecutionListener on the client side. Metrics are calculated with a separate query on the cached DataFrame.
-    val observation = GenericCalculatedObservation(this, aggregateColumns.toIndexedSeq: _*)
-    // Cache the DataFrame to avoid duplicate calculation. If cache is not needed, create a GenericCalculationObservation directly.
-    (if (isExecPhase) this.cache else this, observation)
+    // Cache the DataFrame, so that metrics can be calculated with a separate query without recomputing it.
+    // This is needed for GenericCalculatedObservation, and as fallback of SparkConnectObservation.
+    val dfCached = if (isExecPhase) this.cache.asInstanceOf[SparkConnectDataFrame] else this
+    if (forceGenericObservation) {
+      (dfCached, GenericCalculatedObservation(dfCached, aggregateColumns.toIndexedSeq: _*))
+    } else {
+      // Spark Connect has no QueryExecutionListener on the client side, but the standard Spark Observation API
+      // transports the observed metrics back with the response of the query/command executing this plan.
+      val observation = new SparkConnectObservation(name, dfCached, aggregateColumns)
+      val sparkAggregatedColumns = aggregateColumns.map(_.asInstanceOf[SparkConnectColumn].inner)
+      val dfObserved = observation.on(dfCached.inner, sparkAggregatedColumns.toIndexedSeq: _*)
+      (SparkConnectDataFrame(dfObserved), observation)
+    }
   }
 
   def observe(name: String, aggregateColumns: Seq[GenericColumn], isExecPhase: Boolean): GenericDataFrame = {

--- a/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectObservation.scala
+++ b/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectObservation.scala
@@ -1,0 +1,135 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataframe.sparkconnect
+
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.dataframe.{DataFrameObservation, GenericCalculatedObservation, GenericColumn}
+import org.apache.spark.sql.{Column, Dataset, Observation, Row}
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.Try
+
+/**
+ * DataFrameObservation implementation for the Spark Connect engine, based on the standard Spark API
+ * `org.apache.spark.sql.Observation` and `Dataset.observe(Observation, ...)`.
+ *
+ * Unlike `SparkObservation` of sdl-spark this needs no QueryExecutionListener (there is none on a Spark Connect
+ * client): the observed metrics are transported back to the client with the response of the query or command
+ * executing the plan, and Spark completes the future of the Observation registered in the sessions observation registry.
+ *
+ * Not every execution delivers observed metrics though. The response then contains an empty metrics Row, and the
+ * metrics are calculated with a separate query on the (cached) DataFrame instead, like GenericCalculatedObservation.
+ * Known cases:
+ * - writing with a DataSource which creates its own QueryExecution on the server, e.g. delta lake and Iceberg
+ * - plans which are not sent to the server as such, e.g. because the observed DataFrame was registered as a
+ *   temporary view and is referenced by a SQL statement (SQLDfTransformer, SQLDfsTransformer)
+ * - the observed DataFrame is not part of the executed plan at all, e.g. an input which is not used by the
+ *   transformation of an Action
+ *
+ * An Observation delivers the metrics of its own CollectMetrics node only. Metrics of the sibling input observations
+ * are therefore collected by this observation as well, see linkWithInputObservations: as the input observations are
+ * normally part of the same plan as the output observation, their metrics are delivered with the same response.
+ *
+ * Note 1: Observations are not supported for streaming Datasets.
+ * Note 2: an Observation can be used with one Dataset only.
+ * Note 3: the name is used to make metrics unique across parallel queries in the same Spark session.
+ */
+private[smartdatalake] class SparkConnectObservation(name: String = UUID.randomUUID().toString, df: SparkConnectDataFrame, aggregateColumns: Seq[GenericColumn]) extends DataFrameObservation with SmartDataLakeLogger {
+
+  private val observation = new Observation(name)
+
+  def getName: String = name
+
+  /**
+   * Attach this observation to the given Dataset.
+   * @return the Dataset with the observation attached. Metrics are only delivered when this Dataset is executed.
+   */
+  def on[T](ds: Dataset[T], exprs: Column*): Dataset[T] = {
+    // check this is no streaming Dataset. It would need registering a StreamingQueryListener instead.
+    if (ds.isStreaming) throw new IllegalArgumentException("SparkConnectObservation does not support streaming Datasets")
+    ds.observe(observation, exprs.head, exprs.tail.toIndexedSeq: _*)
+  }
+
+  override def linkWithInputObservations(inputObservations: Seq[DataFrameObservation], prefix: String): Unit = {
+    otherObservations = inputObservations.collect { case x: SparkConnectObservation => x }
+  }
+  private var otherObservations: Seq[SparkConnectObservation] = Seq()
+
+  // input observations are handled by linkWithInputObservations, so that they can be read without waiting for a timeout
+  override def includeInInputObservationCombine: Boolean = false
+
+  /**
+   * Get the observed metrics. This waits for the observed Dataset to be executed and its metrics to be delivered,
+   * and calculates them with a separate query if the execution delivered no metrics.
+   * Metrics of linked input observations are added with the DataObjectId as postfix, e.g. count#src1.
+   *
+   * @param timeoutSec max wait time in seconds for the observed metrics.
+   * @return the observed metrics as a `Map[String, Any]`
+   */
+  override def waitFor(timeoutSec: Int = 1): Map[String, _] = {
+    getMetrics(timeoutSec, addNamePostfix = false) ++
+      otherObservations.flatMap(_.getMetrics(SparkConnectObservation.otherObservationsWaitSec, addNamePostfix = true))
+  }
+
+  /**
+   * @param addNamePostfix if true, the DataObjectId of this observations name is added as postfix to the metric names, e.g. count#src1.
+   */
+  private def getMetrics(timeoutSec: Int, addNamePostfix: Boolean): Map[String, _] = {
+    logger.debug(s"($name) waiting for metrics")
+    // Observation.get/getRow would block forever, use the underlying future to implement the timeout.
+    // Note that an empty Row is delivered if the execution did not report metrics for this observation.
+    val observedRow = Try(Await.result(observation.future, Duration(timeoutSec, TimeUnit.SECONDS))).toOption.filter(_.length > 0)
+    val metrics = observedRow.map(createMetrics)
+      .getOrElse {
+        logger.debug(s"($name) no metrics observed, calculating them with a separate query")
+        GenericCalculatedObservation(df, aggregateColumns: _*).waitFor(timeoutSec)
+      }
+    val postfixedMetrics = if (addNamePostfix) metrics.map { case (k, v) => (s"$k#$metricsPostfix", v) } else metrics
+    logger.debug(s"($name) got metrics ${postfixedMetrics.map { case (k, v) => s"$k=$v" }.mkString(" ")}")
+    postfixedMetrics
+  }
+
+  /**
+   * The observation name is composed by ExpectationValidation as "<dataObjectId>#<uuid>[!pushDownTolerant]".
+   */
+  private def metricsPostfix: String = name.stripSuffix(SparkConnectObservation.pushDownTolerantMetricsMarker).takeWhile(_ != '#')
+
+  private def createMetrics(row: Row): Map[String, _] = {
+    row.getValuesMap[Any](row.schema.fieldNames.toList)
+      .map { case (k, v) => (k, Option(v).getOrElse(None)) } // if value is null convert to None
+  }
+}
+
+private[smartdatalake] object SparkConnectObservation {
+
+  /**
+   * Marker added to observation names by ExpectationValidation, see PushPredicateThroughTolerantCollectMetricsRule of sdl-spark.
+   * Note that the corresponding catalyst rule is a server side session extension and normally not installed on a Spark Connect server.
+   */
+  private val pushDownTolerantMetricsMarker = "!pushDownTolerant"
+
+  /**
+   * Max wait time for metrics of linked input observations. They are delivered with the same response as the metrics
+   * of this observation, so this is just to bridge the gap until all observations of a response are completed.
+   */
+  private val otherObservationsWaitSec = 1
+}

--- a/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableSparkConnectEngine.scala
+++ b/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableSparkConnectEngine.scala
@@ -114,8 +114,6 @@ class DeltaLakeTableSparkConnectEngine(dataObject: DeltaLakeTableDataObject) ext
       session.read.options(dataObject.options).table(table.fullName)
     }
 
-    if (incrementalOutputExpr.isDefined && !propertyExists(enableCdcFeedProperty)) activateCdc()
-
     SparkConnectDataFrame(df)
   }
 

--- a/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataobject/SparkConnectTableDataObject.scala
+++ b/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataobject/SparkConnectTableDataObject.scala
@@ -29,7 +29,8 @@ import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.connection.SparkConnectConnection
 import io.smartdatalake.workflow.dataframe.sparkconnect.{SparkConnectDataFrame, SparkConnectSchema, SparkConnectSubFeed}
 import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchema}
-import io.smartdatalake.workflow.dataobject.generic.{CanEvolveSchema, CanHandlePartitions, CanMergeDataFrame, Table, TransactionalTableDataObject}
+import io.smartdatalake.workflow.dataobject.expectation.Expectation
+import io.smartdatalake.workflow.dataobject.generic.{CanEvolveSchema, CanHandlePartitions, CanMergeDataFrame, Constraint, ExpectationValidation, Table, TransactionalTableDataObject}
 import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed}
 import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SaveMode, SparkSession}
 
@@ -49,6 +50,8 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param table        table to be read/written by this data object
  * @param schemaMin    An optional, minimal schema that this DataObject must have to pass schema validation on reading and writing.
  * @param partitions   partition columns for this data object
+ * @param constraints  List of row-level [[Constraint]]s to enforce when writing to this data object.
+ * @param expectations List of [[Expectation]]s to enforce when writing to this data object. Expectations are checks based on aggregates over all rows of a dataset.
  * @param saveMode     [[SDLSaveMode]] to use when writing the table, default is "Overwrite"
  * @param format       Optional table format used when creating the table, e.g. parquet or delta. Default is the servers default table format.
  * @param allowSchemaEvolution If set to true schema evolution will automatically occur when writing to this DataObject with different schema.
@@ -68,6 +71,8 @@ case class SparkConnectTableDataObject(override val id: DataObjectId,
                                        override var table: Table,
                                        override val schemaMin: Option[GenericSchema] = None,
                                        override val partitions: Seq[String] = Seq(),
+                                       override val constraints: Seq[Constraint] = Seq(),
+                                       override val expectations: Seq[Expectation] = Seq(),
                                        saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                                        format: Option[String] = None,
                                        override val allowSchemaEvolution: Boolean = false,
@@ -80,7 +85,8 @@ case class SparkConnectTableDataObject(override val id: DataObjectId,
                                        override val expectedPartitionsCondition: Option[String] = None,
                                        override val metadata: Option[DataObjectMetadata] = None)
                                       (@transient implicit val instanceRegistry: InstanceRegistry)
-  extends TransactionalTableDataObject with CanMergeDataFrame with CanHandlePartitions with CanEvolveSchema with SmartDataLakeLogger {
+  extends TransactionalTableDataObject with CanMergeDataFrame with CanHandlePartitions with CanEvolveSchema
+    with ExpectationValidation with SmartDataLakeLogger {
 
   val connection: SparkConnectConnection = getConnection[SparkConnectConnection](connectionId)
 

--- a/sdl-sparkconnect/src/test/scala/io/smartdatalake/workflow/sparkconnect/SparkConnectTableDataObjectBehaviourTest.scala
+++ b/sdl-sparkconnect/src/test/scala/io/smartdatalake/workflow/sparkconnect/SparkConnectTableDataObjectBehaviourTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.sparkconnect
+
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.config.SdlConfigObject.ConnectionId
+import io.smartdatalake.definitions.Environment
+import io.smartdatalake.testutils.sparkconnect.SparkConnectTestUtil
+import io.smartdatalake.testutils.{TableDataObjectBehaviour, TableDataObjectTestParams}
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.connection.{Connection, EngineConnection, SparkConnectConnection}
+import io.smartdatalake.workflow.dataobject.SparkConnectTableDataObject
+import io.smartdatalake.workflow.dataobject.generic.Table
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.{Canceled, Outcome}
+
+/**
+ * Tests constraints and expectations of SparkConnectTableDataObject, using the shared engine-agnostic
+ * TableDataObjectBehaviour. Both are evaluated with the standard Spark Observation API, see `SparkConnectObservation`.
+ * Needs a Spark Connect server, see [[SparkConnectTestUtil]] and start-spark-connect.sh.
+ * Tests are cancelled (not failed) if no server is available.
+ */
+class SparkConnectTableDataObjectBehaviourTest extends AnyFunSuite
+  with SmartDataLakeLogger with TableDataObjectBehaviour {
+
+  override val defaultEngineConnection: Connection with EngineConnection =
+    SparkConnectConnection(ConnectionId(Environment.defaultEngineConnectionId), SparkConnectTestUtil.url)
+
+  // cancel all tests of this suite if no spark connect server is available
+  override def withFixture(test: NoArgTest): Outcome = {
+    if (!SparkConnectTestUtil.serverAvailable) Canceled(s"No Spark Connect server available at ${SparkConnectTestUtil.url}")
+    else super.withFixture(test)
+  }
+
+  private def createSrcDataObject(id: String, registry: InstanceRegistry) =
+    SparkConnectTableDataObject(id, Table(Some("default"), s"sdlb_sctdo_behaviour_$id"),
+      connectionId = defaultEngineConnection.id)(registry)
+
+  // Spark Connect has no client-side filesystem access, tables are created as managed tables.
+  // Note that constraints and expectations do not need a table format supporting row-level operations.
+  private def createTableDataObject(id: String, params: TableDataObjectTestParams, registry: InstanceRegistry): SparkConnectTableDataObject =
+    SparkConnectTableDataObject(id, partitions = params.partitions, options = params.options,
+      table = Table(Some("default"), s"sdlb_sctdo_behaviour_$id", primaryKey = params.primaryKey),
+      constraints = params.constraints, expectations = params.expectations, saveMode = params.saveMode,
+      allowSchemaEvolution = params.allowSchemaEvolution, connectionId = defaultEngineConnection.id)(registry)
+
+  test("constraints validation") {
+    testConstraints(createSrcDataObject, createTableDataObject)
+  }
+
+  test("copy load expectations test") {
+    testCopyLoadWithExpectations(createSrcDataObject, createTableDataObject)
+  }
+}


### PR DESCRIPTION
fix some limitations on #953
