### PR TITLE
Improve DataFrameSubFeed filters (#1115)

### DIFF
--- a/docs/docs/reference/executionModes.md
+++ b/docs/docs/reference/executionModes.md
@@ -97,6 +97,23 @@ If you need to read everything from one DataObject, even though it does have the
 you can again use `CustomDataFrameAction.inputIdsToIgnoreFilter` to override the default behavior.
 :::
 
+### Column filters
+
+Besides partition values, an execution mode can also return *column filters*.
+A column filter is a filter expression bound to a column, and it works analogously to partition values:
+it is applied to every input DataObject _that contains the given column_, and it has no effect on input DataObjects
+which don't have it.
+
+A column filter has two options:
+
+* `mainInputOnly`: if set, the filter is only applied to the main input of the Action instead of to all inputs.
+* `propagate`: if set, the filter is passed on to the outputs of the Action, and therefore to the following Actions,
+  again restricted to the columns they contain. Only set this if the filter still describes the data written by the
+  Action, because the filter is then assumed to be applied already. Default is that a filter is not propagated.
+
+`CustomDataFrameAction.inputIdsToIgnoreFilter` excludes an input from column filters as well, exactly like it does
+for partition values.
+
 
 ### FailIfNoPartitionValuesMode
 If you use the method described above, you might want to set the executionMode to `FailIfNoPartitionValuesMode`.
@@ -209,6 +226,13 @@ You configure it by defining the attribute `compareCol` naming a column that exi
 For this mode to work, `compareCol` needs to be of a sortable datatype like int or timestamp.
 
 The attributes `applyCondition` and `alternativeOutputId` work the same as for [PartitionDiffMode](executionModes#partitiondiffmode-dynamic-partition-values-filter).
+
+Internally the mode creates a [column filter](executionModes#column-filters) on `compareCol`, which is applied to the
+main input only.
+By default the filter is not propagated to the following Actions, so they still process the whole output DataObject.
+Set `propagateFilter = true` if the following Actions should process the increment only.
+Note that the filter is then applied to every following DataObject having a `compareCol` column, so only use this if
+the increment can still be identified by the filter after it has been written.
 
 :::info
 This execution mode has a performance drawback as it has to query the maximum value for `compareCol` on input and output DataObjects each time.

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/ProductUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/ProductUtil.scala
@@ -232,6 +232,9 @@ object ProductUtil {
         val value = if (key == fieldName) newValue else inst.reflectMethod(m).apply()
         (key, value)
       }
+    // without this check a wrong fieldName would silently return an unchanged object
+    require(attributes.exists(_._1 == fieldName),
+      s"field $fieldName not found in object of type ${obj.getClass.getSimpleName}, available fields are ${attributes.map(_._1).mkString(", ")}")
     inst.reflectMethod(copyConstructor.asMethod).apply(attributes.map(_._2).toIndexedSeq: _*).asInstanceOf[T]
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionDAGRunState.scala
@@ -88,7 +88,7 @@ case class DataObjectState(dataObjectId: DataObjectId, state: String) {
 private[smartdatalake] object ActionDAGRunState extends SmartDataLakeLogger {
 
   // Note: if increasing this version, please check if a StateMigrator is needed to read files of older versions. See also stateMigrators below.
-  val runStateFormatVersion: Int = 6
+  val runStateFormatVersion: Int = 7
 
   implicit private lazy val workflowReflections: Reflections = ReflectionUtil.getReflections(ConfigParser.WORKFLOW_PACKAGE)
 
@@ -159,7 +159,8 @@ private[smartdatalake] object ActionDAGRunState extends SmartDataLakeLogger {
   private val stateMigrators: Seq[StateMigratorDef] = Seq(
     new StateMigratorDef3To4(),
     new StateMigratorDef4To5(),
-    new StateMigratorDef5To6()
+    new StateMigratorDef5To6(),
+    new StateMigratorDef6To7()
   ).sortBy(_.versionFrom) // force ordering
   assert(stateMigrators.groupBy(_.versionFrom).forall(_._2.size == 1)) // check that versionFrom is unique
   assert(stateMigrators.forall(m => m.versionFrom + 1 == m.versionTo)) // check that a state migrator always converts to the next version, without skipping a version.

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ColumnFilter.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ColumnFilter.scala
@@ -1,0 +1,91 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow
+
+import io.smartdatalake.definitions.Environment
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.dataframe.GenericSchema
+
+/**
+ * A filter expression bound to a column.
+ *
+ * The filter is applied to a DataFrame only if `column` exists in its schema, see [[GenericSchema.columnExists]].
+ * This allows an ExecutionMode to push one filter to all inputs of an Action, and filters to be propagated to
+ * following Actions, applying them where they make sense - analogous to how partition values are handled.
+ *
+ * @param column        name of the column this filter is about. It is used to decide whether the filter is applicable
+ *                      to a DataFrame, and as unique key: a SubFeed holds at most one filter per column.
+ * @param expression    SQL expression returning a boolean value, evaluated by the engine of the SubFeed.
+ * @param mainInputOnly if true this filter is only applied to the main input of the Action, otherwise to all inputs
+ *                      which have the column.
+ * @param propagate     if true this filter is passed on to the outputs of the Action, and therefore to following
+ *                      Actions, restricted to the columns they have. Set this only if the filter still describes the
+ *                      data written by the Action, as the filter is then assumed to be applied already.
+ */
+case class ColumnFilter(column: String, expression: String, mainInputOnly: Boolean = false, propagate: Boolean = false) {
+  override def toString: String = {
+    val flags = Seq(if (mainInputOnly) Some("mainInputOnly") else None, if (propagate) Some("propagate") else None).flatten
+    s"$column: $expression" + (if (flags.nonEmpty) flags.mkString(" (", ", ", ")") else "")
+  }
+}
+
+object ColumnFilter extends SmartDataLakeLogger {
+
+  /**
+   * Normalize a column name for comparison, honouring [[Environment.caseSensitive]].
+   */
+  private def key(colName: String): String = if (Environment.caseSensitive) colName else colName.toLowerCase
+
+  /**
+   * Merge `added` into `existing`, keeping at most one filter per column and preserving insertion order.
+   * A filter for a column which already has a different filter replaces it and logs a warning.
+   *
+   * @param context by-name description of the location, e.g. s"($dataObjectId)". It is only evaluated if a warning
+   *                is logged.
+   */
+  def merge(existing: Seq[ColumnFilter], added: Seq[ColumnFilter], context: => String): Seq[ColumnFilter] = {
+    added.foldLeft(existing) { case (acc, filter) =>
+      val idx = acc.indexWhere(f => key(f.column) == key(filter.column))
+      if (idx < 0) acc :+ filter
+      else if (acc(idx) == filter) acc
+      else {
+        logger.warn(s"$context filter on column ${acc(idx).column} is replaced:" +
+          s" '${acc(idx).expression}' -> '${filter.expression}'")
+        acc.updated(idx, filter)
+      }
+    }
+  }
+
+  /**
+   * Keep only the filters which are applicable to the given schema, e.g. whose column exists.
+   * This is the column analogue of [[SubFeed.filterPartitionValues]].
+   */
+  def filterExistingColumns(filters: Seq[ColumnFilter], schema: GenericSchema): Seq[ColumnFilter] = {
+    filters.filter(f => schema.columnExists(f.column))
+  }
+
+  /**
+   * true if the given filters contain more than one filter for the same column.
+   */
+  def hasDuplicateColumns(filters: Seq[ColumnFilter]): Boolean = {
+    filters.map(f => key(f.column)).distinct.size != filters.size
+  }
+
+  def describe(filters: Seq[ColumnFilter]): String = filters.mkString(", ")
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/DataFrameSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/DataFrameSubFeed.scala
@@ -82,17 +82,34 @@ trait DataFrameSubFeed extends SubFeed {
     throw new IllegalStateException(s"($dataObjectId) schema of this SubFeed is not yet initialized")
   )
 
-  def filter: Option[String]
+  /**
+   * Column-bound filters transported by this SubFeed, at most one per column.
+   * They are applied when the DataFrame is (re)created, and only if their column exists, see [[applyFilter]].
+   */
+  def filters: Seq[ColumnFilter]
+
+  def hasFilters: Boolean = filters.nonEmpty
+
+  /**
+   * Filters to keep when merging two SubFeeds for the same DataObject.
+   * Only filters present in both SubFeeds are kept: dropping a filter widens the data read, whereas keeping a filter
+   * which is not valid for the other SubFeed would lose data.
+   */
+  def unionFilters(other: SubFeed): Seq[ColumnFilter] = other match {
+    case dataFrameSubFeed: DataFrameSubFeed => this.filters.intersect(dataFrameSubFeed.filters)
+    case _ => Seq()
+  }
 
   /** true if this SubFeed holds a streaming DataFrame */
   def isStreamingDataFrame: Boolean = dataFrame.exists(_.isStreaming)
 
-  def clearFilter(breakLineageOnChange: Boolean = true)(implicit context: ActionPipelineContext): DataFrameSubFeed = {
-    // if filter is removed, normally also the DataFrame must be removed so that the next action get's a fresh unfiltered DataFrame with all data of this DataObject
-    if (breakLineageOnChange && filter.isDefined) {
-      logger.info(s"($dataObjectId) breakLineage called for SubFeed from clearFilter")
-      ProductUtil.dynamicCopy(ProductUtil.dynamicCopy(this, "filter", None), "observation", None).breakLineage
-    } else ProductUtil.dynamicCopy(ProductUtil.dynamicCopy(this, "filter", None), "observation", None)
+  def clearFilters(breakLineageOnChange: Boolean = true)(implicit context: ActionPipelineContext): DataFrameSubFeed = {
+    // if filters are removed, normally also the DataFrame must be removed so that the next action get's a fresh unfiltered DataFrame with all data of this DataObject
+    val cleared = ProductUtil.dynamicCopy(ProductUtil.dynamicCopy(this, "filters", Seq.empty[ColumnFilter]), "observation", None)
+    if (breakLineageOnChange && hasFilters) {
+      logger.info(s"($dataObjectId) breakLineage called for SubFeed from clearFilters")
+      cleared.breakLineage
+    } else cleared
   }
 
   override def breakLineage(implicit context: ActionPipelineContext): DataFrameSubFeed = {
@@ -132,8 +149,35 @@ trait DataFrameSubFeed extends SubFeed {
     ProductUtil.dynamicCopy(this, "partitionValues", partitionValues)
   }
 
-  def withFilter(partitionValues: Seq[PartitionValues], filter: Option[String]): DataFrameSubFeed = {
-    ProductUtil.dynamicCopy(withPartitionValues(partitionValues), "filter", filter)
+  /**
+   * Set the filters of this SubFeed, replacing existing ones. This does not apply them, see [[applyFilter]].
+   */
+  def withFilters(filters: Seq[ColumnFilter]): DataFrameSubFeed = {
+    ProductUtil.dynamicCopy(this, "filters", filters)
+  }
+
+  /**
+   * Add filters to this SubFeed. A filter for a column which already has one replaces it, see [[ColumnFilter.merge]].
+   */
+  def addFilters(added: Seq[ColumnFilter]): DataFrameSubFeed = {
+    withFilters(ColumnFilter.merge(filters, added, s"($dataObjectId)"))
+  }
+
+  /**
+   * Restrict the filters of this SubFeed to the columns existing in the given schema, analogous to
+   * [[updatePartitionValues]]. Filters for non-existing columns are dropped, as they do not apply to the
+   * corresponding DataObject.
+   */
+  def updateFilters(schema: GenericSchema): DataFrameSubFeed = {
+    val updatedFilters = ColumnFilter.filterExistingColumns(filters, schema)
+    val droppedFilters = filters.diff(updatedFilters)
+    if (droppedFilters.nonEmpty) logger.debug(s"($dataObjectId) filters ${ColumnFilter.describe(droppedFilters)}" +
+      s" are dropped because their column does not exist")
+    withFilters(updatedFilters)
+  }
+
+  def withFilters(partitionValues: Seq[PartitionValues], filters: Seq[ColumnFilter]): DataFrameSubFeed = {
+    withPartitionValues(partitionValues).withFilters(filters)
       .applyFilter
   }
   def applyFilter: DataFrameSubFeed = {
@@ -149,9 +193,14 @@ trait DataFrameSubFeed extends SubFeed {
       val filterExpr = PartitionValues.createFilterExpr(partitionValues)
       dataFrame.map(_.filter(filterExpr))
     }
-    // apply generic filter
-    val dfResult = if (filter.isDefined) dfPartitionFiltered.map(_.filter(companion.expr(filter.get)))
-    else dfPartitionFiltered
+    // apply column filters. A filter is only applied if its column exists in the DataFrame, so that an ExecutionMode
+    // can push a filter to all inputs of an Action.
+    // Note that df.schema is used deliberately and not schemaOpt: it is the schema the expression is evaluated
+    // against, and filtering only ever happens if a DataFrame is present.
+    val dfResult = dfPartitionFiltered.map { df =>
+      ColumnFilter.filterExistingColumns(filters, df.schema)
+        .foldLeft(df)((dfAcc, f) => dfAcc.filter(companion.expr(f.expression)))
+    }
     // return updated SubFeed
     withDataFrame(dfResult)
   }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/StateMigratorDef.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/StateMigratorDef.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.workflow
 
 import io.smartdatalake.util.misc.SmartDataLakeLogger
 import org.json4s.JArray
-import org.json4s.JsonAST.{JField, JInt, JNothing, JObject}
+import org.json4s.JsonAST.{JField, JInt, JNothing, JObject, JString}
 
 /**
  * Definition of how to migrate from one state version to another.
@@ -161,5 +161,38 @@ class StateMigratorDef5To6 extends StateMigratorDef with SmartDataLakeLogger {
 
     // only the version is updated, executionModeResultOptions defaults to an empty Map when missing
     updateVersion(json, versionTo)
+  }
+}
+
+/**
+ * Migrate state from format version 6 to 7:
+ * - the SubFeed attribute `filter: Option[String]` is replaced by `filters: Seq[ColumnFilter]`.
+ *
+ * The column a legacy filter belongs to is not known, so legacy filters are dropped. This is safe because SubFeeds
+ * read from the state are output SubFeeds of completed Actions, and only filters with propagate=true are passed on
+ * to the next Action anyway, see DataFrameActionImpl.updateOutputFilters.
+ * `filters` defaults to an empty Seq when missing.
+ */
+class StateMigratorDef6To7 extends StateMigratorDef with SmartDataLakeLogger {
+  override val versionFrom = 6
+  override val versionTo = 7
+  override def migrate(json: JObject): JObject = {
+    assert(json \ "runStateFormatVersion" match {
+      case JInt(version) => version <= versionFrom
+      case JNothing => true // first state files did not have an attribute runStateFormatVersion
+      case _ =>
+        throw new IllegalStateException(s"Expected runStateFormatVersion to be an integer or missing," +
+          s" but found unexpected type during migration from version $versionFrom to $versionTo")
+    }, s"Version should be equals or less than $versionFrom")
+
+    // drop the legacy SubFeed attribute `filter`, which is only ever a string
+    val migratedJson = json.removeField {
+      case (name, JString(_)) if name == "filter" =>
+        logger.debug("dropping legacy SubFeed attribute 'filter' during state migration")
+        true
+      case _ => false
+    }.asInstanceOf[JObject]
+
+    updateVersion(migratedJson, versionTo)
   }
 }

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/CustomDataFrameAction.scala
@@ -71,7 +71,7 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param mainInputId            optional selection of main inputId used for execution mode and partition values propagation. Only needed if there are multiple input DataObject's.
  * @param mainOutputId           optional selection of main outputId used for execution mode and partition values propagation. Only needed if there are multiple output DataObject's.
  * @param recursiveInputIds      output of action that are used as input in the same action
- * @param inputIdsToIgnoreFilter optional list of input ids to ignore filter (partition values & filter clause)
+ * @param inputIdsToIgnoreFilter optional list of input ids to ignore filter (partition values & column filters)
  */
 case class CustomDataFrameAction(override val id: ActionId,
                                  inputIds: Seq[DataObjectId],

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
@@ -186,11 +186,11 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
               try {
                 logger.info(s"($id) enrichSubFeedDataFrame: getting DataFrame for ${input.id}" +
                   (if (subFeed.partitionValues.nonEmpty) s" filtered by partition values ${subFeed.partitionValues.mkString(" ")}" else "") +
-                  subFeed.filter.map(f => s" filtered by $f").getOrElse(""))
-                input.getSubFeed(subFeed.partitionValues, subFeedType) // get SubFeed of specified type with fresh DataFrame
-                  .withFilter(subFeed.partitionValues, subFeed.filter)
+                  (if (subFeed.hasFilters) s" filtered by ${ColumnFilter.describe(subFeed.filters)}" else ""))
+                updateInputFilters(input.getSubFeed(subFeed.partitionValues, subFeedType) // get SubFeed of specified type with fresh DataFrame
+                  .withFilters(subFeed.partitionValues, subFeed.filters)
                   // the SubFeed is recreated from the DataObject, so the executionModeResultOptions have to be carried over
-                  .withExecutionModeResultOptions(subFeed.executionModeResultOptions).asInstanceOf[DataFrameSubFeed]
+                  .withExecutionModeResultOptions(subFeed.executionModeResultOptions).asInstanceOf[DataFrameSubFeed])
               } catch {
                 // if there is no data, but it's an action with multiple inputs, we need to avoid that the action gets skipped because of the thrown NoDataToProcessWarning
                 case _: NoDataToProcessWarning if inputs.size > 1 => subFeed.withDataFrame(Some(createEmptyDataFrame(input)))
@@ -201,7 +201,7 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
             }
           } else {
             // existing DataFrame can be used
-            subFeed
+            updateInputFilters(subFeed)
           }
         } else {
           // phase != exec
@@ -212,14 +212,37 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
             val emptyDf = subFeed.schemaOpt
               .map(_.getEmptyDataFrame(subFeed.dataObjectId))
               .getOrElse(createEmptyDataFrame(input))
+            // Note that the filters are not updated here: the empty DataFrame might be created from a declared or
+            // fallback schema, and dropping filters based on that could discard a filter which is valid in exec phase.
             subFeed.withDataFrame(Some(emptyDf))
-              .applyFilter // check that filter is working
+              .applyFilter // check that the filters are working
           } else if (subFeed.isStreamingDataFrame) {
             // convert to empty normal DataFrame
             subFeed.withDataFrame(subFeed.schemaOpt.map(x => x.getEmptyDataFrame(subFeed.dataObjectId)))
           } else subFeed
         }
     }
+  }
+
+  /**
+   * Updates the filters of an input SubFeed to the columns of its DataFrame:
+   * - remove filters for non-existing columns
+   * This is the column analogue of ActionSubFeedsImpl.updateInputPartitionValues. It is done here because the
+   * columns of a DataObject are only reliably known once its DataFrame has been created.
+   */
+  private def updateInputFilters(subFeed: DataFrameSubFeed): DataFrameSubFeed = {
+    subFeed.dataFrame.map(df => subFeed.updateFilters(df.schema)).getOrElse(subFeed)
+  }
+
+  /**
+   * Sets the propagating filters of the main input SubFeed on an output SubFeed:
+   * - keep only filters with propagate=true
+   * - remove filters for non-existing columns
+   */
+  private def updateOutputFilters(subFeed: DataFrameSubFeed, inputSubFeeds: Seq[DataFrameSubFeed]): DataFrameSubFeed = {
+    inputSubFeeds.find(_.dataObjectId == getMainInput.id)
+      .map(mainInputSubFeed => subFeed.withFilters(mainInputSubFeed.filters.filter(_.propagate)).updateFilters(subFeed.schema))
+      .getOrElse(subFeed)
   }
 
   def createEmptyDataFrame(dataObject: DataObject with CanCreateDataFrame)
@@ -244,10 +267,12 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
     require(!context.simulation || !schemaChanges,
       s"($id) write & read schema is not the same for ${input.id}. Need to drop the DataFrame and pass on only the schema, but this is not allowed in simulation!")
     preparedSubFeed = if (schemaChanges) preparedSubFeed.withSchema(readSchema) else preparedSubFeed
-    // remove potential filter and partition values added by execution mode
-    if (ignoreFilters) preparedSubFeed = preparedSubFeed.breakLineage.clearFilter().clearPartitionValues().clearSkipped().asInstanceOf[DataFrameSubFeed]
-    // break lineage if a filter expression is set, as the cached DataFrame does not contain the filter
-    if (preparedSubFeed.filter.isDefined) preparedSubFeed = preparedSubFeed.breakLineage
+    // remove potential filters and partition values added by execution mode
+    if (ignoreFilters) preparedSubFeed = preparedSubFeed.breakLineage.clearFilters().clearPartitionValues().clearSkipped().asInstanceOf[DataFrameSubFeed]
+    // Break lineage if a filter is set which is not already reflected in the DataFrame.
+    // Filters added by the execution mode of this Action already broke the lineage in applyExecutionModeResultForInput,
+    // whereas propagated filters are by definition already applied to the data written by the previous Action.
+    if (preparedSubFeed.filters.exists(!_.propagate)) preparedSubFeed = preparedSubFeed.breakLineage
     // enrich with fresh DataFrame if needed
     preparedSubFeed = enrichSubFeedDataFrame(input = input, subFeed = preparedSubFeed,
       phase = context.phase, isRecursive = isRecursive)
@@ -285,6 +310,8 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
   override def postprocessOutputSubFeedCustomized(subFeed: DataFrameSubFeed, inputSubFeeds: Seq[DataFrameSubFeed])(implicit context: ActionPipelineContext): DataFrameSubFeed = {
     assert(subFeed.dataFrame.isDefined)
     val output = outputs.find(_.id == subFeed.dataObjectId).get
+    // propagate the filters of the main input SubFeed to this output, restricted to the columns it has
+    val outputSubFeed = updateOutputFilters(subFeed, inputSubFeeds)
     // initialize outputs
     if (context.phase == ExecutionPhase.Init) {
       output.init(subFeed.dataFrame.get, subFeed.partitionValues, saveModeOptions)
@@ -314,11 +341,11 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
           }
         }
         // add updated dataframe and observation to SubFeed
-        var postSubFeed = subFeed.withDataFrame(Some(dfExpectations))
+        var postSubFeed = outputSubFeed.withDataFrame(Some(dfExpectations))
         val observations = inputObservationsToCombine ++ outputObservations
         if (observations.nonEmpty) postSubFeed = postSubFeed.withObservation(Some(CombinedObservation.create(inputObservationsToCombine ++ outputObservations)))
         postSubFeed
-      case _ => subFeed
+      case _ => outputSubFeed
     }
   }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataFrameIncrementalMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/DataFrameIncrementalMode.scala
@@ -27,11 +27,12 @@ import io.smartdatalake.workflow.action.ActionHelper.getOptionalDataFrame
 import io.smartdatalake.workflow.action.NoDataToProcessWarning
 import io.smartdatalake.workflow.dataobject.DataObject
 import io.smartdatalake.workflow.dataobject.generic.CanCreateDataFrame
-import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, SubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ColumnFilter, DataFrameSubFeed, SubFeed}
 
 /**
  * Compares max entry in "compare column" between mainOutput and mainInput and incrementally loads the delta.
- * This mode works only with SparkSubFeeds. The filter is not propagated to following actions.
+ * This mode works only with SparkSubFeeds. By default the filter is not propagated to following actions,
+ * see `propagateFilter`.
  *
  * Pick this mode for non-partitioned sources which have a monotonically increasing column, e.g. a technical
  * timestamp or a sequence-based id: the mode reads `max(compareCol)` from the output and adds a filter
@@ -62,10 +63,16 @@ import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, SubFe
  *                            It can be used to ensure processing all partitions over multiple actions in case of errors.
  * @param applyCondition      Condition to decide if execution mode should be applied or not. Define a spark sql expression working with attributes of [[DefaultExecutionModeExpressionData]] returning a boolean.
  *                            Default is to apply the execution mode.
+ * @param propagateFilter     If true the incremental filter is passed on to following actions, where it is applied to
+ *                            every DataObject having the compareCol column. Set this only if the increment written by
+ *                            this action can still be identified by the filter, as the filter is then assumed to be
+ *                            applied already. Default is false, so the filter is only used to read the increment for
+ *                            this action.
  */
 case class DataFrameIncrementalMode(compareCol: String
                                     , override val alternativeOutputId: Option[DataObjectId] = None
                                     , applyCondition: Option[Condition] = None
+                                    , propagateFilter: Boolean = false
                                    ) extends ExecutionMode with ExecutionModeWithMainInputOutput {
   override val applyConditionsDef: Seq[Condition] = applyCondition.toSeq
 
@@ -112,14 +119,15 @@ case class DataFrameIncrementalMode(compareCol: String
               } else None
               warnMsg.foreach(msg => throw NoDataToProcessWarning(actionId.id, msg))
               // prepare filter
-              val dataFilter = if (outputLatestValue != null) {
-                logger.info(s"($actionId) DataFrameIncrementalMode selected increment for writing to ${output.id}: column $compareCol} from $outputLatestValue to $inputLatestValue to process")
-                Some(s"$compareCol > cast('$outputLatestValue' as ${inputColType.sql})")
+              val dataFilters = if (outputLatestValue != null) {
+                logger.info(s"($actionId) DataFrameIncrementalMode selected increment for writing to ${output.id}: column $compareCol from $outputLatestValue to $inputLatestValue to process")
+                Seq(ColumnFilter(compareCol, s"$compareCol > cast('$outputLatestValue' as ${inputColType.sql})",
+                  mainInputOnly = true, propagate = propagateFilter))
               } else {
                 logger.info(s"($actionId) DataFrameIncrementalMode selected all data for writing to ${output.id}: output table is currently empty")
-                None
+                Seq()
               }
-              Some(ExecutionModeResult(filter = dataFilter))
+              Some(ExecutionModeResult(filters = dataFilters))
             // select all if output is empty
             case (Some(_), None) =>
               logger.info(s"($actionId) DataFrameIncrementalMode selected all records for writing to ${output.id}, because output DataObject is still empty.")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/ExecutionMode.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/executionMode/ExecutionMode.scala
@@ -223,11 +223,27 @@ object ProcessAllMode extends FromConfigFactory[ExecutionMode] {
  * Result of execution mode application
  * @param inputPartitionValues selected partition values for main input
  * @param outputPartitionValues override of partition values for main output. If None, output partition values are created by transformPartitionValues in getOutputPartitionValues, otherwise not.
+ * @param filters column-bound filters to apply to the input SubFeeds of the Action. A filter is only applied if its
+ *                column exists in the corresponding DataObject, see [[ColumnFilter]]. There must be at most one
+ *                filter per column.
+ * @param fileRefs selected files for main input, used by file based execution modes.
+ * @param options options to pass on to the transformers and Input/Output DataObjects of the Action.
  */
 case class ExecutionModeResult( inputPartitionValues: Seq[PartitionValues] = Seq(), outputPartitionValues: Option[Seq[PartitionValues]] = None
-                                , filter: Option[String] = None, fileRefs: Option[Seq[FileRef]] = None, options: Map[String,String] = Map()) {
+                                , filters: Seq[ColumnFilter] = Seq(), fileRefs: Option[Seq[FileRef]] = None, options: Map[String,String] = Map()) {
+  require(!ColumnFilter.hasDuplicateColumns(filters),
+    s"ExecutionModeResult must not contain more than one ColumnFilter per column, but got ${ColumnFilter.describe(filters)}")
+
   def getOutputPartitionValues(partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues, PartitionValues]): Seq[PartitionValues] = {
     outputPartitionValues.getOrElse(partitionValuesTransform(inputPartitionValues).values.toSeq.distinct)
+  }
+
+  /**
+   * Get the filters to apply to an input SubFeed of the Action.
+   * Filters with mainInputOnly=true are only returned for the main input.
+   */
+  def filtersForInput(isMainInput: Boolean): Seq[ColumnFilter] = {
+    if (isMainInput) filters else filters.filterNot(_.mainInputOnly)
   }
 }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericDataFrame.scala
@@ -276,8 +276,6 @@ trait GenericDataFrame extends GenericTypedObject {
   /**
    * Create an empty SubFeed for this subFeedType.
    */
-  def getDataFrameSubFeed(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): DataFrameSubFeed
-
   def apply(columnName: String): GenericColumn
 
   def isStreaming: Boolean = false

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaDataFrame.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaDataFrame.scala
@@ -431,10 +431,6 @@ case class ScalaDataFrame(cols: Seq[ScalaColumn[_]], alias: Option[String] = Non
   /**
    * Create an empty SubFeed for this subFeedType.
    */
-  override def getDataFrameSubFeed(dataObjectId: SdlConfigObject.DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): ScalaSubFeed = {
-    ScalaSubFeed(Some(this), dataObjectId, partitionValues, filter = filter)
-  }
-
   override def subFeedType: universe.Type = universe.typeOf[ScalaSubFeed]
 
   def returnEmpty: ScalaDataFrame = ScalaDataFrame.returnEmpty(this.schema)

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaSubFeed.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaSubFeed.scala
@@ -24,7 +24,7 @@ import io.smartdatalake.util.hdfs.PartitionValues
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 import io.smartdatalake.workflow.dataframe._
-import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, DataFrameSubFeedCompanion, SubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ColumnFilter, DataFrameSubFeed, DataFrameSubFeedCompanion, SubFeed}
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.{Type, TypeTag, typeOf}
@@ -41,7 +41,7 @@ case class ScalaSubFeed(@transient override val dataFrame: Option[ScalaDataFrame
                         override val partitionValues: Seq[PartitionValues] = Seq(),
                         override val isDAGStart: Boolean = false,
                         override val isSkipped: Boolean = false,
-                        override val filter: Option[String] = None,
+                        override val filters: Seq[ColumnFilter] = Seq(),
                         @transient override val observation: Option[DataFrameObservation] = None,
                         override val metrics: Option[MetricsMap] = None,
                         @transient override val keptSchema: Option[GenericSchema] = None,
@@ -56,7 +56,7 @@ case class ScalaSubFeed(@transient override val dataFrame: Option[ScalaDataFrame
 
   override def withSchema(schema: Option[GenericSchema]): ScalaSubFeed = this.copy(dataFrame = None, keptSchema = schema)
 
-  override def toOutput(dataObjectId: SdlConfigObject.DataObjectId): ScalaSubFeed = this.copy(dataFrame = None, filter = None, isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
+  override def toOutput(dataObjectId: SdlConfigObject.DataObjectId): ScalaSubFeed = this.copy(dataFrame = None, filters = Seq(), isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
 
   override def union(other: SubFeed)(implicit context: ActionPipelineContext): ScalaSubFeed = {
     val (dataFrame, schema) = other match {
@@ -74,23 +74,21 @@ case class ScalaSubFeed(@transient override val dataFrame: Option[ScalaDataFrame
       , partitionValues = unionPartitionValues(other.partitionValues)
       , isDAGStart = this.isDAGStart || other.isDAGStart
       , isSkipped = this.isSkipped && other.isSkipped
+      , filters = unionFilters(other)
       , executionModeResultOptions = unionExecutionModeResultOptions(other)
     )
   }
 
   override def applyExecutionModeResultForInput(result: ExecutionModeResult, mainInputId: SdlConfigObject.DataObjectId)(implicit context: ActionPipelineContext): ScalaSubFeed = {
-    // apply input filter
-    val inputFilter = if (this.dataObjectId == mainInputId) result.filter else None
-    this.copy(partitionValues = result.inputPartitionValues, filter = inputFilter, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps DataFrame schema without content
+    // apply input filters
+    val inputFilters = result.filtersForInput(this.dataObjectId == mainInputId)
+    this.copy(partitionValues = result.inputPartitionValues, filters = inputFilters, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps DataFrame schema without content
       .asInstanceOf[ScalaSubFeed]
   }
 
-  def applyExecutionModeResultForOutput(result: ExecutionModeResult): ScalaSubFeed = {
-    this.copy(partitionValues = result.inputPartitionValues, filter = result.filter, isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
-  }
-
   def applyExecutionModeResultForOutput(result: ExecutionModeResult, partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues, PartitionValues])(implicit context: ActionPipelineContext): ScalaSubFeed = {
-    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filter = result.filter, isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
+    // filters of the output are set from the main input SubFeed after the transformation, see DataFrameActionImpl.updateOutputFilters
+    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filters = Seq(), isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
   }
 }
 
@@ -126,7 +124,7 @@ object ScalaSubFeed extends DataFrameSubFeedCompanion {
   //TODO: ActionPipelineContext still has Spark dependencies (!)
   def fromSubFeed(subFeed: SubFeed)(implicit context: ActionPipelineContext): DataFrameSubFeed = {
     subFeed match {
-      case scalaSubFeed: ScalaSubFeed => scalaSubFeed.clearFilter().asInstanceOf[ScalaSubFeed].copy(executionModeResultOptions = Map()) // no filter and no executionModeResultOptions are passed between actions
+      case scalaSubFeed: ScalaSubFeed => scalaSubFeed.copy(executionModeResultOptions = Map()) // no executionModeResultOptions are passed between actions. Filters are kept, only propagating filters can be present here.
       case _ => ScalaSubFeed(None, subFeed.dataObjectId, subFeed.partitionValues, subFeed.isDAGStart, subFeed.isSkipped)
     }
   }

--- a/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameSubFeedFilterBehaviour.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/testutils/DataFrameSubFeedFilterBehaviour.scala
@@ -1,0 +1,127 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.testutils
+
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.definitions.Environment
+import io.smartdatalake.util.hdfs.PartitionValues
+import io.smartdatalake.workflow.{ActionPipelineContext, ColumnFilter, DataFrameSubFeed}
+
+import scala.reflect.runtime.universe.Type
+
+/**
+ * Behaviour tests for the column-bound filters of a [[DataFrameSubFeed]], engine-agnostic so they can be
+ * instantiated against any [[io.smartdatalake.workflow.dataframe.GenericDataFrame]] implementation.
+ */
+trait DataFrameSubFeedFilterBehaviour {
+
+  def subFeedType: Type
+  implicit def instanceRegistry: InstanceRegistry
+  implicit def context: ActionPipelineContext
+
+  private lazy val helper = DataFrameSubFeed.getCompanion(subFeedType)
+
+  /**
+   * A SubFeed on a DataFrame with columns "id" and "value", holding 3 rows with id 1..3.
+   */
+  private def testSubFeed: DataFrameSubFeed = {
+    import helper.implicits._
+    val df = Seq((1, "a"), (2, "b"), (3, "c")).toDF("id", "value")
+    helper.getSubFeed(df, DataObjectId("dataObjectId"), Seq())
+  }
+
+  private def ids(subFeed: DataFrameSubFeed): Seq[Int] =
+    subFeed.dataFrame.get.collect.map(_.getAs[Int](0)).toSeq.sorted
+
+  def testApplyFilterOnExistingColumn(): Unit = {
+    val subFeed = testSubFeed.withFilters(Seq(ColumnFilter("id", "id > 1"))).applyFilter
+    assert(ids(subFeed) == Seq(2, 3))
+  }
+
+  def testSkipFilterOnMissingColumn(): Unit = {
+    // the filter must be silently skipped, otherwise the expression could not be resolved
+    val subFeed = testSubFeed.withFilters(Seq(ColumnFilter("notExisting", "notExisting > 1"))).applyFilter
+    assert(ids(subFeed) == Seq(1, 2, 3))
+  }
+
+  def testApplyMultipleFiltersConjunctively(): Unit = {
+    val filters = Seq(ColumnFilter("id", "id > 1"), ColumnFilter("value", "value = 'b'"))
+    val subFeed = testSubFeed.withFilters(filters).applyFilter
+    assert(ids(subFeed) == Seq(2))
+  }
+
+  def testApplyFilterCombinedWithPartitionValues(): Unit = {
+    val subFeed = testSubFeed.withFilters(Seq(PartitionValues(Map("value" -> "b")), PartitionValues(Map("value" -> "c"))),
+      Seq(ColumnFilter("id", "id > 2")))
+    assert(ids(subFeed) == Seq(3))
+  }
+
+  def testUpdateFiltersDropsMissingColumns(): Unit = {
+    val filters = Seq(ColumnFilter("id", "id > 1"), ColumnFilter("notExisting", "notExisting > 1"))
+    val subFeed = testSubFeed.withFilters(filters)
+    val updated = subFeed.updateFilters(subFeed.schema)
+    assert(updated.filters == Seq(ColumnFilter("id", "id > 1")))
+  }
+
+  def testUpdateFiltersCaseInsensitiveByDefault(): Unit = {
+    val previousCaseSensitive = Environment._caseSensitive
+    Environment._caseSensitive = Some(false)
+    try {
+      val subFeed = testSubFeed.withFilters(Seq(ColumnFilter("ID", "ID > 1")))
+      assert(subFeed.updateFilters(subFeed.schema).filters.size == 1)
+    } finally {
+      Environment._caseSensitive = previousCaseSensitive
+    }
+  }
+
+  def testClearFilters(): Unit = {
+    val subFeed = testSubFeed.withFilters(Seq(ColumnFilter("id", "id > 1")))
+    assert(subFeed.hasFilters)
+    val cleared = subFeed.clearFilters()
+    assert(cleared.filters.isEmpty)
+    // clearing filters also drops the DataFrame, so that a fresh unfiltered one is read
+    assert(cleared.dataFrame.isEmpty)
+  }
+
+  def testClearFiltersKeepsDataFrameIfNoFilters(): Unit = {
+    val subFeed = testSubFeed
+    assert(!subFeed.hasFilters)
+    val cleared = subFeed.clearFilters()
+    assert(cleared.filters.isEmpty)
+    assert(cleared.dataFrame.isDefined)
+  }
+
+  def testAddFiltersReplacesSameColumn(): Unit = {
+    val subFeed = testSubFeed.withFilters(Seq(ColumnFilter("id", "id > 1")))
+    val added = subFeed.addFilters(Seq(ColumnFilter("id", "id > 2"), ColumnFilter("value", "value = 'c'")))
+    assert(added.filters == Seq(ColumnFilter("id", "id > 2"), ColumnFilter("value", "value = 'c'")))
+    assert(ids(added.applyFilter) == Seq(3))
+  }
+
+  def testUnionKeepsOnlyCommonFilters(): Unit = {
+    val filterId = ColumnFilter("id", "id > 1")
+    val filterValue = ColumnFilter("value", "value = 'b'")
+    val subFeed1 = testSubFeed.withFilters(Seq(filterId, filterValue))
+    val subFeed2 = testSubFeed.withFilters(Seq(filterId))
+    val unioned = subFeed1.union(subFeed2).asInstanceOf[DataFrameSubFeed]
+    // dropping a filter widens the data read, whereas keeping one not valid for the other SubFeed would lose data
+    assert(unioned.filters == Seq(filterId))
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/ColumnFilterTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/ColumnFilterTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow
+
+import io.smartdatalake.definitions.Environment
+import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
+import io.smartdatalake.workflow.dataframe.plainScala.{ScalaColumnDefinition, ScalaSchema}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ColumnFilterTest extends AnyFlatSpec with Matchers {
+
+  private val filterA = ColumnFilter("colA", "colA > 1")
+  private val filterB = ColumnFilter("colB", "colB = 'x'")
+
+  private def schemaOf(colNames: String*): ScalaSchema =
+    ScalaSchema(colNames.map(n => ScalaColumnDefinition[String](n)).toList)
+
+  /**
+   * Run the given function with Environment.caseSensitive set, restoring the previous value afterwards.
+   */
+  private def withCaseSensitive[T](caseSensitive: Boolean)(fn: => T): T = {
+    val previous = Environment._caseSensitive
+    Environment._caseSensitive = Some(caseSensitive)
+    try fn finally Environment._caseSensitive = previous
+  }
+
+  "merge" should "append a filter for a new column" in {
+    ColumnFilter.merge(Seq(filterA), Seq(filterB), "test") shouldBe Seq(filterA, filterB)
+  }
+
+  it should "keep an identical filter only once" in {
+    ColumnFilter.merge(Seq(filterA), Seq(filterA), "test") shouldBe Seq(filterA)
+  }
+
+  it should "replace a different filter on the same column, keeping its position" in {
+    val newFilterA = filterA.copy(expression = "colA > 99")
+    ColumnFilter.merge(Seq(filterA, filterB), Seq(newFilterA), "test") shouldBe Seq(newFilterA, filterB)
+  }
+
+  it should "match columns case-insensitive by default" in withCaseSensitive(false) {
+    val upperFilterA = ColumnFilter("COLA", "COLA > 99")
+    ColumnFilter.merge(Seq(filterA), Seq(upperFilterA), "test") shouldBe Seq(upperFilterA)
+  }
+
+  it should "match columns case-sensitive if Environment.caseSensitive is set" in withCaseSensitive(true) {
+    val upperFilterA = ColumnFilter("COLA", "COLA > 99")
+    ColumnFilter.merge(Seq(filterA), Seq(upperFilterA), "test") shouldBe Seq(filterA, upperFilterA)
+  }
+
+  "filterExistingColumns" should "keep only filters whose column exists" in {
+    ColumnFilter.filterExistingColumns(Seq(filterA, filterB), schemaOf("colA", "colC")) shouldBe Seq(filterA)
+  }
+
+  it should "find the column case-insensitive by default" in withCaseSensitive(false) {
+    ColumnFilter.filterExistingColumns(Seq(filterA), schemaOf("COLA")) shouldBe Seq(filterA)
+  }
+
+  "hasDuplicateColumns" should "detect two filters for the same column" in withCaseSensitive(false) {
+    ColumnFilter.hasDuplicateColumns(Seq(filterA, filterB)) shouldBe false
+    ColumnFilter.hasDuplicateColumns(Seq(filterA, filterA.copy(expression = "colA > 99"))) shouldBe true
+    ColumnFilter.hasDuplicateColumns(Seq(filterA, ColumnFilter("COLA", "COLA > 99"))) shouldBe true
+  }
+
+  "mainInputOnly and propagate" should "be independent of each other" in {
+    // all four combinations are representable and only mainInputOnly influences filtersForInput
+    val combinations = for {
+      mainInputOnly <- Seq(false, true)
+      propagate <- Seq(false, true)
+    } yield ColumnFilter("colA", "colA > 1", mainInputOnly, propagate)
+    combinations.size shouldBe 4
+    combinations.foreach { filter =>
+      ExecutionModeResult(filters = Seq(filter)).filtersForInput(isMainInput = true) shouldBe Seq(filter)
+      ExecutionModeResult(filters = Seq(filter)).filtersForInput(isMainInput = false) shouldBe
+        (if (filter.mainInputOnly) Seq() else Seq(filter))
+    }
+  }
+
+  "ExecutionModeResult.filtersForInput" should "return mainInputOnly filters for the main input only" in {
+    val mainInputOnlyFilter = filterA.copy(mainInputOnly = true)
+    val result = ExecutionModeResult(filters = Seq(mainInputOnlyFilter, filterB))
+    result.filtersForInput(isMainInput = true) shouldBe Seq(mainInputOnlyFilter, filterB)
+    result.filtersForInput(isMainInput = false) shouldBe Seq(filterB)
+  }
+
+  "ExecutionModeResult" should "reject more than one filter per column" in withCaseSensitive(false) {
+    an[IllegalArgumentException] should be thrownBy
+      ExecutionModeResult(filters = Seq(filterA, filterA.copy(expression = "colA > 99")))
+    an[IllegalArgumentException] should be thrownBy
+      ExecutionModeResult(filters = Seq(filterA, ColumnFilter("COLA", "COLA > 99")))
+    // one filter per column is fine
+    ExecutionModeResult(filters = Seq(filterA, filterB)).filters.size shouldBe 2
+  }
+
+  "toString" should "describe the flags which are set" in {
+    filterA.toString shouldBe "colA: colA > 1"
+    filterA.copy(mainInputOnly = true).toString shouldBe "colA: colA > 1 (mainInputOnly)"
+    filterA.copy(propagate = true).toString shouldBe "colA: colA > 1 (propagate)"
+    filterA.copy(mainInputOnly = true, propagate = true).toString shouldBe "colA: colA > 1 (mainInputOnly, propagate)"
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/StateMigratorDef6To7Test.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/StateMigratorDef6To7Test.scala
@@ -1,0 +1,58 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow
+
+import org.json4s.JsonAST.{JInt, JObject}
+import org.json4s.jackson.JsonMethods
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class StateMigratorDef6To7Test extends AnyFlatSpec with Matchers {
+
+  private val stateV6 =
+    """{
+      |  "runStateFormatVersion": 6,
+      |  "actionsState": {
+      |    "load-test": {
+      |      "results": [
+      |        { "jsonClass": "SparkSubFeed", "dataObjectId": "tgt1", "filter": "dl_ts > 1", "partitionValues": [] }
+      |      ]
+      |    }
+      |  }
+      |}""".stripMargin
+
+  "StateMigratorDef6To7" should "drop the legacy SubFeed filter and update the version" in {
+    val json = JsonMethods.parse(stateV6).asInstanceOf[JObject]
+    // the legacy attribute is present before the migration
+    JsonMethods.compact(JsonMethods.render(json)) should include("\"filter\"")
+
+    val migrated = new StateMigratorDef6To7().migrate(json)
+
+    (migrated \ "runStateFormatVersion") shouldBe JInt(7)
+    // the column a legacy filter belongs to is unknown, so it is dropped. `filters` defaults to an empty Seq.
+    JsonMethods.compact(JsonMethods.render(migrated)) should not include "\"filter\""
+    // the other attributes are untouched
+    (migrated \ "actionsState" \ "load-test" \ "results" \ "dataObjectId") shouldBe
+      (json \ "actionsState" \ "load-test" \ "results" \ "dataObjectId")
+  }
+
+  it should "be registered so that a version 6 state file can be read" in {
+    ActionDAGRunState.runStateFormatVersion shouldBe 7
+  }
+}

--- a/sdl-core/src/test/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaSubFeedFilterTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/workflow/dataframe/plainScala/ScalaSubFeedFilterTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataframe.plainScala
+
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.testutils.DataFrameSubFeedFilterBehaviour
+import io.smartdatalake.testutils.plainScala.ScalaTestUtil
+import io.smartdatalake.workflow.ActionPipelineContext
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.reflect.runtime.universe.{Type, typeOf}
+
+class ScalaSubFeedFilterTest extends AnyFunSuite with DataFrameSubFeedFilterBehaviour {
+
+  override def subFeedType: Type = typeOf[ScalaSubFeed]
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry()
+  implicit val context: ActionPipelineContext = ScalaTestUtil.getDefaultActionPipelineContext
+
+  test("a filter is applied if its column exists") {
+    testApplyFilterOnExistingColumn()
+  }
+
+  test("a filter is skipped if its column does not exist") {
+    testSkipFilterOnMissingColumn()
+  }
+
+  test("multiple filters are applied conjunctively") {
+    testApplyMultipleFiltersConjunctively()
+  }
+
+  test("filters are applied together with partition values") {
+    testApplyFilterCombinedWithPartitionValues()
+  }
+
+  test("updateFilters drops filters for non-existing columns") {
+    testUpdateFiltersDropsMissingColumns()
+  }
+
+  test("clearFilters empties the filters and breaks the lineage") {
+    testClearFilters()
+  }
+
+  test("clearFilters keeps the DataFrame if there were no filters") {
+    testClearFiltersKeepsDataFrameIfNoFilters()
+  }
+
+  test("addFilters replaces an existing filter on the same column") {
+    testAddFiltersReplacesSameColumn()
+  }
+
+  test("union keeps only the filters present in both SubFeeds") {
+    testUnionKeepsOnlyCommonFilters()
+  }
+
+  // Note: case-insensitive column matching is not tested here, as the plain Scala engine handles column names
+  // case-sensitive and is not configurable, see ScalaSubFeed.
+}

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/DataFrameBaseBuilder.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/DataFrameBaseBuilder.scala
@@ -53,6 +53,7 @@ abstract class DataFrameBaseBuilder[R] {
 
   /**
    * Spark Filter expression to be applied on all DataFrames that contain the given column.
+   * The column is matched case-insensitive, unless Environment.caseSensitive is set.
    * @param colName column name
    * @param expr a Spark expression returning a boolean value
    */
@@ -60,6 +61,7 @@ abstract class DataFrameBaseBuilder[R] {
 
   /**
    * SQL Filter expression to be applied on all DataFrames that contain the given column.
+   * The column is matched case-insensitive, unless Environment.caseSensitive is set.
    * @param colName column name
    * @param sqlExpr a Spark SQL expression returning a boolean value
    */

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkActionWrapper.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/LabSparkActionWrapper.scala
@@ -313,7 +313,7 @@ abstract class LabSparkActionWrapper[A <: DataFrameActionImpl, T <: Transformer,
     inputSubFeeds = filters.foldLeft(inputSubFeeds) {
       case (subFeeds, (column, filterExpr)) =>
         subFeeds.map(f =>
-          if (f.schemaOpt.toSeq.flatMap(_.columns).contains(column)) f.withDataFrame(f.dataFrame.map(_.filter(filterExpr))) else f
+          if (f.schemaOpt.exists(_.columnExists(column))) f.withDataFrame(f.dataFrame.map(_.filter(filterExpr))) else f
         )
     }
 

--- a/sdl-lang/src/main/scala/io/smartdatalake/lab/SmartDataLakeBuilderLab.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/lab/SmartDataLakeBuilderLab.scala
@@ -26,6 +26,7 @@ import io.smartdatalake.workflow.ActionPipelineContext
 import io.smartdatalake.workflow.action.generic.transformer.OptionsGenericDfsTransformer.OPTION_OUTPUT_DATAOBJECT_ID
 import io.smartdatalake.workflow.action.spark.customlogic.{CustomDfsTransformer, NotFoundError, TransformDfsMethod, TransformInfo}
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDsNTo1Transformer.prepareTolerantKey
+import io.smartdatalake.workflow.dataframe.spark.SparkSchema
 import io.smartdatalake.workflow.dataobject.spark.CanCreateSparkDataFrame
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
@@ -118,7 +119,7 @@ case class SmartDataLakeBuilderLab[D,A](
     // filter
     dfs = filters.foldLeft(dfs) {
       case (dfs, (column, filterExpr)) =>
-        dfs.view.mapValues(df => if (df.schema.fieldNames.contains(column)) df.filter(filterExpr) else df).toMap
+        dfs.view.mapValues(df => if (SparkSchema(df.schema).columnExists(column)) df.filter(filterExpr) else df).toMap
     }
 
     // transform

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkDataFrame.scala
@@ -100,9 +100,6 @@ case class SnowparkDataFrame(override val inner: DataFrame) extends GenericDataF
 
   override def collect: Seq[GenericRow] = inner.collect().toIndexedSeq.map(SnowparkRow)
   override def distinct: SnowparkDataFrame = SnowparkDataFrame(inner.distinct())
-  override def getDataFrameSubFeed(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): DataFrameSubFeed = {
-    SnowparkSubFeed(Some(this), dataObjectId, partitionValues, filter = filter)
-  }
   override def withColumn(colName: String, expression: GenericColumn): GenericDataFrame = {
     expression match {
       case snowparkExpression: SnowparkColumn => SnowparkDataFrame(inner.withColumn(colName,snowparkExpression.inner))

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataframe/snowflake/SnowparkSubFeed.scala
@@ -27,7 +27,7 @@ import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.action.executionMode.ExecutionModeResult
 import io.smartdatalake.workflow.dataframe._
 import io.smartdatalake.workflow.dataobject.SnowflakeTableDataObject
-import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, DataFrameSubFeedCompanion, SubFeed}
+import io.smartdatalake.workflow.{ActionPipelineContext, ColumnFilter, DataFrameSubFeed, DataFrameSubFeedCompanion, SubFeed}
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe
@@ -38,7 +38,7 @@ case class SnowparkSubFeed(@transient override val dataFrame: Option[SnowparkDat
                            override val partitionValues: Seq[PartitionValues],
                            override val isDAGStart: Boolean = false,
                            override val isSkipped: Boolean = false,
-                           override val filter: Option[String] = None,
+                           override val filters: Seq[ColumnFilter] = Seq(),
                            @transient override val observation: Option[DataFrameObservation] = None,
                            override val metrics: Option[MetricsMap] = None,
                            @transient override val keptSchema: Option[GenericSchema] = None,
@@ -49,7 +49,7 @@ case class SnowparkSubFeed(@transient override val dataFrame: Option[SnowparkDat
   override val tpe: Type = typeOf[SnowparkSubFeed]
 
   override def toOutput(dataObjectId: DataObjectId): SnowparkSubFeed = {
-    this.copy(dataFrame = None, filter = None, isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
+    this.copy(dataFrame = None, filters = Seq(), isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
   }
 
   override def union(other: SubFeed)(implicit context: ActionPipelineContext): SubFeed = {
@@ -68,19 +68,21 @@ case class SnowparkSubFeed(@transient override val dataFrame: Option[SnowparkDat
       , partitionValues = unionPartitionValues(other.partitionValues)
       , isDAGStart = this.isDAGStart || other.isDAGStart
       , isSkipped = this.isSkipped && other.isSkipped
+      , filters = unionFilters(other)
       , executionModeResultOptions = unionExecutionModeResultOptions(other)
     )
   }
 
 
   override def applyExecutionModeResultForInput(result: ExecutionModeResult, mainInputId: DataObjectId)(implicit context: ActionPipelineContext): SnowparkSubFeed = {
-    // apply input filter
-    val inputFilter = if (this.dataObjectId == mainInputId) result.filter else None
-    this.copy(partitionValues = result.inputPartitionValues, filter = inputFilter, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps the schema without the DataFrame
+    // apply input filters
+    val inputFilters = result.filtersForInput(this.dataObjectId == mainInputId)
+    this.copy(partitionValues = result.inputPartitionValues, filters = inputFilters, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps the schema without the DataFrame
       .asInstanceOf[SnowparkSubFeed]
   }
   override def applyExecutionModeResultForOutput(result: ExecutionModeResult, partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues, PartitionValues])(implicit context: ActionPipelineContext): SnowparkSubFeed = {
-    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filter = result.filter, isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
+    // filters of the output are set from the main input SubFeed after the transformation, see DataFrameActionImpl.updateOutputFilters
+    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filters = Seq(), isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
   }
   override def withDataFrame(dataFrame: Option[GenericDataFrame]): SnowparkSubFeed = this.copy(
     dataFrame = dataFrame.map(_.asInstanceOf[SnowparkDataFrame]),

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkDataFrame.scala
@@ -110,10 +110,6 @@ case class SparkDataFrame(override val inner: DataFrame) extends GenericDataFram
 
   override def distinct: SparkDataFrame = SparkDataFrame(inner.distinct())
 
-  override def getDataFrameSubFeed(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): SparkSubFeed = {
-    SparkSubFeed(Some(this), dataObjectId, partitionValues, filter = filter)
-  }
-
   override def withColumn(colName: String, expression: GenericColumn): SparkDataFrame = {
     expression match {
       case sparkExpression: SparkColumn => SparkDataFrame(inner.withColumn(colName, sparkExpression.inner))

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeed.scala
@@ -49,7 +49,7 @@ import scala.util.Try
  * @param partitionValues Values of Partitions transported by this SubFeed
  * @param isDAGStart true if this subfeed is a start node of the dag
  * @param isSkipped true if this subfeed is the result of a skipped action
- * @param filter a spark SQL filter expression. This is used by DataFrameIncrementalMode.
+ * @param filters column-bound filters to be applied when the DataFrame is (re)created, see [[ColumnFilter]].
  * @param keptSchema schema transported by this SubFeed if it holds no DataFrame. Use `schema`/`schemaOpt` to read it.
  */
 case class SparkSubFeed(@transient override val dataFrame: Option[SparkDataFrame],
@@ -57,7 +57,7 @@ case class SparkSubFeed(@transient override val dataFrame: Option[SparkDataFrame
                         override val partitionValues: Seq[PartitionValues],
                         override val isDAGStart: Boolean = false,
                         override val isSkipped: Boolean = false,
-                        override val filter: Option[String] = None,
+                        override val filters: Seq[ColumnFilter] = Seq(),
                         @transient override val observation: Option[DataFrameObservation] = None,
                         override val metrics: Option[MetricsMap] = None,
                         @transient override val keptSchema: Option[GenericSchema] = None,
@@ -66,7 +66,7 @@ case class SparkSubFeed(@transient override val dataFrame: Option[SparkDataFrame
   extends DataFrameSubFeed {
   @transient override val tpe: Type = typeOf[SparkSubFeed]
   override def toOutput(dataObjectId: DataObjectId): SparkSubFeed = {
-    this.copy(dataFrame = None, filter=None, isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
+    this.copy(dataFrame = None, filters = Seq(), isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
   }
   override def union(other: SubFeed)(implicit context: ActionPipelineContext): SubFeed = {
     val (dataFrame, schema) = other match {
@@ -84,17 +84,19 @@ case class SparkSubFeed(@transient override val dataFrame: Option[SparkDataFrame
       , partitionValues = unionPartitionValues(other.partitionValues)
       , isDAGStart = this.isDAGStart || other.isDAGStart
       , isSkipped = this.isSkipped && other.isSkipped
+      , filters = unionFilters(other)
       , executionModeResultOptions = unionExecutionModeResultOptions(other)
     )
   }
   override def applyExecutionModeResultForInput(result: ExecutionModeResult, mainInputId: DataObjectId)(implicit context: ActionPipelineContext): SparkSubFeed = {
-    // apply input filter
-    val inputFilter = if (this.dataObjectId == mainInputId) result.filter else None
-    this.copy(partitionValues = result.inputPartitionValues, filter = inputFilter, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps the schema without the DataFrame
+    // apply input filters
+    val inputFilters = result.filtersForInput(this.dataObjectId == mainInputId)
+    this.copy(partitionValues = result.inputPartitionValues, filters = inputFilters, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps the schema without the DataFrame
       .asInstanceOf[SparkSubFeed]
   }
   override def applyExecutionModeResultForOutput(result: ExecutionModeResult, partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues, PartitionValues])(implicit context: ActionPipelineContext): SparkSubFeed = {
-    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filter = result.filter, isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
+    // filters of the output are set from the main input SubFeed after the transformation, see DataFrameActionImpl.updateOutputFilters
+    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filters = Seq(), isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
   }
   override def withDataFrame(dataFrame: Option[GenericDataFrame]): SparkSubFeed = this.copy(
     dataFrame = dataFrame.map(_.asInstanceOf[SparkDataFrame]),
@@ -109,7 +111,7 @@ object SparkSubFeed extends DataFrameSubFeedCompanion {
    */
   override def fromSubFeed( subFeed: SubFeed )(implicit context: ActionPipelineContext): SparkSubFeed = {
     subFeed match {
-      case sparkSubFeed: SparkSubFeed => sparkSubFeed.clearFilter().asInstanceOf[SparkSubFeed].copy(executionModeResultOptions = Map()) // no filter and no executionModeResultOptions are passed between actions
+      case sparkSubFeed: SparkSubFeed => sparkSubFeed.copy(executionModeResultOptions = Map()) // no executionModeResultOptions are passed between actions. Filters are kept, only propagating filters can be present here.
       case _ => SparkSubFeed(None, subFeed.dataObjectId, subFeed.partitionValues, subFeed.isDAGStart, subFeed.isSkipped)
     }
   }

--- a/sdl-spark/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
+++ b/sdl-spark/src/test/scala/io/smartdatalake/workflow/ActionDAGTest.scala
@@ -18,8 +18,10 @@
  */
 package io.smartdatalake.workflow
 
+import com.typesafe.config.Config
 import io.smartdatalake.app.{DefaultSmartDataLakeBuilder, GlobalConfig, SmartDataLakeBuilderConfig}
-import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.config.SdlConfigObject.ActionId
+import io.smartdatalake.config.{FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions._
 import io.smartdatalake.testutils.spark.{MockSparkDataObject, SparkTestUtil}
 import io.smartdatalake.util.dag.TaskFailedException
@@ -356,6 +358,115 @@ class ActionDAGTest extends AnyFunSuite with BeforeAndAfter {
       .select($"lastname", $"firstname", $"origin")
       .as[(String, String, Int)].collect().toSet
     assert(r1 == Set(("doe", "john", 1), ("doe", "john", 2), ("doe", "john", 3), ("xyz", "john", 3)))
+  }
+
+  test("action dag where a column filter of the execution mode is applied to all inputs having the column") {
+    // setup DataObjects: src3 has no rating column, so the filter must not be applied to it
+    val srcDO1 = MockSparkDataObject("src1").register
+    val srcDO2 = MockSparkDataObject("src2").register
+    val srcDO3 = MockSparkDataObject("src3").register
+    val tgtDO = MockSparkDataObject("tgt1").register
+
+    val l1 = Seq(("doe", "john", 1), ("doe", "jane", 5)).toDF("lastname", "firstname", "rating")
+    srcDO1.writeSparkDataFrame(l1, Seq())
+    srcDO2.writeSparkDataFrame(l1, Seq())
+    srcDO3.writeSparkDataFrame(Seq(("doe", "jim")).toDF("lastname", "firstname"), Seq())
+
+    val action1 = CustomDataFrameAction("a", inputIds = Seq(srcDO1.id, srcDO2.id, srcDO3.id), outputIds = Seq(tgtDO.id)
+      , executionMode = Some(TestColumnFilterMode(Seq(ColumnFilter("rating", "rating > 3"))))
+      , transformers = Seq(ScalaClassSparkDfsTransformer(className = classOf[TestDfsUnionWithoutRating].getName)))
+    val dag = ActionDAGRun(Seq(action1))
+
+    dag.prepare(contextPrep)
+    dag.init(contextInit)
+    dag.exec(contextExec)
+
+    // src1 and src2 have the rating column and are filtered, src3 has not and is not filtered
+    val r1 = tgtDO.getSparkDataFrame(Seq()).select($"firstname", $"origin").as[(String, Int)].collect().toSet
+    assert(r1 == Set(("jane", 1), ("jane", 2), ("jim", 3)))
+  }
+
+  test("action dag where a mainInputOnly column filter of the execution mode is applied to the main input only") {
+    val srcDO1 = MockSparkDataObject("src1").register
+    val srcDO2 = MockSparkDataObject("src2").register
+    val srcDO3 = MockSparkDataObject("src3").register
+    val tgtDO = MockSparkDataObject("tgt1").register
+
+    val l1 = Seq(("doe", "john", 1), ("doe", "jane", 5)).toDF("lastname", "firstname", "rating")
+    srcDO1.writeSparkDataFrame(l1, Seq())
+    srcDO2.writeSparkDataFrame(l1, Seq())
+    srcDO3.writeSparkDataFrame(Seq(("doe", "jim")).toDF("lastname", "firstname"), Seq())
+
+    // mainInputId must be set explicitly, otherwise the main input is chosen by number of partition columns
+    val action1 = CustomDataFrameAction("a", inputIds = Seq(srcDO1.id, srcDO2.id, srcDO3.id), mainInputId = Some(srcDO1.id), outputIds = Seq(tgtDO.id)
+      , executionMode = Some(TestColumnFilterMode(Seq(ColumnFilter("rating", "rating > 3", mainInputOnly = true))))
+      , transformers = Seq(ScalaClassSparkDfsTransformer(className = classOf[TestDfsUnionWithoutRating].getName)))
+    val dag = ActionDAGRun(Seq(action1))
+
+    dag.prepare(contextPrep)
+    dag.init(contextInit)
+    dag.exec(contextExec)
+
+    // only src1 is the main input and gets filtered
+    val r1 = tgtDO.getSparkDataFrame(Seq()).select($"firstname", $"origin").as[(String, Int)].collect().toSet
+    assert(r1 == Set(("jane", 1), ("john", 2), ("jane", 2), ("jim", 3)))
+  }
+
+  test("action dag where a column filter of the execution mode is ignored for inputIdsToIgnoreFilter") {
+    val srcDO1 = MockSparkDataObject("src1").register
+    val srcDO2 = MockSparkDataObject("src2").register
+    val srcDO3 = MockSparkDataObject("src3").register
+    val tgtDO = MockSparkDataObject("tgt1").register
+
+    val l1 = Seq(("doe", "john", 1), ("doe", "jane", 5)).toDF("lastname", "firstname", "rating")
+    srcDO1.writeSparkDataFrame(l1, Seq())
+    srcDO2.writeSparkDataFrame(l1, Seq())
+    srcDO3.writeSparkDataFrame(Seq(("doe", "jim")).toDF("lastname", "firstname"), Seq())
+
+    val action1 = CustomDataFrameAction("a", inputIds = Seq(srcDO1.id, srcDO2.id, srcDO3.id), inputIdsToIgnoreFilter = Seq(srcDO2.id), outputIds = Seq(tgtDO.id)
+      , executionMode = Some(TestColumnFilterMode(Seq(ColumnFilter("rating", "rating > 3"))))
+      , transformers = Seq(ScalaClassSparkDfsTransformer(className = classOf[TestDfsUnionWithoutRating].getName)))
+    val dag = ActionDAGRun(Seq(action1))
+
+    dag.prepare(contextPrep)
+    dag.init(contextInit)
+    dag.exec(contextExec)
+
+    // src2 ignores the filter, so both of its records are kept
+    val r1 = tgtDO.getSparkDataFrame(Seq()).select($"firstname", $"origin").as[(String, Int)].collect().toSet
+    assert(r1 == Set(("jane", 1), ("john", 2), ("jane", 2), ("jim", 3)))
+  }
+
+  test("action dag where a column filter is propagated to the following action only if propagate=true") {
+    def runDag(propagate: Boolean, tgt2HasRating: Boolean): Set[String] = {
+      val srcDO = MockSparkDataObject("src1").register
+      val tgt1DO = MockSparkDataObject("tgt1").register
+      val tgt2DO = MockSparkDataObject("tgt2").register
+
+      srcDO.writeSparkDataFrame(Seq(("doe", "john", 1), ("doe", "jane", 5)).toDF("lastname", "firstname", "rating"), Seq())
+
+      val action1 = CopyAction("a", srcDO.id, tgt1DO.id
+        , executionMode = Some(TestColumnFilterMode(Seq(ColumnFilter("rating", "rating > 3", propagate = propagate)))))
+      // the second action drops the rating column if the filter must not be applicable on tgt2
+      val action2 = if (tgt2HasRating) CopyAction("b", tgt1DO.id, tgt2DO.id)
+      else CopyAction("b", tgt1DO.id, tgt2DO.id, transformers = Seq(SQLDfTransformer(code = Some("select lastname, firstname from tgt1"))))
+      val dag = ActionDAGRun(Seq(action1, action2))
+
+      dag.prepare(contextPrep)
+      dag.init(contextInit)
+      dag.exec(contextExec)
+
+      // tgt1 already only contains the increment, so re-applying the propagated filter changes nothing there.
+      // What is asserted is that the propagated filter is accepted and does not remove data unexpectedly.
+      tgt2DO.getSparkDataFrame(Seq()).select($"firstname").as[String].collect().toSet
+    }
+
+    // without propagation the second action reads all of tgt1
+    assert(runDag(propagate = false, tgt2HasRating = true) == Set("jane"))
+    // with propagation the filter is re-applied on tgt1, which contains the increment only
+    assert(runDag(propagate = true, tgt2HasRating = true) == Set("jane"))
+    // if the column does not exist in the second action's DataFrame, the propagated filter is silently dropped
+    assert(runDag(propagate = true, tgt2HasRating = false) == Set("jane"))
   }
 
   test("action dag with four dependencies") {
@@ -1337,6 +1448,35 @@ class TestStreamingTransformer extends CustomDfsTransformer {
   override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String, DataFrame]): Map[String, DataFrame] = {
     val dfTgt1 = dfs("src1").unionByName(dfs("src2"))
     Map("tgt1" -> dfTgt1)
+  }
+}
+
+/**
+ * Unions three inputs on the columns they have in common, so that src3 does not need a rating column.
+ */
+class TestDfsUnionWithoutRating extends CustomDfsTransformer {
+  override def transform(session: SparkSession, options: Map[String, String], dfs: Map[String, DataFrame]): Map[String, DataFrame] = {
+    import session.implicits._
+    val dfTgt = dfs("src1").select($"lastname", $"firstname").withColumn("origin", lit(1))
+      .union(dfs("src2").select($"lastname", $"firstname").withColumn("origin", lit(2)))
+      .union(dfs("src3").select($"lastname", $"firstname").withColumn("origin", lit(3)))
+    Map("tgt1" -> dfTgt)
+  }
+}
+
+/**
+ * An ExecutionMode returning the given column filters, to test their handling.
+ */
+case class TestColumnFilterMode(testFilters: Seq[ColumnFilter]) extends ExecutionMode {
+  override def apply(actionId: ActionId, mainInput: DataObject, mainOutput: DataObject, subFeed: SubFeed
+                     , partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues, PartitionValues])
+                    (implicit context: ActionPipelineContext): Option[ExecutionModeResult] = {
+    Some(ExecutionModeResult(filters = testFilters))
+  }
+}
+object TestColumnFilterMode extends FromConfigFactory[ExecutionMode] {
+  override def fromConfig(config: Config)(implicit instanceRegistry: InstanceRegistry): TestColumnFilterMode = {
+    extract[TestColumnFilterMode](config)
   }
 }
 

--- a/sdl-spark/src/test/scala/io/smartdatalake/workflow/action/spark/ExecutionModeTest.scala
+++ b/sdl-spark/src/test/scala/io/smartdatalake/workflow/action/spark/ExecutionModeTest.scala
@@ -182,7 +182,7 @@ class ExecutionModeTest extends AnyFunSuite with BeforeAndAfter with BeforeAndAf
     executionMode.prepare(ActionId("test"))
     val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())
     val result = executionMode.apply(ActionId("test"), srcDO, tgt1DO, subFeed, PartitionValues.oneToOneMapping).get
-    assert(result.filter.isEmpty) // no filter if target is empty as everything needs to be copied
+    assert(result.filters.isEmpty) // no filter if target is empty as everything needs to be copied
   }
 
   test("DataFrameIncrementalMode partially filled target") {
@@ -190,21 +190,31 @@ class ExecutionModeTest extends AnyFunSuite with BeforeAndAfter with BeforeAndAf
     executionMode.prepare(ActionId("test"))
     val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())
     val result = executionMode.apply(ActionId("test"), srcDO, tgt2DO, subFeed, PartitionValues.oneToOneMapping).get
-    assert(result.filter.nonEmpty)
+    // the filter is bound to compareCol, applied to the main input only and not propagated by default
+    assert(result.filters.map(_.column) == Seq("rating"))
+    assert(result.filters.forall(f => f.mainInputOnly && !f.propagate))
+  }
+  test("DataFrameIncrementalMode propagateFilter") {
+    val executionMode = DataFrameIncrementalMode(compareCol = "rating", propagateFilter = true)
+    executionMode.prepare(ActionId("test"))
+    val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())
+    val result = executionMode.apply(ActionId("test"), srcDO, tgt2DO, subFeed, PartitionValues.oneToOneMapping).get
+    assert(result.filters.forall(f => f.mainInputOnly && f.propagate))
   }
   test("DataFrameIncrementalMode comparison column has different case than InputDataObject Column") {
     val executionMode = DataFrameIncrementalMode(compareCol = "Rating")
     executionMode.prepare(ActionId("test"))
     val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())
     val result = executionMode.apply(ActionId("test"), srcDO, tgt3DO, subFeed, PartitionValues.oneToOneMapping).get
-    assert(result.filter.nonEmpty)
+    // the filter keeps the configured casing of compareCol
+    assert(result.filters.map(_.column) == Seq("Rating"))
   }
   test("DataFrameIncrementalMode comparison column has different case than OutputDataObject Column") {
     val executionMode = DataFrameIncrementalMode(compareCol = "rating")
     executionMode.prepare(ActionId("test"))
     val subFeed: SparkSubFeed = SparkSubFeed(dataFrame = None, srcDO.id, partitionValues = Seq())
     val result = executionMode.apply(ActionId("test"), srcDO, tgt3DO, subFeed, PartitionValues.oneToOneMapping).get
-    assert(result.filter.nonEmpty)
+    assert(result.filters.map(_.column) == Seq("rating"))
   }
 
   test("DataFrameIncrementalMode no data to process") {

--- a/sdl-spark/src/test/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeedFilterTest.scala
+++ b/sdl-spark/src/test/scala/io/smartdatalake/workflow/dataframe/spark/SparkSubFeedFilterTest.scala
@@ -1,0 +1,77 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataframe.spark
+
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.testutils.DataFrameSubFeedFilterBehaviour
+import io.smartdatalake.testutils.spark.SparkTestUtil
+import io.smartdatalake.workflow.ActionPipelineContext
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.reflect.runtime.universe.{Type, typeOf}
+
+class SparkSubFeedFilterTest extends AnyFunSuite with DataFrameSubFeedFilterBehaviour {
+
+  protected implicit val session: SparkSession = SparkTestUtil.session
+
+  override def subFeedType: Type = typeOf[SparkSubFeed]
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry()
+  implicit val context: ActionPipelineContext = SparkTestUtil.getDefaultActionPipelineContext
+
+  test("a filter is applied if its column exists") {
+    testApplyFilterOnExistingColumn()
+  }
+
+  test("a filter is skipped if its column does not exist") {
+    testSkipFilterOnMissingColumn()
+  }
+
+  test("multiple filters are applied conjunctively") {
+    testApplyMultipleFiltersConjunctively()
+  }
+
+  test("filters are applied together with partition values") {
+    testApplyFilterCombinedWithPartitionValues()
+  }
+
+  test("updateFilters drops filters for non-existing columns") {
+    testUpdateFiltersDropsMissingColumns()
+  }
+
+  test("updateFilters matches the column case insensitive per default") {
+    testUpdateFiltersCaseInsensitiveByDefault()
+  }
+
+  test("clearFilters empties the filters and breaks the lineage") {
+    testClearFilters()
+  }
+
+  test("clearFilters keeps the DataFrame if there were no filters") {
+    testClearFiltersKeepsDataFrameIfNoFilters()
+  }
+
+  test("addFilters replaces an existing filter on the same column") {
+    testAddFiltersReplacesSameColumn()
+  }
+
+  test("union keeps only the filters present in both SubFeeds") {
+    testUnionKeepsOnlyCommonFilters()
+  }
+}

--- a/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectDataFrame.scala
+++ b/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectDataFrame.scala
@@ -109,10 +109,6 @@ case class SparkConnectDataFrame(override val inner: DataFrame) extends GenericD
 
   override def distinct: SparkConnectDataFrame = SparkConnectDataFrame(inner.distinct())
 
-  override def getDataFrameSubFeed(dataObjectId: DataObjectId, partitionValues: Seq[PartitionValues], filter: Option[String]): SparkConnectSubFeed = {
-    SparkConnectSubFeed(Some(this), dataObjectId, partitionValues, filter = filter)
-  }
-
   override def withColumn(colName: String, expression: GenericColumn): SparkConnectDataFrame = {
     expression match {
       case sparkExpression: SparkConnectColumn => SparkConnectDataFrame(inner.withColumn(colName, sparkExpression.inner))

--- a/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectSubFeed.scala
+++ b/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataframe/sparkconnect/SparkConnectSubFeed.scala
@@ -45,7 +45,7 @@ import scala.util.Try
  * @param partitionValues Values of Partitions transported by this SubFeed
  * @param isDAGStart true if this subfeed is a start node of the dag
  * @param isSkipped true if this subfeed is the result of a skipped action
- * @param filter a spark SQL filter expression. This is used by DataFrameIncrementalMode.
+ * @param filters column-bound filters to be applied when the DataFrame is (re)created, see [[ColumnFilter]].
  * @param keptSchema schema transported by this SubFeed if it holds no DataFrame. Use `schema`/`schemaOpt` to read it.
  */
 case class SparkConnectSubFeed(@transient override val dataFrame: Option[SparkConnectDataFrame],
@@ -53,7 +53,7 @@ case class SparkConnectSubFeed(@transient override val dataFrame: Option[SparkCo
                                override val partitionValues: Seq[PartitionValues],
                                override val isDAGStart: Boolean = false,
                                override val isSkipped: Boolean = false,
-                               override val filter: Option[String] = None,
+                               override val filters: Seq[ColumnFilter] = Seq(),
                                @transient override val observation: Option[DataFrameObservation] = None,
                                override val metrics: Option[MetricsMap] = None,
                                @transient override val keptSchema: Option[GenericSchema] = None,
@@ -62,7 +62,7 @@ case class SparkConnectSubFeed(@transient override val dataFrame: Option[SparkCo
   extends DataFrameSubFeed {
   @transient override val tpe: Type = typeOf[SparkConnectSubFeed]
   override def toOutput(dataObjectId: DataObjectId): SparkConnectSubFeed = {
-    this.copy(dataFrame = None, filter = None, isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
+    this.copy(dataFrame = None, filters = Seq(), isDAGStart = false, isSkipped = false, dataObjectId = dataObjectId, observation = None, metrics = None, keptSchema = None, executionModeResultOptions = Map())
   }
   override def union(other: SubFeed)(implicit context: ActionPipelineContext): SubFeed = {
     val (dataFrame, schema) = other match {
@@ -80,17 +80,19 @@ case class SparkConnectSubFeed(@transient override val dataFrame: Option[SparkCo
       , partitionValues = unionPartitionValues(other.partitionValues)
       , isDAGStart = this.isDAGStart || other.isDAGStart
       , isSkipped = this.isSkipped && other.isSkipped
+      , filters = unionFilters(other)
       , executionModeResultOptions = unionExecutionModeResultOptions(other)
     )
   }
   override def applyExecutionModeResultForInput(result: ExecutionModeResult, mainInputId: DataObjectId)(implicit context: ActionPipelineContext): SparkConnectSubFeed = {
-    // apply input filter
-    val inputFilter = if (this.dataObjectId == mainInputId) result.filter else None
-    this.copy(partitionValues = result.inputPartitionValues, filter = inputFilter, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps the schema without the DataFrame
+    // apply input filters
+    val inputFilters = result.filtersForInput(this.dataObjectId == mainInputId)
+    this.copy(partitionValues = result.inputPartitionValues, filters = inputFilters, isSkipped = false, executionModeResultOptions = result.options).breakLineage // breaklineage keeps the schema without the DataFrame
       .asInstanceOf[SparkConnectSubFeed]
   }
   override def applyExecutionModeResultForOutput(result: ExecutionModeResult, partitionValuesTransform: Seq[PartitionValues] => Map[PartitionValues, PartitionValues])(implicit context: ActionPipelineContext): SparkConnectSubFeed = {
-    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filter = result.filter, isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
+    // filters of the output are set from the main input SubFeed after the transformation, see DataFrameActionImpl.updateOutputFilters
+    this.copy(partitionValues = result.getOutputPartitionValues(partitionValuesTransform), filters = Seq(), isSkipped = false, dataFrame = None, keptSchema = None, executionModeResultOptions = result.options)
   }
   override def withDataFrame(dataFrame: Option[GenericDataFrame]): SparkConnectSubFeed = this.copy(
     dataFrame = dataFrame.map(_.asInstanceOf[SparkConnectDataFrame]),
@@ -105,7 +107,7 @@ object SparkConnectSubFeed extends DataFrameSubFeedCompanion {
    */
   override def fromSubFeed( subFeed: SubFeed )(implicit context: ActionPipelineContext): SparkConnectSubFeed = {
     subFeed match {
-      case subFeed: SparkConnectSubFeed => subFeed.clearFilter().asInstanceOf[SparkConnectSubFeed].copy(executionModeResultOptions = Map()) // no filter and no executionModeResultOptions are passed between actions
+      case subFeed: SparkConnectSubFeed => subFeed.copy(executionModeResultOptions = Map()) // no executionModeResultOptions are passed between actions. Filters are kept, only propagating filters can be present here.
       case _ => SparkConnectSubFeed(None, subFeed.dataObjectId, subFeed.partitionValues, subFeed.isDAGStart, subFeed.isSkipped)
     }
   }


### PR DESCRIPTION
DataFrameSubFeed carried a `filter: Option[String]`, a bare engine-SQL expression with no knowledge of the columns it references. Because of that it could only be set on the main input SubFeed, and it was dropped entirely at every Action boundary.

Replace it with `filters: Seq[ColumnFilter]`, binding each expression to a column so it can be handed to all inputs and, on request, propagated to following Actions - applied only where the column exists, the same treatment partition values already get.

- new ColumnFilter(column, expression, mainInputOnly, propagate) with a merge helper keeping at most one filter per column, warning on replace
- ExecutionModeResult.filter -> filters, plus filtersForInput() so the mainInputOnly policy lives in one place
- DataFrameSubFeed: clearFilters/withFilters/addFilters and a new updateFilters(schema), the column analogue of updatePartitionValues
- restriction to existing columns happens where a DataFrame is guaranteed: updateInputFilters in enrichSubFeedDataFrame and updateOutputFilters in postprocessOutputSubFeedCustomized
- propagation is opt-in per filter, so runtime behaviour is unchanged by default. DataFrameIncrementalMode gains a `propagateFilter` attribute
- fromSubFeed no longer clears filters, identically in all four engines, which also removes the pre-existing Snowpark divergence
- break lineage only for filters not already reflected in the DataFrame
- run state format version 6 -> 7, dropping the legacy `filter` attribute

Drive-by: delete dead GenericDataFrame.getDataFrameSubFeed and an unused ScalaSubFeed overload, handle filters in union, let ProductUtil.dynamicCopy fail on an unknown field name instead of silently returning the object unchanged, and make the sdl-lang filter apply-sites honour Environment.caseSensitive via columnExists.