### PR TITLE
Move catalog metadata to deploy time (#1121)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,63 @@ mvn -B test -pl sdl-core -Dsuites=io.smartdatalake.workflow.dataobject.AccessTab
 
 ### Waiting for long-running builds
 
-A full reactor build takes ~10 minutes, so it is usually started in the background. When polling for its
-completion, **do not detect the running build with `pgrep -f "<some part of the maven command line>"`**: the
-polling shell's own command line contains that pattern, so `pgrep` matches itself and reports "still running"
-forever. Detect completion from the build output instead, e.g. by grepping the log for
-`BUILD SUCCESS|BUILD FAILURE`, or by waiting on the process/job directly.
+A full reactor build takes ~10 minutes, so it is usually started in the background, redirecting to a log file.
+
+**Wait for it with a single blocking command that returns the result**, not with repeated progress checks:
+
+```bash
+# one call: blocks until done, then prints the verdict and any real compile errors
+until grep -qE "BUILD SUCCESS|BUILD FAILURE" build.log 2>/dev/null; do sleep 15; done
+echo "=== RESULT ==="
+grep -m1 -E "BUILD SUCCESS|BUILD FAILURE" build.log
+grep -E "\[ERROR\].*\.scala" build.log | head -20
+```
+
+Anti-patterns that waste a lot of time and context — all observed in practice:
+
+- **Polling in a loop of separate tool calls** (`tail -1 build.log`, then again, then again...). Each call costs a
+  round trip and tells you nothing actionable; a build that is "still compiling sdl-spark" needs no decision from
+  you. Issue *one* blocking wait and read the result.
+- **Launching a background waiter and then immediately checking on it.** The waiter returns via its own completion
+  notification; querying the log right after starting it just re-polls by hand. Either block in the foreground
+  (with a generous timeout) or start the waiter and genuinely do something else until it reports.
+- **Detecting the running build with `pgrep -f "<part of the maven command line>"`**: the polling shell's own
+  command line contains that pattern, so `pgrep` matches itself and reports "still running" forever.
+- **Matching on `ERROR` alone to decide the build finished.** Every build logs
+  `'dependencies.dependency.version' for org.scalactic/org.scalatest ... is missing` while resolving the invalid
+  third-party POM of `com.databricks:databricks-dbutils-scala`. These lines are harmless and appear long before the
+  build ends. Match `BUILD SUCCESS|BUILD FAILURE` for completion, and `\[ERROR\].*\.scala` for real compile errors.
+
+Note that maven's elapsed time and `ps` timings are unreliable under WSL on `/mnt/c`; judge progress from the log
+file's content and mtime, not from process elapsed time.
+
+### Which modules to build
+
+`mvn -pl <module>` alone fails for modules whose SDLB dependencies are not installed in `~/.m2`
+(`Cannot access sonatype-snapshots ... in offline mode`). Use `-pl <module> -am` so the dependencies are built in
+the same reactor, or `mvn install` them first. `sdl-lang` depends on nearly every other module, so
+`-pl sdl-lang -am` is effectively a full build.
+
+**Do not combine `-Dsuites=` with `-am`.** The suite filter is applied to *every* module in the reactor, and the
+first module that does not contain the named class aborts the run:
+
+```
+*** RUN ABORTED ***
+Unable to load a Suite class... Missing class: io.smartdatalake.workflow.dataobject.MyTest
+```
+
+So to run one suite in a module whose dependencies are not installed yet, install the reactor first and then run
+the suite against the installed artifacts:
+
+```bash
+mvn -o -B install -DskipTests -Dlicense.skip=true -Dmaven.source.skip=true \
+  -pl '!sdl-debezium/debezium-connector-mysql-shaded,!sdl-debezium/debezium-connector-mariadb-shaded,!sdl-kafka/embedded-kafka-schema-registry-shaded'
+mvn -o -B test -pl sdl-deltalake -Dsuites=io.smartdatalake.workflow.dataobject.MyTest
+```
+
+A wrong FQCN in `-Dsuites` fails the same way (`RUN ABORTED ... Missing class`), so verify it rather than
+guessing from the file path - the package does not always mirror the directory, e.g.
+`FactoryMethodCompletenessTest` lives in `io.smartdatalake.config`, not `io.smartdatalake.meta`.
 
 ## Configuration Patterns
 

--- a/docs/docs/getting-started/part-3/metadata.md
+++ b/docs/docs/getting-started/part-3/metadata.md
@@ -74,7 +74,9 @@ Let's edit therefore file `viz/dataObjects/btl-distance.md`.
 
 The existing file already contains some examples to create titles, tables and include images.
 And there is an example of a special syntax to create column descriptions using `@column` keyword.
-These columns descriptions will be rendered as markdown-table, and are also shown as column comments in the schema.
+These column descriptions are applied as column comments by `DataObjectSchemaExporter`, see
+[Applying table metadata to the catalog](/docs/reference/schema#applying-table-metadata-to-the-catalog),
+and are therefore shown as column comments in the schema. They override a comment coming from the schema itself.
 
 Lets add an additional comment for column `dep_name` to the markdown.
 
@@ -113,6 +115,22 @@ To start the _DataObjectSchemaExporter_ and also the previously mentioned _Confi
 Export configuration, schema and statistics at least with every release of your data pipelines.
 For this you can easily add _ConfigJsonExporter_ and _DataObjectSchemaExporter_ command line tool in the corresponding release pipeline. 
 :::
+
+## Write the metadata into the data catalog
+
+The descriptions above document your pipeline in the SDLB UI. To make them visible in the data catalog
+itself - as table and column comments on the tables SDLB writes - run _DataObjectSchemaExporter_ in `apply`
+mode as part of your deployment. This is a deployment step and not part of a normal SDLB run, so that
+running a pipeline does not repeatedly write to the catalog:
+
+```
+java -cp sdlb.jar io.smartdatalake.meta.configexporter.DataObjectSchemaExporter \
+  --config config/ --mode plan
+```
+
+`--mode plan` reports what would change without changing anything; `--mode apply` writes the changes.
+See [Applying table metadata to the catalog](/docs/reference/schema#applying-table-metadata-to-the-catalog)
+for the full flow, including how to export the schemas of tables that do not exist yet.
 
 ## SDLB UI
 

--- a/docs/docs/reference/commandLine.md
+++ b/docs/docs/reference/commandLine.md
@@ -48,7 +48,8 @@ Usage:  [options]
   -s, --streaming          Enable streaming mode for continuous processing.
   --parallelism <int>      Max number of parallel executed SDLB actions.
   --state-path <path>      Hadoop path to save run state files. Must be set to enable recovery in case of failures.
-  --test <config|dry-run>  Run in test mode: config -> validate configuration, dry-run -> execute prepare- and init-phase only to check environment and spark lineage
+  --test <config|dry-run|dry-run-with-schema-export>
+                           Run in test mode: config -> validate configuration, dry-run -> execute prepare- and init-phase only to check environment and spark lineage, dry-run-with-schema-export -> like dry-run, and export the schemas of the output DataObjects to global.dataObjectsSchemaSource
   --help                   Display the help text.
   --version                Display version information.
 ```

--- a/docs/docs/reference/schema.md
+++ b/docs/docs/reference/schema.md
@@ -124,16 +124,61 @@ Use sdl-parent as maven "parent pom", or add the plugin to your project as follo
 ```
 :::
 
-Note that the column comments have to be persisted by the target DataObject to be visible in the UI,
-as `DataObjectSchemaExporter` reads the schema back from the DataObject.
-This is supported by table DataObjects, e.g. `DeltaLakeTableDataObject` with `updateColumnComments = true`,
-but not by plain file DataObjects.
+Note that column comments are not written to the catalog during a normal SDLB run.
+Table metadata can only change when the configuration or the code changes, so it is applied at
+deployment time instead - see [Applying table metadata to the catalog](#applying-table-metadata-to-the-catalog).
 
 Limitations:
 * Only UDFs created with the typed API, e.g. `udf((x: String) => MyCaseClass(x))`, carry the type information
   needed to find the case class. A UDF declaring its return type explicitly does not.
 * Python UDFs are not supported.
 * The Spark Connect engine is not supported.
+
+## Applying table metadata to the catalog
+
+Table metadata - the table comment from `metadata.description`, the column comments and the primary key -
+is *not* written to the catalog during a normal SDLB run. It can only change when the configuration or the
+code changes, so writing it on every run causes unnecessary load on the catalog and races with concurrent
+write operations. It is applied at deployment time in two steps instead.
+
+**1. Export the schemas on the development environment.** A dry-run with schema export writes the schema of
+every output DataObject, including the column comments SDLB assembled from `schemaMin`, from the Markdown
+description files and from the ScalaDoc of case classes, to `global.dataObjectsSchemaSource`:
+
+```bash
+sdlb --config config/ --feed-sel '.*' --test dry-run-with-schema-export
+```
+
+This is a dry-run: it executes the prepare- and init-phase only and does not write any data. Because the
+schemas come from the init-phase and not from the catalog, this works even if the tables do not exist yet.
+Commit the resulting schema files together with the configuration.
+
+```hocon
+global {
+  dataObjectsSchemaSource = "file:./schema"
+}
+```
+
+**2. Apply the metadata on the target environment.** `DataObjectSchemaExporter` reads the desired state from
+the configuration and from the exported schema files, compares it with the catalog and writes only what
+differs:
+
+```bash
+# report what would change, without changing anything
+java -cp sdlb.jar io.smartdatalake.meta.configexporter.DataObjectSchemaExporter \
+  --config config/ --mode plan --descriptionPath ./description
+
+# apply the changes
+java -cp sdlb.jar io.smartdatalake.meta.configexporter.DataObjectSchemaExporter \
+  --config config/ --mode apply --descriptionPath ./description
+```
+
+Applying is idempotent: running it twice makes no second change. Column descriptions defined with `@column`
+in the Markdown description files override the comments from the exported schema.
+
+This is supported by table DataObjects implementing `CanHandleCatalogMetadata`, currently
+`DeltaLakeTableDataObject`, `IcebergTableDataObject` and `SnowflakeTableDataObject`. Other DataObjects are
+skipped. The primary key is only applied for tables with `table.createAndReplacePrimaryKey = true`.
 
 
 <!-- TODO Review all below -->

--- a/sdl-core/src/main/scala/io/smartdatalake/app/CanBuildSmartDataLakeBuilderConfig.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/CanBuildSmartDataLakeBuilderConfig.scala
@@ -84,7 +84,13 @@ trait CanBuildSmartDataLakeBuilderConfig[R] {
 
   val appName: String = applicationName.getOrElse(feedSel)
 
-  def isDryRun: Boolean = test.contains(TestMode.DryRun)
+  def isDryRun: Boolean = test.exists(Seq(TestMode.DryRun, TestMode.DryRunWithSchemaExport).contains)
+
+  /**
+   * true if the schemas of the output DataObjects should be exported at the end of this (dry) run,
+   * see [[TestMode.DryRunWithSchemaExport]].
+   */
+  def isSchemaExport: Boolean = test.contains(TestMode.DryRunWithSchemaExport)
 
   @JsonIgnore
   def getHoconConfig(validateCompletness: Boolean = true)(implicit hadoopConfiguration: Configuration): Config = {

--- a/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/app/SmartDataLakeBuilder.scala
@@ -23,6 +23,7 @@ import io.smartdatalake.communication.statusinfo.StatusInfoServer
 import io.smartdatalake.communication.statusinfo.api.SnapshotStatusInfoListener
 import io.smartdatalake.communication.statusinfo.websocket.IncrementalStatusInfoListener
 import io.smartdatalake.config.SdlConfigObject.ActionId
+import io.smartdatalake.config.exporter.ExportWriter
 import io.smartdatalake.config.{ConfigParser, ConfigurationException, InstanceRegistry}
 import io.smartdatalake.definitions.Environment
 import io.smartdatalake.util.LogUtils.debugLog
@@ -76,6 +77,17 @@ object TestMode extends Enumeration {
    * phase, but not the "exec" phase of an SDLB run.
    */
   val DryRun: app.TestMode.Value = Value("dry-run")
+
+  /**
+   * Like [[DryRun]], but additionally exports the schemas of all output DataObjects to
+   * `global.dataObjectsSchemaSource`. The schemas are taken from the init phase and therefore include
+   * the column comments assembled by SDLB, e.g. from schemaMin or from the ScalaDoc of case classes
+   * returned by user defined functions.
+   *
+   * Use this on a development environment to create the schema files needed by DataObjectSchemaExporter
+   * to apply table metadata to the catalog of a target environment at deployment time.
+   */
+  val DryRunWithSchemaExport: app.TestMode.Value = Value("dry-run-with-schema-export")
 }
 
 /**
@@ -173,9 +185,10 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
         .text(s"Hadoop path to save run state files. Must be set to enable recovery in case of failures."),
       opt[String]("test")
         .action((arg, config) => config.withTest(Some(TestMode.withName(arg))))
-        .valueName("<config|dry-run>")
+        .valueName("<config|dry-run|dry-run-with-schema-export>")
         .text(
-          "Run in test mode: config -> validate configuration, dry-run -> execute prepare- and init-phase only to check environment and spark lineage"
+          "Run in test mode: config -> validate configuration, dry-run -> execute prepare- and init-phase only to check environment and spark lineage, " +
+            "dry-run-with-schema-export -> like dry-run, and export the schemas of the output DataObjects to global.dataObjectsSchemaSource"
         ),
       help("help").text("Display the help text."),
       version("version").text("Display version information.")
@@ -554,6 +567,7 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
         actionDAGRun.prepare(context)
         actionDAGRun.init(context)
         if (appConfig.isDryRun) { // stop here if only dry-run
+          if (appConfig.isSchemaExport) exportDataObjectSchemas(context)
           logger.info(s"${appConfig.test.get}-Test successful")
           return (Seq(), RunStatistics.empty)
         }
@@ -571,6 +585,37 @@ abstract class SmartDataLakeBuilder extends SmartDataLakeLogger {
 
     // return result statistics as string
     (finalSubFeeds, actionDAGRun.getStatistics(context))
+  }
+
+  /**
+   * Export the schemas collected during the init phase to `global.dataObjectsSchemaSource`,
+   * see [[TestMode.DryRunWithSchemaExport]].
+   *
+   * The exported files are read back by [[GlobalConfig.getSchemaFromSource]] for dry-runs on a local
+   * environment, and by DataObjectSchemaExporter to apply table metadata to a catalog at deployment time.
+   */
+  private[smartdatalake] def exportDataObjectSchemas(context: ActionPipelineContext): Unit = {
+    val globalConfig = context.globalConfig
+    val target = globalConfig.dataObjectsSchemaSource.getOrElse(
+      throw ConfigurationException(
+        s"global.dataObjectsSchemaSource must be defined to use --test ${TestMode.DryRunWithSchemaExport}"
+      )
+    )
+    val schemas = context.schemaExportRegistry.getSchemas
+    if (schemas.isEmpty) {
+      logger.warn(s"No DataObject schemas collected, nothing to export to '$target'")
+    } else {
+      val writer = ExportWriter.apply(
+        target,
+        backendClient = globalConfig.uiBackend.map(_.client),
+        hadoopConfig = Some(context.hadoopConf)
+      )
+      val version = System.currentTimeMillis() / 1000
+      schemas.foreach { case (dataObjectId, schema) =>
+        writer.writeSchema(ExportWriter.formatSchema(Some(schema), None), dataObjectId, version)
+      }
+      logger.info(s"Exported ${schemas.size} DataObject schemas to '$target'")
+    }
   }
 
   private[smartdatalake] def agentExec(

--- a/sdl-core/src/main/scala/io/smartdatalake/util/misc/SQLUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/misc/SQLUtil.scala
@@ -112,14 +112,40 @@ object SQLUtil extends SmartDataLakeLogger {
   }
 
   /**
-   * Execute a SQL statement, prefixed by USE CATALOG/USE SCHEMA statements based on the configured table.
-   * Preserves the semantics of SparkQueryUtil.executeSqlStatementBasedOnTable.
+   * Escape a string to be used as SQL string literal, e.g. a table or column comment.
+   */
+  def escapeSqlStringLiteral(str: String): String = str.replace("'", "''")
+
+  /**
+   * Execute a SQL statement as is.
+   * Use this for SDLB generated statements, which address the table by its fully qualified name, see [[Table.fullName]].
+   */
+  def execSql(stmt: String, execFun: String => Unit, loggerContext: String): Unit = {
+    try {
+      logger.info(s"${loggerContext}Executing SQL statement: $stmt")
+      execFun(stmt)
+    } catch {
+      case e: Exception =>
+        logger.warn(s"${loggerContext}Error in SQL statement '$stmt':\n${e.getMessage}")
+        throw e
+    }
+  }
+
+  /**
+   * Execute a user defined SQL statement, prefixed by a USE statement based on the configured table.
+   * This allows the user to use unqualified table names in the statement, which are then resolved
+   * against the catalog and schema of the configured table.
+   *
+   * Note that the USE statement changes the current catalog and schema of the shared session for all
+   * statements following in that session. For SDLB generated statements use [[execSql]] with a fully
+   * qualified table name instead.
    */
   def execSqlBasedOnTable(stmt: String, table: Table, execSql: String => Unit, loggerContext: String)(implicit context: ActionPipelineContext): Unit = {
     try {
+      // Note that "USE <catalog>.<schema>" is supported by open source Spark and Databricks,
+      // in contrast to "USE CATALOG <catalog>" which is Databricks/Unity Catalog syntax only.
       val newStmt = Seq(
-        table.catalog.map(cat => s"USE CATALOG $cat"),
-        table.db.map(db => s"USE SCHEMA $db"),
+        Some(table.getDbName).filter(_.nonEmpty).map(namespace => s"USE $namespace"),
         Some(stmt)
       ).flatten
       logger.info(s"${loggerContext}Executing SQL statements: ${newStmt.mkString("; ")}")

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/ActionPipelineContext.scala
@@ -71,6 +71,7 @@ case class ActionPipelineContext (
                                    simulation: Boolean = false,
                                    phase: ExecutionPhase = ExecutionPhase.Prepare,
                                    cacheRegistry: DataFrameCacheRegistry = new DataFrameCacheRegistry(),
+                                   schemaExportRegistry: SchemaExportRegistry = new SchemaExportRegistry(),
                                    runtimeRegistry: ActionsRuntimeRegistry = new ActionsRuntimeRegistry(),
                                    actionsSelected: Seq[ActionId] = Seq(),
                                    actionsSkipped: Map[ActionId, RuntimeInfo] = Map(),

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/SchemaExportRegistry.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/SchemaExportRegistry.scala
@@ -1,0 +1,57 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow
+
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.dataframe.GenericSchema
+
+import scala.collection.mutable
+
+/**
+ * Collects the schemas written to output DataObjects during the init phase, so they can be exported
+ * at the end of a dry-run, see [[io.smartdatalake.app.TestMode.DryRunWithSchemaExport]].
+ *
+ * The schemas are taken from the init phase DataFrames and therefore include the column comments
+ * assembled by SDLB, e.g. from schemaMin or from the ScalaDoc of case classes returned by user defined
+ * functions. Asking the DataObject for its schema instead would read it back from the catalog, which
+ * does not work at deployment time when the table might not exist yet.
+ */
+private[smartdatalake] class SchemaExportRegistry extends SmartDataLakeLogger {
+
+  private val schemas = mutable.Map[DataObjectId, GenericSchema]()
+
+  /**
+   * Init phase: remember the schema written to `dataObjectId`.
+   * If an Action writes the same DataObject more than once, the last schema wins.
+   */
+  def register(dataObjectId: DataObjectId, schema: GenericSchema): Unit = synchronized {
+    logger.debug(s"($dataObjectId) registering schema for export")
+    schemas.update(dataObjectId, schema)
+  }
+
+  /**
+   * All schemas collected so far.
+   */
+  def getSchemas: Map[DataObjectId, GenericSchema] = synchronized {
+    schemas.toMap
+  }
+
+  def isEmpty: Boolean = synchronized(schemas.isEmpty)
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/action/DataFrameActionImpl.scala
@@ -317,6 +317,10 @@ abstract class DataFrameActionImpl extends ActionSubFeedsImpl[DataFrameSubFeed] 
     // initialize outputs
     if (context.phase == ExecutionPhase.Init) {
       output.init(commentedSubFeed.dataFrame.get, commentedSubFeed.partitionValues, saveModeOptions)
+      // collect the schema to be exported at the end of a dry-run with schema export
+      if (context.appConfig.isSchemaExport) {
+        context.schemaExportRegistry.register(output.id, commentedSubFeed.dataFrame.get.schema)
+      }
     }
     // apply expectation validation
     output match {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericSchemaUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataframe/GenericSchemaUtil.scala
@@ -1,0 +1,60 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataframe
+
+import scala.annotation.tailrec
+
+/**
+ * Engine independent helpers to work with [[GenericSchema]].
+ *
+ * This mirrors the Spark specific SparkSchemaUtil for the cases where no Spark session is available,
+ * e.g. when applying column comments to a catalog from DataObjectSchemaExporter.
+ */
+object GenericSchemaUtil {
+
+  /**
+   * Collect the comments of all columns of a schema, including nested columns.
+   *
+   * Column names are returned as path, e.g. Seq("address", "street") for a column "street" nested in a
+   * struct column "address". Use [[formatColumnPath]] to get the name to be used in an SQL statement.
+   * Note that arrays are traversed transparently, e.g. a struct nested in an array of the column
+   * "addresses" is returned as Seq("addresses", "street"), matching the SQL syntax to comment it.
+   */
+  def columnComments(schema: GenericSchema): Map[Seq[String], String] = columnComments(schema.fields, Seq())
+
+  private def columnComments(fields: Seq[GenericField], parents: Seq[String]): Map[Seq[String], String] = {
+    fields.foldLeft(Map[Seq[String], String]()) { case (comments, field) =>
+      val path = parents :+ field.name
+      val fieldComment = field.comment.map(c => Map(path -> c)).getOrElse(Map())
+      comments ++ fieldComment ++ nestedComments(field.dataType, path)
+    }
+  }
+
+  @tailrec
+  private def nestedComments(dataType: GenericDataType, parents: Seq[String]): Map[Seq[String], String] = dataType match {
+    case struct: GenericStructDataType => columnComments(struct.fields, parents)
+    case array: GenericArrayDataType => nestedComments(array.elementDataType, parents)
+    case _ => Map()
+  }
+
+  /**
+   * Format a column path as returned by [[columnComments]] for use in an SQL statement.
+   */
+  def formatColumnPath(path: Seq[String]): String = path.mkString(".")
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableDataObject.scala
@@ -23,7 +23,7 @@ import io.smartdatalake.config.SdlConfigObject.{ConnectionId, DataObjectId}
 import io.smartdatalake.config.{ConfigurationException, FromConfigFactory, InstanceRegistry}
 import io.smartdatalake.definitions.SDLSaveMode.SDLSaveMode
 import io.smartdatalake.definitions._
-import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues, UCFileSystemFactory}
+import io.smartdatalake.util.hdfs.{HdfsUtil, PartitionValues}
 import io.smartdatalake.util.misc._
 import io.smartdatalake.workflow.action.ActionSubFeedsImpl.MetricsMap
 import io.smartdatalake.workflow.connection.DeltaLakeTableConnection
@@ -96,9 +96,6 @@ import scala.util.Try
  * @param expectations List of [[Expectation]]s to enforce when writing to this data object. Expectations are checks based on aggregates over all rows of a dataset.
  * @param saveMode     [[SDLSaveMode]] to use when writing files, default is "Overwrite". Overwrite, Append and Merge are supported for now.
  * @param allowSchemaEvolution If set to true schema evolution will automatically occur when writing to this DataObject with different schema, otherwise SDL will stop with error.
- * @param updateColumnComments If set to false, the column comments (read from the provided schema) will only be updated for newly created columns.
- *                             If set to true, the column comments from the provided schema will be updated every time the pipeline runs, which results in
- *                             a lower performance since a column comparison is needed. Defaults to "false".
  * @param retentionPeriod Optional delta lake retention threshold in hours. Files required by the table for reading versions younger than retentionPeriod will be preserved and the rest of them will be deleted.
  * @param minVacuumInterval Optional String to determine the minimum time interval between two vacuum operations. If the parameter is set,
  *                          SDLB will look at the last vacuum-execution time in the table and compare it to the current time. If the parameter is not set or if a vacuum has never happened, it will vacuum the table.
@@ -110,8 +107,8 @@ import scala.util.Try
  *                         E.g. it can be used to clean up, archive and compact partitions.
  *                         See HousekeepingMode for available implementations. Default is None.
  * @param connectionId optional id of [[io.smartdatalake.workflow.connection.HiveTableConnection]]
- * @param metadata metadata of the table. NOTE: if the value metadata.description is set, the table.db and the table.catalog
- *                  attributes are required as the pipeline will try to add the description to the catalog.
+ * @param metadata metadata of the table. metadata.description is applied as table comment in the catalog
+ *                 by the DataObjectSchemaExporter, see also [[io.smartdatalake.workflow.dataobject.generic.CanHandleCatalogMetadata]].
  *
  * @note DeltaLake needs the spark properties spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension and
  *       spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog. They are added automatically
@@ -134,7 +131,6 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
                                     override val postWriteSql: Option[String] = None,
                                     saveMode: SDLSaveMode = SDLSaveMode.Overwrite,
                                     override val allowSchemaEvolution: Boolean = false,
-                                    updateColumnComments: Boolean = false,
                                     retentionPeriod: Option[Int] = None, // hours
                                     minVacuumInterval: Option[String] = None,
                                     connectionId: Option[ConnectionId] = None,
@@ -144,6 +140,7 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
                                    (@transient implicit val instanceRegistry: InstanceRegistry)
   extends TransactionalTableDataObject with CanMergeDataFrame with CanEvolveSchema with CanHandlePartitions
     with HasHadoopStandardFilestore with ExpectationValidation with CanCreateIncrementalOutput with CanHandleConstraints
+    with CanHandleCatalogMetadata
     with HasEngineImplementation[DeltaLakeTableEngine] {
 
   /**
@@ -200,12 +197,6 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
   override def prepare(implicit context: ActionPipelineContext): Unit = {
     super.prepare
     require(isDbExisting, s"($id) DB ${table.getDbName} doesn't exist (needs to be created manually).")
-    metadata.flatMap(_.description).foreach(_ => {
-      require(table.db.isDefined && table.catalog.isDefined,
-        "Since the attribute metadata.description is set, you must also define a " +
-          "table.db and a table.catalog in order to add a the tableComment" +
-          "to the catalog")
-    })
     // engine-specific preparation, e.g. checking spark options and initializing external table path with classic Spark engine
     engine.prepare()
     filterExpectedPartitionValues(Seq()) // validate expectedPartitionsCondition
@@ -234,10 +225,11 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
     super.preWrite
   }
 
+  // Note that table metadata (table comment, column comments, primary key) is not applied here anymore.
+  // It can only change when the configuration or the code changes, so it is applied at deployment time by
+  // DataObjectSchemaExporter, see CanHandleCatalogMetadata.
   override def postWrite(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     super.postWrite(partitionValues)
-    if (table.createAndReplacePrimaryKey && UCFileSystemFactory.isDatabricksEnv) createOrReplacePrimaryKeyConstraint
-    metadata.flatMap(_.description).foreach {addTableComment}
   }
 
   /**
@@ -342,25 +334,22 @@ case class DeltaLakeTableDataObject(override val id: DataObjectId,
 
   def dropPrimaryKeyConstraint(tableName: String, constraintName: String)(implicit context: ActionPipelineContext): Unit = {
     val query = f"ALTER TABLE $tableName DROP CONSTRAINT $constraintName".toLowerCase
-    SQLUtil.execSqlBasedOnTable(query, table, engine.sql, s"($id) ")
+    SQLUtil.execSql(query, engine.sql, s"($id) ")
   }
 
   def createPrimaryKeyConstraint(tableName: String, constraintName: String, cols: Seq[String])(implicit context: ActionPipelineContext): Unit = {
     val query = f"ALTER TABLE $tableName ADD CONSTRAINT $constraintName PRIMARY KEY (${cols.mkString(",")}) RELY"
-    SQLUtil.execSqlBasedOnTable(query, table, engine.sql, s"($id) ")
+    SQLUtil.execSql(query, engine.sql, s"($id) ")
   }
 
-  def addTableComment(comment: String)(implicit context: ActionPipelineContext): Unit = {
-    val query = f"ALTER TABLE ${table.name} SET TBLPROPERTIES ('comment' = '$comment');"
-    SQLUtil.execSqlBasedOnTable(query, table, engine.sql, s"($id) ")
-  }
+  override def getTableComment(implicit context: ActionPipelineContext): Option[String] =
+    CatalogMetadataSqlUtil.getTableComment(table, engine.sql)
 
-  def updateExistingColumnComments(comments: Map[String, String])(implicit context: ActionPipelineContext): Unit = {
-    comments.foreach( comment => {
-      val query = f"ALTER TABLE ${table.name} ALTER COLUMN ${comment._1} COMMENT '${comment._2}';"
-      SQLUtil.execSqlBasedOnTable(query, table, engine.sql, s"($id) ")
-    })
-  }
+  override def setTableComment(comment: String)(implicit context: ActionPipelineContext): Unit =
+    CatalogMetadataSqlUtil.setTableComment(table, comment, engine.sql, s"($id) ")
+
+  override def setColumnComments(comments: Map[Seq[String], String])(implicit context: ActionPipelineContext): Unit =
+    CatalogMetadataSqlUtil.setColumnComments(table, comments, engine.sql, s"($id) ")
 }
 
 object DeltaLakeTableDataObject extends FromConfigFactory[DataObject] {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/IcebergTableDataObject.scala
@@ -124,6 +124,7 @@ case class IcebergTableDataObject(override val id: DataObjectId,
                                  )(@transient implicit val instanceRegistry: InstanceRegistry)
   extends TransactionalTableDataObject with CanMergeDataFrame with CanEvolveSchema with CanHandlePartitions
     with HasHadoopStandardFilestore with ExpectationValidation with CanCreateIncrementalOutput
+    with CanHandleCatalogMetadata
     with HasEngineImplementation[IcebergTableEngine] {
 
   /**
@@ -301,6 +302,15 @@ case class IcebergTableDataObject(override val id: DataObjectId,
   def prepareAndExecSql(sqlOpt: Option[String], configName: Option[String], partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     sqlOpt.foreach(stmt => SQLUtil.execSqlBasedOnTable(stmt, table, engine.sql, s"($id) "))
   }
+
+  override def getTableComment(implicit context: ActionPipelineContext): Option[String] =
+    CatalogMetadataSqlUtil.getTableComment(table, engine.sql)
+
+  override def setTableComment(comment: String)(implicit context: ActionPipelineContext): Unit =
+    CatalogMetadataSqlUtil.setTableComment(table, comment, engine.sql, s"($id) ")
+
+  override def setColumnComments(comments: Map[Seq[String], String])(implicit context: ActionPipelineContext): Unit =
+    CatalogMetadataSqlUtil.setColumnComments(table, comments, engine.sql, s"($id) ")
 }
 
 object IcebergTableDataObject extends FromConfigFactory[DataObject] {

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CanHandleCatalogMetadata.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CanHandleCatalogMetadata.scala
@@ -1,0 +1,64 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject.generic
+
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.dataframe.GenericSchemaUtil
+
+/**
+ * This trait defines how table and column comments are read from and written to the catalog of a
+ * TableDataObject.
+ *
+ * Note that comments are *not* applied during a normal SDLB run: table metadata can only change when the
+ * configuration or the code changes, so it is applied at deployment time by DataObjectSchemaExporter,
+ * which reads the desired state from the configuration and from the exported schema files.
+ * See [[io.smartdatalake.app.TestMode.DryRunWithSchemaExport]] for how these schema files are created.
+ *
+ * Implementations must address the table by its fully qualified name (see [[Table.fullName]]) and must not
+ * change the current catalog or schema of the session, otherwise concurrent statements of a parallel run
+ * resolve table names in the wrong schema.
+ */
+trait CanHandleCatalogMetadata { self: TableDataObject =>
+
+  /**
+   * Read the table comment currently set in the catalog.
+   */
+  def getTableComment(implicit context: ActionPipelineContext): Option[String]
+
+  /**
+   * Write the table comment to the catalog.
+   */
+  def setTableComment(comment: String)(implicit context: ActionPipelineContext): Unit
+
+  /**
+   * Read the column comments currently set in the catalog, keyed by column path,
+   * see [[GenericSchemaUtil.columnComments]].
+   *
+   * The default implementation reads the schema of the table, which for table DataObjects is the schema
+   * as registered in the catalog, including its comments.
+   */
+  def getColumnComments(implicit context: ActionPipelineContext): Map[Seq[String], String] = {
+    GenericSchemaUtil.columnComments(getDataFrame().schema)
+  }
+
+  /**
+   * Write the given column comments to the catalog, keyed by column path.
+   */
+  def setColumnComments(comments: Map[Seq[String], String])(implicit context: ActionPipelineContext): Unit
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CanHandleConstraints.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CanHandleConstraints.scala
@@ -32,6 +32,12 @@ case class PrimaryKeyDefinition(pkColumns: Seq[String], pkName: Option[String] =
 /**
  * This trait defines the general approach to handle constraints such as primary and foreign keys
  * within a TransactionalTableDataObject.
+ *
+ * Note that constraints are not applied during a normal SDLB run. They are applied at deployment time by
+ * DataObjectSchemaExporter, see [[CanHandleCatalogMetadata]].
+ *
+ * Foreign keys (see [[Table.foreignKeys]]) are currently metadata for the data catalog only, no DDL is
+ * generated for them. See issue #1129.
  */
 trait CanHandleConstraints { self: TransactionalTableDataObject =>
   def getExistingPKConstraint(catalog: Option[String], schema: Option[String], tableName: String)(implicit context: ActionPipelineContext): Option[PrimaryKeyDefinition]
@@ -47,18 +53,17 @@ trait CanHandleConstraints { self: TransactionalTableDataObject =>
     def createOrReplacePrimaryKeyConstraint(implicit context: ActionPipelineContext): Unit = {
       val definedPrimaryKeyOp: Option[Seq[String]] = table.primaryKey
       val existingPrimaryKeyOp: Option[PrimaryKeyDefinition] =  getExistingPKConstraint(table.catalog, table.db, table.name)
+      def normalize(cols: Seq[String]): Set[String] = cols.map(_.toLowerCase).toSet
       (definedPrimaryKeyOp, existingPrimaryKeyOp) match {
         case (None, _) =>
           logger.warn(f"$id parameter createAndReplacePrimaryKey not needed as there are no primary Key columns defined!")
         case (Some(pkcols), None) => createPrimaryKeyConstraint(table.fullName, pkConstraintName, pkcols)
-        case (Some(definedPkCols), Some(existingPkCols)) if definedPkCols.toSet.map((s: String) => s.toLowerCase).diff(existingPkCols.pkColumns.toSet.map((s: String) => s.toLowerCase)).nonEmpty =>
+        case (Some(definedPkCols), Some(existingPkCols)) if normalize(definedPkCols) == normalize(existingPkCols.pkColumns) =>
+          logger.debug(s"($id) primary key constraint is already up to date")
+        case (Some(definedPkCols), Some(existingPkCols)) =>
           if (existingPkCols.pkName.isEmpty) throw new SQLException(f"$id: The Primary key in the database already has some columns, but the constraint name returned by the database is null. The PK cannot be updated!")
           dropPrimaryKeyConstraint(table.fullName, existingPkCols.pkName.get)
           createPrimaryKeyConstraint(table.fullName, pkConstraintName, definedPkCols)
-        case t =>
-          throw new IllegalStateException(s"$id: Unexpected state $t in primary key constraint handling." +
-            s" Both defined and existing primary keys are present but identical," +
-            s" or neither defined keys nor existing keys are present but not handled by other cases.")
       }
     }
 

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CatalogMetadataApplier.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CatalogMetadataApplier.scala
@@ -1,0 +1,125 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject.generic
+
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import io.smartdatalake.workflow.ActionPipelineContext
+import io.smartdatalake.workflow.dataframe.{GenericSchema, GenericSchemaUtil}
+import io.smartdatalake.workflow.dataobject.DataObject
+
+/**
+ * The metadata changes to be applied to the catalog for one DataObject.
+ */
+case class CatalogMetadataChanges(dataObjectId: DataObjectId,
+                                  tableComment: Option[String] = None,
+                                  columnComments: Map[Seq[String], String] = Map(),
+                                  primaryKey: Option[Seq[String]] = None) {
+  def isEmpty: Boolean = tableComment.isEmpty && columnComments.isEmpty && primaryKey.isEmpty
+
+  def describe: Seq[String] = {
+    tableComment.map(c => s"set table comment to '$c'").toSeq ++
+      columnComments.toSeq.sortBy(_._1.mkString(".")).map { case (path, c) =>
+        s"set comment of column ${GenericSchemaUtil.formatColumnPath(path)} to '$c'"
+      } ++
+      primaryKey.map(pk => s"create or replace primary key (${pk.mkString(", ")})").toSeq
+  }
+}
+
+/**
+ * Computes and applies the table metadata of a DataObject to the catalog.
+ *
+ * The desired state is taken from the SDLB configuration (table comment, primary key) and from the
+ * exported schema files plus the Markdown description files (column comments). The current state is read
+ * from the catalog, so that nothing is written when it is already up to date.
+ *
+ * This runs at deployment time and not during an SDLB run: table metadata can only change when the
+ * configuration or the code changes, and writing it on every run causes unnecessary catalog load and
+ * races with concurrent write operations.
+ */
+class CatalogMetadataApplier(schemaReader: DataObjectId => Option[GenericSchema],
+                             columnDescriptions: Map[DataObjectId, Map[Seq[String], String]] = Map())
+  extends SmartDataLakeLogger {
+
+  /**
+   * Compute the changes needed to bring the catalog in line with the configuration.
+   * Returns None if the DataObject does not support catalog metadata at all.
+   */
+  def plan(dataObject: DataObject)(implicit context: ActionPipelineContext): Option[CatalogMetadataChanges] = {
+    dataObject match {
+      case tableDo: TableDataObject with CanHandleCatalogMetadata =>
+        if (!tableDo.isTableExisting) {
+          logger.warn(s"(${tableDo.id}) table ${tableDo.table.fullName} does not exist, skipping")
+          None
+        } else Some(planTable(tableDo))
+      case _ =>
+        logger.debug(s"(${dataObject.id}) does not support catalog metadata, skipping")
+        None
+    }
+  }
+
+  private def planTable(dataObject: TableDataObject with CanHandleCatalogMetadata)
+                       (implicit context: ActionPipelineContext): CatalogMetadataChanges = {
+    // table comment
+    val desiredTableComment = dataObject.metadata.flatMap(_.description)
+    val currentTableComment = dataObject.getTableComment
+    val tableCommentChange = desiredTableComment.filterNot(currentTableComment.contains)
+
+    // column comments: exported schema, overridden by the markdown description files
+    val schemaComments = schemaReader(dataObject.id).map(GenericSchemaUtil.columnComments).getOrElse(Map())
+    val describedComments = columnDescriptions.getOrElse(dataObject.id, Map())
+    val desiredColumnComments = schemaComments ++ describedComments
+    val currentColumnComments = dataObject.getColumnComments
+    val columnCommentChanges = desiredColumnComments.filterNot { case (path, comment) =>
+      currentColumnComments.get(path).contains(comment)
+    }
+
+    // primary key
+    val primaryKeyChange = dataObject match {
+      case constraintDo: CanHandleConstraints if dataObject.table.createAndReplacePrimaryKey =>
+        val desired = dataObject.table.primaryKey
+        val existing = constraintDo.getExistingPKConstraint(
+          dataObject.table.catalog, dataObject.table.db, dataObject.table.name
+        )
+        def normalize(cols: Seq[String]) = cols.map(_.toLowerCase).toSet
+        desired.filterNot(pk => existing.exists(e => normalize(e.pkColumns) == normalize(pk)))
+      case _ => None
+    }
+
+    CatalogMetadataChanges(dataObject.id, tableCommentChange, columnCommentChanges, primaryKeyChange)
+  }
+
+  /**
+   * Apply the given changes to the catalog.
+   */
+  def apply(dataObject: DataObject, changes: CatalogMetadataChanges)(implicit context: ActionPipelineContext): Unit = {
+    dataObject match {
+      case tableDo: TableDataObject with CanHandleCatalogMetadata =>
+        changes.tableComment.foreach(tableDo.setTableComment)
+        if (changes.columnComments.nonEmpty) tableDo.setColumnComments(changes.columnComments)
+        changes.primaryKey.foreach { _ =>
+          tableDo match {
+            case constraintDo: CanHandleConstraints => constraintDo.createOrReplacePrimaryKeyConstraint
+            case _ => logger.warn(s"(${dataObject.id}) primary key cannot be applied, DataObject does not support constraints")
+          }
+        }
+      case _ => throw new IllegalStateException(s"(${dataObject.id}) does not support catalog metadata")
+    }
+  }
+}

--- a/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CatalogMetadataSqlUtil.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/workflow/dataobject/generic/CatalogMetadataSqlUtil.scala
@@ -1,0 +1,64 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject.generic
+
+import io.smartdatalake.util.misc.{SQLUtil, SmartDataLakeLogger}
+import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchemaUtil}
+
+import scala.util.Try
+
+/**
+ * Implementation of [[CanHandleCatalogMetadata]] for catalogs using Spark SQL syntax, e.g. Delta Lake
+ * and Iceberg tables.
+ *
+ * All statements address the table by its fully qualified name and none of them changes the current
+ * catalog or schema of the session, see [[CanHandleCatalogMetadata]].
+ */
+object CatalogMetadataSqlUtil extends SmartDataLakeLogger {
+
+  /**
+   * Row of "DESCRIBE TABLE EXTENDED" holding the table comment.
+   */
+  private val tableCommentAttribute = "Comment"
+
+  /**
+   * Read the table comment using "DESCRIBE TABLE EXTENDED", which lists it as an attribute row
+   * named "Comment". Returns None if the table has no comment.
+   */
+  def getTableComment(table: Table, sql: String => GenericDataFrame): Option[String] = {
+    val rows = sql(s"DESCRIBE TABLE EXTENDED ${table.fullName}").collect
+    rows
+      .find(row => Try(row.getAs[String](0)).toOption.contains(tableCommentAttribute))
+      .flatMap(row => Try(row.getAs[String](1)).toOption)
+      .filter(_ != null)
+  }
+
+  def setTableComment(table: Table, comment: String, sql: String => Unit, loggerContext: String): Unit = {
+    val stmt = s"ALTER TABLE ${table.fullName} SET TBLPROPERTIES ('comment' = '${SQLUtil.escapeSqlStringLiteral(comment)}')"
+    SQLUtil.execSql(stmt, sql, loggerContext)
+  }
+
+  def setColumnComments(table: Table, comments: Map[Seq[String], String], sql: String => Unit, loggerContext: String): Unit = {
+    comments.foreach { case (columnPath, comment) =>
+      val stmt = s"ALTER TABLE ${table.fullName} ALTER COLUMN ${GenericSchemaUtil.formatColumnPath(columnPath)}" +
+        s" COMMENT '${SQLUtil.escapeSqlStringLiteral(comment)}'"
+      SQLUtil.execSql(stmt, sql, loggerContext)
+    }
+  }
+}

--- a/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableSparkClassicEngine.scala
+++ b/sdl-deltalake/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableSparkClassicEngine.scala
@@ -241,12 +241,6 @@ class DeltaLakeTableSparkClassicEngine(dataObject: DeltaLakeTableDataObject) ext
         .saveAsTable(table.fullName)
     )
 
-    //if the flag is set, update comments of existing columns (one by one)
-    if (updateColumnComments) {
-      val columnsToUpdate = SparkSchemaUtil.identifyMissingComments(targetDf.schema, session.table(table.fullName).schema).map(kv => (kv._1.mkString("."), kv._2))
-      updateExistingColumnComments(columnsToUpdate)
-    }
-
     // get delta table operational metrics
     val dfHistory = deltaTable.history(1)
     if (logger.isDebugEnabled) dfHistory.show(false)

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeCatalogMetadataTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeCatalogMetadataTest.scala
@@ -1,0 +1,126 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.workflow.dataobject
+
+import io.smartdatalake.config.InstanceRegistry
+import io.smartdatalake.testutils.spark.SparkTestUtil
+import io.smartdatalake.util.hdfs.{HdfsUtil, SparkHdfsUtil}
+import io.smartdatalake.workflow.dataframe.spark.SparkSchema
+import io.smartdatalake.workflow.dataobject.DeltaLakeTestUtils.deltaDb
+import io.smartdatalake.workflow.dataobject.generic.{CatalogMetadataApplier, Table}
+import io.smartdatalake.workflow.{ActionPipelineContext, DataFrameSubFeed, ExecutionPhase}
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{MetadataBuilder, StringType, StructField, StructType}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.file
+import java.nio.file.Files
+
+/**
+ * Test applying table metadata to the catalog at deployment time, see issues #1121 and #1127.
+ *
+ * Note that no catalog metadata is written during a normal SDLB run anymore. It is applied by
+ * DataObjectSchemaExporter, which uses [[CatalogMetadataApplier]].
+ */
+class DeltaLakeCatalogMetadataTest extends AnyFunSuite with BeforeAndAfterAll {
+
+  protected implicit val session: SparkSession = DeltaLakeTestUtils.session
+  implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
+  implicit val context: ActionPipelineContext =
+    SparkTestUtil.getDefaultActionPipelineContext.copy(phase = ExecutionPhase.Exec)
+
+  val tempDir: file.Path = Files.createTempDirectory("catalogMetadata")
+  val tempPath: String = tempDir.toAbsolutePath.toString
+
+  override def beforeAll(): Unit = {
+    val warehousePath = new Path("spark-warehouse/delta.db")
+    implicit val fs: FileSystem = SparkHdfsUtil.getHadoopFsFromSpark(warehousePath)(session)
+    HdfsUtil.deletePath(path = warehousePath, doWarn = false)
+    instanceRegistry.clear()
+    instanceRegistry.register(SparkTestUtil.defaultSparkConnection)
+  }
+
+  /**
+   * The schema a dry-run with schema export would have written, carrying the column comments.
+   */
+  private def exportedSchema = SparkSchema(StructType(Seq(
+    StructField("city", StringType, nullable = true,
+      new MetadataBuilder().putString("comment", "Name of the city").build())
+  )))
+
+  private def createTable(name: String, description: Option[String]): DeltaLakeTableDataObject = {
+    val table = Table(db = Some(deltaDb), name = name)
+    val dataObject = DeltaLakeTableDataObject("tgt_" + name, path = Some(s"$tempPath/${table.fullName}"),
+      table = table, metadata = description.map(d => DataObjectMetadata(description = Some(d))))
+    instanceRegistry.register(dataObject)
+    dataObject.dropTable
+    val helper = DataFrameSubFeed.getCompanion(dataObject.getSubFeedSupportedTypes.head)
+    import helper.implicits._
+    val df = Seq(("Bern", 1), ("Zurich", 2)).toDF("city", "nr")
+    dataObject.writeDataFrame(df, Seq())
+    dataObject
+  }
+
+  test("metadata.description works without table.catalog on open source spark") {
+    // issue #1127: this used to fail in the prepare phase with a require on table.catalog,
+    // and with a PARSE_SYNTAX_ERROR on "USE CATALOG" once the catalog was set.
+    val dataObject = createTable("no_catalog", Some("A table without a catalog"))
+    assert(dataObject.table.catalog.isEmpty)
+    dataObject.prepare
+    dataObject.setTableComment("A table without a catalog")
+    assert(dataObject.getTableComment.contains("A table without a catalog"))
+  }
+
+  test("apply writes table and column comments, and is idempotent") {
+    val dataObject = createTable("apply_meta", Some("Cities of interest"))
+    val applier = new CatalogMetadataApplier(_ => Some(exportedSchema))
+
+    // plan reports the changes to be applied
+    val changes = applier.plan(dataObject)
+    assert(changes.isDefined)
+    assert(changes.get.tableComment.contains("Cities of interest"))
+    assert(changes.get.columnComments == Map(Seq("city") -> "Name of the city"))
+
+    // apply writes them to the catalog
+    applier.apply(dataObject, changes.get)
+    assert(dataObject.getTableComment.contains("Cities of interest"))
+    assert(dataObject.getColumnComments == Map(Seq("city") -> "Name of the city"))
+
+    // issue #1121: applying again must not write anything
+    val changesAfterApply = applier.plan(dataObject)
+    assert(changesAfterApply.exists(_.isEmpty), s"expected no changes, got ${changesAfterApply.map(_.describe)}")
+  }
+
+  test("comments containing a single quote are escaped") {
+    val dataObject = createTable("escaping", Some("Bern's cities"))
+    val applier = new CatalogMetadataApplier(_ => None)
+    val changes = applier.plan(dataObject)
+    applier.apply(dataObject, changes.get)
+    assert(dataObject.getTableComment.contains("Bern's cities"))
+  }
+
+  test("no metadata is written to the catalog during a normal run") {
+    val dataObject = createTable("no_run_write", Some("Not written during the run"))
+    // writing the DataFrame and postWrite must not set the table comment anymore
+    dataObject.postWrite(Seq())
+    assert(dataObject.getTableComment.isEmpty)
+  }
+}

--- a/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeUdfColumnCommentTest.scala
+++ b/sdl-deltalake/src/test/scala/io/smartdatalake/workflow/dataobject/DeltaLakeUdfColumnCommentTest.scala
@@ -18,6 +18,7 @@
  */
 package io.smartdatalake.workflow.dataobject
 
+import io.smartdatalake.app.TestMode
 import io.smartdatalake.config.InstanceRegistry
 import io.smartdatalake.testutils.spark.{MockSparkDataObject, SparkTestUtil}
 import io.smartdatalake.util.hdfs.{HdfsUtil, SparkHdfsUtil}
@@ -25,6 +26,7 @@ import io.smartdatalake.util.spark.SparkSchemaUtil
 import io.smartdatalake.workflow.action.CopyAction
 import io.smartdatalake.workflow.action.spark.customlogic.CustomDfTransformer
 import io.smartdatalake.workflow.action.spark.transformer.ScalaClassSparkDfTransformer
+import io.smartdatalake.workflow.dataframe.GenericSchemaUtil
 import io.smartdatalake.workflow.dataframe.spark.SparkSubFeed
 import io.smartdatalake.workflow.dataobject.DeltaLakeTestUtils.deltaDb
 import io.smartdatalake.workflow.dataobject.generic.Table
@@ -48,6 +50,9 @@ class DeltaLakeUdfColumnCommentTest extends AnyFunSuite with BeforeAndAfterAll {
   implicit val instanceRegistry: InstanceRegistry = new InstanceRegistry
   implicit val contextInit: ActionPipelineContext = SparkTestUtil.getDefaultActionPipelineContext
   val contextExec: ActionPipelineContext = contextInit.copy(phase = ExecutionPhase.Exec)
+  // init phase context of a "--test dry-run-with-schema-export" run, which collects the schemas to export
+  val contextInitExport: ActionPipelineContext =
+    contextInit.copy(appConfig = contextInit.appConfig.copy(test = Some(TestMode.DryRunWithSchemaExport)))
 
   import session.implicits._
 
@@ -67,17 +72,26 @@ class DeltaLakeUdfColumnCommentTest extends AnyFunSuite with BeforeAndAfterAll {
     srcDO.writeSparkDataFrame(Seq("Bern", "Zurich").toDF("city"), Seq(), isRecursiveInput = false, None)(contextExec)
 
     val table = Table(db = Some(deltaDb), name = "udf_comments")
-    val tgtDO = DeltaLakeTableDataObject("tgt1", path = Some(tempPath + s"/${table.fullName}"), table = table,
-      updateColumnComments = true)
+    val tgtDO = DeltaLakeTableDataObject("tgt1", path = Some(tempPath + s"/${table.fullName}"), table = table)
     instanceRegistry.register(tgtDO)
     tgtDO.dropTable
 
     val transformer = ScalaClassSparkDfTransformer(className = classOf[DeltaTestGeoUdfTransformer].getName)
     val action = CopyAction("udfComments", srcDO.id, tgtDO.id, transformers = Seq(transformer))
-    action.init(Seq(SparkSubFeed(None, srcDO.id, Seq())))(contextInit)
+    action.init(Seq(SparkSubFeed(None, srcDO.id, Seq())))(contextInitExport)
     action.exec(Seq(SparkSubFeed(None, srcDO.id, Seq())))(contextExec)
 
-    // read the schema back from the delta table - this is what DataObjectSchemaExporter exports for the UI
+    // the init phase schema is what a dry-run exports for the UI and for DataObjectSchemaExporter
+    val exportedSchema = contextInitExport.schemaExportRegistry.getSchemas.get(tgtDO.id)
+    assert(exportedSchema.isDefined, "no schema was collected for export")
+    val exportedComments = GenericSchemaUtil.columnComments(exportedSchema.get)
+      .map { case (path, c) => path.mkString(".") -> c }
+    assert(exportedComments.get("geo").contains("A geo location enriched from an address."))
+    assert(exportedComments.get("geo.lat").contains("Latitude in decimal degrees, WGS84."))
+    assert(exportedComments.get("geo.lon").contains("Longitude in decimal degrees, WGS84."))
+    assert(exportedComments.get("geo.tags.key").contains("The tag key."))
+
+    // a newly created table persists the comments of the written schema, no catalog DDL is needed for that
     val tableSchema = session.table(table.fullName).schema
     val comments = SparkSchemaUtil.columnsComments(tableSchema).map { case (path, c) => path.mkString(".") -> c }
     assert(comments.get("geo").contains("A geo location enriched from an address."))

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ColumnDescriptionParser.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ColumnDescriptionParser.scala
@@ -1,0 +1,91 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.meta.configexporter
+
+import io.smartdatalake.config.ConfigParser
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.definitions.Environment
+import io.smartdatalake.util.hdfs.HdfsUtil
+import io.smartdatalake.util.hdfs.HdfsUtil.RemoteIteratorWrapper
+import io.smartdatalake.util.misc.SmartDataLakeLogger
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+/**
+ * Parses column descriptions from the Markdown description files of DataObjects.
+ *
+ * A description is introduced by a `@column <name> <text>` tag and continues over the following lines
+ * until the next `@column` tag or the next Markdown header. The column name may be a nested path, e.g.
+ * `address.street`, and may contain array markers, e.g. `addresses.[].street`.
+ *
+ * The descriptions are used by [[ConfigJsonExporter]] to document the columns in the SDLB UI, and by
+ * [[DataObjectSchemaExporter]] to apply them as column comments to the catalog.
+ */
+object ColumnDescriptionParser extends SmartDataLakeLogger {
+
+  private val columnDescriptionRegex = """\s*@column\s+["`']?([^\s"`']+)["`']?\s+(.*)""".r.anchored
+
+  /**
+   * Read the column descriptions of all DataObjects having a Markdown description file in
+   * `<descriptionPath>/dataObjects`.
+   *
+   * @return the column descriptions per DataObject id, keyed by the column name as written in the file.
+   */
+  def parse(descriptionPath: String)(implicit hadoopConf: Configuration): Map[DataObjectId, Map[String, String]] = {
+    val hadoopPath = new Path(descriptionPath, ConfigParser.CONFIG_SECTION_DATAOBJECTS)
+    implicit val filesystem: FileSystem = Environment.fileSystemFactory.getFileSystem(hadoopPath, hadoopConf)
+    logger.info(s"Searching DataObject description files in $hadoopPath")
+    RemoteIteratorWrapper(filesystem.listStatusIterator(hadoopPath)).filterNot(_.isDirectory)
+      .filter(_.getPath.getName.endsWith(".md")).toSeq // only Markdown files
+      .map { p =>
+        val dataObjectId = DataObjectId(p.getPath.getName.split('.').head)
+        (dataObjectId, parseContent(HdfsUtil.readHadoopFile(p.getPath)))
+      }
+      .filter(_._2.nonEmpty)
+      .toMap
+  }
+
+  /**
+   * Parse the column descriptions out of the content of one Markdown description file.
+   */
+  def parseContent(content: String): Map[String, String] = {
+    content.linesIterator.foldLeft((Seq[(String, String)](), false)) {
+      // if new column description tag, add new column description
+      case ((descriptions, _), columnDescriptionRegex(name, description)) =>
+        (descriptions :+ (name, description.trim), true)
+      // if new header tag and column description open, close column description
+      case ((descriptions, true), line) if line.startsWith("#") =>
+        (descriptions, false)
+      // if last column description open, add line to last column description text
+      case ((descriptions, true), line) =>
+        val (lastName, lastDesc) = descriptions.last
+        (descriptions.init :+ (lastName, (lastDesc + System.lineSeparator() + line.trim).trim), true)
+      // if last column description closed, ignore line
+      case ((descriptions, false), _) =>
+        (descriptions, false)
+    }._1.filter(_._2.nonEmpty).toMap
+  }
+
+  /**
+   * Convert a column name as written in a description file into the column path used to address the
+   * column in an SQL statement, e.g. "addresses.[].street" becomes Seq("addresses", "street").
+   * Array markers are dropped as arrays are traversed transparently when commenting a nested column.
+   */
+  def toColumnPath(columnName: String): Seq[String] = columnName.split('.').filter(_ != "[]").toIndexedSeq
+}

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporter.scala
@@ -90,7 +90,7 @@ object ConfigJsonExporter extends SmartDataLakeLogger {
       .text("Whether to add an additional property 'origin' including source filename and line number to first class configuration objects.")
     opt[String]('d', "descriptionPath")
       .action((value, c) => c.copy(descriptionPath = Some(value)))
-      .text("Path to markdown files that contain column descriptions of DataObjects. If set, the exported config is enriched with the column descriptions.")
+      .text("Path to the markdown description files of the DataObjects. Used together with --uploadDescriptions to upload them to the visualizer backend. Note that the column descriptions defined there with @column are applied to the catalog and exported with the schema by DataObjectSchemaExporter, they are not part of the exported config anymore.")
     opt[Unit]("uploadDescriptions")
       .action((_, c) => c.copy(uploadDescriptions = true))
       .text("Upload description markdown files to visualizer backend.")
@@ -188,8 +188,6 @@ object ConfigJsonExporter extends SmartDataLakeLogger {
     sdlConfig = configKeysToRemove.foldLeft(sdlConfig)((config, key) => config.withoutPath(key))
     // enrich origin of first class config objects
     if (config.enrichOrigin) sdlConfig = enrichOrigin(config.configPaths, sdlConfig)
-    // enrich optional column description from description files
-    config.descriptionPath.foreach(path => sdlConfig = enrichColumnDescription(path, sdlConfig))
     // enrich optional source documentation for custom classes from scaladoc
     sdlConfig = enrichCustomClassScalaDoc(sdlConfig)
     // enrich optional custom transformer parameter info
@@ -290,47 +288,6 @@ object ConfigJsonExporter extends SmartDataLakeLogger {
             }
         }
     }
-  }
-
-  private def enrichColumnDescription(descriptionPath: String, config: Config)(implicit hadoopConf: Configuration): Config = {
-    val columnDescriptionRegex = """\s*@column\s+["`']?([^\s"`']+)["`']?\s+(.*)""".r.anchored
-    var enrichedConfig = config
-    val hadoopPath = new Path(descriptionPath, ConfigParser.CONFIG_SECTION_DATAOBJECTS)
-    implicit val filesystem: FileSystem = Environment.fileSystemFactory.getFileSystem(hadoopPath, hadoopConf)
-
-    logger.info(s"Searching DataObject description files in $hadoopPath")
-    RemoteIteratorWrapper(filesystem.listStatusIterator(hadoopPath)).filterNot(_.isDirectory)
-      .filter(_.getPath.getName.endsWith(".md")).toSeq // only Markdown files
-      .foreach { p =>
-        val dataObjectId = p.getPath.getName.split('.').head
-        val dataObjectPath = s"${ConfigParser.CONFIG_SECTION_DATAOBJECTS}.$dataObjectId"
-        if (enrichedConfig.hasPath(dataObjectPath)) {
-          val descriptions = HdfsUtil.readHadoopFile(p.getPath).linesIterator.foldLeft((Seq[(String, String)](), false)) {
-            // if new column description tag, add new column description
-            case ((descriptions, _), columnDescriptionRegex(name, description)) =>
-              (descriptions :+ (name, description.trim), true)
-            // if new header tag and column description open, close column description
-            case ((descriptions, true), line) if line.startsWith("#") =>
-              (descriptions, false)
-            // if last column description open, add line to last column description text
-            case ((descriptions, true), line) =>
-              val (lastName, lastDesc) = descriptions.last
-              (descriptions.init :+ (lastName, (lastDesc + System.lineSeparator() + line.trim).trim), true)
-            // if last column description closed, ignore line
-            case ((descriptions, false), _) =>
-              (descriptions, false)
-          }._1.filter(_._2.nonEmpty).toMap
-          if (descriptions.nonEmpty) {
-            logger.info(s"(${DataObjectId(dataObjectId)}) Merging ${descriptions.size} column descriptions")
-            enrichedConfig = enrichedConfig.withValue(s"$dataObjectPath._columnDescriptions", ConfigValueFactory.fromMap(descriptions.asJava))
-          }
-        } else {
-          logger.error(s"(${DataObjectId(dataObjectId)}) Markdown file found, but DataObject does not exist in configuration")
-        }
-      }
-
-    // return
-    enrichedConfig
   }
 
   private def enrichCustomTransformerParameters(config: Config): Config = {

--- a/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporter.scala
+++ b/sdl-lang/src/main/scala/io/smartdatalake/meta/configexporter/DataObjectSchemaExporter.scala
@@ -19,6 +19,10 @@
 package io.smartdatalake.meta.configexporter
 
 import io.smartdatalake.app.SmartDataLakeBuilderConfig
+import io.smartdatalake.config.SdlConfigObject.DataObjectId
+import io.smartdatalake.workflow.dataframe.GenericSchema
+import io.smartdatalake.workflow.dataobject.generic.CatalogMetadataApplier
+import org.apache.hadoop.conf.Configuration
 import io.smartdatalake.config.exporter.ExportWriter
 import io.smartdatalake.config.exporter.ExportWriter.formatSchema
 import io.smartdatalake.config.{ConfigToolbox, ConfigurationException}
@@ -34,8 +38,34 @@ import scopt.OptionParser
 import java.time.LocalDateTime
 import scala.util.{Failure, Success, Try}
 
+/**
+ * What DataObjectSchemaExporter should do.
+ */
+object ExporterMode extends Enumeration {
+  type ExporterMode = Value
+
+  /**
+   * Read the schemas and statistics of the DataObjects and write them to the configured targets.
+   */
+  val Export: ExporterMode = Value("export")
+
+  /**
+   * Read the desired table metadata from the configuration and the exported schema files, and write it
+   * to the catalog. This is the deployment time counterpart of "--test dry-run-with-schema-export".
+   */
+  val Apply: ExporterMode = Value("apply")
+
+  /**
+   * Like [[Apply]], but only report the changes which would be applied, without changing the catalog.
+   */
+  val Plan: ExporterMode = Value("plan")
+}
+
 case class DataObjectSchemaExporterConfig(configPaths: Seq[String] = null,
+                                          mode: ExporterMode.Value = ExporterMode.Export,
                                           targets: Seq[String] = Seq("./schema"),
+                                          source: Option[String] = None,
+                                          descriptionPath: Option[String] = None,
                                           includeRegex: String = ".*",
                                           excludeRegex: Option[String] = None,
                                           withStats: Boolean = true,
@@ -56,6 +86,18 @@ object DataObjectSchemaExporter extends SmartDataLakeLogger {
       .required()
       .action((value, c) => c.copy(configPaths = value.split(',').toIndexedSeq))
       .text("One or multiple configuration files or directories containing configuration files for SDLB, separated by comma.")
+    opt[String]("mode")
+      .action((value, c) => c.copy(mode = ExporterMode.withName(value)))
+      .valueName("<export|apply|plan>")
+      .text("export: read schemas and statistics of the DataObjects and write them to the target (default). " +
+        "apply: write the table metadata (comments, primary keys) from the configuration and the exported schemas to the catalog. " +
+        "plan: report the changes 'apply' would make, without changing the catalog.")
+    opt[String]("source")
+      .action((value, c) => c.copy(source = Some(value)))
+      .text("Source URI to read exported schemas from in mode apply/plan. Defaults to global.dataObjectsSchemaSource.")
+    opt[String]('d', "descriptionPath")
+      .action((value, c) => c.copy(descriptionPath = Some(value)))
+      .text("Path of the directory containing the Markdown description files of the DataObjects. Column descriptions defined there with @column are applied as column comments in mode apply/plan.")
     opt[String]('p', "exportPath")
       .action((value, c) => c.copy(targets = Seq(value)))
       .text("Deprecated: Use target instead. Path to export schema and statistics to.")
@@ -94,9 +136,13 @@ object DataObjectSchemaExporter extends SmartDataLakeLogger {
     parser.parse(args, DataObjectSchemaExporterConfig()) match {
       case Some(exporterConfig) =>
 
-        // export data object schemas and statistics to json format
         logger.info(s"starting with configuration ${ProductUtil.formatObj(exporterConfig)}")
-        exportSchemaAndStats(exporterConfig)
+        exporterConfig.mode match {
+          // export data object schemas and statistics to json format
+          case ExporterMode.Export => exportSchemaAndStats(exporterConfig)
+          // write table metadata to the catalog, or report what would be written
+          case ExporterMode.Apply | ExporterMode.Plan => applyCatalogMetadata(exporterConfig)
+        }
 
       case None =>
         logAndThrowException(s"Aborting $appType after error", new ConfigurationException("Couldn't set command line parameters correctly."))
@@ -167,6 +213,60 @@ object DataObjectSchemaExporter extends SmartDataLakeLogger {
         }
       }
     }
+  }
+
+  /**
+   * Write the table metadata defined in the configuration and in the exported schemas to the catalog,
+   * or report the changes which would be applied in mode plan.
+   *
+   * The schemas are read from `source`, which defaults to `global.dataObjectsSchemaSource`. They are
+   * created by an SDLB dry-run using "--test dry-run-with-schema-export", so that the column comments
+   * are available even if the tables do not exist yet in the environment where the dry-run is executed.
+   */
+  def applyCatalogMetadata(config: DataObjectSchemaExporterConfig): Unit = {
+
+    val isPlan = config.mode == ExporterMode.Plan
+
+    // get DataObjects
+    val (registry, globalConfig) = ConfigToolbox.loadAndParseConfig(config.configPaths)
+    implicit val hadoopConf: Configuration = globalConfig.getHadoopConfiguration
+    val startTime = LocalDateTime.now()
+    implicit val context: ActionPipelineContext = ActionPipelineContext("feedTest", "appTest", SDLExecutionId.executionId1, registry, SmartDataLakeBuilderConfig("DataObjectSchemaExporter", Some("DataObjectSchemaExporter")), runStartTime = startTime, attemptStartTime = startTime, phase = ExecutionPhase.Init, globalConfig = globalConfig)
+    val dataObjects = registry.getDataObjects
+      .filter(d => d.id.id.matches(config.includeRegex) && (config.excludeRegex.isEmpty || !d.id.id.matches(config.excludeRegex.get)))
+
+    // schemas exported by a previous dry-run, used to get the column comments
+    val source = config.source.orElse(globalConfig.dataObjectsSchemaSource)
+    val schemaWriter = source.map(ExportWriter.apply(_, config.configPaths, globalConfig.uiBackend.map(_.client), Some(hadoopConf)))
+    if (schemaWriter.isEmpty) logger.warn("Neither --source nor global.dataObjectsSchemaSource is defined, no column comments will be applied")
+    def readSchema(dataObjectId: DataObjectId): Option[GenericSchema] =
+      schemaWriter.flatMap(_.readLatestSchema(dataObjectId)).map(ExportWriter.parseSchema(_)._1)
+
+    // column descriptions from the Markdown description files override the exported schema comments
+    val columnDescriptions = config.descriptionPath.map(path => ColumnDescriptionParser.parse(path)).getOrElse(Map())
+      .map { case (dataObjectId, descriptions) =>
+        dataObjectId -> descriptions.map { case (name, d) => ColumnDescriptionParser.toColumnPath(name) -> d }
+      }
+
+    val applier = new CatalogMetadataApplier(readSchema, columnDescriptions)
+    logger.info(s"${if (isPlan) "Planning" else "Applying"} catalog metadata for ${dataObjects.size} DataObjects")
+
+    val changed = dataObjects.flatMap { dataObject =>
+      try {
+        applier.plan(dataObject).filterNot(_.isEmpty).map { changes =>
+          logger.info(s"(${dataObject.id}) ${if (isPlan) "would apply" else "applying"}:\n  ${changes.describe.mkString("\n  ")}")
+          if (!isPlan) applier.apply(dataObject, changes)
+          dataObject.id
+        }
+      } catch {
+        case ex: Exception =>
+          logger.error(s"(${dataObject.id}) ${ex.getClass.getSimpleName}: ${ex.getMessage}")
+          if (config.stopOnError) throw ex else None
+      }
+    }
+
+    if (changed.isEmpty) logger.info("Catalog metadata is up to date, nothing to apply")
+    else logger.info(s"${if (isPlan) "Would change" else "Changed"} catalog metadata of ${changed.size} DataObjects: ${changed.map(_.id).mkString(", ")}")
   }
 
   private[configexporter] def getCurrentVersion = System.currentTimeMillis() / 1000

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ColumnDescriptionParserTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ColumnDescriptionParserTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.smartdatalake.meta.configexporter
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ColumnDescriptionParserTest extends AnyFunSuite {
+
+  test("parse column descriptions of a markdown file") {
+    val content =
+      """# Some DataObject
+        |
+        |Some free text which is not a column description.
+        |
+        |## Columns
+        |@column a  Description of a
+        |@column "b" Description of b,
+        |continued on the next line
+        |
+        |@column `c.c1` Description of a nested column
+        |
+        |# Next header closes the last description
+        |This text is ignored.
+        |""".stripMargin
+    val descriptions = ColumnDescriptionParser.parseContent(content)
+    assert(descriptions("a") == "Description of a")
+    assert(descriptions("b") == s"Description of b,${System.lineSeparator()}continued on the next line")
+    assert(descriptions("c.c1") == "Description of a nested column")
+    assert(descriptions.size == 3)
+  }
+
+  test("column names are converted to column paths, dropping array markers") {
+    assert(ColumnDescriptionParser.toColumnPath("a") == Seq("a"))
+    assert(ColumnDescriptionParser.toColumnPath("c.c1") == Seq("c", "c1"))
+    assert(ColumnDescriptionParser.toColumnPath("b.[].b1") == Seq("b", "b1"))
+  }
+}

--- a/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
+++ b/sdl-lang/src/test/scala/io/smartdatalake/meta/configexporter/ConfigJsonExporterTest.scala
@@ -41,10 +41,9 @@ class ConfigJsonExporterTest extends AnyFunSuite {
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "lineNumber" === JInt(112))
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "endLineNumber" === JNothing)
     assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_origin" \ "path" === JString("dagexporterTest.conf"))
-    assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "a" === JString("Beschreibung A"))
-    assert((actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" \ "b.[].b1").asInstanceOf[
-      JString
-    ].s.linesIterator.toSeq === Seq("Beschreibung B1", "2nd line B1 text"))
+    // column descriptions are not part of the exported config anymore, they are applied to the catalog and
+    // exported with the schema by DataObjectSchemaExporter, see ColumnDescriptionParserTest.
+    assert(actualJsonOutput \ "dataObjects" \ "dataObjectParquet6" \ "_columnDescriptions" === JNothing)
     assert(((actualJsonOutput \ "actions" \ "actionId6" \ "transformers")(0) \ "_parameters")(0) \ "name" === JString("session"))
     assert((actualJsonOutput \ "actions" \ "actionId8" \ "transformers")(0) \ "_sourceDoc" ===
       JString("Documentation for TestTransformer.  \nThis should be exported by ConfigJsonExporter!"))

--- a/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
+++ b/sdl-snowflake/src/main/scala/io/smartdatalake/workflow/dataobject/SnowflakeTableDataObject.scala
@@ -34,7 +34,7 @@ import io.smartdatalake.workflow.action.generic.transformer.GenericDfTransformer
 import io.smartdatalake.workflow.connection.SnowflakeConnection
 import io.smartdatalake.workflow.dataframe.snowflake.{SnowparkDataFrame, SnowparkSchema, SnowparkSubFeed}
 import io.smartdatalake.workflow.dataframe.spark.{SparkDataFrame, SparkSchema, SparkSubFeed}
-import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchema}
+import io.smartdatalake.workflow.dataframe.{GenericDataFrame, GenericSchema, GenericSchemaUtil}
 import io.smartdatalake.workflow.dataobject.expectation.Expectation
 import io.smartdatalake.workflow.dataobject.generic._
 import io.smartdatalake.workflow.dataobject.spark.{CanCreateSparkDataFrame, CanWriteSparkDataFrame, SparkSaveMode}
@@ -90,8 +90,6 @@ import scala.reflect.runtime.universe.{Type, typeOf}
  * @param connectionId The SnowflakeTableConnection to use for the table
  * @param virtualPartitions Virtual partition columns. Note that Snowflake has no partition concept, and SDLB is emulating partitions on its own.
  * @param readTransformer   An optional transformer that is applied on read. This is often used to adapt Snowflakes Decimal datatype to more accurate IntegralTypes like Long, Integer, Byte.
- * @param syncComments   Defines if the comments defined in the schema should be synched the Snowflake table.
- *                       Please note that this can be an expensive operation, and it only works if using Spark as an execution engine.
  * @param expectedPartitionsCondition Optional definition of partitions expected to exist.
  *                                    Define a Spark SQL expression that is evaluated against a [[PartitionValues]] instance and returns true or false
  *                                    Default is to expect all partitions to exist.
@@ -113,11 +111,11 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
                                     sparkOptions: Map[String, String] = Map(),
                                     virtualPartitions: Seq[String] = Seq(),
                                     readTransformer: Option[GenericDfTransformer] = None,
-                                    syncComments: Boolean = false,
                                     override val expectedPartitionsCondition: Option[String] = None,
                                     override val metadata: Option[DataObjectMetadata] = None)
                                    (@transient implicit val instanceRegistry: InstanceRegistry)
   extends TransactionalTableDataObject with CanCreateSparkDataFrame with CanWriteSparkDataFrame
+    with CanHandleCatalogMetadata
     with CanHandlePartitions with ExpectationValidation with CanHandleConstraints {
 
   val connection: SnowflakeConnection = getConnection[SnowflakeConnection](connectionId)
@@ -145,7 +143,6 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
 
   private val instanceSparkOptions = connection.sparkOptions ++ sparkOptions
 
-  private var columnComments: Map[String, String] = Map()
 
   override def prepare(implicit context: ActionPipelineContext): Unit = {
     super.prepare
@@ -185,7 +182,6 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
       val targetSchemaWithMetadata = SparkSchemaUtil.mergeSchemaMetadata(sparkSchemaMin.inner, df.schema)
       SparkSubFeed.getSparkSession.createDataFrame(df.rdd, targetSchemaWithMetadata)//workaround to replace the schema in the DF
     } else df
-    columnComments = SparkSchemaUtil.columnsComments(dfTarget.schema).map(kv => (kv._1.mkString("."), kv._2))
     var finalSaveMode = saveModeOptions.map(_.saveMode).getOrElse(saveMode)
 
     // TODO: merge mode not yet implemented
@@ -209,12 +205,6 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
         .mode(SparkSaveMode.from(finalSaveMode))
         .save()
     )
-    
-    //table comment
-    metadata.flatMap(_.description).foreach { comment =>
-      val sql = s"comment on table ${table.fullName} is '$comment';"
-      connection.execJdbcStatement(sql)
-    }
 
 
     // return
@@ -377,11 +367,29 @@ case class SnowflakeTableDataObject(override val id: DataObjectId,
   def createPrimaryKeyConstraint(tableName: String, constraintName: String, cols: Seq[String])(implicit context: ActionPipelineContext): Unit =
     connection.catalog.createPrimaryKeyConstraint(tableName, constraintName, cols)
 
+  // Note that table metadata (table comment, column comments, primary key) is not applied here anymore,
+  // it is applied at deployment time by DataObjectSchemaExporter, see CanHandleCatalogMetadata.
   override def postWrite(partitionValues: Seq[PartitionValues])(implicit context: ActionPipelineContext): Unit = {
     super.postWrite(partitionValues)
-    if (table.createAndReplacePrimaryKey) createOrReplacePrimaryKeyConstraint
-    if (syncComments) {
-      columnComments.foreach(columnComment => connection.execJdbcStatement(s"comment on column ${table.fullName}.${columnComment._1} is '${columnComment._2}';"))
+  }
+
+  override def getTableComment(implicit context: ActionPipelineContext): Option[String] = {
+    val catalogConstraint = table.catalog.map(c => s" and TABLE_CATALOG = '$c'").getOrElse("")
+    val schemaConstraint = table.db.map(d => s" and TABLE_SCHEMA = '$d'").getOrElse("")
+    val query = s"select COMMENT from INFORMATION_SCHEMA.TABLES where TABLE_NAME = '${table.name}'" +
+      schemaConstraint + catalogConstraint
+    connection.execJdbcQuery(query, rs => if (rs.next()) Option(rs.getString(1)) else None)
+  }
+
+  override def setTableComment(comment: String)(implicit context: ActionPipelineContext): Unit = {
+    connection.execJdbcStatement(s"comment on table ${table.fullName} is '${SQLUtil.escapeSqlStringLiteral(comment)}'")
+  }
+
+  override def setColumnComments(comments: Map[Seq[String], String])(implicit context: ActionPipelineContext): Unit = {
+    comments.foreach { case (columnPath, comment) =>
+      connection.execJdbcStatement(
+        s"comment on column ${table.fullName}.${GenericSchemaUtil.formatColumnPath(columnPath)} is '${SQLUtil.escapeSqlStringLiteral(comment)}'"
+      )
     }
   }
 }

--- a/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/workflow/dataobject/JdbcTableDataObject.scala
@@ -188,7 +188,6 @@ case class JdbcTableDataObject(override val id: DataObjectId,
     }
 
     //If enabled, create or replace the primary Key of the table
-    if (table.createAndReplacePrimaryKey) createOrReplacePrimaryKeyConstraint
 
     // test partition columns exist
     if (virtualPartitions.nonEmpty && isTableExisting) {

--- a/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableSparkConnectEngine.scala
+++ b/sdl-sparkconnect/src/main/scala/io/smartdatalake/workflow/dataobject/DeltaLakeTableSparkConnectEngine.scala
@@ -185,7 +185,6 @@ class DeltaLakeTableSparkConnectEngine(dataObject: DeltaLakeTableDataObject) ext
       dfWriter.saveAsTable(table.fullName)
     }
 
-    if (dataObject.updateColumnComments) logger.warn(s"($id) updateColumnComments is not supported with the Spark Connect engine")
 
     // get delta table operational metrics
     // Note: there is no QueryExecutionListener to collect Spark stage metrics on the Spark Connect client side, delta operation metrics only.


### PR DESCRIPTION
Table and column comments and primary keys are no longer written to the catalog during an SDLB run. They can only change when the configuration or the code changes, so writing them on every run puts unnecessary load on the catalog and races the merge operation.

A dry-run with the new mode --test dry-run-with-schema-export exports the init phase schemas, including the column comments assembled by SDLB, to global.dataObjectsSchemaSource. DataObjectSchemaExporter --mode apply reads them back at deployment time, compares them with the catalog and writes only what differs, so applying twice makes no second change. --mode plan reports the changes without applying them.

Statements now address the table by its fully qualified name instead of mutating the current catalog and schema of the shared session. This restores the fix of #1092, which was lost when DeltaLakeTableDataObject moved to sdl-core, and fixes #1127: USE CATALOG is Databricks syntax that open source Spark rejects, which together with a require on table.catalog made metadata.description unusable there.

Comments are applied through the new CanHandleCatalogMetadata, which also adds comment support to IcebergTableDataObject. They are escaped now, so a description containing a quote no longer breaks the statement, and a primary key that already matches no longer throws.

The removed attributes updateColumnComments and syncComments only bounded the per run cost of the writes that are now gone. ConfigJsonExporter no longer exports _columnDescriptions: the column descriptions of the markdown files are applied as column comments and exported with the schema. See sdl-visualization#129 for the UI cleanup.

Foreign keys stay metadata for the catalog only, see #1129.