### PR TITLE
Quality: strip qualifier in withComment(column)

### DIFF
--- a/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
+++ b/sdl-core/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
@@ -47,7 +47,8 @@ trait Quality extends Transform {
         s" as it is not a NamedExpression." +
         s" use withComment(colName: String, column: Column, commentText: String) instead.")
     }
-    withComment(colName, column, commentText)
+    // strip the qualifier, e.g. col("t.src") -> "src", consistent with withComment(colName, commentText)
+    withComment(colName.split('.').last, column, commentText)
   }
 
   implicit class DsColComment(column: Column) {

--- a/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
+++ b/sdl-core/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
@@ -21,7 +21,7 @@ package io.smartdatalake.util.spark.dataset
 
 import io.smartdatalake.testutils.TestUtil
 import io.smartdatalake.util.spark.GetSession.loggEnv
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{coalesce, col, lit}
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -65,10 +65,40 @@ class DsCommentTest extends AnyFlatSpec with Matchers
     dfCommented.columns shouldBe df.columns
   }
 
+  it should "keep the given expression if the column name is new to the input DataFrame" in {
+    val df = List((1, "a")).toDF("id", "src")
+    val dfCommented = df.select(withComment(coalesce(lit(null).cast("string"), $"src").as("derived"), "desc_derived"))
+    dfCommented.columns shouldBe Array("derived")
+    dfCommented.as[String].collect().toSeq shouldBe Seq("a")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_derived")
+  }
+
+  it should "keep the given expression if the column name collides with an input column" in {
+    val df = List((1, "old")).toDF("id", "country_code")
+    val dfCommented = df.select(withComment(coalesce(lit(null).cast("string"), lit("new")).as("country_code"), "desc_country_code"))
+    dfCommented.as[String].collect().toSeq shouldBe Seq("new")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_country_code")
+  }
+
+  it should "comment a plain qualified column reference" in {
+    val df = List((1, "a")).toDF("id", "src")
+    val dfCommented = df.as("t").select(withComment($"t.src", "desc_src"))
+    dfCommented.columns shouldBe Array("src")
+    dfCommented.as[String].collect().toSeq shouldBe Seq("a")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_src")
+  }
+
   "DsColComment.withComment" should "add a comment fluently on a Column" in {
     val df = List(TestCaseClass(1, 1f, TestInnerClass(1, 1))).toDF()
     val dfCommented = df.select(col("id").withComment("desc_id"))
     dfCommented.getColumnComments.select("comment").as[String].collect().toSet shouldBe Set("desc_id")
+  }
+
+  it should "keep the given expression if the column name collides with an input column" in {
+    val df = List((1, "old")).toDF("id", "country_code")
+    val dfCommented = df.select(coalesce(lit(null).cast("string"), lit("new")).as("country_code").withComment("desc_country_code"))
+    dfCommented.as[String].collect().toSeq shouldBe Seq("new")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_country_code")
   }
 
   "DsColComment.makeNotNullable" should "mark the column as not-nullable in the schema" in {


### PR DESCRIPTION
#1103 fixed withComment(column, commentText) to alias the given column, but passed the extracted name through unsplit. A qualified reference now yields a column named after the qualifier, e.g. withComment($"t.src", ...) produces t.src instead of src, and col("addr.city") produces addr.city instead of city. This undoes 4472995 for the single-Column overload and leaves it inconsistent with withComment(colName, commentText), which still splits.

Restore the split and add the regression tests #1103 went in without: the alias being new to the input, the alias colliding with an existing input column (which silently returned that column's value), a qualified reference, and the same collision through the fluent DsColComment.withComment.

Refs #1103


Spark 4 counterpart: #1140
