### PR TITLE
Fix Quality.withComment and port DsColComment to the Spark 4 line

### DIFF
--- a/sdl-spark/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
@@ -21,6 +21,8 @@ package io.smartdatalake.util.spark.dataset
 import io.smartdatalake.util.LogUtils.{debLogFun, debugLog}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
+import org.apache.spark.sql.classic.SdlColumnExpression
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
@@ -50,6 +52,29 @@ trait Quality extends Transform {
     // the comment must be attached to the given column: re-resolving colName against the input DataFrame drops the
     // expression, failing with UNRESOLVED_COLUMN or - if that name already exists in the input - returning its value
     withComment(colName.split('.').last, column, commentText)
+  }
+
+  implicit class DsColComment(column: Column) {
+
+    /**
+     * Fluent alternative to withComment(column, commentText): col("abc").withComment("my description")
+     */
+    def withComment(commentText: String): Column = Quality.this.withComment(column, commentText)
+
+    /**
+     * Marks this column as not-nullable. The check is enforced at runtime: an actual null value in the
+     * underlying data throws a NullPointerException.
+     */
+    def makeNotNullable: Column = {
+      import org.apache.spark.sql.classic.ColumnConversions._
+      // Spark 4 has no public way to build a Column from a catalyst Expression, see SdlColumnExpression
+      val expr = column.expr
+      val asserted = SdlColumnExpression.toColumn(AssertNotNull(expr))
+      expr match {
+        case named: NamedExpression => asserted.as(named.name)
+        case _                      => asserted
+      }
+    }
   }
 
   /**

--- a/sdl-spark/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
+++ b/sdl-spark/src/main/scala/io/smartdatalake/util/spark/dataset/Quality.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.util.spark.dataset
 
 import io.smartdatalake.util.LogUtils.{debLogFun, debugLog}
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
@@ -39,13 +39,17 @@ trait Quality extends Transform {
   final def withComment(colName: String, commentText: String): Column = withComment(colName.split('.').last, col(colName), commentText)
 
   final def withComment(column: Column, commentText: String): Column = {
-    val colName = column.node match {
-      case a: Alias => a.name
-      case _        => throw new IllegalArgumentException(
-          s"Cannot extract name from Column $column, as it has no direct alias. Use withComment(colName: String, column: Column, commentText: String) instead."
+    import org.apache.spark.sql.classic.ColumnConversions._
+    val colName = column.expr match {
+      case c: NamedExpression => c.name
+      case _                  => throw new IllegalArgumentException(
+          s"Cannot extract name from Column $column, as it is not a NamedExpression." +
+            " Use withComment(colName: String, column: Column, commentText: String) instead."
         )
     }
-    withComment(colName, commentText)
+    // the comment must be attached to the given column: re-resolving colName against the input DataFrame drops the
+    // expression, failing with UNRESOLVED_COLUMN or - if that name already exists in the input - returning its value
+    withComment(colName.split('.').last, column, commentText)
   }
 
   /**

--- a/sdl-spark/src/main/scala/org/apache/spark/sql/classic/SdlColumnExpression.scala
+++ b/sdl-spark/src/main/scala/org/apache/spark/sql/classic/SdlColumnExpression.scala
@@ -1,0 +1,33 @@
+/*
+ * Smart Data Lake Builder - Build your data lake the smart way.
+ *
+ * Copyright © 2019-2026 ELCA Informatique SA (<https://www.elca.ch>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.apache.spark.sql.classic
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+/**
+ * Wrap a catalyst Expression into a Column.
+ *
+ * Spark 4 replaced `new Column(expression)` with ColumnNodes. The remaining bridge, `ExpressionUtils.column`,
+ * is private to Spark, so this helper lives in Sparks package. The other direction is available through
+ * `ColumnConversions`.
+ */
+object SdlColumnExpression {
+  def toColumn(expression: Expression): Column = ExpressionUtils.column(expression)
+}

--- a/sdl-spark/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
+++ b/sdl-spark/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
@@ -20,6 +20,7 @@ package io.smartdatalake.util.spark.dataset
 
 import io.smartdatalake.testutils.spark.SparkTestUtil
 import io.smartdatalake.util.spark.GetSession.loggEnv
+import org.apache.spark.sql.functions.{coalesce, lit}
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -61,6 +62,29 @@ class DsCommentTest extends AnyFlatSpec with Matchers
     val expected = Set("desc_id", "desc_x", "desc_y")
     actual shouldBe expected
     dfCommented.columns shouldBe df.columns
+  }
+
+  it should "keep the given expression if the column name is new to the input DataFrame" in {
+    val df = List((1, "a")).toDF("id", "src")
+    val dfCommented = df.select(withComment(coalesce(lit(null).cast("string"), $"src").as("derived"), "desc_derived"))
+    dfCommented.columns shouldBe Array("derived")
+    dfCommented.as[String].collect().toSeq shouldBe Seq("a")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_derived")
+  }
+
+  it should "keep the given expression if the column name collides with an input column" in {
+    val df = List((1, "old")).toDF("id", "country_code")
+    val dfCommented = df.select(withComment(coalesce(lit(null).cast("string"), lit("new")).as("country_code"), "desc_country_code"))
+    dfCommented.as[String].collect().toSeq shouldBe Seq("new")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_country_code")
+  }
+
+  it should "comment a plain qualified column reference" in {
+    val df = List((1, "a")).toDF("id", "src")
+    val dfCommented = df.as("t").select(withComment($"t.src", "desc_src"))
+    dfCommented.columns shouldBe Array("src")
+    dfCommented.as[String].collect().toSeq shouldBe Seq("a")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_src")
   }
 
 }

--- a/sdl-spark/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
+++ b/sdl-spark/src/test/scala/io/smartdatalake/util/spark/dataset/DsCommentTest.scala
@@ -20,7 +20,7 @@ package io.smartdatalake.util.spark.dataset
 
 import io.smartdatalake.testutils.spark.SparkTestUtil
 import io.smartdatalake.util.spark.GetSession.loggEnv
-import org.apache.spark.sql.functions.{coalesce, lit}
+import org.apache.spark.sql.functions.{coalesce, col, lit}
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -85,6 +85,35 @@ class DsCommentTest extends AnyFlatSpec with Matchers
     dfCommented.columns shouldBe Array("src")
     dfCommented.as[String].collect().toSeq shouldBe Seq("a")
     dfCommented.schema.head.getComment() shouldBe Some("desc_src")
+  }
+
+  "DsColComment.withComment" should "add a comment fluently on a Column" in {
+    val df = List(TestCaseClass(1, 1f, TestInnerClass(1, 1))).toDF()
+    val dfCommented = df.select(col("id").withComment("desc_id"))
+    dfCommented.getColumnComments.select("comment").as[String].collect().toSet shouldBe Set("desc_id")
+  }
+
+  it should "keep the given expression if the column name collides with an input column" in {
+    val df = List((1, "old")).toDF("id", "country_code")
+    val dfCommented = df.select(coalesce(lit(null).cast("string"), lit("new")).as("country_code").withComment("desc_cc"))
+    dfCommented.as[String].collect().toSeq shouldBe Seq("new")
+    dfCommented.schema.head.getComment() shouldBe Some("desc_cc")
+  }
+
+  "DsColComment.makeNotNullable" should "mark a nullable column as not-nullable in the schema" in {
+    val df = List(Some(1), None).toDF("id")
+    df.schema("id").nullable shouldBe true
+    df.select(col("id").makeNotNullable).schema("id").nullable shouldBe false
+  }
+
+  it should "keep the column name" in {
+    val df = List((1, "a")).toDF("id", "src")
+    df.select(col("id").makeNotNullable).columns shouldBe Array("id")
+  }
+
+  it should "throw at runtime if the column actually contains a null value" in {
+    val df = List(Some(1), None).toDF("id")
+    a[Exception] should be thrownBy df.select(col("id").makeNotNullable).collect()
   }
 
 }


### PR DESCRIPTION
Fix Quality.withComment and port DsColComment to the Spark 4 line

## Why

Two things are wrong with column comments on `develop-spark4`, and both are invisible on the Spark 3 line:

**1. `withComment(column, commentText)` throws for every column.** The name extraction pattern-matches
`org.apache.spark.sql.catalyst.expressions.Alias` against `column.node`, which in Spark 4 is an
`org.apache.spark.sql.internal.Alias` — an unrelated `ColumnNode` type. The branch is statically
unreachable, so every call ends in the `IllegalArgumentException` fallback, including a plain
`withComment(col("x"), "…")` that worked before the Spark 4 migration. It compiles only because the two
`Alias` types are unrelated non-final types, so scalac accepts the dead branch.

**2. Once past that, the expression is discarded.** The method extracted the column name and delegated to
the two-string overload, which rebuilds a fresh `col(colName)`. So `someExpr.alias("y").withComment(…)`
behaved like `col("y").withComment(…)` resolved against the select's input, with two failure modes:

- the alias is new to the input (a value computed by `coalesce()`/`when()`, or a join-derived column) →
  `UNRESOLVED_COLUMN` at analysis time;
- the alias collides with a column that already exists in the input → **no exception**, and the
  pre-existing column's value is returned instead of the computed one. This is the dangerous case: it is
  invisible unless output values are compared against what the expression should have produced.

Defect 2 is the same one fixed for the Spark 3 line in #1103; defect 1 is specific to Spark 4.

**3. `DsColComment` never reached this line.** The fluent `col(...).withComment(...)` and
`makeNotNullable` from #1099 exist only on `develop-spark3`, so the two lines expose different APIs.

## What this does

`Quality.withComment(column, commentText)`:

- take the name from `Column.expr` via `ColumnConversions` and match `NamedExpression`, the way
  `SparkColumn.getName` already does in `SparkDataFrame.scala`. This also restores
  `withComment(col("x"), "…")`, which threw before;
- pass the given `column` to the three-argument overload instead of rebuilding it from its name;
- keep `.split('.').last`, so a qualified reference still yields `src` rather than `t.src`, consistent
  with `withComment(colName, commentText)`. Note that #1103 dropped this on the Spark 3 line; #1139
  restores it there, so both lines end up with the same behaviour.

`DsColComment` ported to this line, with one addition it needs. `makeNotNullable` cannot be ported as
written: Spark 4 replaced `new Column(expression)` with `ColumnNode`, and every remaining bridge from a
catalyst `Expression` back to a `Column` is `private[sql]` — the `Column` companion,
`ClassicConversions.ColumnConstructorExt` and `ExpressionUtils`. `SdlColumnExpression` therefore exposes
that one direction from inside Spark's package, following the precedent and rationale of the existing
`org.apache.spark.sql.classic.SdlDataFrameMetadata`. `Column` → `Expression` needs no shim; it is public
through `ColumnConversions`. `AssertNotNull` is unchanged in Spark 4.1.3, so the semantics of
`makeNotNullable` carry over as-is.

## Tests

`DsCommentTest` had no coverage of the single-`Column` overload at all, which is why this line has now
been wrong twice. Added:

- the alias being new to the input;
- the alias colliding with an existing input column, asserting the resulting **value**, not just the
  comment — the previous tests only checked comments, which is exactly what let the silent case through;
- a qualified column reference;
- the collision again through the fluent `DsColComment.withComment`;
- `makeNotNullable`: schema, preserved column name, and the runtime throw. The schema case starts from a
  genuinely nullable column (`List(Some(1), None)`) and asserts `nullable` both before and after — #1099's
  version asserted it on an `Int` from a case class, which is already non-nullable and so would pass even
  if `makeNotNullable` did nothing.

The failure modes were confirmed by reverting the fix and re-running, which reproduces both:

```
- should keep the given expression if the column name is new … *** FAILED ***
  [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column … named `derived` cannot be resolved.
- should keep the given expression if the column name collides … *** FAILED ***
  Array("old") was not equal to List("new")     <- the silent wrong value
```

With the fix, `mvn -P scala-2.13 -pl sdl-spark test`:

- `DsCommentTest` — 11 passed, 0 failed
- whole `io.smartdatalake.util.spark.dataset` package, 6 suites — 115 passed, 0 failed

Verified against Spark 4.1.3 / Scala 2.13.

## Notes for review

- `SdlColumnExpression` lives under `sdl-spark/src/main/scala/org/apache/spark/sql/classic/`. If you would
  rather not add a second file in Spark's namespace, the alternative is to fold `toColumn` into
  `SdlDataFrameMetadata` or a shared `Sdl*` helper there — happy to move it.
- No caller in the repo used the single-`Column` overload (every other `withComment` hit is Spark's own
  `StructField.withComment`), so the behaviour change is confined to the new `DsColComment` API and any
  downstream project calling it directly.

Refs #1099, #1103

Spark 3 counterpart: #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
